### PR TITLE
initial attempt at debug mode controller

### DIFF
--- a/static/js/controllers/help.js
+++ b/static/js/controllers/help.js
@@ -2,17 +2,22 @@
 
   'use strict';
 
-  var inboxControllers = angular.module('inboxControllers');
+  var inboxControllers = angular.module('inboxControllers'),
+      debugCookieName = 'medic-webapp-enableDebug';
 
   inboxControllers.controller('HelpCtrl',
-    ['$scope', 'Session',
-    function ($scope, Session) {
+    ['$scope', 'Session', 'Debug',
+    function ($scope, Session, Debug) {
       $scope.filterModel.type = 'help';
       $scope.url = window.location.hostname;
       $scope.userCtx = Session.userCtx();
       $scope.reload = function() {
         window.location.reload(false);
       };
+      $scope.enableDebugModel = {
+        val: Debug.get()
+      };
+      $scope.$watch('enableDebugModel.val', Debug.set);
     }
   ]);
 

--- a/static/js/controllers/help.js
+++ b/static/js/controllers/help.js
@@ -2,8 +2,7 @@
 
   'use strict';
 
-  var inboxControllers = angular.module('inboxControllers'),
-      debugCookieName = 'medic-webapp-enableDebug';
+  var inboxControllers = angular.module('inboxControllers');
 
   inboxControllers.controller('HelpCtrl',
     ['$scope', 'Session', 'Debug',

--- a/static/js/services/debug.js
+++ b/static/js/services/debug.js
@@ -1,0 +1,42 @@
+/*
+ * Manage debug mode.
+ *
+ * When enabled:
+ *
+ *   - persist setting to a cookie
+ *   - put PouchDB in debug mode
+ *   - display $log.debug() output throughout the app
+ *
+ */
+angular.module('inboxServices').config([
+  '$provide', '$logProvider', function($provide, $logProvider) {
+    $provide.service('Debug', [
+      'ipCookie', 'pouchDB', function(ipCookie, pouchDB) {
+        var cookieName = 'medic-webapp-debug';
+        var get = function() {
+          return Boolean(ipCookie(cookieName));
+        };
+        var set = function(bool) {
+          // this changes the default angular behavior and hides debug level
+          // log messages.
+          $logProvider.debugEnabled(bool);
+          var db = pouchDB.debug ? pouchDB : window.PouchDB;
+          if (bool) {
+            console.log('set cookie, enabled debug');
+            db.debug.enable('*');
+            ipCookie(cookieName, bool, {expires: 360});
+          } else {
+            console.log('remove cookie');
+            db.debug.disable();
+            ipCookie.remove(cookieName);
+          }
+        };
+        set(get()); // initialize
+        return {
+          get: get,
+          set: set
+        }
+      }
+    ]);
+  }
+]);

--- a/static/js/services/debug.js
+++ b/static/js/services/debug.js
@@ -35,7 +35,7 @@ angular.module('inboxServices').config([
         return {
           get: get,
           set: set
-        }
+        };
       }
     ]);
   }

--- a/static/js/services/index.js
+++ b/static/js/services/index.js
@@ -17,8 +17,8 @@
   require('./db');
   require('./db-sync');
   require('./db-view');
-  require('./delete-doc');
   require('./debug');
+  require('./delete-doc');
   require('./download-url');
   require('./edit-group');
   require('./enketo');

--- a/static/js/services/index.js
+++ b/static/js/services/index.js
@@ -18,6 +18,7 @@
   require('./db-sync');
   require('./db-view');
   require('./delete-doc');
+  require('./debug');
   require('./download-url');
   require('./edit-group');
   require('./enketo');

--- a/templates/partials/help.html
+++ b/templates/partials/help.html
@@ -26,14 +26,10 @@
       <h3>{{'Debug' | translate}}</h3>
     </div>
     <div>
-      <p>
-      Debug mode will print information into the browser console to help
-      developers diagnose problems with the application.  After changing this
-      setting reload the app so it applies.
-      </p>
+      <p>{{ 'debug.mode.description' | translate }}</p>
       <form>
         <label>
-          <input ng-model="enableDebugModel.val" type="checkbox" /> Enable debug mode
+          <input ng-model="enableDebugModel.val" type="checkbox" /> {{ 'debug.mode.title' | translate }}
         </label>
       </form>
     </div>

--- a/templates/partials/help.html
+++ b/templates/partials/help.html
@@ -22,5 +22,20 @@
         <li><a ui-sref="help.export">{{'help.export.title' | translate}}</a></li>
       </ul>
     </div>
+    <div>
+      <h3>{{'Debug' | translate}}</h3>
+    </div>
+    <div>
+      <p>
+      Debug mode will print information into the browser console to help
+      developers diagnose problems with the application.  After changing this
+      setting reload the app so it applies.
+      </p>
+      <form>
+        <label>
+          <input ng-model="enableDebugModel.val" type="checkbox" /> Enable debug mode
+        </label>
+      </form>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
Issue: https://github.com/medic/medic-webapp/issues/1647

Couple things that are a bit strange:

Since we're using the ipCookie service the $logProvider.debugEnabled() gets called kind of late, so you will see $log.debug() output until then.  I don't think we have many $log.debug() calls currently so there's not much effect atm.

The pouchDB service doesn't seem to have a `debug` property on it.