### PR TITLE
Make binding stricter

### DIFF
--- a/static/js/services/enketo-prepopulation-data.js
+++ b/static/js/services/enketo-prepopulation-data.js
@@ -22,7 +22,8 @@ angular.module('inboxServices').service('EnketoPrepopulationData', [
 
         if (data) {
           EnketoTranslation.bindJsonToXml(bindRoot, data, function(name) {
-            return ['>', name, ', ', '>inputs>', name].join('');
+            // Either a direct child or a direct child of inputs
+            return '>%, >inputs>%'.replace(/%/g, name);
           });
         }
 

--- a/static/js/services/enketo-translation.js
+++ b/static/js/services/enketo-translation.js
@@ -97,8 +97,8 @@ function N(tagName, text, attrs, children) {
 
 
 angular.module('inboxServices').service('EnketoTranslation', [
-  '$translate',
-  function($translate) {
+  '$translate', '$log',
+  function($translate, $log) {
     var self = this;
 
     function extraAttributesFor(conf) {
@@ -327,11 +327,24 @@ angular.module('inboxServices').service('EnketoTranslation', [
       return res;
     };
 
+    var findCurrentElement = function(elem, name, childMatcher) {
+      if (childMatcher) {
+        var found = elem.find(childMatcher(name));
+        if (found.length > 1) {
+          $log.warn('Using the matcher "' + childMatcher() + '" we found ' + found.length + ' elements, ' +
+            'we should only ever bind one.', elem);
+        }
+        return found;
+      } else {
+        return elem.children(name);
+      }
+    };
+
     // NB: childMatcher intentionally does not recurse.
     //     It exists to allow the initial layer of binding to be flexible.
     self.bindJsonToXml = function(elem, data, childMatcher) {
       _.pairs(data).forEach(function(pair) {
-        var current = childMatcher ? elem.find(childMatcher([pair[0]])) : elem.children(pair[0]);
+        var current = findCurrentElement(elem, pair[0], childMatcher);
         var value = pair[1];
 
         if (_.isObject(value)) {

--- a/static/js/services/enketo-translation.js
+++ b/static/js/services/enketo-translation.js
@@ -327,16 +327,13 @@ angular.module('inboxServices').service('EnketoTranslation', [
       return res;
     };
 
-    self.bindJsonToXml = function(elem, data) {
-      // Pairs get sorted so that values are bound before objects:
-      // - data is bound to any decendents of the given elem
-      // - least specific (in terms of path) get bound first
-      // - more specific get to bind *over* potentially too unspecific values
-      _.sortBy(_.pairs(data), function(pair) {
-        return _.isObject(pair[1]);
-      }).forEach(function(pair) {
-        var current = elem.find(pair[0]);
+    // NB: childMatcher intentionally does not recurse.
+    //     It exists to allow the initial layer of binding to be flexible.
+    self.bindJsonToXml = function(elem, data, childMatcher) {
+      _.pairs(data).forEach(function(pair) {
+        var current = childMatcher ? childMatcher[pair[0]] : elem.children(pair[0]);
         var value = pair[1];
+
         if (_.isObject(value)) {
           if(current.children().length) {
             self.bindJsonToXml(current, value);

--- a/static/js/services/enketo-translation.js
+++ b/static/js/services/enketo-translation.js
@@ -331,7 +331,7 @@ angular.module('inboxServices').service('EnketoTranslation', [
     //     It exists to allow the initial layer of binding to be flexible.
     self.bindJsonToXml = function(elem, data, childMatcher) {
       _.pairs(data).forEach(function(pair) {
-        var current = childMatcher ? childMatcher[pair[0]] : elem.children(pair[0]);
+        var current = childMatcher ? elem.find(childMatcher([pair[0]])) : elem.children(pair[0]);
         var value = pair[1];
 
         if (_.isObject(value)) {

--- a/tests/karma/unit/services/enketo-prepopulation-data.js
+++ b/tests/karma/unit/services/enketo-prepopulation-data.js
@@ -35,10 +35,12 @@ describe('EnketoPrepopulationData service', function() {
             '<user>' +
               '<name/>' +
             '</user>' +
-            '<location>' +
-              '<lat/>' +
-              '<long/>' +
-            '</location>' +
+            '<meta>' +
+              '<location>' +
+                '<lat/>' +
+                '<long/>' +
+              '</location>' +
+            '</meta>' +
           '</inputs>' +
           '<person>' +
             '<type>person</type>' +
@@ -102,10 +104,12 @@ describe('EnketoPrepopulationData service', function() {
             '<user>' +
               '<name/>' +
             '</user>' +
-            '<location>' +
-              '<lat/>' +
-              '<long/>' +
-            '</location>' +
+            '<meta>' +
+              '<location>' +
+                '<lat/>' +
+                '<long/>' +
+              '</location>' +
+            '</meta>' +
           '</inputs>' +
           '<person>' +
             '<type>person</type>' +
@@ -254,8 +258,8 @@ describe('EnketoPrepopulationData service', function() {
     service(editPersonForm, data)
       .then(function(actual) {
         var xml = $($.parseXML(actual));
-        chai.expect(xml.find('inputs > location > lat')[0].innerHTML).to.equal(location.lat);
-        chai.expect(xml.find('inputs > location > long')[0].innerHTML).to.equal(location.long);
+        chai.expect(xml.find('inputs > meta > location > lat')[0].innerHTML).to.equal(location.lat);
+        chai.expect(xml.find('inputs > meta > location > long')[0].innerHTML).to.equal(location.long);
         chai.expect(UserSettings.callCount).to.equal(1);
         done();
       })

--- a/tests/karma/unit/services/enketo-translation.js
+++ b/tests/karma/unit/services/enketo-translation.js
@@ -731,7 +731,7 @@ describe('EnketoTranslation service', function() {
             '<instanceID/>' +
           '</meta>' +
         '</data>';
-      var element = $($.parseXML(model));
+      var element = $($.parseXML(model)).children().first();
       var data = {
           district_hospital: {
             name: 'Davesville',
@@ -764,7 +764,7 @@ describe('EnketoTranslation service', function() {
             '<instanceID/>' +
           '</meta>' +
         '</data>';
-      var element = $($.parseXML(model));
+      var element = $($.parseXML(model)).children().first();
       var data = {
           district_hospital: {
             name: 'Davesville',
@@ -805,7 +805,7 @@ describe('EnketoTranslation service', function() {
             '<instanceID/>' +
           '</meta>' +
         '</data>';
-      var element = $($.parseXML(model));
+      var element = $($.parseXML(model)).children().first();
       var data = {
           district_hospital: {
             name: 'Davesville',
@@ -831,27 +831,45 @@ describe('EnketoTranslation service', function() {
       assert.equal(element.find('contact > name').text(), 'Dr. D');
     });
 
-    it('binds single data values to all matching elems of the model', function() {
-      var TEST_VALUE = 'testValue';
-
-      var element = $($.parseXML('<foo><bar></bar><bar></bar><baz><bar></bar></baz></foo>'));
+    it('binds data 1:1 with its representation', function() {
+      var element = $($.parseXML(
+        '<data id="district_hospital" version="1">' +
+          '<district_hospital>' +
+            '<name/>' +
+            '<contact>' +
+              '<_id/>' +
+              '<name/>' +
+            '</contact>' +
+            '<external_id/>' +
+            '<notes/>' +
+          '</district_hospital>' +
+          '<meta>' +
+            '<instanceID/>' +
+          '</meta>' +
+        '</data>'
+      )).children().first();
       var data = {
-        bar: TEST_VALUE
+        district_hospital: {
+          name: 'Davesville',
+          contact: {
+            _id: 'abc-123',
+          },
+          external_id: 'THING',
+          notes: 'Some notes',
+          type: 'district_hospital',
+        },
       };
 
       service.bindJsonToXml(element, data);
-      var results = element.find('bar');
 
-      assert.equal(results.length, 3);
-      results.each(function(idx, bar) {
-        assert.equal($(bar).text(), TEST_VALUE);
-      });
+      assert.equal(element.find('contact > name').text(), '',
+        'The contact name should not get the value of the district hospital');
     });
 
     it('preferentially binds to more specific data structures', function() {
       var DEEP_TEST_VALUE = 'deep';
 
-      var element = $($.parseXML('<foo><bar><baz><smang /></baz></bar></foo>'));
+      var element = $($.parseXML('<foo><bar><baz><smang /></baz></bar></foo>')).children().first();
       var data = {
         foo: {
           smang: 'shallow5',


### PR DESCRIPTION
Allows the first layer of binding to be a bit looser (at the callers
description); all layers of binding after that are strict 1:1 mappings between
the data and the XML.

Issue: #2164