### PR TITLE
Don't replicate ddocs back to server

### DIFF
--- a/static/js/services/db-sync.js
+++ b/static/js/services/db-sync.js
@@ -1,6 +1,7 @@
 var _ = require('underscore'),
     READ_ONLY_TYPES = [ 'form', 'translations' ],
-    READ_ONLY_IDS = [ '_design/medic-client', 'resources', 'appcache', 'zscore-charts' ];
+    READ_ONLY_IDS = [ 'resources', 'appcache', 'zscore-charts' ],
+    DDOC_PREFIX = [ '_design/' ];
 
 (function () {
 
@@ -88,7 +89,8 @@ var _ = require('underscore'),
               filter: function(doc) {
                 // don't try to replicate read only docs back to the server
                 return READ_ONLY_TYPES.indexOf(doc.type) === -1 &&
-                       READ_ONLY_IDS.indexOf(doc._id) === -1;
+                       READ_ONLY_IDS.indexOf(doc._id) === -1 &&
+                       doc._id.indexOf(DDOC_PREFIX) !== 0;
               }
             });
           })

--- a/tests/karma/unit/services/db-sync.js
+++ b/tests/karma/unit/services/db-sync.js
@@ -127,6 +127,11 @@ describe('DBSync service', function() {
       chai.expect(actual).to.equal(false);
     });
 
+    it('does not replicate any ddoc - #3268', function() {
+      var actual = filterFunction({ _id: '_design/sneaky-mcsneakface' });
+      chai.expect(actual).to.equal(false);
+    });
+
     it('does not replicate the resources doc', function() {
       var actual = filterFunction({ _id: 'resources' });
       chai.expect(actual).to.equal(false);
@@ -138,17 +143,17 @@ describe('DBSync service', function() {
     });
 
     it('does not replicate forms', function() {
-      var actual = filterFunction({ type: 'form' });
+      var actual = filterFunction({ _id: '1', type: 'form' });
       chai.expect(actual).to.equal(false);
     });
 
     it('does not replicate translations', function() {
-      var actual = filterFunction({ type: 'translations' });
+      var actual = filterFunction({ _id: '1', type: 'translations' });
       chai.expect(actual).to.equal(false);
     });
 
     it('does replicate reports', function() {
-      var actual = filterFunction({ type: 'data_record' });
+      var actual = filterFunction({ _id: '1', type: 'data_record' });
       chai.expect(actual).to.equal(true);
     });
   });


### PR DESCRIPTION
If a client has an old medic ddoc lying around it shouldn't be
replicated back to the server as it's massive and quickly blows out
the auditing database.

medic/medic-webapp#3268