### PR TITLE
Move initial replication into bootstrap. Issue: #2394

### DIFF
--- a/static/js/controllers/inbox.js
+++ b/static/js/controllers/inbox.js
@@ -59,19 +59,8 @@ var feedback = require('../modules/feedback'),
       'ngInject';
 
       Session.init();
-
       TrafficStats($scope);
-
-      $scope.initialReplication = {
-        status: 'initial.replication.status.in_progress'
-      };
-
-      DBSync(function(err, result) {
-        if (err) {
-          $log.debug('Error initializing DB sync. Continuing anyway.', err);
-        }
-        $scope.initialReplication = result;
-      });
+      DBSync();
 
       RulesEngine.init
         .then(function() {

--- a/templates/partials/about.html
+++ b/templates/partials/about.html
@@ -17,28 +17,6 @@
       </ul>
     </div>
 
-    <div ng-if="initialReplication">
-      <h3 translate>initial.replication.title</h3>
-      <ul>
-        <li>
-          <span translate>initial.replication.status</span>:
-          <span translate>{{initialReplication.status}}</span>
-        </li>
-        <li ng-show="initialReplication.duration">
-          <span translate>initial.replication.duration</span>:
-          <span translate="number.seconds" translate-values="{ number: '{{initialReplication.duration / 1000 | number:1}}' }"></span>
-        </li>
-        <li ng-show="initialReplication.dataUsage">
-          <span translate>android_app.data_usage.rx</span>:
-          <span translate="number.bytes" translate-values="{ number: '{{initialReplication.dataUsage.rx | number}}' }"></span>
-        </li>
-        <li ng-show="initialReplication.dataUsage">
-          <span translate>android_app.data_usage.tx</span>:
-          <span translate="number.bytes" translate-values="{ number: '{{initialReplication.dataUsage.tx | number}}' }"></span>
-        </li>
-      </ul>
-    </div>
-
     <div ng-if="androidDataUsage">
       <h3 translate>android_app.data_usage.title</h3>
       <p translate>android_app.data_usage.description</p>

--- a/tests/karma/unit/services/db-sync.js
+++ b/tests/karma/unit/services/db-sync.js
@@ -65,28 +65,23 @@ describe('DBSync service', function() {
       { id: 'i' },
       { id: 'c' }
     ] }));
-    service(function() {
-      setTimeout(function() {
-        chai.expect(query.callCount).to.equal(2); // 2 'from' calls, 0 'to' calls
-        chai.expect(query.args[0][0]).to.equal('medic/doc_by_place');
-        chai.expect(query.args[0][1].keys).to.deep.equal([['_all'], ['abc']]);
-        chai.expect(from.callCount).to.equal(2); // initial sync then continuous
-        console.log(JSON.stringify(from.args[0]));
-        chai.expect(from.args[0][1].live).to.equal(false);
-        chai.expect(from.args[0][1].retry).to.equal(false);
-        chai.expect(from.args[0][1].doc_ids).to.deep.equal(['m','e','d','i','c','mobile']);
-        chai.expect(from.args[1][1].live).to.equal(true);
-        chai.expect(from.args[1][1].retry).to.equal(true);
-        chai.expect(from.args[1][1].doc_ids).to.deep.equal(['m','e','d','i','c','mobile']);
-        chai.expect(to.callCount).to.equal(1);
-        chai.expect(to.args[0][1].live).to.equal(true);
-        chai.expect(to.args[0][1].retry).to.equal(true);
-        var backoff = to.args[0][1].back_off_function;
-        chai.expect(backoff(0)).to.equal(1000);
-        chai.expect(backoff(2000)).to.equal(4000);
-        chai.expect(backoff(31000)).to.equal(60000);
-        done();
-      });
+    service();
+    setTimeout(function() {
+      chai.expect(query.callCount).to.equal(1); // 1 'from' calls, 0 'to' calls
+      chai.expect(query.args[0][0]).to.equal('medic/doc_by_place');
+      chai.expect(query.args[0][1].keys).to.deep.equal([['_all'], ['abc']]);
+      chai.expect(from.callCount).to.equal(1);
+      chai.expect(from.args[0][1].live).to.equal(true);
+      chai.expect(from.args[0][1].retry).to.equal(true);
+      chai.expect(from.args[0][1].doc_ids).to.deep.equal(['m','e','d','i','c','mobile']);
+      chai.expect(to.callCount).to.equal(1);
+      chai.expect(to.args[0][1].live).to.equal(true);
+      chai.expect(to.args[0][1].retry).to.equal(true);
+      var backoff = to.args[0][1].back_off_function;
+      chai.expect(backoff(0)).to.equal(1000);
+      chai.expect(backoff(2000)).to.equal(4000);
+      chai.expect(backoff(31000)).to.equal(60000);
+      done();
     });
   });
 


### PR DESCRIPTION
This moves the initial replication into the bootstrap layer which means it runs once per user+device+server, not every page load. The user will now see a spinner while the initial replication is going. This means they won't be querying the database until all the data is up to date which speeds up the overall initial replication time.

One downside is because this is running before Angular has started it's not easy to capture the replication data to show on the About page. I've tried to capture the same data and output it to the console. That combined with the fact the app won't load until the replication completes hopefully gives enough info about the state of replication. I'd welcome feedback here about how to include more information.

With this patch initial startup takes about 3.5 minutes with a real user on a tecno on a real server which includes downloading static resources, doing initial replication, getting the ddoc, starting angular, and waiting for the rules engine to start up. CPU usage is about 2-3% above baseline during the replication phase.