### PR TITLE
Throw better error when editing contact without facilityId

### DIFF
--- a/static/js/controllers/contacts-edit.js
+++ b/static/js/controllers/contacts-edit.js
@@ -34,7 +34,7 @@ var _ = require('underscore');
         return UserDistrict()
           .then(function(facilityId) {
             if (!facilityId) {
-              return $q.resolve();
+              return $q.reject('Facility ID not supplied');
             }
             return DB().get(facilityId);
           })


### PR DESCRIPTION
If `UserDistrict()` returns null, the `then()` block following this edit would
previously throw:

         TypeError: Cannot read property 'type' of undefined

Now instead, a useful error message is thrown.