### PR TITLE
Don't clear selected if loading specific task

### DIFF
--- a/static/js/controllers/tasks.js
+++ b/static/js/controllers/tasks.js
@@ -27,13 +27,16 @@ var _ = require('underscore');
       };
 
       $scope.setSelected = function(id) {
-        var refreshing = ($scope.selected && $scope.selected._id) === id,
-            task = _.findWhere(LiveList.tasks.getList(), { _id: id });
+        if (!id) {
+          LiveList.tasks.clearSelected();
+          $scope.clearSelected();
+          return;
+        }
+        var task = _.findWhere(LiveList.tasks.getList(), { _id: id });
         if (task) {
+          var refreshing = ($scope.selected && $scope.selected._id) === id;
           $scope.settingSelected(refreshing);
           setSelectedTask(task);
-        } else {
-          $scope.clearSelected();
         }
       };
 


### PR DESCRIPTION
Because we load the livelist and the task report in parallel it's
highly likely the list won't contain the ID on page load. So instead of
clearing if the item isn't in the livelist, only clear if we haven't
been given an ID to select. This is consistent with other tabs.

medic/medic-webapp#3090