### PR TITLE
Don't use Devanagari numerals with Hindi locale

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -143,6 +143,7 @@ module.exports = function(grunt) {
             src: [
               'bootstrap-daterangepicker/**',
               'font-awesome/**',
+              'moment/**',
               'pouchdb-adapter-idb/**',
             ],
             dest: 'node_modules_backup'
@@ -211,6 +212,7 @@ module.exports = function(grunt) {
           var modulesToPatch = [
             'bootstrap-daterangepicker',
             'font-awesome',
+            'moment',
             'pouchdb-adapter-idb',
           ];
           return modulesToPatch.map(function(module) {
@@ -239,6 +241,9 @@ module.exports = function(grunt) {
             // patch font-awesome to remove version attributes so appcache works
             // https://github.com/FortAwesome/Font-Awesome/issues/3286
             'patch node_modules/font-awesome/less/path.less < patches/font-awesome-remove-version-attribute.patch',
+
+            // patch moment.js to use western arabic (european) numerals in Hindi
+            'patch node_modules/moment/locale/hi.js < patches/moment-hindi-use-euro-numerals.patch',
 
             // patch pouch to improve safari checks
             // https://github.com/medic/medic-webapp/issues/2797

--- a/patches/moment-hindi-use-euro-numerals.patch
+++ b/patches/moment-hindi-use-euro-numerals.patch
@@ -1,0 +1,63 @@
+*** node_modules/moment/locale/hi.js	2017-03-21 23:58:48.000000000 +0100
+--- patched_hi.js	2017-04-03 18:47:22.000000000 +0200
+***************
+*** 10,40 ****
+  }(this, (function (moment) { 'use strict';
+  
+  
+- var symbolMap = {
+-     '1': '१',
+-     '2': '२',
+-     '3': '३',
+-     '4': '४',
+-     '5': '५',
+-     '6': '६',
+-     '7': '७',
+-     '8': '८',
+-     '9': '९',
+-     '0': '०'
+- };
+- var numberMap = {
+-     '१': '1',
+-     '२': '2',
+-     '३': '3',
+-     '४': '4',
+-     '५': '5',
+-     '६': '6',
+-     '७': '7',
+-     '८': '8',
+-     '९': '9',
+-     '०': '0'
+- };
+- 
+  var hi = moment.defineLocale('hi', {
+      months : 'जनवरी_फ़रवरी_मार्च_अप्रैल_मई_जून_जुलाई_अगस्त_सितम्बर_अक्टूबर_नवम्बर_दिसम्बर'.split('_'),
+      monthsShort : 'जन._फ़र._मार्च_अप्रै._मई_जून_जुल._अग._सित._अक्टू._नव._दिस.'.split('_'),
+--- 10,15 ----
+***************
+*** 74,87 ****
+          yy : '%d वर्ष'
+      },
+      preparse: function (string) {
+!         return string.replace(/[१२३४५६७८९०]/g, function (match) {
+!             return numberMap[match];
+!         });
+      },
+      postformat: function (string) {
+!         return string.replace(/\d/g, function (match) {
+!             return symbolMap[match];
+!         });
+      },
+      // Hindi notation for meridiems are quite fuzzy in practice. While there exists
+      // a rigid notion of a 'Pahar' it is not used as rigidly in modern Hindi.
+--- 49,58 ----
+          yy : '%d वर्ष'
+      },
+      preparse: function (string) {
+!       return string;
+      },
+      postformat: function (string) {
+!       return string;
+      },
+      // Hindi notation for meridiems are quite fuzzy in practice. While there exists
+      // a rigid notion of a 'Pahar' it is not used as rigidly in modern Hindi.


### PR DESCRIPTION
Closes #3335 

An alternative to this would be to redefine our Hindi locale as e.g. `hi-u-nu-latn`, but @shreyakb is confident that no one ever uses Devanagari numbers when writing in Hindi.