### PR TITLE
Scope contacts search

### DIFF
--- a/static/js/controllers/contacts.js
+++ b/static/js/controllers/contacts.js
@@ -14,6 +14,7 @@ var _ = require('underscore'),
       $scope,
       $state,
       $timeout,
+      CONTACT_TYPES,
       DB,
       Export,
       LiveList,
@@ -28,6 +29,18 @@ var _ = require('underscore'),
 
       $scope.selected = null;
       $scope.filters = {};
+
+      function setInitialFilterConfiguration() {
+        $scope.filters = {};
+        return UserSettings().then(function(u) {
+          return u.facility_id && DB().get(u.facility_id).then(function(facility) {
+            var targetType = CONTACT_TYPES[CONTACT_TYPES.indexOf(facility.type) + 1];
+            $scope.filters.types = {
+              selected: [targetType]
+            };
+          });
+        });
+      }
 
       function completeLoad() {
         $scope.loading = false;
@@ -160,12 +173,15 @@ var _ = require('underscore'),
         SearchFilters.freetext($scope.search);
       };
       $scope.resetFilterModel = function() {
-        $scope.filters = {};
-        SearchFilters.reset();
-        $scope.search();
+        setInitialFilterConfiguration().then(function() {
+          SearchFilters.reset();
+          $scope.search();
+        });
       };
 
-      $scope.search();
+      setInitialFilterConfiguration().then(function() {
+        $scope.search();
+      });
 
       $scope.$on('$destroy', function() {
         if (!$state.includes('contacts')) {


### PR DESCRIPTION
Search defaults (and is constrained) to the direct level below the
user's facility type. a CHP will only see families for example.
Admins are excluded and see everything.