### PR TITLE
Fixes daterangepicker on mobile 

### DIFF
--- a/static/js/services/search-filters.js
+++ b/static/js/services/search-filters.js
@@ -155,50 +155,42 @@ var _ = require('underscore'),
       };
 
       var initDate = function(callback) {
-        $translate.onReady().then(function() {
-          $('#date-filter').daterangepicker({
-            startDate: moment().subtract(1, 'months'),
-            endDate: moment(),
-            maxDate: moment(),
-            opens: 'center',
-            applyClass: 'btn-primary',
-            cancelClass: 'btn-link',
-            locale: {
-              applyLabel: $translate.instant('Apply'),
-              cancelLabel: $translate.instant('Cancel'),
-              fromLabel: $translate.instant('date.from'),
-              toLabel: $translate.instant('date.to'),
-              daysOfWeek: moment.weekdaysMin(),
-              monthNames: moment.monthsShort(),
-              firstDay: moment.localeData()._week.dow
-            }
-          },
-          function(start, end) {
-            callback({
-              from: start.valueOf(),
-              to: end.valueOf()
-            });
-          })
-          .on('show.daterangepicker', function(e, picker) {
-            setTimeout(function() {
-              if ($('#dateRangeDropdown').is('.disabled')) {
-                picker.hide();
-              }
-            });
-          })
-          .on('mm.dateSelected.daterangepicker', function(e, picker) {
-            if (isMobile()) {
-              // mobile version - only show one calendar at a time
-              if (picker.container.is('.show-from')) {
-                picker.container.removeClass('show-from').addClass('show-to');
-              } else {
-                picker.container.removeClass('show-to').addClass('show-from');
-                picker.hide();
-              }
+        $('#date-filter').daterangepicker({
+          startDate: moment().subtract(1, 'months'),
+          endDate: moment(),
+          maxDate: moment(),
+          opens: 'center',
+          autoApply: true,
+          locale: {
+            daysOfWeek: moment.weekdaysMin(),
+            monthNames: moment.monthsShort(),
+            firstDay: moment.localeData()._week.dow
+          }
+        },
+        function(start, end) {
+          callback({
+            from: start.valueOf(),
+            to: end.valueOf()
+          });
+        })
+        .on('show.daterangepicker', function(e, picker) {
+          setTimeout(function() {
+            if ($('#dateRangeDropdown').is('.disabled')) {
+              picker.hide();
             }
           });
-          $('.daterangepicker').addClass('filter-daterangepicker mm-dropdown-menu show-from');
+        })
+        .on('mm.dateSelected.daterangepicker', function(e, picker) {
+          if (isMobile()) {
+            // mobile version - only show one calendar at a time
+            if (picker.container.is('.show-from')) {
+              picker.container.removeClass('show-from').addClass('show-to');
+            } else {
+              picker.container.removeClass('show-to').addClass('show-from');
+            }
+          }
         });
+        $('.daterangepicker').addClass('filter-daterangepicker mm-dropdown-menu show-from');
       };
 
       return {

--- a/tests/protractor/e2e/report-date-filter.js
+++ b/tests/protractor/e2e/report-date-filter.js
@@ -1,7 +1,7 @@
 var utils = require('../utils'),
     moment = require('moment');
 
-describe('Bulk delete reports', function() {
+describe('Filters reports', function() {
 
   'use strict';
 
@@ -107,7 +107,7 @@ describe('Bulk delete reports', function() {
       .then(done, done);
   });
 
-  it('reports', function() {
+  it('by date', function() {
     element(by.id('reports-tab')).click();
 
     // refresh - live list only updates on changes but changes are disabled for e2e
@@ -123,8 +123,8 @@ describe('Bulk delete reports', function() {
 
     element(by.css('#date-filter')).click();
     element(by.css('.daterangepicker [name="daterangepicker_start"]')).click().sendKeys(clear + '05/16/2016');
-    element(by.css('.daterangepicker [name="daterangepicker_end"]')).click().sendKeys(clear + '05/17/2016');
-    element(by.css('.daterangepicker .applyBtn')).click();
+    element(by.css('.daterangepicker [name="daterangepicker_end"]')).click().sendKeys(clear + '05/17/2016' + protractor.Key.ENTER);
+    element(by.css('#freetext')).click(); // blur the datepicker
 
     browser.wait(function() {
       return browser.isElementPresent(by.css('#reports-list .filtered li:first-child'));


### PR DESCRIPTION
Our custom mobile daterangepicker was broken by an update in the
daterangepicker library at some point. This modifies our custom code
to no longer hide the picker and lets the library do that automatically
via a new 'autoApply' option which selects as soon as the end date is
selected. This also applies to the desktop but it's an improvement
there as well I think.

Also removes a bunch of translations which are no longer used.

medic/medic-webapp#3467