### PR TITLE
Fix for #945 cannot delete a contact whose catchment area has been deleted

### DIFF
--- a/static/js/services/delete-doc.js
+++ b/static/js/services/delete-doc.js
@@ -8,6 +8,9 @@
     if (doc.type === 'person' && doc.parent && doc.parent._id) {
       db.getDoc(doc.parent._id, function(err, parent)  {
         if (err) {
+          if (err.reason === "deleted") {
+            return callback();
+          }
           return callback(err);
         }
         if (parent.contact.phone !== doc.phone) {


### PR DESCRIPTION
Fix for #945 

Before deleting a contact, we GET its catchment area.  If the
catchment area has already been deleted, this GET will fail.  This
commit ignores the failure if it is because the catchment area is
deleted.