### PR TITLE
Support weakly-validated ETag headers

### DIFF
--- a/static/js/services/db.js
+++ b/static/js/services/db.js
@@ -1,5 +1,7 @@
 var utils = require('kujua-utils'),
-    async = require('async');
+    async = require('async'),
+    etagRegex = /(?:^W\/)|['"]/g;
+
 
 (function () {
 
@@ -84,7 +86,7 @@ var utils = require('kujua-utils'),
                 method: 'HEAD',
                 url: getRemoteUrl() + '/_design/medic'
               }).success(function(data, status, headers) {
-                var rev = headers().etag.replace(/"/g, '');
+                var rev = headers().etag.replace(etagRegex, '');
                 checkLocalDesignDoc(rev, callback);
               });
             }

--- a/static/js/services/import-contacts.js
+++ b/static/js/services/import-contacts.js
@@ -1,5 +1,5 @@
 var async = require('async'),
-    etagRegex = /['"]/g;
+    etagRegex = /(?:^W\/)|['"]/g;
 
 (function () {
 


### PR DESCRIPTION
This fixes a repeated spurious "Update available" message on page load/reload. The version detection relies on an ETag header but does not correctly discard the `W/` prefix for weak ETags, leading
to a presumed version mismatch.

This doesn't appear to be covered by unit tests, and probably should be split out to an ETag parser module one way or another so it can be unit tested without lots of screaming and gnashing of teeth.