### PR TITLE
XML form content stored as attachment

### DIFF
--- a/static/js/controllers/reports-add.js
+++ b/static/js/controllers/reports-add.js
@@ -52,7 +52,7 @@
           var content = doc.content || (
             doc._attachments &&
             doc._attachments.content &&
-            atob(doc._attachments.content.data))
+            atob(doc._attachments.content.data));
           Enketo.render($('#report-form'), doc.form, content)
             .then(function(form) {
               $scope.form = form;

--- a/static/js/controllers/reports-add.js
+++ b/static/js/controllers/reports-add.js
@@ -23,7 +23,9 @@
           return $q.resolve({ form: $state.params.formId });
         }
         if ($state.params.reportId) { // editing
-          return DB().get($state.params.reportId);
+          return DB().get($state.params.reportId, {
+            attachments: true
+          });
         }
         return $q.reject(new Error('Must have either formId or reportId'));
       };
@@ -44,7 +46,14 @@
         .then(function(doc) {
           $log.debug('setting selected', doc);
           $scope.setSelected(doc);
-          Enketo.render($('#report-form'), doc.form, doc.content)
+          // TODO: check doc.content as this is where legacy documents stored
+          //       their XML. Consider removing this check at some point in the
+          //       future.
+          var content = doc.content || (
+            doc._attachments &&
+            doc._attachments.content &&
+            atob(doc._attachments.content.data))
+          Enketo.render($('#report-form'), doc.form, content)
             .then(function(form) {
               $scope.form = form;
               $scope.loadingContent = false;

--- a/static/js/services/enketo.js
+++ b/static/js/services/enketo.js
@@ -254,12 +254,25 @@ angular.module('inboxServices').service('Enketo',
         });
     };
 
+    var attachContent = function(doc, content) {
+      doc._attachments = doc._attachments || {};
+      doc._attachments.content = {
+        content_type: 'application/xml',
+        data: btoa(content)
+      }
+    }
+
     var update = function(formInternalId, record, docId) {
       // update an existing doc.  For convenience, get the latest version
       // and then modify the content.  This will avoid most concurrent
       // edits, but is not ideal.
       return DB().get(docId).then(function(doc) {
-        doc.content = record;
+        // previously XML was stored in the content property
+        // TODO delete this and other "legacy" code support commited against
+        //      the same git commit at some point in the future?
+        delete doc.content;
+
+        attachContent(doc, record);
         doc.fields = EnketoTranslation.reportRecordToJs(record);
         return DB().put(doc).then(function(res) {
           doc._rev = res.rev;
@@ -280,7 +293,6 @@ angular.module('inboxServices').service('Enketo',
     var create = function(formInternalId, record) {
       return getUserContact().then(function(contact) {
         var doc = {
-          content: record,
           fields: EnketoTranslation.reportRecordToJs(record),
           form: formInternalId,
           type: 'data_record',
@@ -290,6 +302,7 @@ angular.module('inboxServices').service('Enketo',
           from: contact && contact.phone,
           hidden_fields: EnketoTranslation.getHiddenFieldList(record),
         };
+        attachContent(doc, record);
         return DB().post(doc).then(function(res) {
           doc._id = res.id;
           doc._rev = res.rev;

--- a/static/js/services/enketo.js
+++ b/static/js/services/enketo.js
@@ -259,8 +259,8 @@ angular.module('inboxServices').service('Enketo',
       doc._attachments.content = {
         content_type: 'application/xml',
         data: btoa(content)
-      }
-    }
+      };
+    };
 
     var update = function(formInternalId, record, docId) {
       // update an existing doc.  For convenience, get the latest version

--- a/tests/karma/unit/services/enketo.js
+++ b/tests/karma/unit/services/enketo.js
@@ -340,7 +340,7 @@ describe('Enketo service', function() {
           chai.expect(UserContact.callCount).to.equal(1);
           chai.expect(actual._id).to.equal('5');
           chai.expect(actual._rev).to.equal('1-abc');
-          chai.expect(actual.content).to.equal(content);
+          chai.expect(atob(actual._attachments.content.data)).to.equal(content);
           chai.expect(actual.fields.name).to.equal('Sally');
           chai.expect(actual.fields.lmp).to.equal('10');
           chai.expect(actual.form).to.equal('V');
@@ -372,7 +372,7 @@ describe('Enketo service', function() {
           chai.expect(UserContact.callCount).to.equal(1);
           chai.expect(actual._id).to.equal('5');
           chai.expect(actual._rev).to.equal('1-abc');
-          chai.expect(actual.content).to.equal(content);
+          chai.expect(atob(actual._attachments.content.data)).to.equal(content);
           chai.expect(actual.fields.name).to.equal('Sally');
           chai.expect(actual.fields.lmp).to.equal('10');
           chai.expect(actual.fields.secret_code_name).to.equal('S4L');
@@ -411,7 +411,7 @@ describe('Enketo service', function() {
           chai.expect(dbPut.callCount).to.equal(1);
           chai.expect(actual._id).to.equal('6');
           chai.expect(actual._rev).to.equal('2-abc');
-          chai.expect(actual.content).to.equal(content);
+          chai.expect(atob(actual._attachments.content.data)).to.equal(content);
           chai.expect(actual.fields.name).to.equal('Sally');
           chai.expect(actual.fields.lmp).to.equal('10');
           chai.expect(actual.form).to.equal('V');


### PR DESCRIPTION
Creating a new report or updating an existing one will save the xml
content as an attachment instead of as a property on the object. Both
types (property or attachemnt) are supported for opening documents, so
no migration is neccessary.