### PR TITLE
fix initial replication bug so all docs are synced. Issue #1695

### DIFF
--- a/static/js/services/db-sync.js
+++ b/static/js/services/db-sync.js
@@ -36,6 +36,18 @@ var _ = require('underscore'),
           })
           .on('error', function(err) {
             $log.error('Error replicating ' + direction + ' remote server', err);
+          })
+          .on('change', function (info) {
+            $log.debug('replication change', info);
+          })
+          .on('paused', function () {
+            $log.debug('replication paused');
+          })
+          .on('active', function () {
+            $log.debug('replication active');
+          })
+          .on('complete', function (info) {
+            $log.debug('replication complete', info);
           });
       };
 
@@ -76,7 +88,15 @@ var _ = require('underscore'),
           }
           replicate(true, {
             filter: 'medic/doc_by_place',
-            query_params: params
+            query_params: params,
+            live: false
+          }).on('complete', function (info) {
+            $log.info('initial replication complete: ' + JSON.stringify(info));
+            $log.info('setting up continuous replication from server');
+            replicate(true, {
+              filter: 'medic/doc_by_place',
+              query_params: params
+            });
           });
         });
       };

--- a/tests/karma/unit/services/db-sync.js
+++ b/tests/karma/unit/services/db-sync.js
@@ -71,7 +71,7 @@ describe('DBSync service', function() {
       chai.expect(to.args[0][1].live).to.equal(true);
       chai.expect(to.args[0][1].retry).to.equal(true);
       chai.expect(from.args[0][0]).to.equal('REMOTEDBURL');
-      chai.expect(from.args[0][1].live).to.equal(true);
+      chai.expect(from.args[0][1].live).to.equal(false);
       chai.expect(from.args[0][1].retry).to.equal(true);
       chai.expect(from.args[0][1].filter).to.equal('medic/doc_by_place');
       chai.expect(from.args[0][1].query_params.id).to.equal('a');


### PR DESCRIPTION
DBSync was using `live:true` on all replication requests so that will only get new changes.  It does not initiate replication from update_seq 0. This could be the cause of the perceived "app never finishes installing" problem.  Trying to think of bad repercussions of this change but not coming up with much.

I added an extra replication that is `live:false` and only makes the continuous replication after it completes.  There is no `complete` event for `live:true` replication requests becuase it's designed to never complete.