### PR TITLE
Stop setting language in a cookie

### DIFF
--- a/static/js/controllers/inbox.js
+++ b/static/js/controllers/inbox.js
@@ -38,7 +38,7 @@ var feedback = require('../modules/feedback'),
       Select2Search,
       SendMessage,
       Session,
-      SetLanguageCookie,
+      SetLanguage,
       Settings,
       Snackbar,
       Tour,
@@ -408,10 +408,7 @@ var feedback = require('../modules/feedback'),
       moment.locale(['en']);
 
       Language()
-        .then(function(language) {
-          moment.locale([language, 'en']);
-          $translate.use(language);
-        })
+        .then(SetLanguage)
         .catch(function(err) {
           $log.error('Error loading language', err);
         });

--- a/static/js/services/language.js
+++ b/static/js/services/language.js
@@ -5,30 +5,15 @@ var moment = require('moment');
   'use strict';
 
   var inboxServices = angular.module('inboxServices');
-  var localeCookieKey = 'locale';
-
-  inboxServices.factory('SetLanguageCookie',
-    function(
-      ipCookie
-    ) {
-      'ngInject';
-      return function(value) {
-        ipCookie(localeCookieKey, value, { expires: 365, path: '/' });
-        return value;
-      };
-    }
-  );
 
   inboxServices.factory('SetLanguage',
     function(
-      $translate,
-      SetLanguageCookie
+      $translate
     ) {
       'ngInject';
       return function(code) {
         moment.locale([code, 'en']);
         $translate.use(code);
-        SetLanguageCookie(code);
       };
     }
   );
@@ -37,14 +22,11 @@ var moment = require('moment');
     function(
       $q,
       ipCookie,
-      SetLanguageCookie,
       Settings,
       UserSettings
     ) {
-
       'ngInject';
-
-      var fetchLocale = function() {
+      return function () {
         return UserSettings()
           .then(function(user) {
             if (user && user.language) {
@@ -55,14 +37,6 @@ var moment = require('moment');
                 return settings.locale || 'en';
               });
           });
-      };
-
-      return function() {
-        var cookieVal = ipCookie(localeCookieKey);
-        if (cookieVal) {
-          return $q.resolve(cookieVal);
-        }
-        return fetchLocale().then(SetLanguageCookie);
       };
     }
   );

--- a/tests/karma/unit/controllers/inbox.js
+++ b/tests/karma/unit/controllers/inbox.js
@@ -92,7 +92,7 @@ describe('InboxCtrl controller', function() {
           init: sinon.stub()
         };
       });
-      $provide.factory('SetLanguageCookie', function() {
+      $provide.factory('SetLanguage', function() {
         return sinon.stub();
       });
       $provide.factory('Settings', function() {

--- a/tests/karma/unit/services/language.js
+++ b/tests/karma/unit/services/language.js
@@ -12,7 +12,6 @@ describe('Language service', function() {
     module(function($provide) {
       $provide.value('UserSettings', UserSettings);
       $provide.value('Settings', Settings);
-      $provide.value('ipCookie', ipCookie);
       $provide.value('$q', Q); // bypass $q so we don't have to digest
     });
     inject(function(_Language_) {
@@ -25,64 +24,34 @@ describe('Language service', function() {
   });
 
   it('uses the language configured in user', function(done) {
-    ipCookie.returns(null);
     UserSettings.returns(KarmaUtils.mockPromise(null, { language: 'latin' }));
     service().then(function(actual) {
       chai.expect(actual).to.equal('latin');
       chai.expect(UserSettings.callCount).to.equal(1);
       chai.expect(Settings.callCount).to.equal(0);
-      chai.expect(ipCookie.callCount).to.equal(2);
-      chai.expect(ipCookie.args[0][0]).to.equal('locale');
-      chai.expect(ipCookie.args[1][0]).to.equal('locale');
-      chai.expect(ipCookie.args[1][1]).to.equal('latin');
-      chai.expect(ipCookie.args[1][2]).to.deep.equal({ expires: 365, path: '/' });
       done();
     });
   });
 
   it('uses the language configured in settings', function(done) {
-    ipCookie.returns(null);
     UserSettings.returns(KarmaUtils.mockPromise(null, { }));
     Settings.returns(KarmaUtils.mockPromise(null, { locale: 'yiddish' }));
     service().then(function(actual) {
       chai.expect(actual).to.equal('yiddish');
       chai.expect(UserSettings.callCount).to.equal(1);
       chai.expect(Settings.callCount).to.equal(1);
-      chai.expect(ipCookie.callCount).to.equal(2);
-      chai.expect(ipCookie.args[0][0]).to.equal('locale');
-      chai.expect(ipCookie.args[1][0]).to.equal('locale');
-      chai.expect(ipCookie.args[1][1]).to.equal('yiddish');
-      chai.expect(ipCookie.args[1][2]).to.deep.equal({ expires: 365, path: '/' });
       done();
     });
   });
 
   it('defaults', function(done) {
-    ipCookie.returns(null);
     UserSettings.returns(KarmaUtils.mockPromise(null, { }));
     Settings.returns(KarmaUtils.mockPromise(null, { }));
     service().then(function(actual) {
       chai.expect(actual).to.equal('en');
       chai.expect(UserSettings.callCount).to.equal(1);
       chai.expect(Settings.callCount).to.equal(1);
-      chai.expect(ipCookie.callCount).to.equal(2);
-      chai.expect(ipCookie.args[0][0]).to.equal('locale');
-      chai.expect(ipCookie.args[1][0]).to.equal('locale');
-      chai.expect(ipCookie.args[1][1]).to.equal('en');
-      chai.expect(ipCookie.args[1][2]).to.deep.equal({ expires: 365, path: '/' });
       done();
     });
   });
-
-  it('uses cookie if set', function(done) {
-    ipCookie.returns('ca');
-    service().then(function(actual) {
-      chai.expect(UserSettings.callCount).to.equal(0);
-      chai.expect(Settings.callCount).to.equal(0);
-      chai.expect(ipCookie.callCount).to.equal(1);
-      chai.expect(actual).to.equal('ca');
-      done();
-    });
-  });
-
 });


### PR DESCRIPTION
Instead, always retrieve the language fresh from user settings. This
results in more than one user with a different language being able to
share a browser. It also means that a language won't get "stuck" on
one browser if you change language in another.

medic/medic-webapp#3279