### PR TITLE
Improve reuse rendering contact and report forms

### DIFF
--- a/static/js/controllers/contacts-edit.js
+++ b/static/js/controllers/contacts-edit.js
@@ -100,14 +100,19 @@ angular.module('inboxControllers').controller('ContactsEditCtrl',
             .addClass('disabled');
         return;
       }
-      return Enketo.renderFromXmlString(container, form, getFormInstanceData())
-        .then(function(form) {
-          $scope.enketoContact = {
-            type: $scope.contact.type,
-            formInstance: form,
-            docId: $scope.contactId,
-          };
-        });
+      var instanceData = getFormInstanceData();
+      if (form.id) {
+        return Enketo.render('#contact-form', form.id, instanceData);
+      }
+      return Enketo.renderFromXmlString('#contact-form', form.xml, instanceData);
+    };
+
+    var setEnketoContact = function(formInstance) {
+      $scope.enketoContact = {
+        type: $scope.contact.type,
+        formInstance: formInstance,
+        docId: $scope.contactId,
+      };
     };
 
     $scope.unmodifiedSchema = ContactSchema.get();
@@ -126,6 +131,7 @@ angular.module('inboxControllers').controller('ContactsEditCtrl',
       })
       .then(getForm)
       .then(renderForm)
+      .then(setEnketoContact)
       .then(function() {
         $scope.loadingContent = false;
       })

--- a/static/js/controllers/contacts-report.js
+++ b/static/js/controllers/contacts-report.js
@@ -7,7 +7,8 @@ angular.module('inboxControllers').controller('ContactsReportCtrl',
     DB,
     Enketo,
     Snackbar,
-    TranslateFrom
+    TranslateFrom,
+    XmlForm
   ) {
 
     'use strict';
@@ -22,11 +23,15 @@ angular.module('inboxControllers').controller('ContactsReportCtrl',
         source: 'contact',
         contact: doc,
       };
-      return Enketo
-        .render($('#contact-report'), $state.params.formId, instanceData)
+      return XmlForm($state.params.formId, { include_docs: true })
         .then(function(form) {
-          $scope.form = form;
-          $scope.loadingForm = false;
+          return Enketo
+            .render('#contact-report', form.id, instanceData)
+            .then(function(formInstance) {
+              $scope.setTitle(TranslateFrom(form.doc.title));
+              $scope.form = formInstance;
+              $scope.loadingForm = false;
+            });
         });
     };
 
@@ -64,14 +69,6 @@ angular.module('inboxControllers').controller('ContactsReportCtrl',
     DB()
       .get($state.params.id)
       .then(render)
-      .then(function() {
-        return DB().query('medic-client/forms', { include_docs: true, key: $state.params.formId });
-      })
-      .then(function(res) {
-        if (res.rows[0]) {
-          $scope.setTitle(TranslateFrom(res.rows[0].doc.title));
-        }
-      })
       .catch(function(err) {
         $log.error('Error loading form', err);
         $scope.contentError = true;

--- a/static/js/controllers/reports-add.js
+++ b/static/js/controllers/reports-add.js
@@ -4,12 +4,12 @@ angular.module('inboxControllers').controller('ReportsAddCtrl',
     $q,
     $scope,
     $state,
-    $timeout,
     $translate,
     DB,
     Enketo,
     FileReader,
-    Snackbar
+    Snackbar,
+    XmlForm
   ) {
 
     'ngInject';
@@ -58,19 +58,20 @@ angular.module('inboxControllers').controller('ReportsAddCtrl',
         // TODO: check doc.content as this is where legacy documents stored
         //       their XML. Consider removing this check at some point in the
         //       future.
-        return getReportContent(doc).then(function(content) {
-          $timeout(function() {
-            Enketo.render($('#report-form'), doc.form, content)
-              .then(function(form) {
-                $scope.form = form;
-                $scope.loadingContent = false;
-              })
-              .catch(function(err) {
-                $scope.loadingContent = false;
-                $scope.contentError = true;
-                $log.error('Error loading form.', err);
-              });
-          });
+        return $q.all([
+          getReportContent(doc),
+          XmlForm(doc.form, { include_docs: true })
+        ]).then(function(results) {
+          Enketo.render('#report-form', results[1].id, results[0])
+            .then(function(form) {
+              $scope.form = form;
+              $scope.loadingContent = false;
+            })
+            .catch(function(err) {
+              $scope.loadingContent = false;
+              $scope.contentError = true;
+              $log.error('Error loading form.', err);
+            });
         });
       })
       .catch(function(err) {

--- a/static/js/controllers/tasks-content.js
+++ b/static/js/controllers/tasks-content.js
@@ -7,7 +7,8 @@ angular.module('inboxControllers').controller('TasksContentCtrl',
     DB,
     Enketo,
     TranslateFrom,
-    Snackbar
+    Snackbar,
+    XmlForm
   ) {
 
     'use strict';
@@ -43,18 +44,14 @@ angular.module('inboxControllers').controller('TasksContentCtrl',
       if (action.type === 'report') {
         $scope.loadingForm = true;
         $scope.formId = action.form;
-        Enketo.render($('#task-report'), action.form, action.content)
-          .then(function(form) {
-            $scope.form = form;
-            $scope.loadingForm = false;
-          })
-          .then(function() {
-            return DB().query('medic-client/forms', { include_docs: true, key: action.form });
-          })
-          .then(function(res) {
-            if (res.rows[0]) {
-              $scope.setTitle(TranslateFrom(res.rows[0].doc.title));
-            }
+        XmlForm(action.form, { include_docs: true })
+          .then(function(formDoc) {
+            Enketo.render('#task-report', formDoc.id, action.content)
+              .then(function(formInstance) {
+                $scope.form = formInstance;
+                $scope.loadingForm = false;
+                $scope.setTitle(TranslateFrom(formDoc.doc.title));
+              });
           })
           .catch(function(err) {
             $scope.contentError = true;

--- a/static/js/services/enketo.js
+++ b/static/js/services/enketo.js
@@ -6,7 +6,6 @@ angular.module('inboxServices').service('Enketo',
     $translate,
     $window,
     AddAttachment,
-    Auth,
     DB,
     EnketoPrepopulationData,
     EnketoTranslation,
@@ -24,47 +23,30 @@ angular.module('inboxServices').service('Enketo',
     var FORM_ATTACHMENT_NAME = 'xml';
     var REPORT_ATTACHMENT_NAME = this.REPORT_ATTACHMENT_NAME = 'content';
 
-    var replaceJavarosaMediaWithLoaders = function(formInternalId, form) {
-      var mediaElements = form.find('img,video,audio');
-
-      if (!mediaElements.length) {
-        return;
-      }
-
-      DB().query('medic-client/forms', { key: formInternalId })
-        .then(function(res) {
-          if (!res.rows.length) {
-            throw new Error('Requested form not found');
-          }
-          var formDoc = res.rows[0];
-
-          mediaElements.each(function(i, elem) {
-            elem = $(elem);
-            var src = elem.attr('src');
-            if (!(/^jr:\/\//.test(src))) {
-              return;
-            }
-            // Change URL to fragment to prevent browser trying to load it
-            elem.attr('src', '#' + src);
-            elem.css('visibility', 'hidden');
-            elem.wrap('<div class="loader">');
-            DB()
-              .getAttachment(formDoc.id, src.substring(5))
-              .then(function(blob) {
-                var objUrl = ($window.URL || $window.webkitURL).createObjectURL(blob);
-                objUrls.push(objUrl);
-                elem.attr('src', objUrl);
-                elem.css('visibility', '');
-                elem.unwrap();
-              })
-              .catch(function(err) {
-                $log.error('Error fetching media file', formDoc.id, src, err);
-              });
+    var replaceJavarosaMediaWithLoaders = function(id, form) {
+      form.find('img,video,audio').each(function() {
+        var elem = $(this);
+        var src = elem.attr('src');
+        if (!(/^jr:\/\//.test(src))) {
+          return;
+        }
+        // Change URL to fragment to prevent browser trying to load it
+        elem.attr('src', '#' + src);
+        elem.css('visibility', 'hidden');
+        elem.wrap('<div class="loader">');
+        DB()
+          .getAttachment(id, src.substring(5))
+          .then(function(blob) {
+            var objUrl = ($window.URL || $window.webkitURL).createObjectURL(blob);
+            objUrls.push(objUrl);
+            elem.attr('src', objUrl);
+            elem.css('visibility', '');
+            elem.unwrap();
+          })
+          .catch(function(err) {
+            $log.error('Error fetching media file', id, src, err);
           });
-        })
-        .catch(function(err) {
-          $log.error('replaceJavarosaMediaWithLoaders', 'Error finding form by internal ID', formInternalId, err);
-        });
+      });
     };
 
     var transformXml = function(doc) {
@@ -74,11 +56,10 @@ angular.module('inboxServices').service('Enketo',
       ])
       .then(function(results) {
         var html = $(results[0]);
-        html.find('[data-i18n]')
-          .each(function() {
-            var $this = $(this);
-            $this.text($translate.instant('enketo.' + $this.attr('data-i18n')));
-          });
+        html.find('[data-i18n]').each(function() {
+          var $this = $(this);
+          $this.text($translate.instant('enketo.' + $this.attr('data-i18n')));
+        });
         return {
           html: html,
           model: results[1]
@@ -100,36 +81,26 @@ angular.module('inboxServices').service('Enketo',
     };
 
     var getFormXml = function(form, language) {
-      return DB().getAttachment(form.id, FORM_ATTACHMENT_NAME)
+      return DB().getAttachment(form._id, FORM_ATTACHMENT_NAME)
         .then(FileReader)
         .then(function(text) {
-          return translateXml(text, language, form.doc.title);
+          return translateXml(text, language, form.title);
         });
     };
 
-    var withFormByFormInternalId = function(formInternalId, language) {
-      if (!xmlCache[formInternalId]) {
-        xmlCache[formInternalId] = {};
+    var withForm = function(id, language) {
+      if (!xmlCache[id]) {
+        xmlCache[id] = {};
       }
-      if (!xmlCache[formInternalId][language]) {
-        xmlCache[formInternalId][language] = DB()
-          .query('medic-client/forms', { include_docs: true, key: formInternalId })
-          .then(function(res) {
-            if (!res.rows.length) {
-              throw new Error('Requested form not found: ' + formInternalId);
-            }
-            return res.rows[0];
-          })
+      if (!xmlCache[id][language]) {
+        xmlCache[id][language] = DB()
+          .get(id)
           .then(function(form) {
             return getFormXml(form, language);
           })
           .then(transformXml);
       }
-      return xmlCache[formInternalId][language];
-    };
-
-    var checkPermissions = function() {
-      return Auth('can_create_records').then(getUserContact);
+      return xmlCache[id][language];
     };
 
     var handleKeypressOnInputField = function(e) {
@@ -182,7 +153,8 @@ angular.module('inboxServices').service('Enketo',
       }
     };
 
-    var renderFromXmls = function(doc, wrapper, instanceData) {
+    var renderFromXmls = function(doc, selector, instanceData) {
+      var wrapper = $(selector);
       wrapper.find('.form-footer')
              .addClass('end')
              .find('.previous-page,.next-page')
@@ -250,11 +222,11 @@ angular.module('inboxServices').service('Enketo',
       });
     };
 
-    this.render = function(wrapper, formInternalId, instanceData) {
-      return checkPermissions()
+    this.render = function(selector, id, instanceData) {
+      return getUserContact()
         .then(Language)
         .then(function(language) {
-          return withFormByFormInternalId(formInternalId, language);
+          return withForm(id, language);
         })
         .then(function(doc) {
           // clone doc to avoid leaking of data between instances of a form
@@ -262,19 +234,20 @@ angular.module('inboxServices').service('Enketo',
             html: doc.html.clone(),
             model: doc.model,
           };
-          replaceJavarosaMediaWithLoaders(formInternalId, doc.html);
-          return renderFromXmls(doc, wrapper, instanceData);
+          replaceJavarosaMediaWithLoaders(id, doc.html);
+          return renderFromXmls(doc, selector, instanceData);
         });
     };
 
-    this.renderFromXmlString = function(wrapper, xmlString, instanceData) {
-      return Language()
+    this.renderFromXmlString = function(selector, xmlString, instanceData) {
+      return getUserContact()
+        .then(Language)
         .then(function(language) {
           return translateXml(xmlString, language);
         })
         .then(transformXml)
         .then(function(doc) {
-          return renderFromXmls(doc, wrapper, instanceData);
+          return renderFromXmls(doc, selector, instanceData);
         });
     };
 
@@ -293,19 +266,17 @@ angular.module('inboxServices').service('Enketo',
       });
     };
 
-    var update = function(formInternalId, record, docId) {
+    var update = function(docId) {
       // update an existing doc.  For convenience, get the latest version
       // and then modify the content.  This will avoid most concurrent
       // edits, but is not ideal.
-      return DB().get(docId)
-        .then(function(doc) {
-          // previously XML was stored in the content property
-          // TODO delete this and other "legacy" code support commited against
-          //      the same git commit at some point in the future?
-          delete doc.content;
-          return storeXMLRecord(doc, record);
-        })
-        .then(saveReport);
+      return DB().get(docId).then(function(doc) {
+        // previously XML was stored in the content property
+        // TODO delete this and other "legacy" code support commited against
+        //      the same git commit at some point in the future?
+        delete doc.content;
+        return doc;
+      });
     };
 
     var getUserContact = function() {
@@ -317,35 +288,34 @@ angular.module('inboxServices').service('Enketo',
       });
     };
 
-    var create = function(formInternalId, record) {
-      return getUserContact()
-        .then(function(contact) {
-          var doc = {
-            form: formInternalId,
-            type: 'data_record',
-            content_type: 'xml',
-            reported_date: Date.now(),
-            contact: contact,
-            from: contact && contact.phone
-          };
-          return storeXMLRecord(doc, record);
-        })
-        .then(saveReport);
+    var create = function(formInternalId) {
+      return getUserContact().then(function(contact) {
+        return {
+          form: formInternalId,
+          type: 'data_record',
+          content_type: 'xml',
+          reported_date: Date.now(),
+          contact: contact,
+          from: contact && contact.phone
+        };
+      });
     };
 
     this.save = function(formInternalId, form, docId) {
-      return $q.when(form.validate())
+      return $q.resolve(form.validate())
         .then(function(valid) {
           if (!valid) {
             throw new Error('Form is invalid');
           }
-          var record = form.getDataStr();
           if (docId) {
-            return update(formInternalId, record, docId);
-          } else {
-            return create(formInternalId, record);
+            return update(docId);
           }
-        });
+          return create(formInternalId);
+        })
+        .then(function(doc) {
+          return storeXMLRecord(doc, form.getDataStr());
+        })
+        .then(saveReport);
     };
 
     this.unload = function(form) {

--- a/static/js/services/index.js
+++ b/static/js/services/index.js
@@ -75,6 +75,7 @@
   require('./user');
   require('./user-contact');
   require('./web-worker');
+  require('./xml-form');
   require('./xml-forms');
   require('./xml-forms-context-utils');
   require('./xslt');

--- a/static/js/services/xml-form.js
+++ b/static/js/services/xml-form.js
@@ -1,0 +1,25 @@
+angular.module('inboxServices').factory('XmlForm',
+  function(
+    DB
+  ) {
+
+    'use strict';
+    'ngInject';
+
+    return function(internalId, options) {
+      options = options || {};
+      options.key = internalId;
+      return DB()
+        .query('medic-client/forms', options)
+        .then(function(result) {
+          if (!result.rows.length) {
+            throw new Error('No form found for internalId: ', internalId);
+          }
+          if (result.rows.length > 1) {
+            throw new Error('Multiple forms found for internalId: ', internalId);
+          }
+          return result.rows[0];
+        });
+    };
+  }
+);

--- a/tests/karma/unit/controllers/tasks-content.js
+++ b/tests/karma/unit/controllers/tasks-content.js
@@ -5,10 +5,12 @@ describe('TasksContentCtrl', function() {
       task,
       watchCallback,
       createController,
-      render;
+      render,
+      XmlForm;
 
   beforeEach(function() {
     render = sinon.stub();
+    XmlForm = sinon.stub();
     $scope = {
       $on: function() {},
       $watch: function(prop, cb) {
@@ -24,32 +26,39 @@ describe('TasksContentCtrl', function() {
       createController = function() {
         $controller('TasksContentCtrl', {
           $scope: $scope,
+          $q: Q,
           Enketo: { render: render },
           DB: sinon.stub(),
-          WatchDesignDoc: sinon.stub()
+          XmlForm: XmlForm
         });
       };
     });
   });
 
   afterEach(function() {
-    KarmaUtils.restore(render);
+    KarmaUtils.restore(render, XmlForm);
   });
 
   it('loads form when task has one action and no fields', function(done) {
     task = {
       actions: [{
         type: 'report',
-        form: 'A'
+        form: 'A',
+        content: 'nothing'
       }]
     };
+    XmlForm.returns(KarmaUtils.mockPromise(null, { id: 'myform', doc: { title: 'My Form' } }));
     createController();
     watchCallback();
     chai.expect($scope.formId).to.equal('A');
-    chai.expect($scope.loadingForm).to.equal(true);
-    chai.expect(render.callCount).to.equal(1);
-    chai.expect(render.getCall(0).args.length).to.equal(3);
-    done();
+    setTimeout(function() {
+      chai.expect(render.callCount).to.equal(1);
+      chai.expect(render.getCall(0).args.length).to.equal(3);
+      chai.expect(render.getCall(0).args[0]).to.equal('#task-report');
+      chai.expect(render.getCall(0).args[1]).to.equal('myform');
+      chai.expect(render.getCall(0).args[2]).to.equal('nothing');
+      done();
+    });
   });
 
   it('does not load form when task has more than one action', function(done) {


### PR DESCRIPTION
Refactor the Enketo service to promote code reuse so both contact and
report forms benefit from features like translation and xml caching.

Also various other code cleanups where appropriate.

medic/medic-webapp#3325