### PR TITLE
Identify if a doc is unsaved by checking rev, not id

### DIFF
--- a/static/js/controllers/contacts-edit.js
+++ b/static/js/controllers/contacts-edit.js
@@ -236,8 +236,11 @@ angular.module('inboxControllers').controller('ContactsEditCtrl',
     // referenced by _id by other docs if required.
     function prepare(doc) {
       if(!doc._id) {
-        doc.reported_date = Date.now();
         doc._id = uuidV4();
+      }
+
+      if (!doc._rev) {
+        doc.reported_date = Date.now();
       }
 
       return doc;


### PR DESCRIPTION
As per https://github.com/medic/medic-webapp/issues/2912#issuecomment-299800741

While this does relate to #2912, I think the change is generally more correct.  Adding it to #2912 will significantly delay and obscure it, hence separate PR.