### PR TITLE
Hide the date filter button from the filter bar on small screens

### DIFF
--- a/static/css/inbox.less
+++ b/static/css/inbox.less
@@ -1371,6 +1371,9 @@ a.fa:hover {
     .reset-filter {
       float: right;
     }
+    #dateRangeDropdown {
+      display: none;
+    }
   }
   .header {
     font-size: 0.65em;


### PR DESCRIPTION
The small filter doesn't work.  It needs to be fixed in the future, but hiding
it hides the problem.

Closes #3467