### PR TITLE
Fix for #925 - conversations can linger when empty

### DIFF
--- a/static/js/services/message-contacts.js
+++ b/static/js/services/message-contacts.js
@@ -12,7 +12,7 @@ var async = require('async'),
     function(HttpWrapper, BaseUrlService) {
       return function(params, callback) {
         var url = BaseUrlService() + '/message_contacts';
-        HttpWrapper.get(url, { params: params })
+        HttpWrapper.get(url, { params: params, timeout: false })
           .success(function(res) {
             callback(null, res.rows);
           })


### PR DESCRIPTION
Don't let message_contact requests timeout.

Possible fix for #925.  This makes all requests from `MessageContactsRaw` set `timeout: false`.  Alternative would be to add a timeout option to `MessageContactsRaw`, but it's not clear to me at this point which requests should and which shouldn't have it set.