### PR TITLE
Extra debouncing for slow devices #2909

### DIFF
--- a/static/js/controllers/contacts-edit.js
+++ b/static/js/controllers/contacts-edit.js
@@ -151,6 +151,11 @@ var _ = require('underscore');
         });
 
       $scope.save = function() {
+        if ($scope.saving) {
+          $log.debug('Attempted to call contacts-edit:$scope.save more than once');
+          return;
+        }
+
         var form = $scope.enketoContact.formInstance;
         var docId = $scope.enketoContact.docId;
         $scope.saving = true;

--- a/static/js/controllers/contacts-report.js
+++ b/static/js/controllers/contacts-report.js
@@ -26,6 +26,11 @@
       };
 
       $scope.save = function() {
+        if ($scope.saving) {
+          $log.debug('Attempted to call contacts-report:$scope.save more than once');
+          return;
+        }
+
         $scope.saving = true;
         Enketo.save($state.params.formId, $scope.form)
           .then(function(doc) {

--- a/static/js/controllers/reports-add.js
+++ b/static/js/controllers/reports-add.js
@@ -61,6 +61,11 @@
         });
 
       $scope.save = function() {
+        if ($scope.saving) {
+          $log.debug('Attempted to call reports-add:$scope.save more than once');
+          return;
+        }
+
         $scope.saving = true;
         var doc = $scope.selected[0].report;
         Enketo.save(doc.form, $scope.form, doc._id)

--- a/static/js/controllers/tasks-content.js
+++ b/static/js/controllers/tasks-content.js
@@ -62,6 +62,11 @@
       };
 
       $scope.save = function() {
+        if ($scope.saving) {
+          $log.debug('Attempted to call tasks-content:$scope.save more than once');
+          return;
+        }
+
         $scope.saving = true;
         Enketo.save($scope.formId, $scope.form)
           .then(function(doc) {


### PR DESCRIPTION
Our main debouncing strategy of setting $scope.saving and having angular
disable the button on that value mostly works, but on slower phones
you're able to get more than one action in before Angular gets itself
together.

This doubly-checks to make sure save isn't called more than once.