### PR TITLE
Fix for #925: tag HTTP requests with their update target

### DIFF
--- a/static/js/controllers/edit-contact.js
+++ b/static/js/controllers/edit-contact.js
@@ -17,7 +17,7 @@ var libphonenumber = require('libphonenumber/utils'),
           endkey: [{}],
           reduce: false,
           include_docs: true,
-          updateTarget: "filter"
+          targetScope: "filter"
         };
         DbView('facilities', options, function(err, results) {
           if (err) {

--- a/static/js/controllers/edit-contact.js
+++ b/static/js/controllers/edit-contact.js
@@ -17,7 +17,7 @@ var libphonenumber = require('libphonenumber/utils'),
           endkey: [{}],
           reduce: false,
           include_docs: true,
-          targetScope: "filter"
+          targetScope: "contacts"
         };
         DbView('facilities', options, function(err, results) {
           if (err) {

--- a/static/js/controllers/edit-contact.js
+++ b/static/js/controllers/edit-contact.js
@@ -17,7 +17,7 @@ var libphonenumber = require('libphonenumber/utils'),
           endkey: [{}],
           reduce: false,
           include_docs: true,
-          timeout: false
+          updateTarget: "filter"
         };
         DbView('facilities', options, function(err, results) {
           if (err) {

--- a/static/js/controllers/edit-contact.js
+++ b/static/js/controllers/edit-contact.js
@@ -17,7 +17,7 @@ var libphonenumber = require('libphonenumber/utils'),
           endkey: [{}],
           reduce: false,
           include_docs: true,
-          targetScope: "contacts"
+          targetScope: 'root'
         };
         DbView('facilities', options, function(err, results) {
           if (err) {

--- a/static/js/controllers/inbox.js
+++ b/static/js/controllers/inbox.js
@@ -278,7 +278,7 @@ require('moment/locales');
         ReadMessages({
           user: UserCtxService().name,
           district: $scope.permissions.district,
-          timeout: false
+          targetScope: "messages"
         }, function(err, data) {
           if (err) {
             return console.log(err);
@@ -303,7 +303,7 @@ require('moment/locales');
         sendMessage.init(Settings, Contact, translateFilter);
       };
 
-      Form({ timeout: false }, function(err, forms) {
+      Form({ targetScope: 'root' }, function(err, forms) {
         if (err) {
           return console.log('Failed to retrieve forms', err);
         }
@@ -440,7 +440,7 @@ require('moment/locales');
       });
 
       var updateEditUserModel = function(callback) {
-        User({ timeout: false }, function(err, user) {
+        User({ targetScope: 'root' }, function(err, user) {
           if (err) {
             return console.log('Error getting user', err);
           }
@@ -459,7 +459,7 @@ require('moment/locales');
         });
       };
 
-      Settings({ timeout: false }, function(err, settings) {
+      Settings({ targetScope: 'root' }, function(err, settings) {
         if (err) {
           return console.log('Error fetching settings', err);
         }
@@ -476,7 +476,7 @@ require('moment/locales');
 
       moment.locale(['en']);
 
-      Language({ timeout: false }, function(err, language) {
+      Language({ targetScope: 'root' }, function(err, language) {
         if (err) {
           return console.log('Error loading language', err);
         }
@@ -628,7 +628,7 @@ require('moment/locales');
         });
 
         // we have to wait for language to respond before initing the multidropdowns
-        Language({ timeout: false }, function(err, language) {
+        Language({ targetScope: 'root' }, function(err, language) {
 
           $translate.use(language);
 
@@ -774,7 +774,7 @@ require('moment/locales');
       };
 
       $scope.setupHeader = function() {
-        Settings({ timeout: false }, function(err, settings) {
+        Settings({ targetScope: 'root' }, function(err, settings) {
           if (err) {
             return console.log('Error retrieving settings', err);
           }
@@ -794,13 +794,7 @@ require('moment/locales');
 
       CountMessages.init();
 
-      $scope.$on('$stateChangeStart', function(event, toState, toParams, fromState) {
-        if(fromState.name !== toState.name) {
-          ActiveRequests.cancelExceptFor(["filters"]);
-        } else {
-          ActiveRequests.cancelExceptFor(["filters", "left"]);
-        }
-      });
+      $scope.$on('$stateChangeStart', ActiveRequests.cancel);
 
       $scope.reloadWindow = function() {
         $window.location.reload();

--- a/static/js/controllers/inbox.js
+++ b/static/js/controllers/inbox.js
@@ -794,8 +794,12 @@ require('moment/locales');
 
       CountMessages.init();
 
-      $scope.$on('$stateChangeStart', function() {
-        ActiveRequests.cancelAll();
+      $scope.$on('$stateChangeStart', function(event, toState, toParams, fromState) {
+        if(fromState.name !== toState.name) {
+          ActiveRequests.cancelExceptFor(["filters"]);
+        } else {
+          ActiveRequests.cancelExceptFor(["filters", "left"]);
+        }
       });
 
       $scope.reloadWindow = function() {

--- a/static/js/services/http-wrapper.js
+++ b/static/js/services/http-wrapper.js
@@ -18,10 +18,10 @@ var _ = require('underscore');
             return p.url !== url;
           });
         },
-        cancelExceptFor: function(allow) {
+        cancel: function(event, toState) {
           var stillPending = [];
           _.each(pending, function(p) {
-            if(_.contains(allow, p.targetScope)) {
+            if (toState.name.startsWith(p.targetScope)) {
               stillPending.push(p);
             } else {
               p.canceller.resolve();
@@ -39,7 +39,7 @@ var _ = require('underscore');
 
       var wrap = function(args, fn) {
         var options = args[args.length - 1] = args[args.length - 1] || {};
-        if (options.timeout === false) {
+        if (options.targetScope === "root") {
           return fn.apply(this, args);
         }
         var canceller = $q.defer();
@@ -53,7 +53,7 @@ var _ = require('underscore');
       };
 
       /**
-       * To disable the cancel on navigation feature, set 'timeout' to false
+       * To disable the cancel on navigation feature, set 'targetScope' to "root"
        * in the options param.
        */
       return {

--- a/static/js/services/http-wrapper.js
+++ b/static/js/services/http-wrapper.js
@@ -37,14 +37,14 @@ var _ = require('underscore');
     '$http', '$q', 'ActiveRequests',
     function($http, $q, ActiveRequests) {
 
-      var wrap = function(args, fn, updateTarget) {
-        args[args.length - 1] = args[args.length - 1] || {};
-        if (args[args.length - 1].timeout === false) {
+      var wrap = function(args, fn) {
+        var options = args[args.length - 1] = args[args.length - 1] || {};
+        if (options.timeout === false) {
           return fn.apply(this, args);
         }
         var canceller = $q.defer();
-        ActiveRequests.add({ url: args[0], canceller: canceller, updateTarget: updateTarget });
-        args[args.length - 1].timeout = canceller.promise;
+        ActiveRequests.add({ url: args[0], canceller: canceller, updateTarget: options.updateTarget });
+        options.timeout = canceller.promise;
         var promise = fn.apply(this, args);
         promise.finally(function() {
           ActiveRequests.remove(args[0]);
@@ -58,16 +58,13 @@ var _ = require('underscore');
        */
       return {
         get: function(url, options) {
-          var updateTarget = options ? options.updateTarget : null;
-          return wrap([ url, options ], $http.get, updateTarget);
+          return wrap([ url, options ], $http.get);
         },
         put: function(url, data, options) {
-          var updateTarget = options ? options.updateTarget : null;
-          return wrap([ url, data, options ], $http.put, updateTarget);
+          return wrap([ url, data, options ], $http.put);
         },
         head: function(url, options) {
-          var updateTarget = options ? options.updateTarget : null;
-          return wrap([ url, options ], $http.head, updateTarget);
+          return wrap([ url, options ], $http.head);
         }
       };
 

--- a/static/js/services/http-wrapper.js
+++ b/static/js/services/http-wrapper.js
@@ -21,7 +21,7 @@ var _ = require('underscore');
         cancel: function(event, toState) {
           var stillPending = [];
           _.each(pending, function(p) {
-            if (toState.name.startsWith(p.targetScope)) {
+            if (toState.name.indexOf(p.targetScope) === 0) {
               stillPending.push(p);
             } else {
               p.canceller.resolve();

--- a/static/js/services/http-wrapper.js
+++ b/static/js/services/http-wrapper.js
@@ -21,7 +21,7 @@ var _ = require('underscore');
         cancelExceptFor: function(allow) {
           var stillPending = [];
           _.each(pending, function(p) {
-            if(_.contains(allow, p.updateTarget)) {
+            if(_.contains(allow, p.targetScope)) {
               stillPending.push(p);
             } else {
               p.canceller.resolve();
@@ -43,7 +43,7 @@ var _ = require('underscore');
           return fn.apply(this, args);
         }
         var canceller = $q.defer();
-        ActiveRequests.add({ url: args[0], canceller: canceller, updateTarget: options.updateTarget });
+        ActiveRequests.add({ url: args[0], canceller: canceller, targetScope: options.targetScope });
         options.timeout = canceller.promise;
         var promise = fn.apply(this, args);
         promise.finally(function() {

--- a/static/js/services/message-contacts.js
+++ b/static/js/services/message-contacts.js
@@ -10,9 +10,9 @@ var async = require('async'),
   inboxServices.factory('MessageContactsRaw', [
     'HttpWrapper', 'BaseUrlService',
     function(HttpWrapper, BaseUrlService) {
-      return function(params, callback, updateTarget) {
+      return function(params, callback, targetScope) {
         var url = BaseUrlService() + '/message_contacts';
-        HttpWrapper.get(url, { params: params, updateTarget: updateTarget })
+        HttpWrapper.get(url, { params: params, targetScope: targetScope })
           .success(function(res) {
             callback(null, res.rows);
           })
@@ -50,7 +50,7 @@ var async = require('async'),
       },
       request: ['district', function(callback, results) {
         var query = generateQuery(options, results.district || 'admin');
-        MessageContactsRaw(query, callback, options.updateTarget);
+        MessageContactsRaw(query, callback, options.targetScope);
       }],
       unallocated: function(callback) {
         if (!options.districtAdmin) {
@@ -65,7 +65,7 @@ var async = require('async'),
         if (!results.unallocated) {
           return callback();
         }
-        MessageContactsRaw(generateQuery(options, 'none'), callback, options.updateTarget);
+        MessageContactsRaw(generateQuery(options, 'none'), callback, options.targetScope);
       }]
     }, function(err, results) {
       var merged;
@@ -84,7 +84,7 @@ var async = require('async'),
   inboxServices.factory('MessageContact', ['$rootScope', 'MessageContactsRaw', 'UserDistrict', 'Settings',
     function($rootScope, MessageContactsRaw, UserDistrict, Settings) {
       return function(options, callback) {
-        options.updateTarget = "left";
+        options.targetScope = "left";
         options.queryOptions = { group_level: 2 };
         query($rootScope, MessageContactsRaw, UserDistrict, Settings, options, callback);
       };
@@ -94,7 +94,7 @@ var async = require('async'),
   inboxServices.factory('ContactConversation', ['$rootScope', 'MessageContactsRaw', 'UserDistrict', 'Settings',
     function($rootScope, MessageContactsRaw, UserDistrict, Settings) {
       return function(options, callback) {
-        options.updateTarget = "right";
+        options.targetScope = "right";
         options.queryOptions = {
           reduce: false,
           descending: true,

--- a/static/js/services/message-contacts.js
+++ b/static/js/services/message-contacts.js
@@ -84,7 +84,7 @@ var async = require('async'),
   inboxServices.factory('MessageContact', ['$rootScope', 'MessageContactsRaw', 'UserDistrict', 'Settings',
     function($rootScope, MessageContactsRaw, UserDistrict, Settings) {
       return function(options, callback) {
-        options.targetScope = "left";
+        options.targetScope = "messages";
         options.queryOptions = { group_level: 2 };
         query($rootScope, MessageContactsRaw, UserDistrict, Settings, options, callback);
       };
@@ -94,7 +94,7 @@ var async = require('async'),
   inboxServices.factory('ContactConversation', ['$rootScope', 'MessageContactsRaw', 'UserDistrict', 'Settings',
     function($rootScope, MessageContactsRaw, UserDistrict, Settings) {
       return function(options, callback) {
-        options.targetScope = "right";
+        options.targetScope = "messages.details";
         options.queryOptions = {
           reduce: false,
           descending: true,

--- a/static/js/services/message-contacts.js
+++ b/static/js/services/message-contacts.js
@@ -10,9 +10,9 @@ var async = require('async'),
   inboxServices.factory('MessageContactsRaw', [
     'HttpWrapper', 'BaseUrlService',
     function(HttpWrapper, BaseUrlService) {
-      return function(params, callback) {
+      return function(params, callback, updateTarget) {
         var url = BaseUrlService() + '/message_contacts';
-        HttpWrapper.get(url, { params: params })
+        HttpWrapper.get(url, { params: params, updateTarget: updateTarget })
           .success(function(res) {
             callback(null, res.rows);
           })
@@ -45,7 +45,7 @@ var async = require('async'),
       },
       request: ['district', function(callback, results) {
         var query = generateQuery(options, results.district || 'admin');
-        MessageContactsRaw(query, callback);
+        MessageContactsRaw(query, callback, options.updateTarget);
       }],
       unallocated: function(callback) {
         if (!options.districtAdmin) {
@@ -60,7 +60,7 @@ var async = require('async'),
         if (!results.unallocated) {
           return callback();
         }
-        MessageContactsRaw(generateQuery(options, 'none'), callback);
+        MessageContactsRaw(generateQuery(options, 'none'), callback, options.updateTarget);
       }]
     }, function(err, results) {
       var merged;
@@ -79,6 +79,7 @@ var async = require('async'),
   inboxServices.factory('MessageContact', ['$rootScope', 'MessageContactsRaw', 'UserDistrict', 'Settings',
     function($rootScope, MessageContactsRaw, UserDistrict, Settings) {
       return function(options, callback) {
+        options.updateTarget = "left";
         options.queryOptions = { group_level: 2 };
         query($rootScope, MessageContactsRaw, UserDistrict, Settings, options, callback);
       };
@@ -88,6 +89,7 @@ var async = require('async'),
   inboxServices.factory('ContactConversation', ['$rootScope', 'MessageContactsRaw', 'UserDistrict', 'Settings',
     function($rootScope, MessageContactsRaw, UserDistrict, Settings) {
       return function(options, callback) {
+        options.updateTarget = "right";
         options.queryOptions = {
           reduce: false,
           descending: true,

--- a/static/js/services/message-contacts.js
+++ b/static/js/services/message-contacts.js
@@ -16,7 +16,12 @@ var async = require('async'),
           .success(function(res) {
             callback(null, res.rows);
           })
-          .error(function(data) {
+          .error(function(data, status) {
+            if(status === 0) {
+              // request failed unnaturally.  It was probably cancelled by a
+              // state change, so we can safely ignore it.
+              return;
+            }
             callback(new Error(data));
           });
       };

--- a/tests/karma/unit/services/http-wrapper.js
+++ b/tests/karma/unit/services/http-wrapper.js
@@ -58,22 +58,22 @@ describe('HttpWrapper service', function() {
       done();
     });
 
-    ActiveRequests.cancelExceptFor([]);
+    ActiveRequests.cancel({}, { name: 'test' });
     $httpBackend.flush();
   });
 
-  it('get ignores timeout if flag set', function(done) {
+  it('get ignores timeout if targetScope is root', function(done) {
     var expected = { _id: 'abc' };
     $httpBackend
       .expect('GET', '/_users/abc')
       .respond(200, expected);
 
-    service.get('/_users/abc', { timeout: false }).success(function(actual) {
+    service.get('/_users/abc', { targetScope: "root" }).success(function(actual) {
       chai.expect(actual).to.deep.equal(expected);
       done();
     });
 
-    ActiveRequests.cancelExceptFor([]);
+    ActiveRequests.cancel({}, { name: 'test' });
     $httpBackend.flush();
   });
 
@@ -102,22 +102,22 @@ describe('HttpWrapper service', function() {
       done();
     });
 
-    ActiveRequests.cancelExceptFor([]);
+    ActiveRequests.cancel({}, { name: 'test' });
     $httpBackend.flush();
   });
 
-  it('put ignores timeout if flag set', function(done) {
+  it('put ignores timeout if targetScope is root', function(done) {
     var expected = { _id: 'abc', name: 'gareth' };
     $httpBackend
       .expect('PUT', '/_users/abc', expected)
       .respond(200, 'Done');
 
-    service.put('/_users/abc', expected, { timeout: false }).success(function(actual) {
+    service.put('/_users/abc', expected, { targetScope: 'root' }).success(function(actual) {
       chai.expect(actual).to.deep.equal('Done');
       done();
     });
 
-    ActiveRequests.cancelExceptFor([]);
+    ActiveRequests.cancel({}, { name: 'test' });
     $httpBackend.flush();
   });
 
@@ -144,21 +144,21 @@ describe('HttpWrapper service', function() {
       done();
     });
 
-    ActiveRequests.cancelExceptFor([]);
+    ActiveRequests.cancel({}, { name: 'test' });
     $httpBackend.flush();
   });
 
-  it('head ignores timeout if flag set', function(done) {
+  it('head ignores timeout if targetScope is root', function(done) {
     $httpBackend
       .expect('HEAD', '/_users/abc')
       .respond(200, 'Found');
 
-    service.head('/_users/abc', { timeout: false }).success(function(actual) {
+    service.head('/_users/abc', { targetScope: 'root' }).success(function(actual) {
       chai.expect(actual).to.deep.equal('Found');
       done();
     });
 
-    ActiveRequests.cancelExceptFor([]);
+    ActiveRequests.cancel({}, { name: 'test' });
     $httpBackend.flush();
   });
 

--- a/tests/karma/unit/services/http-wrapper.js
+++ b/tests/karma/unit/services/http-wrapper.js
@@ -58,7 +58,7 @@ describe('HttpWrapper service', function() {
       done();
     });
 
-    ActiveRequests.cancelAll();
+    ActiveRequests.cancelExceptFor([]);
     $httpBackend.flush();
   });
 
@@ -73,7 +73,7 @@ describe('HttpWrapper service', function() {
       done();
     });
 
-    ActiveRequests.cancelAll();
+    ActiveRequests.cancelExceptFor([]);
     $httpBackend.flush();
   });
 
@@ -102,7 +102,7 @@ describe('HttpWrapper service', function() {
       done();
     });
 
-    ActiveRequests.cancelAll();
+    ActiveRequests.cancelExceptFor([]);
     $httpBackend.flush();
   });
 
@@ -117,7 +117,7 @@ describe('HttpWrapper service', function() {
       done();
     });
 
-    ActiveRequests.cancelAll();
+    ActiveRequests.cancelExceptFor([]);
     $httpBackend.flush();
   });
 
@@ -144,7 +144,7 @@ describe('HttpWrapper service', function() {
       done();
     });
 
-    ActiveRequests.cancelAll();
+    ActiveRequests.cancelExceptFor([]);
     $httpBackend.flush();
   });
 
@@ -158,7 +158,7 @@ describe('HttpWrapper service', function() {
       done();
     });
 
-    ActiveRequests.cancelAll();
+    ActiveRequests.cancelExceptFor([]);
     $httpBackend.flush();
   });
 


### PR DESCRIPTION
An alternative approach to (https://github.com/medic/medic-webapp/pull/955) for fixing #925.

This adds a new parameter for HTTP requests made through the
`HttpWrapper` service - `updateTarget`.  Current options for
`updateTarget` are `filter`, `left` and `right`, referring to different
sections of the UI which an HTTP request might update on successful
completion.

When the user navigates to different states, the `stateChangeStart`
listener selectively cancels pending HTTP requests depending on the old
and new states.

There are three tests which are broken by this commit.  They check that
the callback functions are working by testing that the error callbacks
are executed for cancelled requests.  This commit changed the behaviour
of the rest canceller from calling `resolve()` on request promises, to
instead calling `reject()`.  This seems to be better bahaviour, as it
prevents the deliberately-cancelled requests from being handled as
errors, but it is not clear to me how the tests should be modified to
reflect this change in behaviour.

@garethbowen please review