### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ require_valid_user = true
 ```
 Create an admin user
 ```
-curl -X POST http://admin:password@localhost:5984/_users -d '{"_id": "org.couchdb.user:admin", "name": "admin", "password":"pass", "type":"user", "roles":[]}' -H "Content-Type: application/json"
+curl -X POST http://admin:pass@localhost:5984/_users -d '{"_id": "org.couchdb.user:admin", "name": "admin", "password":"pass", "type":"user", "roles":[]}' -H "Content-Type: application/json"
 ```
 
 ### Kanso


### PR DESCRIPTION
Change "password" to the correct starter password specified in the README, "pass", so that users following the setup guide will be able to exactly replicate the steps to setup an admin account (otherwise, will throw an incorrect password error)
