### PR TITLE
Disable client-side validation #3236

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -968,11 +968,6 @@
         }
       }
     },
-    "pouchdb-validation": {
-      "version": "1.2.1",
-      "from": "pouchdb-validation@>=1.2.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/pouchdb-validation/-/pouchdb-validation-1.2.1.tgz"
-    },
     "pouchdb-wrappers": {
       "version": "1.3.6",
       "from": "pouchdb-wrappers@>=1.0.0 <2.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "nools": "^0.4.4",
     "openrosa-xpath-evaluator": "^1.2.2",
     "pouchdb-browser": "^6.1.2",
-    "pouchdb-validation": "^1.2.1",
     "properties": "^1.2.1",
     "select2": "^4.0.3",
     "underscore": "^1.8.3",

--- a/static/js/services/db.js
+++ b/static/js/services/db.js
@@ -23,7 +23,6 @@ var _ = require('underscore');
       var pouchWorker = WebWorker(require('worker-pouch/workerified'));
 
       $window.PouchDB.adapter('worker', require('worker-pouch/client'));
-      $window.PouchDB.plugin(require('pouchdb-validation'));
 
       var getRemote = function() {
         return getFromCache(Location.url, POUCHDB_OPTIONS.remote);
@@ -48,9 +47,6 @@ var _ = require('underscore');
       var getFromCache = function(name, options) {
         if (!cache[name]) {
           var db = pouchDB(name, options);
-          // NB: This is a no-op when PouchDB runs against a remote DB, this
-          //     only runs validations client-side for client-side PouchDB.
-          db.installValidationMethods();
           cache[name] = db;
         }
         return cache[name];

--- a/tests/karma/unit/services/db.js
+++ b/tests/karma/unit/services/db.js
@@ -99,17 +99,6 @@ describe('DB service', function() {
       chai.expect(pouchDB.callCount).to.equal(2);
       done();
     });
-
-    it('installs validation functions', function() {
-      isAdmin.returns(false);
-      Location.dbName = 'medicdb';
-      Location.url = 'ftp//myhost:21/medicdb';
-      userCtx.returns({ name: 'johnny' });
-
-      // init
-      getService();
-      chai.expect(expected.installValidationMethods.callCount).to.equal(1);
-    });
   });
 
   describe('get local', function() {
@@ -178,17 +167,6 @@ describe('DB service', function() {
       chai.expect(expected.viewCleanup.callCount).to.equal(0);
 
       done();
-    });
-
-    it('installs validation functions', function() {
-      isAdmin.returns(false);
-      Location.dbName = 'medicdb';
-      Location.url = 'ftp//myhost:21/medicdb';
-      userCtx.returns({ name: 'johnny' });
-
-      // init
-      getService();
-      chai.expect(expected.installValidationMethods.callCount).to.equal(1);
     });
 
   });


### PR DESCRIPTION
For some reason this breaks replication: changes are seen and accepted
by the validator, but then they don't continue to propagate.

We're going to revert for now and look into pouchdb-validation later.