### PR TITLE
Don't minify alpha and beta releases

### DIFF
--- a/scripts/ci/after_success.sh
+++ b/scripts/ci/after_success.sh
@@ -32,8 +32,10 @@ function tagSubmodules {
 function push {
     ((COUNT++))
     local market="$1"
+    local maxify=$2
     if [ $COUNT -le $MAX ]; then
-        node --stack_size=10000 `which kanso` push --minify \
+        echo node --stack_size=10000 `which kanso` push \
+            `[[ $maxify != true ]] && echo --minify` \
             "${UPLOAD_URL}/markets-$market/upload" && exit 0
         push $market
     else
@@ -44,7 +46,7 @@ function push {
 
 # every master build gets pushed to alpha market
 if [ "$TRAVIS_BRANCH" == "master" ]; then
-    push 'alpha'
+    push 'alpha' true
 
 # match tags of the form "0.n.n"
 elif [[ "$TRAVIS_TAG" =~ ^0\.[0-9]+\.[0-9]+$ ]]; then
@@ -58,7 +60,7 @@ elif [[ "$TRAVIS_TAG" =~ ^2\.[0-9]+\.[0-9]+$ ]]; then
 
 # match tags of the form "n.n.n-beta.n"
 elif [[ "$TRAVIS_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+$ ]]; then
-    push 'beta'
+    push 'beta' true
 
 # match tags of the form "n.n.n-rc.n"
 elif [[ "$TRAVIS_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then

--- a/scripts/ci/after_success.sh
+++ b/scripts/ci/after_success.sh
@@ -34,7 +34,7 @@ function push {
     local market="$1"
     local maxify=$2
     if [ $COUNT -le $MAX ]; then
-        echo node --stack_size=10000 `which kanso` push \
+        node --stack_size=10000 `which kanso` push \
             `[[ $maxify != true ]] && echo --minify` \
             "${UPLOAD_URL}/markets-$market/upload" && exit 0
         push $market


### PR DESCRIPTION
Minification is the default, but if you want you can specify to not
do it. Currently set to alpha and beta to make debugging things easier,
because debugging is more important than performance in these stages.