### PR TITLE
Fix for #963 - view can't find `getName` method

### DIFF
--- a/packages/kujua-sms/kujua-sms/views.js
+++ b/packages/kujua-sms/kujua-sms/views.js
@@ -276,7 +276,7 @@ exports.data_records_by_contact = {
                 facility = doc.contact;
                 districtId = getDistrictId(facility);
                 message = doc.sms_message;
-                position = getName(facility.parent) || doc.from;
+                position = facility && getPosition(facility.parent) || doc.from;
                 contactName = (facility && facility.name) || doc.from;
                 key = (facility && facility._id) || doc.from;
                 emitContact(districtId, key, doc.reported_date, {


### PR DESCRIPTION
Fix for #963

`getName` was renamed to `getPosition` in
25324a399c19ad9027f666716578a9db89448b7b.  This commit updates
`kujua-sms/views.js` to correctly reference `getPosition` instead of `getName`.

Also adds null-safe dereference for `facility.parent` which is passed to
`getPosition`.