### PR TITLE
app_setting translation import / export fixes

### DIFF
--- a/static/js/services/outgoing-messages-configuration.js
+++ b/static/js/services/outgoing-messages-configuration.js
@@ -14,12 +14,17 @@ var _ = require('underscore');
       var mapGroupModel = function(translations, path, labelParts) {
         return {
           label: labelParts.join(' › '),
-          translations: _.map(translations, function(translation, index) {
-            return {
-              path: path + '[' + index + ']',
-              translations: translation.message
-            };
-          })
+          translations: _.chain(translations)
+            .filter(function(translation) {
+              return translation && translation.message;
+            })
+            .map(function(translation, index) {
+              return {
+                path: path + '[' + index + ']',
+                translations: translation.message
+              };
+            })
+            .value()
         };
       };
 
@@ -91,4 +96,4 @@ var _ = require('underscore');
     }
   );
 
-}()); 
+}());

--- a/static/js/services/properties.js
+++ b/static/js/services/properties.js
@@ -35,7 +35,9 @@ var _ = require('underscore'),
         return Settings()
           .then(function(settings) {
             var updated = false;
-            _.pairs(parsed).forEach(function(pair) {
+            _.pairs(parsed).filter(function(pair) {
+              return pair && pair[0] && pair[1];
+            }).forEach(function(pair) {
               var setting = objectpath.get(settings, pair[0]);
               if (setting) {
                 mergeTranslation(setting.message, locale, pair[1]);
@@ -127,4 +129,4 @@ var _ = require('underscore'),
     }
   );
 
-}()); 
+}());

--- a/tests/karma/unit/services/import-properties.js
+++ b/tests/karma/unit/services/import-properties.js
@@ -142,7 +142,6 @@ describe('ImportProperties service', function() {
     return service(content, doc).then(() => {
       chai.expect(put.callCount).to.equal(0);
       chai.expect(UpdateSettings.args[0][0]).to.deep.equal(expected(e => {
-        console.log(e);
         e.registrations[0].validations.list[2] = {
           translation_key: 'test.translation.key'
         };

--- a/tests/karma/unit/services/outgoing-messages-configuration.js
+++ b/tests/karma/unit/services/outgoing-messages-configuration.js
@@ -11,12 +11,9 @@ describe('OutgoingMessagesConfiguration service', function() {
     });
   });
 
-  it('creates models', function(done) {
-
+  it('creates models', function() {
     var actual = service(exampleSettings);
-    chai.expect(actual).to.deep.equal(expected);
-    done();
-
+    chai.expect(JSON.stringify(actual)).to.equal(JSON.stringify(expected));
   });
 
   var expected = [
@@ -306,6 +303,11 @@ describe('OutgoingMessagesConfiguration service', function() {
                   locale: 'sw'
                 }
               ]
+            },
+            {
+              translation_key: 'test.translation.key',
+              property: 'test_property',
+              rule: ''
             }
           ]
         },


### PR DESCRIPTION
In medic/medic-webapp#3127 support is added for moving message
translation out of app_settings into the standard translation files.

Here, we add support for this change in import and export functions.

Translation export no longer exports when the translation is actually in
the translation file. This stop empty lines with a key but no value
appearing in translation files.

Translation import ignores translation lines when importing into
app_settings, so as to not break on exports generated prior to this
change.

medic/medic-webapp#3350