### PR TITLE
Translate contact forms

### DIFF
--- a/static/js/services/enketo.js
+++ b/static/js/services/enketo.js
@@ -86,14 +86,16 @@ angular.module('inboxServices').service('Enketo',
       });
     };
 
-    var translateXml = function(text, title, language) {
+    var translateXml = function(text, language, title) {
       var xml = $.parseXML(text);
       var $xml = $(xml);
       // set the user's language as default so it'll be used for itext translations
       $xml.find('model itext translation[lang="' + language + '"]').attr('default', '');
       // manually translate the title as enketo-core doesn't have any way to do this
       // https://github.com/enketo/enketo-core/issues/405
-      $xml.find('h\\:title,title').text(TranslateFrom(title));
+      if (title) {
+        $xml.find('h\\:title,title').text(TranslateFrom(title));
+      }
       return xml;
     };
 
@@ -101,7 +103,7 @@ angular.module('inboxServices').service('Enketo',
       return DB().getAttachment(form.id, FORM_ATTACHMENT_NAME)
         .then(FileReader)
         .then(function(text) {
-          return translateXml(text, form.doc.title, language);
+          return translateXml(text, language, form.doc.title);
         });
     };
 
@@ -266,7 +268,11 @@ angular.module('inboxServices').service('Enketo',
     };
 
     this.renderFromXmlString = function(wrapper, xmlString, instanceData) {
-      return transformXml($.parseXML(xmlString))
+      return Language()
+        .then(function(language) {
+          return translateXml(xmlString, language);
+        })
+        .then(transformXml)
         .then(function(doc) {
           return renderFromXmls(doc, wrapper, instanceData);
         });


### PR DESCRIPTION
Run contact forms through the same translation function that report
forms go through so itext elements work as expected and contact forms
can be translated to the user's language.

medic/medic-webapp#3323