### PR TITLE
#1762 - no letters in phone numbers

### DIFF
--- a/packages/libphonenumber/libphonenumber/utils.js
+++ b/packages/libphonenumber/libphonenumber/utils.js
@@ -1,17 +1,10 @@
 var i18n = require('libphonenumber/phoneformat'),
     standardFormat = i18n.phonenumbers.PhoneNumberFormat.E164;
 
-var _cleanPhone = function(phone) {
-  phone = phone.replace(/[^\d\+]/g, '');
-  var prefix = phone.substr(0, 1) === '+' ? '+' : '';
-  phone = phone.replace(/[^\d]/g, '');
-  return prefix + phone;
-};
-
 var _init = function(settings, phone) {
   return {
     util: i18n.phonenumbers.PhoneNumberUtil.getInstance(),
-    phone: _cleanPhone(phone),
+    phone: phone,
     countryCode: settings && settings.default_country_code,
     country: function() {
       return this.util.getRegionCodeForCountryCode(this.countryCode);

--- a/packages/libphonenumber/libphonenumber/utils.js
+++ b/packages/libphonenumber/libphonenumber/utils.js
@@ -1,3 +1,6 @@
+/**
+* Our wrapper around google's libphonenumber.
+*/
 var i18n = require('libphonenumber/phoneformat'),
   standardFormat = i18n.phonenumbers.PhoneNumberFormat.E164;
 
@@ -28,6 +31,7 @@ var _init = function(settings, phone) {
   };
 };
 
+/** Returns international format if valid number, false if invalid number. */
 exports.format = function(settings, phone) {
   try {
     return _init(settings, phone).format();
@@ -35,6 +39,7 @@ exports.format = function(settings, phone) {
   return false;
 };
 
+/** Returns true if valid number. Allows dots, brackets, spaces, but not letters. */
 exports.validate = function(settings, phone) {
   try {
     return _init(settings, phone).validate();

--- a/packages/libphonenumber/libphonenumber/utils.js
+++ b/packages/libphonenumber/libphonenumber/utils.js
@@ -1,5 +1,5 @@
 var i18n = require('libphonenumber/phoneformat'),
-    standardFormat = i18n.phonenumbers.PhoneNumberFormat.E164;
+  standardFormat = i18n.phonenumbers.PhoneNumberFormat.E164;
 
 var _init = function(settings, phone) {
   return {
@@ -13,14 +13,17 @@ var _init = function(settings, phone) {
       return this.util.parseAndKeepRawInput(this.phone, this.country());
     },
     format: function() {
-      var parsed = this.parse();
-      if (!this.util.isValidNumber(parsed)) {
+      if (!this.validate()) {
         return false;
       }
-      return this.util.format(parsed, standardFormat).toString();
+      return this.util.format(this.parse(), standardFormat).toString();
     },
     validate: function() {
-      return this.util.isValidNumber(this.parse());
+      return this.util.isValidNumber(this.parse()) &&
+        // Disallow alpha numbers, e.g. 1-800-MICROSOFT. We only take digits.
+        // Disallow weirdness in liphonenumber : 1 or 2 letters are ignored 
+        // ('<validnumber>aa' is valid).
+        !this.phone.match(/[a-z]/i);
     }
   };
 };

--- a/packages/libphonenumber/libphonenumber/utils.js
+++ b/packages/libphonenumber/libphonenumber/utils.js
@@ -13,7 +13,11 @@ var _init = function(settings, phone) {
       return this.util.parseAndKeepRawInput(this.phone, this.country());
     },
     format: function() {
-      return this.util.format(this.parse(), standardFormat).toString();
+      var parsed = this.parse();
+      if (!this.util.isValidNumber(parsed)) {
+        return false;
+      }
+      return this.util.format(parsed, standardFormat).toString();
     },
     validate: function() {
       return this.util.isValidNumber(this.parse());

--- a/packages/libphonenumber/tests/libphonenumber.js
+++ b/packages/libphonenumber/tests/libphonenumber.js
@@ -1,38 +1,97 @@
 var phonenumber = require('libphonenumber/utils');
 
+var validNumNZDomestic = '0275552636'; 
+var validNumNZInternational = '+64275552636';
+// Watch out : right number of digits may still be invalid number!
+var invalidNumNZDomestic = '5155556442'; 
+var validNumUSInternational = '+15155556442';
 var settings = {
   default_country_code: 64
 };
 
 exports['format does nothing when already formatted'] = function(test) {
-  var number = '+15155556442';
+  var number = validNumNZInternational;
   var actual = phonenumber.format(settings, number);
   test.equal(actual, number);
   test.done();
 };
 
-exports['format does not require configured country code'] = function(test) {
-  var number = '+151555564422';
+exports['format does nothing when already formatted, conflicting contry code in settings'] = function(test) {
+  // Settings has NZ country code, number is US/Canada number.
+  var number = validNumUSInternational;
+  var actual = phonenumber.format(settings, number);
+  test.equal(actual, number);
+  test.done();
+};
+
+exports['format does not require country code in settings when number has international format'] = function(test) {
+  var number = validNumNZInternational;
   var actual = phonenumber.format({}, number);
   test.equal(actual, number);
   test.done();
 };
 
 exports['format adds country code when missing'] = function(test) {
-  var actual = phonenumber.format(settings, '5155556442');
-  test.equal(actual, '+645155556442');
+  var actual = phonenumber.format(settings, validNumNZDomestic);
+  test.equal(actual, validNumNZInternational);
   test.done();
 };
 
-exports['format returns false when no configured country code'] = function(test) {
-  var actual = phonenumber.format({}, '5155556442');
+exports['format returns false when domestic number and no country code in settings'] = function(test) {
+  var actual = phonenumber.format({}, validNumNZDomestic);
+  test.strictEqual(actual, false);
+  test.done();
+};
+
+exports['format returns false for empty number'] = function(test) {
+  var actual = phonenumber.format(settings, '');
   test.strictEqual(actual, false);
   test.done();
 };
 
 exports['format returns false for invalid number'] = function(test) {
-  var actual = phonenumber.format(settings, '');
+  var actual = phonenumber.format(settings, invalidNumNZDomestic);
   test.strictEqual(actual, false);
+  test.done();
+};
+
+exports['format returns false for invalid number - replaced letter <-> digit'] = function(test) {
+  // Invalid number for NZ
+  var actual = phonenumber.format(settings, '02755K2636');
+  test.strictEqual(actual, false);
+  test.done();
+};
+
+exports['format returns false for invalid number - extra letters'] = function(test) {
+  var actual = phonenumber.format(settings, '0275552636fff');
+  test.strictEqual(actual, false);
+  test.done();
+};
+
+exports['format returns false for invalid number - invalid punctuation'] = function(test) {
+  var actual = phonenumber.format(settings, '0275552<636>');
+  test.strictEqual(actual, false);
+  test.done();
+};
+
+exports['format removes spaces, brackets and dots'] = function(test) {
+  var expected = validNumNZInternational;
+  var actual = phonenumber.format(settings, '+ 6 4 - 02 7.-.5.(55((2636.');
+  test.strictEqual(actual, expected);
+  test.done();
+};
+
+exports['format removes spaces, brackets and dots, and adds country code'] = function(test) {
+  var expected = validNumNZInternational;
+  var actual = phonenumber.format(settings, ' 0  2 7-..5.(55((26 36.');
+  test.strictEqual(actual, expected);
+  test.done();
+};
+
+exports['format removes extra zeros in international format'] = function(test) {
+  var expected = validNumNZInternational;
+  var actual = phonenumber.format(settings, '+640275552636'); // Remove leading 0 from domestic format
+  test.strictEqual(actual, expected);
   test.done();
 };
 
@@ -48,13 +107,13 @@ exports['validate returns false for short number'] = function(test) {
   test.done();
 };
 
-exports['validate returns false for invalid characters'] = function(test) {
-  var actual = phonenumber.validate(settings, '027555Z636');
+exports['validate returns false for invalid number - replaced letter <-> digit'] = function(test) {
+  var actual = phonenumber.validate(settings, '027555H636');
   test.strictEqual(actual, false);
   test.done();
 };
 
-exports['validate returns false when letters in valid number'] = function(test) {
+exports['validate returns false for invalid number - extra letters'] = function(test) {
   // Insert letters within valid number : they shouldn't be filtered out.
   var actual = phonenumber.validate(settings, '0275552kkk636');
   test.strictEqual(actual, false);
@@ -62,19 +121,19 @@ exports['validate returns false when letters in valid number'] = function(test) 
 };
 
 exports['validate returns false for number without country code'] = function(test) {
-  var actual = phonenumber.validate({}, '5155556442');
+  var actual = phonenumber.validate({}, validNumNZDomestic);
   test.strictEqual(actual, false);
   test.done();
 };
 
 exports['validate returns true for number with default country code'] = function(test) {
-  var actual = phonenumber.validate(settings, '0275552636');
+  var actual = phonenumber.validate(settings, validNumNZDomestic);
   test.strictEqual(actual, true);
   test.done();
 };
 
 exports['validate returns true for number with explicit country code'] = function(test) {
-  var actual = phonenumber.validate({}, '+64275552636');
+  var actual = phonenumber.validate({}, validNumNZInternational);
   test.strictEqual(actual, true);
   test.done();
 };
@@ -95,6 +154,12 @@ exports['validate returns true when spaces, brackets, dots, dashes in number'] =
 exports['validate returns false when funky punctuation in number'] = function(test) {
   var actual = phonenumber.validate({default_country_code: '1'}, '+1 <800> 556 8725');
   test.strictEqual(actual, false);
+  test.done();
+};
+
+exports['validate returns true when extra zeros in international format'] = function(test) {
+  var actual = phonenumber.validate(settings, '+640275552636'); // Unnecessary leading 0 from domestic format
+  test.strictEqual(actual, true);
   test.done();
 };
 

--- a/packages/libphonenumber/tests/libphonenumber.js
+++ b/packages/libphonenumber/tests/libphonenumber.js
@@ -55,15 +55,40 @@ exports['format returns false for invalid number'] = function(test) {
   test.done();
 };
 
-exports['format returns false for invalid number - replaced letter <-> digit'] = function(test) {
+exports['format returns false for invalid number - replaced 1 letter <-> 1 digit'] = function(test) {
   // Invalid number for NZ
   var actual = phonenumber.format(settings, '02755K2636');
   test.strictEqual(actual, false);
   test.done();
 };
 
-exports['format returns false for invalid number - extra letters'] = function(test) {
-  var actual = phonenumber.format(settings, '0275552636fff');
+exports['format returns false for invalid number - alpha number'] = function(test) {
+  // Note : 3 letters or more can be considered an alpha number (e.g. 1-(800)-MICROSOFT). We don't allow it.
+  var actual = phonenumber.format(settings, '0275HHH636');
+  test.strictEqual(actual, false);
+  test.done();
+};
+
+exports['format returns false for invalid number - 3 extra letters'] = function(test) {
+  // Insert letters within valid number : they shouldn't be ignored.
+  var actual = phonenumber.format(settings, '0275552kkk636');
+  test.strictEqual(actual, false);
+  test.done();
+};
+
+// Correct for libphonenumber weirdness : 
+// For some reason, '<validnumber>a' or '<validnumber>aa' is valid for libphonenumber.
+// Issue : https://github.com/googlei18n/libphonenumber/issues/328
+exports['format returns false for invalid number - two extra letters - trailing'] = function(test) {
+  // Insert letters within valid number : they shouldn't be ignored.
+  var actual = phonenumber.format(settings, validNumNZDomestic + 'ff');
+  test.strictEqual(actual, false);
+  test.done();
+};
+
+exports['format returns false for invalid number - two extra letters - inside'] = function(test) {
+  // Insert letters within valid number : they shouldn't be ignored.
+  var actual = phonenumber.format(settings, '02755526ff36');
   test.strictEqual(actual, false);
   test.done();
 };
@@ -89,6 +114,7 @@ exports['format removes spaces, brackets and dots, and adds country code'] = fun
 };
 
 exports['format removes extra zeros in international format'] = function(test) {
+  // Note : that's for NZ format. Would be nice to test specific formatting issues for target countries.
   var expected = validNumNZInternational;
   var actual = phonenumber.format(settings, '+640275552636'); // Remove leading 0 from domestic format
   test.strictEqual(actual, expected);
@@ -107,15 +133,45 @@ exports['validate returns false for short number'] = function(test) {
   test.done();
 };
 
-exports['validate returns false for invalid number - replaced letter <-> digit'] = function(test) {
+exports['validate returns false for invalid number'] = function(test) {
+  var actual = phonenumber.validate(settings, invalidNumNZDomestic);
+  test.strictEqual(actual, false);
+  test.done();
+};
+
+exports['validate returns false for invalid number - replaced 1 letter <-> 1 digit'] = function(test) {
   var actual = phonenumber.validate(settings, '027555H636');
   test.strictEqual(actual, false);
   test.done();
 };
 
-exports['validate returns false for invalid number - extra letters'] = function(test) {
-  // Insert letters within valid number : they shouldn't be filtered out.
+exports['validate returns false for invalid number - alpha number'] = function(test) {
+  // Note : 3 letters or more can be considered an alpha number (e.g. 1-(800)-MICROSOFT). We don't allow it.
+  var actual = phonenumber.validate(settings, '0275HHH636');
+  test.strictEqual(actual, false);
+  test.done();
+};
+
+exports['validate returns false for invalid number - 3 extra letters'] = function(test) {
+  // Insert letters within valid number : they shouldn't be ignored.
   var actual = phonenumber.validate(settings, '0275552kkk636');
+  test.strictEqual(actual, false);
+  test.done();
+};
+
+// Correct for libphonenumber weirdness : 
+// For some reason, '<validnumber>a' or '<validnumber>aa' is valid for libphonenumber.
+// Issue : https://github.com/googlei18n/libphonenumber/issues/328
+exports['validate returns false for invalid number - two extra letters - trailing'] = function(test) {
+  // Insert letters within valid number : they shouldn't be ignored.
+  var actual = phonenumber.validate(settings, validNumNZDomestic + 'ff');
+  test.strictEqual(actual, false);
+  test.done();
+};
+
+exports['validate returns false for invalid number - two extra letters - inside'] = function(test) {
+  // Insert letters within valid number : they shouldn't be ignored.
+  var actual = phonenumber.validate(settings, '02755526ff36');
   test.strictEqual(actual, false);
   test.done();
 };
@@ -158,6 +214,7 @@ exports['validate returns false when funky punctuation in number'] = function(te
 };
 
 exports['validate returns true when extra zeros in international format'] = function(test) {
+  // Note : that's for NZ format. Would be nice to test specific formatting issues for target countries.
   var actual = phonenumber.validate(settings, '+640275552636'); // Unnecessary leading 0 from domestic format
   test.strictEqual(actual, true);
   test.done();

--- a/packages/libphonenumber/tests/libphonenumber.js
+++ b/packages/libphonenumber/tests/libphonenumber.js
@@ -54,6 +54,13 @@ exports['validate returns false for invalid characters'] = function(test) {
   test.done();
 };
 
+exports['validate returns false when letters in valid number'] = function(test) {
+  // Insert letters within valid number : they shouldn't be filtered out.
+  var actual = phonenumber.validate(settings, '0275552kkk636');
+  test.strictEqual(actual, false);
+  test.done();
+};
+
 exports['validate returns false for number without country code'] = function(test) {
   var actual = phonenumber.validate({}, '5155556442');
   test.strictEqual(actual, false);
@@ -71,3 +78,23 @@ exports['validate returns true for number with explicit country code'] = functio
   test.strictEqual(actual, true);
   test.done();
 };
+
+exports['validate returns true when spaces in number'] = function(test) {
+  var actual = phonenumber.validate(settings, '02 75 55 26 36');
+  test.strictEqual(actual, true);
+  test.done();
+};
+
+exports['validate returns true when spaces, brackets, dots, dashes in number'] = function(test) {
+  // Including space after '+' and unmatched brackets.
+  var actual = phonenumber.validate({default_country_code: '1'}, '+   1 --(80.0 ()()55..6 -8725');
+  test.strictEqual(actual, true);
+  test.done();
+};
+
+exports['validate returns false when funky punctuation in number'] = function(test) {
+  var actual = phonenumber.validate({default_country_code: '1'}, '+1 <800> 556 8725');
+  test.strictEqual(actual, false);
+  test.done();
+};
+

--- a/static/js/enketo/widgets/phone-widget.js
+++ b/static/js/enketo/widgets/phone-widget.js
@@ -22,11 +22,10 @@ define( function( require, exports, module ) {
 
             return Settings()
                 .then(function(settings) {
-                    var phoneNumber = libphonenumber.format(settings, fieldValue);
-                    if (!libphonenumber.validate(settings, phoneNumber)) {
-                        throw new Error('invalid phone number: "' + phoneNumber + '"');
+                    if (!libphonenumber.validate(settings, fieldValue)) {
+                        throw new Error('invalid phone number: "' + fieldValue + '"');
                     }
-                    return phoneNumber;
+                    return libphonenumber.format(settings, fieldValue);
                 })
                 .then(function(phoneNumber) {
                     // Check the phone number is unique.  N.B. this makes the

--- a/tests/karma/unit/services/send-message.js
+++ b/tests/karma/unit/services/send-message.js
@@ -71,11 +71,13 @@ describe('SendMessage service', function() {
   });
 
   it('normalizes phone numbers', function(done) {
+    // Note : only valid phone numbers can be normalized.
 
     id.returns(KarmaUtils.mockPromise(null, 53));
     post.returns(KarmaUtils.mockPromise());
 
-    var recipient = { contact: { phone: '5552' } };
+    var phoneNumber = '700123456';
+    var recipient = { contact: { phone: phoneNumber } };
 
     settings = {
       default_country_code: 254
@@ -88,7 +90,7 @@ describe('SendMessage service', function() {
         assertMessage(post.args[0][0].tasks[0], {
           from: '+5551',
           sent_by: 'jack',
-          to: '+2545552',
+          to: '+254' + phoneNumber,
           uuid: 53
         });
         done();


### PR DESCRIPTION
https://github.com/medic/medic-webapp/issues/1762

See the tests for what is valid or invalid. 
This follows what libphonenumber does : allow any dots, dashes, spaces, but not other punctuation, and not letters.

Please advise on whether this would break existing instances, if users already saved invalid phone numbers for instance.