### PR TITLE
Translate task schedule group titles 

### DIFF
--- a/kanso.json
+++ b/kanso.json
@@ -786,6 +786,11 @@
                             "title": "Name",
                             "description": "A unique name to define this schedule. e.g. ANC Reminders"
                         },
+                        "translation_key": {
+                            "type": "string",
+                            "title": "Translation key",
+                            "description": "The key to look up in the translation files for the name of this schedule. The group number can be accessed in the translation value as '{{group}}'."
+                        },
                         "summary": {
                             "type": "string",
                             "title": "Summary",

--- a/packages/kujua-sms/kujua-sms/utils.js
+++ b/packages/kujua-sms/kujua-sms/utils.js
@@ -104,6 +104,22 @@ var includeNonFormFields = function(doc, form_keys, locale) {
     });
 };
 
+var getGroupName = function(task) {
+    if (task.group) {
+        return task.type + ':' + task.group;
+    }
+    return task.type;
+};
+
+var getGroupDisplayName = function(task, language) {
+    if (task.translation_key) {
+        return exports.info.translate(
+            task.translation_key, language, { group: task.group }
+        );
+    }
+    return getGroupName(task);
+};
+
 /*
  * Take data record document and return nice formated JSON object.
  */
@@ -144,14 +160,14 @@ exports.makeDataRecordReadable = function(doc, appinfo, language) {
             }
 
             // setup scheduled groups
-            var group_name = t.type;
-            if (t.group) {
-                group_name += ":" + t.group;
-            }
 
-            if (!groups[group_name]) {
-                groups[group_name] = {
-                    group: group_name,
+            var groupName = getGroupName(t);
+            var displayName = getGroupDisplayName(t, language);
+            var group = groups[groupName];
+            if (!group) {
+                groups[groupName] = group = {
+                    group: groupName,
+                    name: displayName,
                     type: t.type,
                     number: t.group,
                     rows: []
@@ -161,7 +177,7 @@ exports.makeDataRecordReadable = function(doc, appinfo, language) {
             // Warning: _idx is used on frontend during save.
             //
             copy._idx = i;
-            groups[group_name].rows.push(copy);
+            group.rows.push(copy);
         }
         for (var k in groups) {
             data_record.scheduled_tasks_by_group.push(groups[k]);

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -25,7 +25,10 @@ require('angular-ui-router');
 require('moment');
 require('moment/locale/es');
 require('moment/locale/fr');
+require('moment/locale/hi');
+require('moment/locale/id');
 require('moment/locale/ne');
+require('moment/locale/sw');
 
 require('./services');
 require('./controllers');

--- a/templates/partials/reports_content.html
+++ b/templates/partials/reports_content.html
@@ -88,7 +88,7 @@
           <ul>
             <li ng-repeat="group in selection.report.scheduled_tasks_by_group">
               <p>
-                {{group.group}}
+                {{group.name}}
                 <span ng-hide="group.loading">
                   <a class="btn btn-link" ng-click="edit(selection, group)" translate>Edit</a>
                   <a class="btn btn-link" ng-click="mute(selection, group)" ng-show="canMute(group)" translate>Mute</a>


### PR DESCRIPTION
If the schedule task name translation_key is available use it to
generate group name, otherwise fall back to concatenating the group
number to the untranslated schedule name.

medic/medic-webapp#3283