### PR TITLE
Remove UTC usage as its not needed.

### DIFF
--- a/static/js/modules/nootils.js
+++ b/static/js/modules/nootils.js
@@ -7,9 +7,9 @@ module.exports = function(settings) {
     isTimely: function(date, event) {
       var due = new Date(date);
       var start = new Date();
-      start.setUTCDate(start.getUTCDate() + event.start);
+      start.setDate(start.getDate() + event.start);
       var end = new Date();
-      end.setUTCDate(end.getUTCDate() - event.end - 1);
+      end.setDate(end.getDate() - event.end - 1);
       return due.getTime() < start.getTime() && due.getTime() > end.getTime();
     },
     addDate: function(date, days) {


### PR DESCRIPTION
These tests fail for me with UTC code in there (my tz is UTC+1) right
now). It's probable we don't notice because a) no one runs these tests
locally and b) travis runs against UTC so we never notice.