### PR TITLE
validation for user-settings docs

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -9,5 +9,5 @@ module.exports = {
     filters: require('./filters'),
     rewrites: require('./rewrites'),
     views: require('./views'),
-    validate_doc_update: require('./validate_doc_update')
+    validate_doc_update: require('./validate_doc_update').validate_doc_update
 };

--- a/lib/validate_doc_update.js
+++ b/lib/validate_doc_update.js
@@ -108,10 +108,7 @@ var validateUserSettings = function(newDoc, oldDoc) {
   if (newDoc.name.toLowerCase() !== username.toLowerCase()) {
     _err('name must be equivalent to username');
   };
-  if (typeof newDoc.known !== 'boolean') {
-    _err('known is not a boolean.');
-  }
-  if (typeof newDoc.known !== 'boolean') {
+  if (typeof newDoc.known !== 'undefined' && typeof newDoc.known !== 'boolean') {
     _err('known is not a boolean.');
   }
   if (typeof newDoc.roles !== 'object') {

--- a/lib/validate_doc_update.js
+++ b/lib/validate_doc_update.js
@@ -24,7 +24,7 @@ var isDbAdmin = function(userCtx, secObj) {
 var allowed = function(newDoc, oldDoc, userCtx, secObj) {
 
     // ensure logged in
-    if (typeof userCtx.name === 'undefined' || userCtx.name === null) {
+    if (!userCtx.name) {
         return {
             allowed: false,
             message: 'You must be logged in to edit documents'

--- a/lib/validate_doc_update.js
+++ b/lib/validate_doc_update.js
@@ -24,7 +24,7 @@ var isDbAdmin = function(userCtx, secObj) {
 var allowed = function(newDoc, oldDoc, userCtx, secObj) {
 
     // ensure logged in
-    if (userCtx.name === null) {
+    if (typeof userCtx.name === 'undefined' || userCtx.name === null) {
         return {
             allowed: false,
             message: 'You must be logged in to edit documents'
@@ -85,14 +85,57 @@ var validateForm = function(newDoc, oldDoc) {
     };
 };
 
-module.exports = function(newDoc, oldDoc, userCtx, secObj) {
-    var result = allowed(newDoc, oldDoc, userCtx, secObj);
+var validateUserSettings = function(newDoc, oldDoc) {
+  var id_parts = newDoc._id.split(':'),
+      prefix = id_parts[0],
+      username = id_parts.slice(1).join(':'),
+      idExample = ' e.g. "org.couchdb.user:sally"';
+  function _err(msg) {
+    throw({forbidden: msg});
+  };
+  if (prefix !== 'org.couchdb.user') {
+    _err('_id must be prefixed with "org.couchdb.user:".' + idExample);
+  };
+  if (!username) {
+    _err('_id must define a value after "org.couchdb.user:".' + idExample);
+  };
+  if (newDoc._id !== newDoc._id.toLowerCase()) {
+    _err('_id must be lower case.' + idExample);
+  };
+  if (typeof newDoc.name === 'undefined' || newDoc.name !== username) {
+    _err('name property must be equivalent to username.' + idExample);
+  }
+  if (newDoc.name.toLowerCase() !== username.toLowerCase()) {
+    _err('name must be equivalent to username');
+  };
+  if (typeof newDoc.known !== 'boolean') {
+    _err('known is not a boolean.');
+  }
+  if (typeof newDoc.known !== 'boolean') {
+    _err('known is not a boolean.');
+  }
+  if (typeof newDoc.roles !== 'object') {
+    _err('roles is a required array');
+  }
+};
+
+module.exports = {
+  _allowed: allowed,
+  _validateForm: validateForm,
+  _validateUserSettings: validateUserSettings,
+  validate_doc_update: function(newDoc, oldDoc, userCtx, secObj) {
+    var self = module.exports,
+        result = self._allowed(newDoc, oldDoc, userCtx, secObj);
     if (result.allowed) {
         log("User '" + userCtx.name + "' changing document '" +  newDoc._id + "'");
     } else {
         throw({ forbidden: result.message });
     }
     if (newDoc.type === 'form') {
-        validateForm(newDoc, oldDoc);
+        self._validateForm(newDoc, oldDoc);
     }
+    if (newDoc.type === 'user-settings') {
+        self._validateUserSettings(newDoc, oldDoc);
+    }
+  }
 };

--- a/tests/nodeunit/unit/validate_doc_update.js
+++ b/tests/nodeunit/unit/validate_doc_update.js
@@ -1,0 +1,105 @@
+var proxyquire = require('proxyquire').noCallThru();
+
+var kujuaUtils = {
+  isUserAdmin: function() {
+    return false;
+  },
+  isUserDistrictAdmin: function() {
+    return false;
+  },
+  hasRole: function() {
+    return false;
+  }
+};
+
+var lib = proxyquire('../../../lib/validate_doc_update', {
+  'kujua-utils': kujuaUtils
+});
+
+var userSettings;
+
+exports.setUp = function(cb) {
+  // A valid user-settings doc. Does not require type property because that is
+  // already matched before passing to the validation function.
+  userSettings = {
+    _id: 'org.couchdb.user:sally',
+    name: 'sally',
+    known: false,
+    roles: []
+  };
+  cb();
+};
+
+exports['allowed returns false on empty userCtx'] = function(test) {
+  test.equal(lib._allowed({}, {}, {}).allowed, false);
+  test.done();
+};
+
+exports['allowed returns false on userCtx with null name'] = function(test) {
+  test.equal(lib._allowed({}, {}, {name: null}).allowed, false);
+  test.done();
+};
+
+exports['allowed returns truen when userCtx has _admin role'] = function(test) {
+  var userCtx = {
+    name: 'a',
+    roles: ['_admin']
+  };
+  test.equal(lib._allowed({}, {}, userCtx).allowed, true);
+  test.done();
+};
+
+exports['validateUserSettings succeeds if doc is valid'] = function(test) {
+  test.doesNotThrow(function() {
+    lib._validateUserSettings(userSettings);
+  });
+  test.done();
+};
+
+exports['validateUserSettings fails if no name is defined'] = function(test) {
+  delete userSettings.name;
+  test.throws(function() {
+    lib._validateUserSettings(userSettings);
+  });
+  test.done();
+};
+
+exports['validateUserSettings _id prefix must be org.couchdb.user'] = function(test) {
+  userSettings._id = 'org.couchdb.foo:sally';
+  test.throws(function() {
+    lib._validateUserSettings(userSettings);
+  });
+  test.done();
+};
+
+exports['validateUserSettings _id must define a value after :'] = function(test) {
+  userSettings._id = 'org.couchdb.foo:';
+  test.throws(function() {
+    lib._validateUserSettings(userSettings);
+  });
+  test.done();
+};
+
+exports['validateUserSettings name and usernaem must match'] = function(test) {
+  userSettings.name = 'foo';
+  test.throws(function() {
+    lib._validateUserSettings(userSettings);
+  });
+  test.done();
+};
+
+exports['validateUserSettings known must be boolean'] = function(test) {
+  userSettings.known = 3;
+  test.throws(function() {
+    lib._validateUserSettings(userSettings);
+  });
+  test.done();
+};
+
+exports['validateUserSettings roles must exist'] = function(test) {
+  delete userSettings.roles;
+  test.throws(function() {
+    lib._validateUserSettings(userSettings);
+  });
+  test.done();
+};

--- a/tests/nodeunit/unit/validate_doc_update.js
+++ b/tests/nodeunit/unit/validate_doc_update.js
@@ -24,7 +24,6 @@ exports.setUp = function(cb) {
   userSettings = {
     _id: 'org.couchdb.user:sally',
     name: 'sally',
-    known: false,
     roles: []
   };
   cb();
@@ -91,6 +90,10 @@ exports['validateUserSettings name and usernaem must match'] = function(test) {
 exports['validateUserSettings known must be boolean'] = function(test) {
   userSettings.known = 3;
   test.throws(function() {
+    lib._validateUserSettings(userSettings);
+  });
+  userSettings.known = false;
+  test.doesNotThrow(function() {
     lib._validateUserSettings(userSettings);
   });
   test.done();


### PR DESCRIPTION
Issue #2047  

Ok here's the updated testable validate_doc_update.js for user-settings docs. Remember this could potentially affect any doc change.

Couple changes worth looking at below. 

I did this for easier testing so I could pass in an empty object `{}` and it would return properly.  I can't imagine it having a negative affect, worth a second pair of eyes or maybe some tests.

```
-    if (userCtx.name === null) {
+    if (typeof userCtx.name === 'undefined' || userCtx.name === null) {
```

I added a few tests against `validate_doc_update.allowed` just to kick the tires a bit.  I wasn't sure how much coverage we wanted on this issue. I could continue writing coverage against other parts of the  module if we want.  I just focused on the validateUserSettings function.  Please have a look at the tests let me know if you think this fulfills our validation needs.