### PR TITLE
Make `doc.errors` dereferencing safe in couch views

### DIFF
--- a/lib/fulltext.js
+++ b/lib/fulltext.js
@@ -74,7 +74,7 @@ exports.data_records = {
     ret.add(type, { field: 'type' });
 
     ret.add(
-      doc.errors.length,
+      doc.errors ? doc.errors.length : 0,
       { field: 'errors', type: 'int' }
     );
 

--- a/lib/views.js
+++ b/lib/views.js
@@ -102,7 +102,7 @@ exports.delivery_reports_by_district_and_code = {
   map: function(doc) {
     if (doc.type === 'data_record' &&
         doc.form === 'D' &&
-        doc.errors.length === 0 &&
+        !(doc.errors && doc.errors.length) &&
         doc.fields.delivery_code) {
       var getDistrictId = function(facility) {
         while (facility && facility.type !== 'district_hospital') {
@@ -125,7 +125,7 @@ exports.delivery_reports_by_year_month_and_code = {
   map: function(doc) {
     if (doc.type === 'data_record' &&
         doc.form === 'D' &&
-        doc.errors.length === 0 &&
+        !(doc.errors && doc.errors.length) &&
         doc.fields.delivery_code) {
       var date = new Date(doc.reported_date);
       var code = doc.fields.delivery_code.toUpperCase();
@@ -140,7 +140,7 @@ exports.delivery_reports_by_year_month_and_code = {
 exports.data_records_by_year_month_form_facility = {
   map: function(doc) {
     if (doc.type === 'data_record' &&
-        doc.errors.length === 0 &&
+        !(doc.errors && doc.errors.length) &&
         doc.contact &&
         doc.contact.parent) {
       var date = new Date(doc.reported_date);
@@ -156,7 +156,7 @@ exports.visits_by_district_and_patient = {
   map: function(doc) {
     if (doc.type === 'data_record' &&
         doc.form === 'V' &&
-        doc.errors.length === 0) {
+        !(doc.errors && doc.errors.length)) {
 
       var getDistrictId = function(facility) {
         while (facility && facility.type !== 'district_hospital') {


### PR DESCRIPTION
Should prevent couch errors like this:
```
08:24:05 couch.1  | [info] [<0.940.0>] OS Process #Port<0.3612> Log :: function raised exception (new TypeError("doc.errors is undefined", "undefined", 3)) with doc._id abc-123
```