### PR TITLE
Use strings to define replication direction

### DIFF
--- a/static/js/services/db-sync.js
+++ b/static/js/services/db-sync.js
@@ -20,7 +20,7 @@ var _ = require('underscore'),
     '$log', 'DB', 'UserDistrict', 'Session', 'Settings', '$q',
     function($log, DB, UserDistrict, Session, Settings, $q) {
 
-      var replicate = function(from, options) {
+      var replicate = function(direction, options) {
         options = options || {};
         _.defaults(options, {
           live: true,
@@ -28,7 +28,6 @@ var _ = require('underscore'),
           timeout: false,
           back_off_function: backOffFunction
         });
-        var direction = from ? 'from' : 'to';
         var fn = DB.get().replicate[direction];
         return fn(DB.getRemoteUrl(), options)
           .on('denied', function(err) {
@@ -72,7 +71,7 @@ var _ = require('underscore'),
           $log.debug('You have administrative privileges; not replicating');
           return;
         }
-        replicate(false, {
+        replicate('to', {
           filter: function(doc) {
             // don't try to replicate ddoc back to the server
             return doc._id !== '_design/medic';
@@ -80,7 +79,7 @@ var _ = require('underscore'),
         });
         getQueryParams(userCtx)
           .then(function(params) {
-            replicate(true, {
+            replicate('from', {
               filter: 'erlang_filters/doc_by_place',
               query_params: params
             });


### PR DESCRIPTION
Previously this used a boolean which is then converted to a string.