### PR TITLE
Sync status : online only, with monkeypatch on pouch.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -74,6 +74,20 @@ module.exports = function(grunt) {
           from: /(\/fonts\/fontawesome-webfont[^?]*)[^']*/gi,
           to: '$1'
         }]
+      },
+      monkeypatchpouchreplication: {
+        src:[ 'bower_components/concat.js' ],
+        overwrite: true,
+        replacements: [
+          {
+            from: /startChanges\(\);/g,
+            to: '// MONKEY PATCH BY GRUNT: emit checkpoints.\n console.log(\'monkey patch\'); \n    returnValue.emit(\'checkpoint\', 0);\n    startChanges();\n'
+          },
+          {
+            from: /return checkpointer\.getCheckpoint\(\)\.then\(function \(checkpoint\) \{/g,
+            to: '// MONKEY PATCH BY GRUNT: emit checkpoints.\nreturn checkpointer.getCheckpoint().then(function (checkpoint) {\n console.log(\'monkey patch 2\'); \n    returnValue.emit(\'checkpoint\', checkpoint);\n'
+          }
+        ]
       }
     },
     browserify: {
@@ -359,6 +373,7 @@ module.exports = function(grunt) {
     'bower:install',
     'bower_concat',
     'replace:monkeypatchdate',
+    'replace:monkeypatchpouchreplication',
     'replace:monkeypatchpouchtocacheddoc',
     'copy:inbox'
   ]);

--- a/static/js/controllers/inbox.js
+++ b/static/js/controllers/inbox.js
@@ -22,7 +22,7 @@ require('moment/locales');
       CheckDate($scope);
 
       Session.init();
-      DBSync();
+      DBSync.sync();
       feedback.init(
         function(doc, callback) {
           DB.get()

--- a/static/js/services/db-sync.js
+++ b/static/js/services/db-sync.js
@@ -19,6 +19,15 @@ var _ = require('underscore'),
   inboxServices.factory('DBSync', [
     '$log', 'DB', 'UserDistrict', 'Session', 'Settings', '$q',
     function($log, DB, UserDistrict, Session, Settings, $q) {
+      var lastSeqRemote = 0;
+      var lastSeqLocal = 0;
+
+      var toReplicationFilter = function(doc) {
+          // don't try to replicate ddoc back to the server
+          return doc._id !== '_design/medic';
+        };
+
+      var fromReplicationFilter = 'medic/doc_by_place';
 
       var replicate = function(from, options) {
         options = options || {};
@@ -30,15 +39,26 @@ var _ = require('underscore'),
         });
         var direction = from ? 'from' : 'to';
         var fn = DB.get().replicate[direction];
-        return fn(DB.getRemoteUrl(), options)
+        var repl = fn(DB.getRemoteUrl(), options);
+        repl.on('checkpoint', function(checkpoint) {
+            if (from) {
+              lastSeqRemote = checkpoint;
+            } else {
+              lastSeqLocal = checkpoint;
+            }
+          })
           .on('denied', function(err) {
             $log.error('Denied replicating ' + direction + ' remote server', err);
+          })
+          .on('change', function(event) {
+            $log.debug('Replication change ' + direction + ' remote server', event);
           })
           .on('error', function(err) {
             $log.error('Error replicating ' + direction + ' remote server', err);
           });
       };
 
+      // Remove this function when UserDistrict is refactored into promises.
       var getUserDistrict = function() {
         var deferred = $q.defer();
         UserDistrict(function(err, district) {
@@ -65,30 +85,130 @@ var _ = require('underscore'),
           });
       };
 
-      return function() {
+      var getRemoteChanges = function(last_seq) {
+        var userCtx = Session.userCtx();
+        if (utils.isUserAdmin(userCtx)) {
+          return $q.reject('No remote changes : admin doesn\t have local DB.');
+        }
+        return getQueryParams(userCtx)
+          .then(function(params) {
+            return DB.getRemote().changes(
+              {since: last_seq,
+               filter : fromReplicationFilter,
+               query_params: params});
+          });
+      };
+
+      var getLocalChanges = function(last_seq) {
+        var userCtx = Session.userCtx();
+        if (utils.isUserAdmin(userCtx)) {
+          return $q.reject('No local changes : admin doesn\t have local DB.');
+        }
+        return DB.get().changes(
+          {since: last_seq,
+           filter : toReplicationFilter});
+      };
+
+      var isOnline = function() {
+        return DB.getRemote().info()
+          .then(function() {
+            return true;
+          })
+          .catch (function() {
+            return false;
+          });
+      };
+
+      // changes.results format: [{seq: 123, id: id1, changes: [{rev: revId1}, {rev: revId2}]}]
+      // revsDiff format: e.g. {docId1: [revId1, revId2], docId2: [revId3]}
+      // return revdiffs format: e.g. {docId1 : {missing: [revId1, revId2]}, docId2: {missing: [revId3]}}
+      var changesToDiff = function(changes) {
+        var diff = {};
+        changes.results.forEach(function (change) {
+          diff[change.id] = change.changes.map(function (x) {
+            return x.rev;
+          });
+        });
+        return diff;
+      };
+
+      // Number of changes that are missing in the db, and need to be replicated in.
+      var numNewChanges = function(db, changes) {
+        return db.revsDiff(changes)
+          .then(function (diffs) {
+            if (db._db_name === 'http://localhost:5988/medic') {
+              $log.debug('----', Object.keys(diffs).length, 'changes to send', diffs);
+            } else {
+              $log.debug('----', Object.keys(diffs).length, 'changes (or more) to fetch', diffs);
+            }
+
+            return Object.keys(diffs).length;
+          });
+      };
+
+      var numChangesToFetch = function() {
+        return numChanges(true);
+      };
+
+      var numChangesToSend = function() {
+        return numChanges(false);
+      };
+
+      var numChanges = function(from) {
+        var direction = from ? 'fetch' : 'send';
+        var lastSeq = from ? lastSeqRemote : lastSeqLocal;
+        var getChangesFunc = from ? getRemoteChanges : getLocalChanges;
+        var receivingDb = from ? DB.get() : DB.getRemote();
+
+        var userCtx = Session.userCtx();
+        if (utils.isUserAdmin(userCtx)) {
+          return $q.reject('No changes to ' + direction + ' : admin doesn\t have local DB.');
+        }
+        return isOnline()
+          .then(function(online) {
+            if (!online) {
+              throw 'No changes to ' + direction + ' : offline.';
+            }
+            return getChangesFunc(lastSeq)
+              .then(function(changes) {
+                if (!changes.results || changes.results.length === 0) {
+                  return 0;
+                }
+                return numNewChanges(receivingDb, changesToDiff(changes));
+              });
+          });
+      };
+
+      var sync = function() {
         var userCtx = Session.userCtx();
         if (utils.isUserAdmin(userCtx)) {
           // admins have potentially too much data so bypass local pouch
           $log.debug('You have administrative privileges; not replicating');
           return;
         }
+        // Replicate to server
         replicate(false, {
-          filter: function(doc) {
-            // don't try to replicate ddoc back to the server
-            return doc._id !== '_design/medic';
-          }
+          filter: toReplicationFilter
         });
         getQueryParams(userCtx)
           .then(function(params) {
+            // Replicate from server
             replicate(true, {
               batch_size: 1,
-              filter: 'medic/doc_by_place',
+              filter: fromReplicationFilter,
               query_params: params
             });
           })
           .catch(function(err) {
             $log.error('Error initializing DB sync', err);
           });
+      };
+
+      return {
+        sync: sync,
+        isOnline: isOnline,
+        numChangesToSend: numChangesToSend,
+        numChangesToFetch: numChangesToFetch
       };
     }
   ]);

--- a/tests/karma/unit/controllers/inbox.js
+++ b/tests/karma/unit/controllers/inbox.js
@@ -34,7 +34,9 @@ describe('InboxCtrl controller', function() {
         };
       });
       $provide.factory('DBSync', function() {
-        return sinon.stub();
+        return {
+          sync : sinon.stub()
+        };
       });
       $provide.factory('Changes', function() {
         return sinon.stub();
@@ -145,7 +147,7 @@ describe('InboxCtrl controller', function() {
 
     createController();
     spyDeleteDoc.reset();
-    spyState.go.reset();    
+    spyState.go.reset();
   });
 
   afterEach(function() {});

--- a/tests/karma/unit/services/db-sync.js
+++ b/tests/karma/unit/services/db-sync.js
@@ -9,7 +9,17 @@ describe('DBSync service', function() {
       UserDistrict,
       Settings,
       userCtx,
-      $rootScope;
+      $rootScope,
+      $q,
+      changes,
+      revsDiffInput,
+      diff,
+      localDb,
+      remoteDb,
+      changesStubLocal,
+      revsDiffStubLocal,
+      changesStubRemote,
+      revsDiffStubRemote;
 
   beforeEach(function() {
     to = sinon.stub();
@@ -18,11 +28,44 @@ describe('DBSync service', function() {
     getRemoteUrl = sinon.stub();
     Settings = sinon.stub();
     userCtx = {};
+    changes = {last_seq: 123, results: [
+      {
+        seq: 3,
+        id: 'id1',
+        changes: [{rev: 'revId1'}]
+      },
+      {
+        seq: 4,
+        id: 'id2',
+        changes: [{rev: 'revId2'}]
+      }
+    ]};
+    revsDiffInput = {
+      'id1': ['revId1'],
+      'id2': ['revId2']
+    };
+    diff = {
+      'id1': {
+        missing: ['revId1']
+      },
+      'id2': {
+        missing: ['revId2']
+      }
+    };
+    changesStubLocal = sinon.stub();
+    revsDiffStubLocal = sinon.stub();
+    changesStubRemote = sinon.stub();
+    revsDiffStubRemote = sinon.stub();
+    localDb = makeMockDb(to, from, changesStubLocal, changes, revsDiffStubLocal, diff);
+    localDb.local = true;
+    remoteDb = makeMockDb(to, from, changesStubRemote, changes, revsDiffStubRemote, diff);
+    remoteDb.local = false;
     module('inboxApp');
     module(function ($provide) {
       $provide.factory('DB', KarmaUtils.mockDB(
-        { replicate: { to: to, from: from } },
-        getRemoteUrl
+        localDb,
+        getRemoteUrl,
+        remoteDb
       ));
       $provide.factory('UserDistrict', function() {
         return UserDistrict;
@@ -38,19 +81,33 @@ describe('DBSync service', function() {
         };
       });
     });
-    inject(function(_DBSync_, _$rootScope_) {
+    inject(function(_DBSync_, _$rootScope_, _$q_) {
       service = _DBSync_;
       $rootScope = _$rootScope_;
+      $q = _$q_;
     });
   });
 
+  var makeMockDb = function(to, from, changesStub, changes, revsDiffStub, diff) {
+    return {
+      replicate: {
+        to: to,
+        from: from
+      },
+      info: function() { return KarmaUtils.mockPromise(null, {}); },
+      changes: changesStub,
+      revsDiff: revsDiffStub
+    };
+  };
+
   afterEach(function() {
-    KarmaUtils.restore(to, from, getRemoteUrl, UserDistrict, Settings);
+    KarmaUtils.restore(to, from, getRemoteUrl, UserDistrict, Settings,
+      changesStubLocal, changesStubRemote, revsDiffStubLocal, revsDiffStubRemote);
   });
 
-  it('does nothing for admin', function(done) {
+  it('doesn\'t sync for admin', function(done) {
     userCtx = { roles: [ '_admin' ] };
-    service();
+    service.sync();
     chai.expect(to.callCount).to.equal(0);
     chai.expect(from.callCount).to.equal(0);
     chai.expect(UserDistrict.callCount).to.equal(0);
@@ -64,7 +121,7 @@ describe('DBSync service', function() {
     from.returns(KarmaUtils.mockPromise());
     UserDistrict.callsArgWith(0, null, 'a');
     Settings.returns(KarmaUtils.mockPromise(null, {}));
-    service();
+    service.sync();
     setTimeout(function() {
       $rootScope.$apply(); // needed to resolve the promises
       chai.expect(to.callCount).to.equal(1);
@@ -94,7 +151,7 @@ describe('DBSync service', function() {
     from.returns(KarmaUtils.mockPromise());
     UserDistrict.callsArgWith(0, null, 'a');
     Settings.returns(KarmaUtils.mockPromise(null, { district_admins_access_unallocated_messages: true }));
-    service();
+    service.sync();
     setTimeout(function() {
       $rootScope.$apply(); // needed to resolve the promises
       chai.expect(from.args[0][1].query_params.unassigned).to.equal(true);
@@ -109,7 +166,7 @@ describe('DBSync service', function() {
     from.returns(KarmaUtils.mockPromise());
     UserDistrict.callsArgWith(0, null, 'a');
     Settings.returns(KarmaUtils.mockPromise(null, { district_admins_access_unallocated_messages: true }));
-    service();
+    service.sync();
     setTimeout(function() {
       $rootScope.$apply(); // needed to resolve the promises
       chai.expect(from.args[0][1].query_params.unassigned).to.equal(undefined);
@@ -117,4 +174,170 @@ describe('DBSync service', function() {
     });
   });
 
+  it('returns online status = true when online', function(done) {
+    userCtx = { };
+    service.isOnline()
+      .then(function (status) {
+        chai.expect(status).to.equal(true);
+        done();
+      })
+      .catch(done);
+    setTimeout(function() {
+      $rootScope.$apply();
+    });
+  });
+
+  it('returns online status = false when offline', function(done) {
+    userCtx = { };
+    remoteDb.info = function() { return KarmaUtils.mockPromise('no info for you brew', {}); };
+    service.isOnline()
+      .then(function (status) {
+        chai.expect(status).to.equal(false);
+        done();
+      })
+      .catch(done);
+    setTimeout(function() {
+      $rootScope.$apply();
+    });
+  });
+
+  it('does not return changes if user is admin', function(done) {
+    userCtx = { roles: [ '_admin' ] };
+    service.numChangesToSend().then(function() {
+      done('should not return changes!');
+    })
+    .catch(function() {
+      done();
+    });
+    setTimeout(function() {
+      $rootScope.$apply();
+    });
+  });
+
+  it('returns changes to fetch', function(done) {
+    userCtx = { };
+
+    // For getQueryParams
+    Settings.returns(KarmaUtils.mockPromise(null, {}));
+    UserDistrict.callsArgWith(0, null, 'a');
+
+    changesStubRemote.returns(KarmaUtils.mockQPromise($q, null, changes));
+    revsDiffStubLocal.returns(KarmaUtils.mockQPromise($q, null, diff));
+
+    service.numChangesToFetch().then(function(numChanges) {
+      chai.expect(numChanges).to.equal(2);
+      var changesArgs = changesStubRemote.getCall(0).args[0];
+      chai.expect(changesArgs.hasOwnProperty('filter')).to.equal(true);
+      chai.expect(changesArgs.hasOwnProperty('query_params')).to.equal(true);
+      chai.expect(revsDiffStubLocal.getCall(0).args[0]).to.deep.equal(revsDiffInput);
+      done();
+    })
+    .catch(done);
+    setTimeout(function() {
+      $rootScope.$apply();
+    });
+  });
+
+  it('returns changes to send', function(done) {
+    userCtx = { };
+
+    changesStubLocal.returns(KarmaUtils.mockQPromise($q, null, changes));
+    revsDiffStubRemote.returns(KarmaUtils.mockQPromise($q, null, diff));
+
+    service.numChangesToSend().then(function(numChanges) {
+      chai.expect(numChanges).to.equal(2);
+      var changesArgs = changesStubLocal.getCall(0).args[0];
+      chai.expect(changesArgs.hasOwnProperty('filter')).to.equal(true);
+      chai.expect(revsDiffStubRemote.getCall(0).args[0]).to.deep.equal(revsDiffInput);
+      done();
+    })
+    .catch(done);
+    setTimeout(function() {
+      $rootScope.$apply();
+    });
+  });
+
+  it('gets the initial lastSeq from checkpoint event, fetch', function(done) {
+    userCtx = { };
+    // For getQueryParams
+    Settings.returns(KarmaUtils.mockPromise(null, {}));
+    UserDistrict.callsArgWith(0, null, 'a');
+
+    getRemoteUrl.returns('REMOTEDBURL');
+    to.returns(KarmaUtils.mockPromise());
+
+    // Capture the onCheckpoint callback for from repli.
+    var fromPromise = KarmaUtils.mockQPromiseWithOnStub($q, null, {});
+    from.returns(fromPromise);
+
+    var lastSeqRemote = 1234;
+
+    changesStubRemote.returns(KarmaUtils.mockQPromise($q, null, changes));
+    revsDiffStubLocal.returns(KarmaUtils.mockQPromise($q, null, diff));
+
+    service.sync();
+
+    setTimeout(function() {
+      $rootScope.$apply();
+      // Call the onCheckpoint callback
+      var checkpointCallback;
+      var onStub = fromPromise.on;
+      for (var i = 0; i < onStub.callCount; i ++) {
+        var args = onStub.getCall(i).args;
+        if (args[0] === 'checkpoint') {
+          checkpointCallback = args[1];
+        }
+      }
+      checkpointCallback(lastSeqRemote);
+
+      service.numChangesToFetch().catch(done);
+      setTimeout(function() {
+        $rootScope.$apply();
+        chai.expect(changesStubRemote.getCall(0).args[0].since).to.equal(lastSeqRemote);
+        done();
+      });
+    });
+  });
+
+  it('gets the initial lastSeq from checkpoint event, send', function(done) {
+    userCtx = { };
+    // For getQueryParams
+    Settings.returns(KarmaUtils.mockPromise(null, {}));
+    UserDistrict.callsArgWith(0, null, 'a');
+
+    getRemoteUrl.returns('REMOTEDBURL');
+    from.returns(KarmaUtils.mockPromise());
+
+    // Capture the onCheckpoint callback for from repli.
+    var toPromise = KarmaUtils.mockQPromiseWithOnStub($q, null, {});
+    to.returns(toPromise);
+
+    var lastSeqLocal = 1234;
+
+    changesStubLocal.returns(KarmaUtils.mockQPromise($q, null, changes));
+    revsDiffStubRemote.returns(KarmaUtils.mockQPromise($q, null, diff));
+
+    service.sync();
+
+    setTimeout(function() {
+      $rootScope.$apply();
+      // Call the onCheckpoint callback
+      var checkpointCallback;
+      var onStub = toPromise.on;
+      for (var i = 0; i < onStub.callCount; i ++) {
+        var args = onStub.getCall(i).args;
+        if (args[0] === 'checkpoint') {
+          checkpointCallback = args[1];
+        }
+      }
+      checkpointCallback(lastSeqLocal);
+
+      service.numChangesToSend().catch(done);
+      setTimeout(function() {
+        $rootScope.$apply();
+        chai.expect(changesStubLocal.getCall(0).args[0].since).to.equal(lastSeqLocal);
+        done();
+      });
+    });
+  });
 });

--- a/tests/karma/utils.js
+++ b/tests/karma/utils.js
@@ -33,11 +33,37 @@ window.KarmaUtils = {
       };
     };
   },
-  mockDB: function(db, getRemoteUrl) {
+  // With a mix of $q and JS native promises, sometimes $rootscope.apply() doesn't resolve all layers of promises.
+  // Use $q promises to avoid it.
+  mockQPromise: function($q, err, doc) {
+    var result = $q(function(resolve, reject) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(doc);
+      }
+    });
+    result.on = function() {
+      return result;
+    };
+    return result;
+  },
+  // For spying on promise.on()
+  mockQPromiseWithOnStub: function($q, err, doc) {
+    var result = KarmaUtils.mockQPromise($q, null, {});
+    var onStub = sinon.stub();
+    result.on = onStub;
+    onStub.returns(result);
+    return result;
+  },
+  mockDB: function(db, getRemoteUrl, dbRemote) {
     return function() {
       return {
         get: function() {
           return db;
+        },
+        getRemote: function() {
+          return dbRemote;
         },
         getRemoteUrl: getRemoteUrl
       };


### PR DESCRIPTION
Issue #1270

When online, gives number of docs to send/fetch. Useful for knowing when your replication is done (for now).
No UI changes in this PR, waiting for UX design.

Next steps : 
 - remove the monkeypatch and use a pouch plugin instead
 - expose in UI
 - when offline, get number of changes made locally.