### PR TITLE
Fix typo in API port number in Protractor auth module

### DIFF
--- a/tests/protractor/constants.js
+++ b/tests/protractor/constants.js
@@ -1,5 +1,5 @@
 module.exports = {
-  API_PORT: 5998,
+  API_PORT: 5988,
   API_HOST: 'localhost',
 
   COUCH_PORT: 5984,


### PR DESCRIPTION
Is this a mistake?