### PR TITLE
Layout service

### DIFF
--- a/static/js/controllers/contacts-edit.js
+++ b/static/js/controllers/contacts-edit.js
@@ -17,6 +17,7 @@ var _ = require('underscore');
       DB,
       Enketo,
       EnketoTranslation,
+      Layout,
       Snackbar,
       UserDistrict
     ) {
@@ -98,7 +99,7 @@ var _ = require('underscore');
           $scope.category,
           ($scope.contactId ? 'edit' : 'new')
         ].join('.');
-        $translate(key).then($scope.setTitle);
+        $translate(key).then(_.partial(Layout.setTitle, $scope, _));
       };
 
       var getFormInstanceData = function() {
@@ -372,7 +373,7 @@ var _ = require('underscore');
 
       $scope.$on('$destroy', function() {
         if (!$state.includes('contacts.add')) {
-          $scope.setTitle();
+          Layout.setTitle($scope);
           if ($scope.enketoContact && $scope.enketoContact.formInstance) {
             Enketo.unload($scope.enketoContact.formInstance);
           }

--- a/static/js/controllers/contacts-report.js
+++ b/static/js/controllers/contacts-report.js
@@ -4,9 +4,9 @@
 
   var inboxControllers = angular.module('inboxControllers');
 
-  inboxControllers.controller('ContactsReportCtrl', 
-    ['$scope', '$state', '$log', '$translate', 'DB', 'Enketo', 'TranslateFrom', 'Snackbar',
-    function ($scope, $state, $log, $translate, DB, Enketo, TranslateFrom, Snackbar) {
+  inboxControllers.controller('ContactsReportCtrl',
+    function ($scope, $state, $log, $translate, DB, Enketo, Layout, TranslateFrom, Snackbar) {
+      'ngInject';
 
       var render = function(doc) {
         $scope.setSelected({ doc: doc });
@@ -55,7 +55,7 @@
         })
         .then(function(res) {
           if (res.rows[0]) {
-            $scope.setTitle(TranslateFrom(res.rows[0].doc.title));
+            Layout.setTitle($scope, TranslateFrom(res.rows[0].doc.title));
           }
         })
         .catch(function(err) {
@@ -66,11 +66,11 @@
 
       $scope.$on('$destroy', function() {
         if (!$state.includes('contacts.report')) {
-          $scope.setTitle();
+          Layout.setTitle($scope);
           Enketo.unload($scope.form);
         }
       });
     }
-  ]);
+  );
 
 }());

--- a/static/js/controllers/contacts-report.js
+++ b/static/js/controllers/contacts-report.js
@@ -42,7 +42,7 @@
 
       $scope.form = null;
       $scope.loadingForm = true;
-      $scope.setActionBar();
+      Layout.setActionBar($scope);
       $scope.setShowContent(true);
       $scope.setCancelTarget(function() {
         $state.go('contacts.detail', { id: $state.params.id });

--- a/static/js/controllers/contacts.js
+++ b/static/js/controllers/contacts.js
@@ -169,7 +169,7 @@ var scrollLoader = require('../modules/scroll-loader');
               } else {
                 actionBarData.relevantForms = forms;
               }
-              $scope.setRightActionBar(actionBarData);
+              Layout.setRightActionBar($scope, actionBarData);
             });
           });
       };
@@ -221,7 +221,7 @@ var scrollLoader = require('../modules/scroll-loader');
             return $translate(ContactSchema.get(type).addButtonLabel)
               .then(function(label) {
                 actionBarData.addPlaceLabel = label;
-                $scope.setLeftActionBar(actionBarData);
+                Layout.setLeftActionBar($scope, actionBarData);
               });
           } else {
             if (Session.isAdmin()) {

--- a/static/js/controllers/contacts.js
+++ b/static/js/controllers/contacts.js
@@ -16,6 +16,7 @@ var scrollLoader = require('../modules/scroll-loader');
       $translate,
       ContactSchema,
       DB,
+      Layout,
       LiveList,
       Search,
       SearchFilters,
@@ -148,7 +149,7 @@ var scrollLoader = require('../modules/scroll-loader');
       $scope.setSelected = function(selected) {
         liveList.setSelected(selected.doc._id);
         $scope.selected = selected;
-        $scope.setTitle(selected.doc.name);
+        Layout.setTitle($scope, selected.doc.name);
         $scope.clearCancelTarget();
         var selectedDoc = selected.doc;
         return getActionBarDataForChild(selectedDoc.type)

--- a/static/js/controllers/inbox.js
+++ b/static/js/controllers/inbox.js
@@ -455,24 +455,6 @@ var feedback = require('../modules/feedback'),
         });
       });
 
-      $scope.setRightActionBar = function(model) {
-        if (!$scope.actionBar) {
-          $scope.actionBar = {};
-        }
-        $scope.actionBar.right = model;
-      };
-
-      $scope.setLeftActionBar = function(model) {
-        if (!$scope.actionBar) {
-          $scope.actionBar = {};
-        }
-        $scope.actionBar.left = model;
-      };
-
-      $scope.setActionBar = function(model) {
-        $scope.actionBar = model;
-      };
-
       $scope.emit = function() {
         $rootScope.$broadcast.apply($rootScope, arguments);
       };

--- a/static/js/controllers/inbox.js
+++ b/static/js/controllers/inbox.js
@@ -31,6 +31,7 @@ var feedback = require('../modules/feedback'),
       FacilityHierarchy,
       JsonForms,
       Language,
+      Layout,
       LiveListConfig,
       Location,
       Modal,
@@ -156,7 +157,7 @@ var feedback = require('../modules/feedback'),
         $scope.setShowContent(false);
         $scope.loadingContent = false;
         $scope.showActionBar = false;
-        $scope.setTitle();
+        Layout.setTitle($scope);
         $scope.$broadcast('ClearSelected');
       };
 
@@ -198,10 +199,6 @@ var feedback = require('../modules/feedback'),
 
       $scope.setCancelTarget = function(callback) {
         $scope.cancelCallback = callback;
-      };
-
-      $scope.setTitle = function(title) {
-        $scope.title = title;
       };
 
       $scope.setLoadingContent = function(id) {

--- a/static/js/controllers/messages-content.js
+++ b/static/js/controllers/messages-content.js
@@ -15,6 +15,7 @@ var _ = require('underscore');
       $timeout,
       Changes,
       ContactConversation,
+      Layout,
       MarkAllRead,
       Modal,
       SendMessage,
@@ -110,7 +111,7 @@ var _ = require('underscore');
           (!message.form && message.name) ||
           message.from ||
           message.sent_by;
-        $scope.setTitle(title);
+        Layout.setTitle($scope, title);
       };
 
       var updateConversation = function(options) {

--- a/static/js/controllers/reports.js
+++ b/static/js/controllers/reports.js
@@ -16,6 +16,7 @@ var _ = require('underscore'),
       $timeout,
       DB,
       FormatDataRecord,
+      Layout,
       LiveList,
       MarkRead,
       Modal,
@@ -70,7 +71,7 @@ var _ = require('underscore'),
         if (form) {
           name = form.name || form.title;
         }
-        $scope.setTitle(TranslateFrom(name));
+        Layout.setTitle($scope, TranslateFrom(name));
       };
 
       var getFields = function(results, values, labelPrefix, depth) {

--- a/static/js/controllers/reports.js
+++ b/static/js/controllers/reports.js
@@ -127,7 +127,7 @@ var _ = require('underscore'),
           model.type = doc.content_type;
           model.sendTo = doc.contact;
         }
-        $scope.setActionBar(model);
+        Layout.setActionBar($scope, model);
       };
 
       $scope.setSelected = function(doc) {

--- a/static/js/controllers/tasks-content.js
+++ b/static/js/controllers/tasks-content.js
@@ -5,8 +5,8 @@
   var inboxControllers = angular.module('inboxControllers');
 
   inboxControllers.controller('TasksContentCtrl',
-    ['$log', '$scope', '$state', '$translate', 'DB', 'Enketo', 'TranslateFrom', 'Snackbar',
-    function ($log, $scope, $state, $translate, DB, Enketo, TranslateFrom, Snackbar) {
+    function ($log, $scope, $state, $translate, DB, Enketo, Layout, TranslateFrom, Snackbar) {
+      'ngInject';
 
       var hasOneFormAndNoFields = function(task) {
         return Boolean(
@@ -48,7 +48,7 @@
             })
             .then(function(res) {
               if (res.rows[0]) {
-                $scope.setTitle(TranslateFrom(res.rows[0].doc.title));
+                Layout.setTitle($scope, TranslateFrom(res.rows[0].doc.title));
               }
             })
             .catch(function(err) {
@@ -98,6 +98,6 @@
       $scope.formId = null;
       $scope.setSelected($state.params.id);
     }
-  ]);
+  );
 
 }());

--- a/static/js/controllers/tasks.js
+++ b/static/js/controllers/tasks.js
@@ -7,13 +7,13 @@ var _ = require('underscore');
   var inboxControllers = angular.module('inboxControllers');
 
   inboxControllers.controller('TasksCtrl',
-    function($scope, $state, $timeout, LiveList, RulesEngine, TranslateFrom) {
+    function($scope, $state, $timeout, Layout, LiveList, RulesEngine, TranslateFrom) {
       'ngInject';
 
       var setSelectedTask = function(task) {
         LiveList.tasks.setSelected(task._id);
         $scope.selected = task;
-        $scope.setTitle(TranslateFrom(task.title, task));
+        Layout.setTitle($scope, TranslateFrom(task.title, task));
         $scope.setShowContent(true);
       };
 

--- a/static/js/services/index.js
+++ b/static/js/services/index.js
@@ -39,9 +39,10 @@
   require('./import-contacts');
   require('./kanso-packages');
   require('./language');
+  require('./layout');
   require('./location');
-  require('./markdown');
   require('./live-list');
+  require('./markdown');
   require('./mark-read');
   require('./merge-uri-parameters');
   require('./message-contacts');

--- a/static/js/services/layout.js
+++ b/static/js/services/layout.js
@@ -11,7 +11,28 @@ inboxServices.factory('Layout',
       scope.title = title;
     };
 
+    var setActionBar = function(scope, model) {
+      scope.actionBar = model;
+    };
+
+    var setRightActionBar = function(scope, model) {
+      if (!scope.actionBar) {
+        scope.actionBar = {};
+      }
+      scope.actionBar.right = model;
+    };
+
+    var setLeftActionBar = function(scope, model) {
+      if (!scope.actionBar) {
+        scope.actionBar = {};
+      }
+      scope.actionBar.left = model;
+    };
+
     return {
+      setActionBar: setActionBar,
+      setLeftActionBar: setLeftActionBar,
+      setRightActionBar : setRightActionBar,
       setTitle: setTitle
     };
 

--- a/static/js/services/layout.js
+++ b/static/js/services/layout.js
@@ -1,0 +1,18 @@
+/* jshint node: true */
+'use strict';
+
+var inboxServices = angular.module('inboxServices');
+
+inboxServices.factory('Layout',
+  function() {
+    'ngInject';
+
+    var setTitle = function(scope, title) {
+      scope.title = title;
+    };
+
+    return {
+      setTitle: setTitle
+    };
+
+  });


### PR DESCRIPTION
Service to handle the shared functions across the whole layout. Currently they're in inbox.js, which is not cool. 
I moved setTitle and setActionBar as examples, there's probably more.

I debated between passing the rootscope object to the service once as a setup step, vs. passing it to each function call.
In the end I'd rather pass it each time, because I don't like dumping everything in the rootscope, it's bad scoping (it's kindof what I'm trying to move out of in the first place!!). I'd rather that the $scope for BlahCtrl hold the variable that's used in the corresponding Blah template, and other controllers know nothing about it, because it's none of their beeswax.

Edit: yeah I know it breaks all the unit tests, proof-of-concept right now.
