### PR TITLE
ported a patch from `diy` branch that was lost.

### DIFF
--- a/packages/kujua-sms/kujua-sms/updates.js
+++ b/packages/kujua-sms/kujua-sms/updates.js
@@ -263,9 +263,15 @@ var add_sms = exports.add_sms = function(doc, request) {
     };
     options = _.extend(req.form, options);
 
-    // if locale was not passed in form data then check query string
-    if (!options.locale) {
-        options.locale = (req.query && req.query.locale) || utils.info.locale;
+    /**
+     * If a locale value was passed in using form or query string then save
+     * that to the sms_message data, otherwise leave locale undefined.  The
+     * sms_message.locale property can be used as an override when supporting
+     * responses in multiple languages based on a gateway configuration or a
+     * special form field `locale`.
+     */
+    if (!options.locale && (req.query && req.query.locale)) {
+        options.locale = req.query.locale;
     }
 
     var def = utils.info.getForm(options.form),

--- a/packages/kujua-sms/kujua-sms/utils.js
+++ b/packages/kujua-sms/kujua-sms/utils.js
@@ -372,8 +372,20 @@ function getLabel(field, locale) {
 }
 
 
+/**
+ * Determine locale/language of a record based on a locale value:
+ *  - Set on the document
+ *  - Reported in a form field named `locale`
+ *  - Configured in the gateway and set on message post
+ *  - Configured in the settings
+ *  - Defaults to 'en'
+ */
 function getLocale(record) {
-    return record.locale || (record.sms_message && record.sms_message.locale) || 'en';
+    return record.locale ||
+           (record.fields && record.fields.locale) ||
+           (record.sms_message && record.sms_message.locale) ||
+           exports.info.locale ||
+           'en';
 }
 
 /*


### PR DESCRIPTION
cf4c3ff fixed bug where default response did not respect locale value

Not sure if this is necessary for DIY/v0.4 compatibility. I know there
is a project or two that use this feature.  It allows you to support
reporters in multiple languages based on a field named `locale` set in
the form or a query parameter `locale` set on the gateway.

Issue: https://github.com/medic/medic-webapp/issues/2410