### PR TITLE
Allow creation of multiple docs from a single XForm

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -83,6 +83,7 @@ module.exports = function(grunt) {
         jshintrc: true,
         reporter: require('jshint-stylish'),
         ignores: [
+          'static/js/modules/xpath-element-path.js',
           'tests/karma/q.js'
         ]
       },

--- a/static/js/controllers/contacts-report.js
+++ b/static/js/controllers/contacts-report.js
@@ -44,8 +44,8 @@ angular.module('inboxControllers').controller('ContactsReportCtrl',
       $scope.enketoStatus.saving = true;
       $scope.enketoStatus.error = null;
       Enketo.save($state.params.formId, $scope.form)
-        .then(function(doc) {
-          $log.debug('saved report', doc);
+        .then(function(docs) {
+          $log.debug('saved report and associated docs', docs);
           $scope.enketoStatus.saving = false;
           $translate('report.created').then(Snackbar);
           $state.go('contacts.detail', { id: $state.params.id });

--- a/static/js/controllers/reports-add.js
+++ b/static/js/controllers/reports-add.js
@@ -89,12 +89,12 @@ angular.module('inboxControllers').controller('ReportsAddCtrl',
       $scope.enketoStatus.error = null;
       var doc = $scope.selected[0].report;
       Enketo.save(doc.form, $scope.form, doc._id)
-        .then(function(doc) {
-          $log.debug('saved report', doc);
+        .then(function(docs) {
+          $log.debug('saved report and associated docs', docs);
           $scope.enketoStatus.saving = false;
           $translate($state.params.reportId ? 'report.updated' : 'report.created')
             .then(Snackbar);
-          $state.go('reports.detail', { id: doc._id });
+          $state.go('reports.detail', { id: docs[0]._id });
         })
         .catch(function(err) {
           $scope.enketoStatus.saving = false;

--- a/static/js/controllers/tasks-content.js
+++ b/static/js/controllers/tasks-content.js
@@ -72,8 +72,8 @@ angular.module('inboxControllers').controller('TasksContentCtrl',
       $scope.enketoStatus.saving = true;
       $scope.enketoStatus.error = null;
       Enketo.save($scope.formId, $scope.form)
-        .then(function(doc) {
-          $log.debug('saved report', doc);
+        .then(function(docs) {
+          $log.debug('saved report and associated docs', docs);
           $translate('report.created').then(Snackbar);
           $scope.enketoStatus.saving = false;
           Enketo.unload($scope.form);

--- a/static/js/modules/xpath-element-path.js
+++ b/static/js/modules/xpath-element-path.js
@@ -1,0 +1,61 @@
+/*
+ * Simple module for calculating XPath of an element using the browser's built-
+ * in XML support.
+ *
+ * Copyright (c) 2009, Mozilla Foundation
+ *
+ * Taken from Firebug, licensed under BSD:
+ * https://github.com/firebug/firebug/blob/master/extension/content/firebug/lib/xpath.js
+ */
+
+var Xpath = {};
+
+// ********************************************************************************************* //
+// XPATH
+
+/**
+ * Gets an XPath for an element which describes its hierarchical location.
+ */
+Xpath.getElementXPath = function(element)
+{
+    if (element && element.id)
+        return '//*[@id="' + element.id + '"]';
+    else
+        return Xpath.getElementTreeXPath(element);
+};
+
+Xpath.getElementTreeXPath = function(element)
+{
+    var paths = [];
+
+    // Use nodeName (instead of localName) so namespace prefix is included (if any).
+    for (; element && element.nodeType == Node.ELEMENT_NODE; element = element.parentNode)
+    {
+        var index = 0;
+        var hasFollowingSiblings = false;
+        for (var sibling = element.previousSibling; sibling; sibling = sibling.previousSibling)
+        {
+            // Ignore document type declaration.
+            if (sibling.nodeType == Node.DOCUMENT_TYPE_NODE)
+                continue;
+
+            if (sibling.nodeName == element.nodeName)
+                ++index;
+        }
+
+        for (var sibling = element.nextSibling; sibling && !hasFollowingSiblings;
+            sibling = sibling.nextSibling)
+        {
+            if (sibling.nodeName == element.nodeName)
+                hasFollowingSiblings = true;
+        }
+
+        var tagName = (element.prefix ? element.prefix + ":" : "") + element.localName;
+        var pathIndex = (index || hasFollowingSiblings ? "[" + (index + 1) + "]" : "");
+        paths.splice(0, 0, tagName + pathIndex);
+    }
+
+    return paths.length ? "/" + paths.join("/") : null;
+};
+
+module.exports = Xpath.getElementXPath;

--- a/static/js/services/enketo-translation.js
+++ b/static/js/services/enketo-translation.js
@@ -254,6 +254,11 @@ angular.module('inboxServices').service('EnketoTranslation', [
       var fields = {};
       withElements(data)
         .each(function(n) {
+          var dbDocAttribute = n.attributes.getNamedItem('db-doc');
+          if (dbDocAttribute && dbDocAttribute.value === 'true') {
+            return;
+          }
+
           var hasChildren = withElements(n.childNodes).size().value();
           if(hasChildren) {
             fields[n.nodeName] = nodesToJs(n.childNodes);

--- a/static/js/services/enketo.js
+++ b/static/js/services/enketo.js
@@ -1,3 +1,6 @@
+var uuid = require('uuid/v4');
+var xpathPath = require('../modules/xpath-element-path');
+
 /* globals EnketoForm */
 angular.module('inboxServices').service('Enketo',
   function(
@@ -258,19 +261,74 @@ angular.module('inboxServices').service('Enketo',
         });
     };
 
-    var storeXMLRecord = function(doc, record) {
+    var xmlToDocs = function(doc, record) {
+      var docsToStore = [], recordDoc, $record;
+
+      function mapOrAssignId(e, id) {
+        var $e, $id;
+
+        if (!id) {
+          $e = $(e);
+          $id = $e.children('_id');
+
+          if ($id.length) {
+            id = $id.text();
+          }
+
+          if (!id) {
+            id = uuid();
+          }
+        }
+
+        e._couchId = id;
+      }
+
+      function getId(xpath) {
+        return recordDoc.evaluate(xpath, recordDoc, null, XPathResult.ANY_TYPE, null)
+            .iterateNext()._couchId;
+      }
+
+      recordDoc = $.parseXML(record);
+      $record = $($(recordDoc).children()[0]);
+      mapOrAssignId($record[0], doc._id || uuid());
+
+      $record.find('[db-doc=true]').each(function() {
+        mapOrAssignId(this);
+      });
+
+      $record.find('[db-doc-ref]').each(function() {
+        var $ref = $(this);
+        var refId = getId($ref.attr('db-doc-ref'));
+        $ref.text(refId);
+      });
+
+      $record.find('[db-doc=true]').each(function() {
+        var docToStore = EnketoTranslation.reportRecordToJs(this.outerHTML);
+        docToStore._id = getId(xpathPath(this));
+        docsToStore.push(docToStore);
+      });
+
+      record = $record[0].outerHTML;
+
       AddAttachment(doc, REPORT_ATTACHMENT_NAME, record, 'application/xml');
+      doc._id = getId('/*');
       doc.fields = EnketoTranslation.reportRecordToJs(record);
       doc.hidden_fields = EnketoTranslation.getHiddenFieldList(record);
-      return doc;
+
+      docsToStore.unshift(doc);
+
+      return docsToStore;
     };
 
-    var saveReport = function(doc) {
-      return DB().post(doc).then(function(res) {
-        doc._id = res.id;
-        doc._rev = res.rev;
-        return doc;
-      });
+    var saveDocs = function(docs) {
+      return $q.all(docs.map(function(doc) {
+        return DB()
+          .put(doc)
+          .then(function(res) {
+            doc._rev = res.rev;
+            return doc;
+          });
+      }));
     };
 
     var update = function(docId) {
@@ -331,9 +389,9 @@ angular.module('inboxServices').service('Enketo',
           return create(formInternalId);
         })
         .then(function(doc) {
-          return storeXMLRecord(doc, form.getDataStr());
+          return xmlToDocs(doc, form.getDataStr());
         })
-        .then(saveReport);
+        .then(saveDocs);
     };
 
     this.unload = function(form) {


### PR DESCRIPTION
TODO before merging:
- [ ] test it locally
- [x] write a decent commit message explaining the feature.  can probably come from the original ticket



Extensions to the form Model:

## Extra docs

* extra docs can be added by defining structures in the model with the attribute `db-doc="true"`, e.g.:

### Example Form Model

```
<data>
  <root_prop_1>val A</root_prop_1>
  <other_doc db-doc="true">
    <type>whatever</type>
    <other_prop>val B</other_prop>
  </other_doc>
</data>
```

### Resulting docs

Report (as before):
```
{
  _id: '...',
  _rev: '...',
  type: 'report',
  _attachments: { xml: ... ],
  fields: {
    root_prop_1: 'val A',
  }
}
```

Other doc:
```
{
  _id: '...',
  _rev: '...',
  type: 'whatever',
  other_prop: 'val B',
}
```
## Linked docs

* linked docs can be referred to using the `doc-ref` attribute, with an xpath.  This can be done at any point in the model, e.g.:

### Example Form Model

```
<sickness>
  <sufferer doc-ref="/sickness/new">
  <new db-doc="true">
    <type>person</type>
    <name>Gómez</name>
    <original_report db-ref="/sickness"/>
  </new>
</sickness>
```

### Resulting docs

Report:
```
{
  _id: 'abc-123',
  _rev: '...',
  type: 'report',
  _attachments: { xml: ... ],
  fields: {
    sufferer: 'def-456',
  }
}
```

Other doc:
```
{
  _id: 'def-456',
  _rev: '...',
  type: 'person',
  name: 'Gómez',
  original_report: 'abc-123',
}
```


## Repeated docs

* can have references to other docs, including the parent
* these currently cannot be linked from other docs, as no provision is made for indexing these docs

### Example Form

```
<thing>
  <name>Ab</name>
  <related db-doc="true">
    <type>relative</type>
    <name>Bo</name>
    <parent db-ref="/thing"/>
  </related>
  <related db-doc="true">
    <type>relative</type>
    <name>Ca</name>
    <parent db-ref="/thing"/>
  </related>
</artist>
```

### Resulting docs

Report:
```
{
  _id: 'abc-123',
  _rev: '...',
  type: 'report',
  _attachments: { xml: ... ],
  fields: {
    name: 'Ab',
  }
}
```

Other docs:
```
{
  _id: '...',
  _rev: '...',
  type: 'relative',
  name: 'Bo',
  parent: 'abc-123',
}
{
  _id: '...',
  _rev: '...',
  type: 'relative',
  name: 'Ch',
  parent: 'abc-123',
}
```

Closes #2912 