### PR TITLE
WIP default responses attic cleanup

### DIFF
--- a/packages/kujua-sms/kujua-sms/lists.js
+++ b/packages/kujua-sms/kujua-sms/lists.js
@@ -470,7 +470,7 @@ var json_headers = {
  *
  * @api public
  */
-exports.data_record = function (head, req) {
+exports.old_data_record = function (head, req) {
     start({code: 200, headers: json_headers});
 
     var _id = JSON.parse(req.body).uuid,

--- a/packages/kujua-sms/kujua-sms/rewrites.js
+++ b/packages/kujua-sms/kujua-sms/rewrites.js
@@ -53,51 +53,5 @@ exports.rules = [
             descending: 'true',
             form: ':form'
         }
-    },
-    {
-        from: '/:form/data_record/add/clinic/:phone',
-        to: '_list/data_record/clinic_by_phone',
-        query: {
-            startkey: [':phone'],
-            endkey: [':phone',{}]
-        }
-    },
-    {
-        from: '/data_record/add/facility/:phone',
-        to: '_list/data_record/facility_by_phone',
-        query: {
-            startkey: [':phone'],
-            endkey: [':phone',{}]
-        }
-    },
-    {
-        from: '/data_record/update/:id',
-        to: '_update/updateRelated/:id',
-        method: 'PUT'
-    },
-    {
-        from: '/:form/data_record/add/facility/:phone',
-        to: '_list/data_record/facility_by_phone',
-        query: {
-            startkey: [':phone'],
-            endkey: [':phone',{}]
-        }
-    },
-    {
-        from: '/:form/data_record/add/health_center/:phone',
-        to: '_list/data_record/clinic_by_parent_phone',
-        query: {
-            startkey: [':phone'],
-            endkey: [':phone',{}]
-        }
-    },
-    {
-        from: '/:form/data_record/add/refid/:refid',
-        to: '_list/data_record/clinic_by_refid',
-        query: {
-            startkey: [':refid',{}],
-            endkey: [':refid'],
-            descending: 'true'
-        }
     }
 ];

--- a/packages/kujua-sms/views/lib/app_settings.js
+++ b/packages/kujua-sms/views/lib/app_settings.js
@@ -756,8 +756,10 @@ module.exports = {
              * e.g: [{to: '+123', message: 'foo'},...]
              * context includes: phone, clinic, keys, labels, values
              * Health Center -> Hospital
-             */
+            */
+            /* deprecated
             messages_task: "function() {var msg = [], ignore = [], dh_ph = clinic && clinic.parent && clinic.parent.parent && clinic.parent.parent.contact && clinic.parent.parent.contact.phone; keys.forEach(function(key) { if (ignore.indexOf(key) === -1) { msg.push(labels.shift() + ': ' + values.shift()); } else { labels.shift(); values.shift(); } }); return {to:dh_ph, message:msg.join(', ')}; }"
+             */
         },
         "YYYZ": {
             meta: {code: "YYYZ", label: 'Test Form - Required fields'},


### PR DESCRIPTION
When form not found:
- if app_settings.forms_only_mode add `form_not_found` error message.
- if not forms_only_mode add `sms_received` response message.

When form is found:
- form validation and response messaging happens with app_settings.

When facility is not found:
- add error facilty_not_found
- sentinel will try to resolve facility
- if public_form property is true on form registrations transition will run
  on form and responses can be set there.

Removed following unused translations:

`form_received`
`reporting_unit_not_found`

Removed support for following form properties:

`messages_task`
- Use app settings; define a form and setup a response.

`autoreply`
- Use translations on sms_received and form_not_found or use
  settings to define a form and setup a response.

`facility_required`
- Replaced by `public_form` property on form.

Removed doc.responses legacy property. Use doc.tasks.

Removed updateRelated update function since it's basically dead code, and related tests etc. Sentinel provides this function.

This also fixes #614.

TODO:

Removed following unused settings:

`public_access` (?)

modify sentinel:
- if public_form is false we set a response

check if views are unused:
- clinic_by_refid
- clinic_by_phone
- clinic_by_parent_phone
- facility_by_phone
