### PR TITLE
Fix for #930 - add an explicit blank contact to Place Edit

### DIFF
--- a/static/js/controllers/edit-contact.js
+++ b/static/js/controllers/edit-contact.js
@@ -11,6 +11,13 @@ var libphonenumber = require('libphonenumber/utils'),
     ['$scope', '$rootScope', 'translateFilter', 'Settings', 'UpdateContact', 'DbView',
     function ($scope, $rootScope, translateFilter, Settings, UpdateContact, DbView) {
 
+      var NO_CONTACT =  {
+          name: '',
+          type: 'person',
+          _id: null,
+          order: 1
+        };
+
       var populateParents = function() {
         var options = {
           startkey: [],
@@ -29,12 +36,7 @@ var libphonenumber = require('libphonenumber/utils'),
             _id: 'NEW',
             order: 1
           });
-          results.unshift({
-            name: '',
-            type: 'person',
-            _id: null,
-            order: 1
-          });
+          results.unshift(NO_CONTACT);
           $scope.parents = results;
         });
       };
@@ -94,7 +96,7 @@ var libphonenumber = require('libphonenumber/utils'),
           $scope.contactId = null;
           if ($scope.category === 'place') {
             // set the Primary Contact field for places to be 'blank'
-            $scope.contact.contact = $scope.parents[0];
+            $scope.contact.contact = NO_CONTACT;
           }
         }
 

--- a/static/js/controllers/edit-contact.js
+++ b/static/js/controllers/edit-contact.js
@@ -23,10 +23,16 @@ var libphonenumber = require('libphonenumber/utils'),
           if (err) {
             return console.log('Error fetching parents', err);
           }
-          results.push({
+          results.unshift({
             name: translateFilter('New person'),
             type: 'person',
             _id: 'NEW',
+            order: 1
+          });
+          results.unshift({
+            name: '',
+            type: 'person',
+            _id: null,
             order: 1
           });
           $scope.parents = results;
@@ -86,6 +92,10 @@ var libphonenumber = require('libphonenumber/utils'),
           };
           $scope.category = $scope.contact.type === 'person' ? 'person' : 'place';
           $scope.contactId = null;
+          if ($scope.category === 'place') {
+            // set the Primary Contact field for places to be 'blank'
+            $scope.contact.contact = $scope.parents[0];
+          }
         }
 
         $('#edit-contact').modal('show');


### PR DESCRIPTION
This is a fix for #930 

This removes dependence on AngularJS's default blank field when editing
a place.  We now define the 'no contact' explicitly, and also explcitly
select it when initialising the 'create place' dialog for a new place.