### PR TITLE
Rebuild inbox.js in grunt dev when changes are made in node_modules

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -278,6 +278,10 @@ module.exports = function(grunt) {
       translations: {
         files: ['translations/*'],
         tasks: ['appcache', 'deploy']
+      },
+      node_modules: {
+        files: ['node_modules/**/*'],
+        tasks: ['mmjs', 'deploy']
       }
     },
     notify_hooks: {


### PR DESCRIPTION
This greatly eases testing of patches to dependencies.

@garethbowen please review.  I'm in two minds about whether this should really be included by default or not - it's really helpful when it's helpful, but generally fiddling with stuff in `node_modules` is a quick way to get your working directory into an inconsistent state...so, what do you reckon?