### PR TITLE
Use unicode code point for bullet in CSS. #3020

### DIFF
--- a/static/css/inbox.less
+++ b/static/css/inbox.less
@@ -1261,7 +1261,7 @@ a.fa:hover {
 .lineage {
   margin-bottom: 0;
   li:after {
-    content: "•";
+    content: "\2022"; /* bullet */
     padding: 0 5px;
   }
 }


### PR DESCRIPTION
Attempt to fix issue where bullet is sometimes rendered as å€¢.

#3020