### PR TITLE
Allow text overflow in target titles

### DIFF
--- a/static/css/analytics-widgets.less
+++ b/static/css/analytics-widgets.less
@@ -240,9 +240,16 @@
     width: 33.33333%;
     background-color: @background-color;
     border: 1px solid @seperator-color;
+    .title {
+      display: flex;
+      flex-wrap: nowrap;
+    }
     h4 {
       margin: 0;
+      flex-grow: 1;
+      word-break: break-all;
     }
+    h4,
     .icon {
       margin-right: 0.5em;
     }
@@ -255,16 +262,11 @@
     .goal {
       color: @analytics-color;
     }
-    .right-wrapper {
-      overflow: hidden;
-    }
     .count-only {
       clear: both;
       text-align: center;
     }
     .right-column {
-      margin-left: 15px;
-      float: right;
       text-align: right;
     }
     .progress {

--- a/templates/partials/analytics/targets.html
+++ b/templates/partials/analytics/targets.html
@@ -4,14 +4,12 @@
 <div class="targets">
   <div class="target" ng-repeat="target in targets">
     <div class="contents" ng-class="{ 'has-goal': target.goal >= 0 }">
-      <div>
-        <div class="pull-left icon" ng-bind-html="target.icon | resourceIcon"></div>
-        <div class="right-wrapper">
-          <div class="right-column" ng-if="target.goal >= 0">
-            <div translate>analytics.target.monthly_goal</div>
-            <div class="goal"><span class="large">{{target.goal}}</span><span ng-if="target.type === 'percent'">%</span></div>
-          </div>
-          <h4>{{target.name | translateFrom}}</h4>
+      <div class="title">
+        <div class="icon" ng-bind-html="target.icon | resourceIcon"></div>
+        <h4>{{target.name | translateFrom}}</h4>
+        <div class="right-column" ng-if="target.goal >= 0">
+          <div translate>analytics.target.monthly_goal</div>
+          <div class="goal"><span class="large">{{target.goal}}</span><span ng-if="target.type === 'percent'">%</span></div>
         </div>
       </div>
       <div ng-if="target.goal >= 0">


### PR DESCRIPTION
Allows non-English characters (eg: Hindi) to overflow where necessary.
To get the title to line up nicely we need flexbox which also means
floating is no longer necessary.

medic/medic-webapp#3297