### PR TITLE
Messages API

### DIFF
--- a/packages/kujua-sms/kujua-sms/rewrites.js
+++ b/packages/kujua-sms/kujua-sms/rewrites.js
@@ -1,7 +1,15 @@
 exports.rules = [
-    {from: '/add', to: '_update/add', method: 'POST'},
-    // by default smssync uses the same URL for tasks polling
-    {from: '/add',
+    /*
+     * A rewrite entry is needed for the POST and the GET because in SMSSync
+     * the Sync URL is used for both.
+     */
+    {
+        from: '/add',
+        to: '_update/add',
+        method: 'POST'
+    },
+    {
+        from: '/add',
         to: '_list/tasks_pending/tasks_pending',
         query: {
             include_docs: 'true',
@@ -9,9 +17,18 @@ exports.rules = [
         },
         method: 'GET'
     },
-    /* use this path if you need to specify the limit */
-    {from: '/add/limit/*', to: '_update/add_sms', method: 'POST'},
-    {from: '/add/limit/:limit',
+    /*
+     * Use this path to specify a limit on the number of documents the view
+     * will return. This allows you reduce the JSON payload the gateway
+     * processes, or to increase it from the default of 25 hard coded above.
+     */
+    {
+        from: '/add/limit/*',
+        to: '_update/add',
+        method: 'POST'
+    },
+    {
+        from: '/add/limit/:limit',
         to: '_list/tasks_pending/tasks_pending',
         query: {
             include_docs: 'true',

--- a/packages/kujua-sms/kujua-sms/rewrites.js
+++ b/packages/kujua-sms/kujua-sms/rewrites.js
@@ -42,6 +42,22 @@ exports.rules = [
         method: 'PUT'
     },
     {
+        from: '/messages',
+        to: '_view/tasks_messages',
+        method: 'GET',
+        query: {
+            limit: '25'
+        }
+    },
+    {
+        from: '/messages/:uuid',
+        to: '_view/tasks_messages',
+        query: {
+            key: ':uuid'
+        },
+        method: 'GET'
+    },
+    {
         from: '/:form/data_record/add/clinic/:phone',
         to: '_list/data_record/clinic_by_phone',
         query: {

--- a/packages/kujua-sms/kujua-sms/rewrites.js
+++ b/packages/kujua-sms/kujua-sms/rewrites.js
@@ -37,6 +37,11 @@ exports.rules = [
         method: 'GET'
     },
     {
+        from: '/update_message_task/:data_record',
+        to: '_update/update_message_task/:data_record',
+        method: 'PUT'
+    },
+    {
         from: '/:form/data_record/add/clinic/:phone',
         to: '_list/data_record/clinic_by_phone',
         query: {

--- a/packages/kujua-sms/kujua-sms/rewrites.js
+++ b/packages/kujua-sms/kujua-sms/rewrites.js
@@ -36,11 +36,6 @@ exports.rules = [
         }
     },
     {
-        from: '/data_record/update/:id',
-        to: '_update/updateRelated/:id',
-        method: 'PUT'
-    },
-    {
         from: '/:form/data_record/add/facility/:phone',
         to: '_list/data_record/facility_by_phone',
         query: {

--- a/packages/kujua-sms/kujua-sms/views.js
+++ b/packages/kujua-sms/kujua-sms/views.js
@@ -405,7 +405,14 @@ exports.tasks_messages = {
                      * to be processed/valid.
                      */
                     if (msg.uuid && msg.to && msg.message) {
-                        emit(msg.uuid, {record: doc._id});
+                        emit(msg.uuid, {
+                            message: msg.message,
+                            to: msg.to,
+                            id: msg.uuid,
+                            state: task.state,
+                            state_details: task.state_details,
+                            _record_id: doc._id
+                        });
                     }
                 });
             });

--- a/packages/kujua-sms/kujua-sms/views.js
+++ b/packages/kujua-sms/kujua-sms/views.js
@@ -395,6 +395,26 @@ exports.clinic_by_refid = {
     }
 };
 
+exports.tasks_messages = {
+    map: function (doc) {
+        var _emit = function(tasks) {
+            tasks.forEach(function(task) {
+                task.messages.forEach(function(msg) {
+                    /*
+                     * uuid, to and message properties are required for message
+                     * to be processed/valid.
+                     */
+                    if (msg.uuid && msg.to && msg.message) {
+                        emit(msg.uuid, {record: doc._id});
+                    }
+                });
+            });
+        };
+        _emit(doc.tasks || []);
+        _emit(doc.scheduled_tasks || []);
+    }
+};
+
 exports.tasks_pending = {
     map: function (doc) {
         var has_pending,

--- a/packages/kujua-utils/kujua-utils.js
+++ b/packages/kujua-utils/kujua-utils.js
@@ -52,7 +52,7 @@ var months = function () {
     ];
 };
 
-exports.logger = {
+var logger = exports.logger = {
     levels: {silent:0, error:1, warn:2, info:3, debug:4},
     log: function(obj) {
         if (typeof(console) !== 'undefined') {
@@ -247,11 +247,35 @@ exports.updateTopNav = function(key, title) {
     $('body > .container div').filter(':first').attr('class', 'content');
 };
 
-exports.setTaskState = function(task, state) {
+/*
+ * Return task object that matches message uuid or a falsey value if match
+ * fails.
+ */
+exports.getTask = function(uuid, doc, type) {
+    type = type || 'message';
+    var ret;
+    if (!uuid || !doc || !doc.tasks) {
+        return;
+    }
+    if (type === 'message') {
+        for (var i in doc.tasks) {
+            for (var j in doc.tasks[i].messages) {
+                if (uuid === doc.tasks[i].messages[j].uuid) {
+                    return doc.tasks[i];
+                }
+            }
+        };
+    }
+    return ret;
+};
+
+exports.setTaskState = function(task, state, message) {
     task.state = state;
+    task.state_message = message;
     task.state_history = task.state_history || [];
     task.state_history.push({
         state: state,
+        state_message: message,
         timestamp: new Date().toISOString()
     });
 };


### PR DESCRIPTION
Add lower level couchdb support to update a document's message tasks.   Also add a higher level API to medic-api that will accept a message's UUID and new state value as an argument.  This requires a view to index all messages so a document lookup can be done based on a message uuid.  Opening PR for potential discussion.