### PR TITLE
Clean up loading indicators

### DIFF
--- a/static/js/controllers/tasks.js
+++ b/static/js/controllers/tasks.js
@@ -69,6 +69,7 @@ var _ = require('underscore');
       TaskGenerator('TasksCtrl', function(err, tasks) {
         if (err) {
           $log.error('Error getting tasks', err);
+          $scope.loading = false;
           $scope.error = true;
           $scope.tasks = [];
           $scope.clearSelected();

--- a/static/js/controllers/tasks.js
+++ b/static/js/controllers/tasks.js
@@ -50,6 +50,9 @@ var _ = require('underscore');
             }
             $scope.tasks.push(task);
           });
+        })
+        .then(function() {
+          $scope.loading = false;
         });
       };
 
@@ -64,7 +67,6 @@ var _ = require('underscore');
       $scope.error = false;
 
       TaskGenerator('TasksCtrl', function(err, tasks) {
-        $scope.loading = false;
         if (err) {
           $log.error('Error getting tasks', err);
           $scope.error = true;

--- a/templates/partials/tasks_list.html
+++ b/templates/partials/tasks_list.html
@@ -1,5 +1,5 @@
 <div id="tasks-list" class="col-sm-4 inbox-items left-pane">
-  <ul ng-show="!loading && !error">
+  <ul ng-show="!loading && !error && tasks.length">
     <li ng-repeat="task in tasks | orderBy:'date'" ng-class="{'selected': task._id === loadingContent || !loadingContent && task._id === selected._id, 'high-priority': task.priority === 'high', 'medium-priority': task.priority === 'medium'}" data-record-id="{{task._id}}">
       <a class="message-wrapper" ui-sref="tasks.detail({ id: task._id })">
         <span ng-bind-html="task.icon | resourceIcon" class="mm-badge"></span>

--- a/tests/karma/unit/controllers/tasks.js
+++ b/tests/karma/unit/controllers/tasks.js
@@ -25,9 +25,7 @@ describe('TasksCtrl controller', function() {
       return $controller('TasksCtrl', {
         '$scope': scope,
         'TaskGenerator': TaskGenerator,
-        '$timeout': function(cb) {
-          cb();
-        }
+        '$timeout': KarmaUtils.inlineTimeout
       });
     };
   }));

--- a/tests/karma/utils.js
+++ b/tests/karma/utils.js
@@ -30,5 +30,11 @@ window.KarmaUtils = {
         getRemoteUrl: getRemoteUrl
       };
     };
+  },
+  inlineTimeout: function(work) {
+    work();
+    return {'then': function(then) {
+      then();
+    }};
   }
 };


### PR DESCRIPTION
On some pages (notably the tasks page) the loading indicator doesn't
work properly. This is due to offloading work in $timeout calls, which
gives Angular a chance to do work between those calls. To fix this I
moved the loading state change to occur after the work done in $timeout
calls.