### PR TITLE
Stringify log arguments to be worker friendly

### DIFF
--- a/static/js/modules/feedback.js
+++ b/static/js/modules/feedback.js
@@ -17,7 +17,7 @@ var registerConsoleInterceptor = function() {
     var original = options.console[level];
     options.console[level] = function() {
       // push the error onto the stack
-      log.splice(0, 0, { level: level, arguments: arguments });
+      log.splice(0, 0, { level: level, arguments: JSON.stringify(arguments) });
       // remove any old log entries
       log.splice(20, Number.MAX_VALUE);
       // output to the console as per usual

--- a/tests/nodeunit/unit/feedback.js
+++ b/tests/nodeunit/unit/feedback.js
@@ -28,7 +28,7 @@ exports.tearDown = function (callback) {
 };
 
 exports['unhandled error submits feedback'] = function(test) {
-  test.expect(22);
+  test.expect(17);
 
   getUserCtx.callsArgWith(0, null, { name: 'fred' });
   saveDoc.callsArgWith(1);
@@ -60,18 +60,13 @@ exports['unhandled error submits feedback'] = function(test) {
     
     test.equals(submittedDoc.log.length, 4);
     test.equals(submittedDoc.log[0].level, 'error');
-    test.equals(submittedDoc.log[0].arguments.length, 2);
-    test.equals(submittedDoc.log[0].arguments[0], 'Failed to save');
-    test.equals(submittedDoc.log[0].arguments[1], '404');
+    test.equals(submittedDoc.log[0].arguments, '{"0":"Failed to save","1":"404"}');
     test.equals(submittedDoc.log[1].level, 'warn');
-    test.equals(submittedDoc.log[1].arguments.length, 1);
-    test.equals(submittedDoc.log[1].arguments[0], 'Saving taking a while');
+    test.equals(submittedDoc.log[1].arguments, '{"0":"Saving taking a while"}');
     test.equals(submittedDoc.log[2].level, 'info');
-    test.equals(submittedDoc.log[2].arguments.length, 1);
-    test.equals(submittedDoc.log[2].arguments[0], 'Saving in process');
+    test.equals(submittedDoc.log[2].arguments, '{"0":"Saving in process"}');
     test.equals(submittedDoc.log[3].level, 'log');
-    test.equals(submittedDoc.log[3].arguments.length, 1);
-    test.equals(submittedDoc.log[3].arguments[0], 'Trying to save');
+    test.equals(submittedDoc.log[3].arguments, '{"0":"Trying to save"}');
 
     test.done();
 
@@ -100,8 +95,8 @@ exports['log history restricted to 20 lines'] = function(test) {
 
     var submittedDoc = saveDoc.args[0][0];
     test.equals(submittedDoc.log.length, 20);
-    test.equals(submittedDoc.log[0].arguments[0], 'item 24');
-    test.equals(submittedDoc.log[19].arguments[0], 'item 5');
+    test.equals(submittedDoc.log[0].arguments, '{"0":"item 24"}');
+    test.equals(submittedDoc.log[19].arguments, '{"0":"item 5"}');
 
     test.done();
 


### PR DESCRIPTION
Workers use a serialization function that can't handle some common
types such as DOM, URLs, etc. If these get logged at any point it
breaks the feedback mechanism because the feedback doc can't be saved
to pouch. Stringify these as we go.

medic/medic-webapp#3273