### PR TITLE
Bump enketo-xslt version to fix firefox bug

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -587,9 +587,9 @@
       "resolved": "http://registry.npmjs.org/make-plural/-/make-plural-3.0.6.tgz"
     },
     "medic-enketo-xslt": {
-      "version": "1.1.0",
-      "from": "medic-enketo-xslt@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/medic-enketo-xslt/-/medic-enketo-xslt-1.1.0.tgz"
+      "version": "1.1.1",
+      "from": "medic-enketo-xslt@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/medic-enketo-xslt/-/medic-enketo-xslt-1.1.1.tgz"
     },
     "mergexml": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "font-awesome": "^4.7.0",
     "google-libphonenumber": "^2.0.14",
     "jquery": "^3.2.1",
-    "medic-enketo-xslt": "^1.0.0",
+    "medic-enketo-xslt": "^1.1.1",
     "messageformat": "^1.0.0",
     "moment": "^2.17.1",
     "nools": "^0.4.4",


### PR DESCRIPTION
The XSL stylesheet was mistakenly marked as XSL version 1.0, which caused
Firefox to reject it.

Closes #3354