### PR TITLE
Include a list of installed xforms on the forms config page

### DIFF
--- a/static/js/controllers/configuration-forms.js
+++ b/static/js/controllers/configuration-forms.js
@@ -26,7 +26,8 @@ var moment = require('moment'),
       FileReader,
       JsonParse,
       Settings,
-      UpdateSettings
+      UpdateSettings,
+      XmlForms
     ) {
 
       'ngInject';
@@ -166,6 +167,13 @@ var moment = require('moment'),
         .catch(function(err) {
           $log.error('Error fetching settings', err);
         });
+
+      XmlForms('configuration-forms', { ignoreContext:true }, function(err, forms) {
+        if (err) {
+          return console.log('Error fetching XForms for form config page.', err);
+        }
+        $scope.xForms = forms;
+      });
     }
   );
 

--- a/templates/partials/configuration_forms.html
+++ b/templates/partials/configuration_forms.html
@@ -26,6 +26,19 @@
     </div>
   </form>
 
+  <div class="section">
+    <fieldset>
+      <legend translate>Installed Forms</legend>
+      <ul>
+        <li ng-repeat="form in xForms">
+          <a href="/_utils/#database/medic/{{form._id}}">
+            {{form.title}}
+          </a>
+        </li>
+      </ul>
+    </fieldset>
+  </div>
+
   <form id="forms-upload-json">
     <div>
       <fieldset>

--- a/templates/partials/configuration_forms.html
+++ b/templates/partials/configuration_forms.html
@@ -31,16 +31,8 @@
       <legend translate>Installed Forms</legend>
       <ul>
         <li ng-repeat="form in xForms" class="row">
-          <div class="col-sm-6">
-            <a href="/_utils/#database/medic/{{form._id}}">
-              {{form._id}}
-            </a>
-          </div>
-          <div class="col-sm-6">
-            <a href="/_utils/#database/medic/{{form._id}}">
-              {{form.title}}
-            </a>
-          </div>
+          <div class="col-sm-6">{{form._id}}</div>
+          <div class="col-sm-6">{{form.title}}</div>
         </li>
       </ul>
     </fieldset>

--- a/templates/partials/configuration_forms.html
+++ b/templates/partials/configuration_forms.html
@@ -30,10 +30,17 @@
     <fieldset>
       <legend translate>Installed Forms</legend>
       <ul>
-        <li ng-repeat="form in xForms">
-          <a href="/_utils/#database/medic/{{form._id}}">
-            {{form.title}}
-          </a>
+        <li ng-repeat="form in xForms" class="row">
+          <div class="col-sm-6">
+            <a href="/_utils/#database/medic/{{form._id}}">
+              {{form._id}}
+            </a>
+          </div>
+          <div class="col-sm-6">
+            <a href="/_utils/#database/medic/{{form._id}}">
+              {{form.title}}
+            </a>
+          </div>
         </li>
       </ul>
     </fieldset>


### PR DESCRIPTION
The futon links look a bit dodgy right now, and possibly only work for couch 2.  Would be possible to make a futon link service or something, but seems like a lot of effort.  In fact, in hindsight, linking straight to the "forms" view in futon might be as helpful as this change.