### PR TITLE
Rename clinic filter to lineage.

### DIFF
--- a/static/js/filters/message.js
+++ b/static/js/filters/message.js
@@ -64,7 +64,17 @@ var format = require('../modules/format'),
   ) {
     'ngInject';
     return function(entity) {
-      return format.clinic(entity, $state);
+      console.log('`clinic` filter is deprecated. Use `lineage` filter instead.');
+      return format.lineage(entity, $state);
+    };
+  });
+
+  module.filter('lineage', function(
+    $state
+  ) {
+    'ngInject';
+    return function(entity) {
+      return format.lineage(entity, $state);
     };
   });
 

--- a/static/js/filters/message.js
+++ b/static/js/filters/message.js
@@ -60,11 +60,12 @@ var format = require('../modules/format'),
   });
 
   module.filter('clinic', function(
+    $log,
     $state
   ) {
     'ngInject';
     return function(entity) {
-      console.log('`clinic` filter is deprecated. Use `lineage` filter instead.');
+      $log.warn('`clinic` filter is deprecated. Use `lineage` filter instead.');
       return format.lineage(entity, $state);
     };
   });

--- a/static/js/modules/format.js
+++ b/static/js/modules/format.js
@@ -4,7 +4,7 @@ var _ = require('underscore');
 
   'use strict';
 
-  exports.clinic = function(entity, $state) {
+  exports.lineage = function(entity, $state) {
     var parts;
     if (_.isArray(entity)) {
       parts = entity;
@@ -33,6 +33,9 @@ var _ = require('underscore');
     return '<ol class="horizontal lineage">' + items.join('') + '</ol>';
   };
 
+  // Deprecated, use lineage filter instead.
+  exports.clinic = exports.lineage;
+
   exports.sender = function(options) {
     var parts = [];
     if (options.name) {
@@ -41,7 +44,7 @@ var _ = require('underscore');
     if (options.phone) {
       parts.push('<span>' + _.escape(options.phone) + '</span>');
     }
-    var position = exports.clinic(options.parent);
+    var position = exports.lineage(options.parent);
     if (position) {
       parts.push('<div class="position">' + position + '</div>');
     }


### PR DESCRIPTION
Seems like the name is some legacy situation : it's not limited to clinics anyway.

Kept the old name as legacy cos filter are used in unexpected places, it's hard to track down. `contact_summary`s use it for instance.