### PR TITLE
PouchDB learns about Tecnos #2797

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -142,7 +142,8 @@ module.exports = function(grunt) {
             cwd: 'node_modules',
             src: [
               'bootstrap-daterangepicker/**',
-              'font-awesome/**'
+              'font-awesome/**',
+              'pouchdb-adapter-idb/**',
             ],
             dest: 'node_modules_backup'
           }
@@ -198,7 +199,8 @@ module.exports = function(grunt) {
         cmd: function() {
           var modulesToPatch = [
             'bootstrap-daterangepicker',
-            'font-awesome'
+            'font-awesome',
+            'pouchdb-adapter-idb',
           ];
           return modulesToPatch.map(function(module) {
             var backupPath = 'node_modules_backup/' + module;
@@ -226,6 +228,10 @@ module.exports = function(grunt) {
             // patch font-awesome to remove version attributes so appcache works
             // https://github.com/FortAwesome/Font-Awesome/issues/3286
             'patch node_modules/font-awesome/less/path.less < patches/font-awesome-remove-version-attribute.patch',
+
+            // patch pouch to improve safari checks
+            // https://github.com/medic/medic-webapp/issues/2797
+            'patch node_modules/pouchdb-adapter-idb/src/index.js < patches/pouchdb-ignore-safari-check.patch',
           ];
           return patches.join(' && ');
         }

--- a/patches/pouchdb-ignore-safari-check.patch
+++ b/patches/pouchdb-ignore-safari-check.patch
@@ -1,0 +1,12 @@
+*** ./pouchdb-adapter-idb/src/index.js	2016-06-16 15:55:47.000000000 +0100
+--- index-patched.js	2016-10-12 13:09:39.000000000 +0100
+***************
+*** 980,985 ****
+--- 980,986 ----
+    var isSafari = typeof openDatabase !== 'undefined' &&
+      /(Safari|iPhone|iPad|iPod)/.test(navigator.userAgent) &&
+      !/Chrome/.test(navigator.userAgent) &&
++     !/TECNO/.test(navigator.userAgent) &&
+      !/BlackBerry/.test(navigator.platform);
+  
+    // some outdated implementations of IDB that appear on Samsung


### PR DESCRIPTION
On some TECNO phones they omit Chrome from their userAgent, causing
PouchDB to mis-categorise them as Safari, which disables IDB support,
which causes crazy issues.