### PR TITLE
Refactor setupListeners

### DIFF
--- a/lib/data_records.js
+++ b/lib/data_records.js
@@ -1078,21 +1078,29 @@ var handleClickRevision = function(ev) {
  * TODO move all listeners into object so they are named and can be
  * removed/added with iterator.
  **/
-var setupListeners = function() {
-    $(window).off('scroll');
-    $(window).on('scroll', function () {
-        if ($(window).scrollTop() >= $(document).height() - $(window).height() - 10) {
-            setupScroll();
+function setupListeners() {
+    var $document = $(document),
+        $window = $(window),
+        onScroll;
+
+    onScroll = _.throttle(function() {
+        if (!lastRecord) {
+            $('.ajax-loader').show();
+            renderRecords();
+        }
+    }, 700);
+
+    $window.on('scroll', function () {
+        if ($window.scrollTop() >= $document.height() - $window.height() - 10) {
+            onScroll();
         }
     });
 
     // update screen from new records in changes feed
-    $(document).off('data-record-updated');
-    $(document).on('data-record-updated', onDataRecordUpdated);
+    $document.on('data-record-updated', onDataRecordUpdated);
 
     // bind to: field error marks so they can be updated
-    $(document).off('click', '.tasks-data_record .error-missing-phone');
-    $(document).on('click', '.tasks-data_record .error-missing-phone',
+    $document.on('click', '.tasks-data_record .error-missing-phone',
         function(ev) {
             $(this).hide();
             var form = $(this).siblings('form');
@@ -1117,14 +1125,12 @@ var setupListeners = function() {
     });
 
     // remove error highlighting on subsequent tries
-    $(document).off( 'focus', '.tasks-data_record .control-group [type=text]');
-    $(document).on( 'focus', '.tasks-data_record .control-group [type=text]', function(ev) {
+    $document.on( 'focus', '.tasks-data_record .control-group [type=text]', function(ev) {
             $(this).closest('.control-group').removeClass('error');
     });
 
     // handle updating of 'to' field in message task
-    $(document).off('click', '.tasks-data_record [type=submit]');
-    $(document).on('click', '.tasks-data_record [type=submit]', function(ev) {
+    $document.on('click', '.tasks-data_record [type=submit]', function(ev) {
         ev.stopPropagation();
         ev.preventDefault();
         var btn = $(this),
@@ -1170,50 +1176,30 @@ var setupListeners = function() {
     });
 
 
-    $(document).off('click', '#data-records [name=select-row-checkbox]');
-    $(document).on('click', '#data-records [name=select-row-checkbox]', handleSelectRow);
+    $document.on('click', '#data-records [name=select-row-checkbox]', handleSelectRow);
 
-    $(document).off('click', '#data-records [data-action=select-all]');
-    $(document).on('click', '#data-records [data-action=select-all]', handleSelectAllRows);
+    $document.on('click', '#data-records [data-action=select-all]', handleSelectAllRows);
 
-    $(document).off('click', '#data-records [data-action=unselect-all]');
-    $(document).on('click', '#data-records [data-action=unselect-all]', handleUnselectAllRows);
+    $document.on('click', '#data-records [data-action=unselect-all]', handleUnselectAllRows);
 
-    $(document).off('click', '.controls .edit-mode li:not(.disabled) .edit-update');
-    $(document).on('click', '.controls .edit-mode li:not(.disabled) .edit-update', handleUpdateFacility);
+    $document.on('click', '.controls .edit-mode li:not(.disabled) .edit-update', handleUpdateFacility);
 
-    $(document).off('click', '.controls .edit-mode li:not(.disabled) .edit-delete');
-    $(document).on('click', '.controls .edit-mode li:not(.disabled) .edit-delete', handleEditDelete);
+    $document.on('click', '.controls .edit-mode li:not(.disabled) .edit-delete', handleEditDelete);
 
-    $(document).off('click', '.controls .edit-mode li:not(.disabled) .mark-invalid');
-    $(document).on('click', '.controls .edit-mode li:not(.disabled) .mark-invalid', handleMarkInvalid);
+    $document.on('click', '.controls .edit-mode li:not(.disabled) .mark-invalid', handleMarkInvalid);
 
-    $(document).off('click', '.controls .edit-mode li:not(.disabled) .clear-invalid');
-    $(document).on('click', '.controls .edit-mode li:not(.disabled) .clear-invalid', handleClearInvalid);
+    $document.on('click', '.controls .edit-mode li:not(.disabled) .clear-invalid', handleClearInvalid);
 
-    $(document).off('click', '#data-records .message');
-    $(document).on('click', '#data-records .message', function(ev) {
+    $document.on('click', '#data-records .message', function(ev) {
         if ($(ev.target).closest('button').length === 0) {
             ev.preventDefault();
             $(this).parents('.data-record').toggleClass('expanded');
         }
     });
 
-    $(document).off('click', '[data-toggle=extended]');
-    $(document).on('click', '[data-toggle=extended]', function(ev) {
-        $(this).siblings('.extended').toggle();
-    });
+    $document.on('click', '.tasks-data_record .group-header .update', handleScheduleGroupUpdate);
 
-    $(document).off('click', '[data-dismiss=extended]');
-    $(document).on('click', '[data-dismiss=extended]', function(ev) {
-        $(this).closest('.extended').addClass('hide');
-    });
-
-    $(document).off('click', '.tasks-data_record .group-header .update');
-    $(document).on('click', '.tasks-data_record .group-header .update', handleScheduleGroupUpdate);
-
-    $(document).off('click', '.tasks-data_record .group-header .edit');
-    $(document).on('click', '.tasks-data_record .group-header .edit', function(ev) {
+    $document.on('click', '.tasks-data_record .group-header .edit', function(ev) {
         ev.preventDefault();
         var el = $(ev.target),
             table = el.closest('tbody');
@@ -1232,8 +1218,7 @@ var setupListeners = function() {
         setupPhoneTypeahead(table.find('.tasks-to input'));
     });
 
-    $(document).off('click', '.tasks-data_record .group-header .cancel');
-    $(document).on('click', '.tasks-data_record .group-header .cancel', function(ev) {
+    $document.on('click', '.tasks-data_record .group-header .cancel', function(ev) {
         // undo changes for group
         ev.preventDefault();
         var table = $(ev.target).closest('tbody');
@@ -1268,8 +1253,7 @@ var setupListeners = function() {
         toggleEditMode(table);
     });
 
-    $(document).off('click', '.tasks-data_record .remove');
-    $(document).on('click', '.tasks-data_record .remove', function(ev) {
+    $document.on('click', '.tasks-data_record .remove', function(ev) {
         ev.preventDefault();
         var el = $(ev.target),
             row = el.closest('tr');
@@ -1290,8 +1274,7 @@ var setupListeners = function() {
         }
     });
 
-    $(document).off('click', '.tasks-data_record .add-new');
-    $(document).on('click', '.tasks-data_record .add-new', function(ev) {
+    $document.on('click', '.tasks-data_record .add-new', function(ev) {
         ev.preventDefault();
         var el = $(ev.target),
             table = el.closest('table');
@@ -1305,11 +1288,9 @@ var setupListeners = function() {
         setupPhoneTypeahead(new_task.find('.tasks-to input'));
     });
 
-    $(document).off('click', '.tasks-data_record .group-header .save', handleScheduleGroupSave);
-    $(document).on('click', '.tasks-data_record .group-header .save', handleScheduleGroupSave);
+    $document.on('click', '.tasks-data_record .group-header .save', handleScheduleGroupSave);
 
-    $(document).off('click', '.tasks-data_record .tasks-state .dropdown-menu a');
-    $(document).on('click', '.tasks-data_record .tasks-state .dropdown-menu a', function(ev) {
+    $document.on('click', '.tasks-data_record .tasks-state .dropdown-menu a', function(ev) {
         // maintain data-orig-val and data-save-val on state element. used for
         // saving later on.
         ev.preventDefault();
@@ -1331,14 +1312,8 @@ var setupListeners = function() {
         changeEl.addClass('tasks-state-'+new_val);
     });
 
-
-    $(document).off('click', '.data-record-revisions a');
-    $(document).on('click', '.data-record-revisions a', handleClickRevision);
-
-    //$(document).off('update-facilities');
-    //$(document).on('update-facilities', updateFacility);
-
-};
+    $document.on('click', '.data-record-revisions a', handleClickRevision);
+}
 
 // return boolean true if the record matches the logged in user
 var isInDistrict = function(record) {
@@ -1816,12 +1791,16 @@ var subDataRecordChanges = function() {
 };
 
 exports.onDualityInit = function() {
-    if (!db) db = require('db').current();
+    db = db || require('db').current();
+
+    setupListeners();
     subDataRecordChanges();
 };
 
 exports.init = function(req, options) {
-    if (!options) return;
+    if (!options) {
+        return;
+    }
     district = options.district;
     isAdmin = options.isAdmin;
     locale = utils.getUserLocale(req);
@@ -1837,5 +1816,4 @@ exports.init = function(req, options) {
     updateControls(req, function() {
         renderRecords(options);
     });
-    setupListeners();
 }


### PR DESCRIPTION
Fixes #156

The risk of this is low as all of the handlers already remain when
switching tabs from records to export. The handleScroll was refactored
to use _.throttle
