### PR TITLE
Show report subject name on patient page

### DIFF
--- a/static/js/controllers/contacts-content.js
+++ b/static/js/controllers/contacts-content.js
@@ -320,6 +320,10 @@ var _ = require('underscore'),
 
                 selected.children = children;
 
+                if (contactDoc.patient_id) {
+                  addPatientName(selected.reports, [ selected ]);
+                }
+
                 return getPersonReports(children.persons).then(function(childrenReports) {
                   if (childrenReports.length) {
                     addPatientName(childrenReports, children.persons);


### PR DESCRIPTION
Show the patient name underneath the report type on the patient
profile page for consistency with everywhere else it's shown.

medic/medic-webapp#3309