### PR TITLE
Fix #923 and #919 - bugs when deleting contacts

### DIFF
--- a/static/js/controllers/contacts-content.js
+++ b/static/js/controllers/contacts-content.js
@@ -11,11 +11,12 @@
       $scope.selectContact($stateParams.id);
 
       $scope.$on('ContactUpdated', function(e, contact) {
-        if (!contact || (
-            contact._deleted &&
-            $scope.selected &&
-            $scope.selected._id === contact._id)) {
+        if (!contact) {
           $scope.select();
+        } else if(contact._deleted &&
+            $scope.selected &&
+            $scope.selected._id === contact._id) {
+          $scope.selected = null;
         } else if ($scope.selected && $scope.selected._id === contact._id) {
           contact.children = $scope.selected.children;
           contact.contactFor = $scope.selected.contactFor;

--- a/static/js/controllers/contacts-content.js
+++ b/static/js/controllers/contacts-content.js
@@ -16,7 +16,7 @@
         } else if(contact._deleted &&
             $scope.selected &&
             $scope.selected._id === contact._id) {
-          $scope.selected = null;
+          $scope.setSelected();
         } else if ($scope.selected && $scope.selected._id === contact._id) {
           contact.children = $scope.selected.children;
           contact.contactFor = $scope.selected.contactFor;

--- a/static/js/controllers/contacts.js
+++ b/static/js/controllers/contacts.js
@@ -128,7 +128,6 @@ var _ = require('underscore'),
       });
 
       var removeContact = function(contact) {
-        var id = contact._id;
         $scope.items = _.filter($scope.items, function(i) {
             return i._id !== contact._id; });
       };

--- a/static/js/controllers/contacts.js
+++ b/static/js/controllers/contacts.js
@@ -116,7 +116,7 @@ var _ = require('underscore'),
         if (!contact) {
           return $scope.query();
         } else if (contact._deleted) {
-          removeContact(contact);
+          $scope.removeContact(contact);
           return;
         }
         $state.go('contacts.detail', { id: contact._id });
@@ -126,11 +126,6 @@ var _ = require('underscore'),
         }
         _.extend(outdated, contact);
       });
-
-      var removeContact = function(contact) {
-        $scope.items = _.filter($scope.items, function(i) {
-            return i._id !== contact._id; });
-      };
     }
   ]);
 

--- a/static/js/controllers/contacts.js
+++ b/static/js/controllers/contacts.js
@@ -116,7 +116,8 @@ var _ = require('underscore'),
         if (!contact) {
           return $scope.query();
         } else if (contact._deleted) {
-          return $scope.removeContact(contact);
+          removeContact(contact);
+          return;
         }
         $state.go('contacts.detail', { id: contact._id });
         var outdated = _.findWhere($scope.items, { _id: contact._id });
@@ -126,6 +127,11 @@ var _ = require('underscore'),
         _.extend(outdated, contact);
       });
 
+      var removeContact = function(contact) {
+        var id = contact._id;
+        $scope.items = _.filter($scope.items, function(i) {
+            return i._id !== contact._id; });
+      };
     }
   ]);
 

--- a/static/js/controllers/contacts.js
+++ b/static/js/controllers/contacts.js
@@ -113,8 +113,10 @@ var _ = require('underscore'),
       });
 
       $scope.$on('ContactUpdated', function(e, contact) {
-        if (!contact || contact._deleted) {
+        if (!contact) {
           return $scope.query();
+        } else if (contact._deleted) {
+          return $scope.removeContact(contact);
         }
         $state.go('contacts.detail', { id: contact._id });
         var outdated = _.findWhere($scope.items, { _id: contact._id });

--- a/static/js/controllers/edit-contact.js
+++ b/static/js/controllers/edit-contact.js
@@ -16,7 +16,8 @@ var libphonenumber = require('libphonenumber/utils'),
           startkey: [],
           endkey: [{}],
           reduce: false,
-          include_docs: true
+          include_docs: true,
+          timeout: false
         };
         DbView('facilities', options, function(err, results) {
           if (err) {
@@ -53,13 +54,7 @@ var libphonenumber = require('libphonenumber/utils'),
 
       populateParents();
 
-      $scope.$on('ContactUpdated', function(e, contact) {
-        if (contact && contact._deleted) {
-          // allow the ContactCtrl to handle contact deletion
-          return;
-        }
-        populateParents();
-      });
+      $scope.$on('ContactUpdated', populateParents);
 
       $scope.$on('EditContactInit', function(e, contact) {
 

--- a/static/js/controllers/edit-contact.js
+++ b/static/js/controllers/edit-contact.js
@@ -53,7 +53,13 @@ var libphonenumber = require('libphonenumber/utils'),
 
       populateParents();
 
-      $scope.$on('ContactUpdated', populateParents);
+      $scope.$on('ContactUpdated', function(e, contact) {
+        if (contact && contact._deleted) {
+          // allow the ContactCtrl to handle contact deletion
+          return;
+        }
+        populateParents();
+      });
 
       $scope.$on('EditContactInit', function(e, contact) {
 

--- a/static/js/controllers/inbox.js
+++ b/static/js/controllers/inbox.js
@@ -149,13 +149,9 @@ require('moment/locales');
       };
 
       $scope.removeContact = function(contact) {
-        var i, id = contact._id;
-        for (i=$scope.items.length-1; i>=0; --i) {
-          if($scope.items[i]._id === id) {
-            $scope.items.splice(i, 1);
-            return;
-          }
-        }
+        var id = contact._id;
+        $scope.items = _.filter($scope.items, function(i) {
+            return i._id !== contact._id; });
       };
 
       $scope.isRead = function(message) {

--- a/static/js/controllers/inbox.js
+++ b/static/js/controllers/inbox.js
@@ -202,7 +202,7 @@ require('moment/locales');
         });
       };
 
-      $scope.$on('ContactUpdated', function(contact) {
+      $scope.$on('ContactUpdated', function() {
         $scope.updateAvailableFacilities();
       });
 

--- a/static/js/controllers/inbox.js
+++ b/static/js/controllers/inbox.js
@@ -209,10 +209,6 @@ require('moment/locales');
       };
 
       $scope.$on('ContactUpdated', function(contact) {
-        if (!contact || contact._deleted) {
-          // allow the ContactCtrl to handle contact deletion
-          return;
-        }
         $scope.updateAvailableFacilities();
       });
 

--- a/static/js/controllers/inbox.js
+++ b/static/js/controllers/inbox.js
@@ -202,6 +202,11 @@ require('moment/locales');
         });
       };
 
+      $scope.removeContact = function(contact) {
+        $scope.items = _.filter($scope.items, function(i) {
+            return i._id !== contact._id; });
+      };
+
       $scope.$on('ContactUpdated', function() {
         $scope.updateAvailableFacilities();
       });

--- a/static/js/controllers/inbox.js
+++ b/static/js/controllers/inbox.js
@@ -148,12 +148,6 @@ require('moment/locales');
         $scope.items = contacts || [];
       };
 
-      $scope.removeContact = function(contact) {
-        var id = contact._id;
-        $scope.items = _.filter($scope.items, function(i) {
-            return i._id !== contact._id; });
-      };
-
       $scope.isRead = function(message) {
         if ($scope.filterModel.type === 'reports' &&
             $scope.selected &&

--- a/static/js/controllers/inbox.js
+++ b/static/js/controllers/inbox.js
@@ -148,6 +148,16 @@ require('moment/locales');
         $scope.items = contacts || [];
       };
 
+      $scope.removeContact = function(contact) {
+        var i, id = contact._id;
+        for (i=$scope.items.length-1; i>=0; --i) {
+          if($scope.items[i]._id === id) {
+            $scope.items.splice(i, 1);
+            return;
+          }
+        }
+      };
+
       $scope.isRead = function(message) {
         if ($scope.filterModel.type === 'reports' &&
             $scope.selected &&
@@ -202,7 +212,11 @@ require('moment/locales');
         });
       };
 
-      $scope.$on('ContactUpdated', function() {
+      $scope.$on('ContactUpdated', function(contact) {
+        if (!contact || contact._deleted) {
+          // allow the ContactCtrl to handle contact deletion
+          return;
+        }
         $scope.updateAvailableFacilities();
       });
 


### PR DESCRIPTION
This changes the behaviours of the `ContactUdpated` listeners in various
controllers to simplify their handling of deleted contacts.  In short,
the listeners update `$scope.items` directly, where appropriate, in
place of triggering database queries.

This should fix #919 and #923.

@garethbowen please review!