### PR TITLE
added outgoing deny list setting to kanso.json.

### DIFF
--- a/kanso.json
+++ b/kanso.json
@@ -189,6 +189,11 @@
                     }
                 }
             },
+            "outgoing_deny_list": {
+                "type": "string",
+                "title": "Outgoing Deny List",
+                "description": "Case insensitive, comma separated list of strings or numbers to never send messages to. e.g. +5511986, +551198765432, Orange"
+            },
             "schedule_morning_hours" : {
                 "title": "Scheduled Message Morning Hours",
                 "description": "Only send messages on or after this hour.",


### PR DESCRIPTION
Not sure how this got lost, probably never forwarded ported from 0.4.x
branch.  Sentinel looks good though, I think the minor change to webapp
was left behind.

Issue: https://github.com/medic/medic-webapp/issues/3125