### PR TITLE
Handle missing user contact better. Issue: #2944

### DIFF
--- a/static/js/services/user-contact.js
+++ b/static/js/services/user-contact.js
@@ -7,7 +7,15 @@ angular.module('inboxServices').factory('UserContact',
     'ngInject';
     return function() {
       return UserSettings().then(function(user) {
-        return user.contact_id && DB().get(user.contact_id);
+        if (!user.contact_id) {
+          return;
+        }
+        return DB().get(user.contact_id).catch(function(err) {
+          if (err.status === 404) {
+            return;
+          }
+          throw err;
+        });
       });
     };
   }

--- a/static/js/services/user.js
+++ b/static/js/services/user.js
@@ -72,21 +72,6 @@ var utils = require('kujua-utils');
     }
   );
 
-  inboxServices.factory('UserContact',
-    function(
-      DB,
-      UserSettings
-    ) {
-      'ngInject';
-      return function() {
-        return UserSettings()
-          .then(function(user) {
-            return user.contact_id && DB().get(user.contact_id);
-          });
-      };
-    }
-  );
-
   inboxServices.factory('Admins',
     function(
       $http


### PR DESCRIPTION
Now when the users contact_id is configured but the referenced doc isn't found it's treated the same as if the contact_id isn't configured. This means errors are handled and user friendly messages shown.