### PR TITLE
Temporary fix tour bug. Issue: #933

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
     "async": "~1.4.0",
     "bootstrap": "~3.3.5",
     "bootstrap-daterangepicker": "~1.3.19",
-    "bootstrap-tour": "~0.10.2",
+    "bootstrap-tour": "https://github.com/SCdF/bootstrap-tour.git#v0.10.3",
     "d3": "~3.4.11",
     "fontawesome": "~4.4.0",
     "jquery": "~2.1.4",


### PR DESCRIPTION
bootstrap-tour has a bug in its latest tag with tours that contain orphan
steps. This has been fixed but only in master; there is not yet a release.

I've forked the repo and created a v0.10.3 tag that contains v0.10.2 plus
this one fix which we can use until they release a real version.