### PR TITLE
Adds a listener to Enketo to notify on change

### DIFF
--- a/static/js/controllers/contacts-edit.js
+++ b/static/js/controllers/contacts-edit.js
@@ -94,6 +94,10 @@ angular.module('inboxControllers').controller('ContactsEditCtrl',
       return $q.resolve();
     };
 
+    var markFormEdited = function() {
+      $scope.enketoStatus.edited = true;
+    };
+
     var renderForm = function(form) {
       return $timeout(function() {
         var container = $('#contact-form');
@@ -106,9 +110,9 @@ angular.module('inboxControllers').controller('ContactsEditCtrl',
         }
         var instanceData = getFormInstanceData();
         if (form.id) {
-          return Enketo.renderContactForm('#contact-form', form.id, instanceData);
+          return Enketo.renderContactForm('#contact-form', form.id, instanceData, markFormEdited);
         }
-        return Enketo.renderFromXmlString('#contact-form', form.xml, instanceData);
+        return Enketo.renderFromXmlString('#contact-form', form.xml, instanceData, markFormEdited);
       });
     };
 

--- a/static/js/controllers/contacts-edit.js
+++ b/static/js/controllers/contacts-edit.js
@@ -108,6 +108,7 @@ angular.module('inboxControllers').controller('ContactsEditCtrl',
               .addClass('disabled');
           return;
         }
+        $scope.enketoStatus.edited = false;
         var instanceData = getFormInstanceData();
         if (form.id) {
           return Enketo.renderContactForm('#contact-form', form.id, instanceData, markFormEdited);

--- a/static/js/controllers/contacts-report.js
+++ b/static/js/controllers/contacts-report.js
@@ -29,6 +29,7 @@ angular.module('inboxControllers').controller('ContactsReportCtrl',
       };
       return XmlForm($state.params.formId, { include_docs: true })
         .then(function(form) {
+          $scope.enketoStatus.edited = false;
           return Enketo
             .render('#contact-report', form.id, instanceData, markFormEdited)
             .then(function(formInstance) {

--- a/static/js/controllers/contacts-report.js
+++ b/static/js/controllers/contacts-report.js
@@ -14,6 +14,10 @@ angular.module('inboxControllers').controller('ContactsReportCtrl',
     'use strict';
     'ngInject';
 
+    var markFormEdited = function() {
+      $scope.enketoStatus.edited = true;
+    };
+
     var render = function(doc) {
       $scope.setSelected({ doc: doc });
       $scope.setCancelTarget(function() {
@@ -26,7 +30,7 @@ angular.module('inboxControllers').controller('ContactsReportCtrl',
       return XmlForm($state.params.formId, { include_docs: true })
         .then(function(form) {
           return Enketo
-            .render('#contact-report', form.id, instanceData)
+            .render('#contact-report', form.id, instanceData, markFormEdited)
             .then(function(formInstance) {
               $scope.setTitle(TranslateFrom(form.doc.title));
               $scope.form = formInstance;

--- a/static/js/controllers/inbox.js
+++ b/static/js/controllers/inbox.js
@@ -156,18 +156,28 @@ var feedback = require('../modules/feedback'),
 
       // User wants to cancel current flow, or pressed back button, etc.
       $scope.navigationCancel = function() {
-        if (!$scope.enketoStatus.saving) {
-          Modal({
-            templateUrl: 'templates/modals/navigation_confirm.html',
-            controller: 'NavigationConfirmCtrl',
-            singleton: true
-          })
-          .then(function() {
-            if ($scope.cancelCallback) {
-              $scope.cancelCallback();
-            }
-          });
+        if ($scope.enketoStatus.saving) {
+          // wait for save to finish
+          return;
         }
+        if (!$scope.enketoStatus.edited) {
+          // form hasn't been modified - return immediately
+          if ($scope.cancelCallback) {
+            $scope.cancelCallback();
+          }
+          return;
+        }
+        // otherwise data will be discarded so confirm navigation
+        Modal({
+          templateUrl: 'templates/modals/navigation_confirm.html',
+          controller: 'NavigationConfirmCtrl',
+          singleton: true
+        })
+        .then(function() {
+          if ($scope.cancelCallback) {
+            $scope.cancelCallback();
+          }
+        });
       };
 
       /**

--- a/static/js/controllers/reports-add.js
+++ b/static/js/controllers/reports-add.js
@@ -62,6 +62,10 @@ angular.module('inboxControllers').controller('ReportsAddCtrl',
         .then(FileReader);
     };
 
+    var markFormEdited = function() {
+      $scope.enketoStatus.edited = true;
+    };
+
     getSelected()
       .then(function(model) {
         $log.debug('setting selected', model);
@@ -70,7 +74,8 @@ angular.module('inboxControllers').controller('ReportsAddCtrl',
           getReportContent(model.doc),
           XmlForm(model.formInternalId, { include_docs: true })
         ]).then(function(results) {
-          Enketo.render('#report-form', results[1].id, results[0])
+          $scope.enketoStatus.edited = false;
+          Enketo.render('#report-form', results[1].id, results[0], markFormEdited)
             .then(function(form) {
               $scope.form = form;
               $scope.loadingContent = false;

--- a/static/js/controllers/tasks-content.js
+++ b/static/js/controllers/tasks-content.js
@@ -50,6 +50,7 @@ angular.module('inboxControllers').controller('TasksContentCtrl',
         $scope.formId = action.form;
         XmlForm(action.form, { include_docs: true })
           .then(function(formDoc) {
+            $scope.enketoStatus.edited = false;
             Enketo.render('#task-report', formDoc.id, action.content, markFormEdited)
               .then(function(formInstance) {
                 $scope.form = formInstance;

--- a/static/js/controllers/tasks-content.js
+++ b/static/js/controllers/tasks-content.js
@@ -28,6 +28,10 @@ angular.module('inboxControllers').controller('TasksContentCtrl',
       );
     };
 
+    var markFormEdited = function() {
+      $scope.enketoStatus.edited = true;
+    };
+
     $scope.performAction = function(action, skipDetails) {
       $scope.setCancelTarget(function() {
         if (skipDetails) {
@@ -46,7 +50,7 @@ angular.module('inboxControllers').controller('TasksContentCtrl',
         $scope.formId = action.form;
         XmlForm(action.form, { include_docs: true })
           .then(function(formDoc) {
-            Enketo.render('#task-report', formDoc.id, action.content)
+            Enketo.render('#task-report', formDoc.id, action.content, markFormEdited)
               .then(function(formInstance) {
                 $scope.form = formInstance;
                 $scope.loadingForm = false;

--- a/static/js/services/enketo.js
+++ b/static/js/services/enketo.js
@@ -227,7 +227,13 @@ angular.module('inboxServices').service('Enketo',
       });
     };
 
-    var renderForm = function(selector, id, instanceData) {
+    var registerEditedListener = function(selector, listener) {
+      if (listener) {
+        $(selector).on('edited.enketo', listener);
+      }
+    };
+
+    var renderForm = function(selector, id, instanceData, editedListener) {
       return Language()
         .then(function(language) {
           return withForm(id, language);
@@ -239,26 +245,30 @@ angular.module('inboxServices').service('Enketo',
             model: doc.model,
           };
           replaceJavarosaMediaWithLoaders(id, doc.html);
-          return renderFromXmls(doc, selector, instanceData);
+          var form = renderFromXmls(doc, selector, instanceData);
+          registerEditedListener(selector, editedListener);
+          return form;
         });
     };
 
-    this.render = function(selector, id, instanceData) {
+    this.render = function(selector, id, instanceData, editedListener) {
       return getUserContact().then(function() {
-        return renderForm(selector, id, instanceData);
+        return renderForm(selector, id, instanceData, editedListener);
       });
     };
 
     this.renderContactForm = renderForm;
 
-    this.renderFromXmlString = function(selector, xmlString, instanceData) {
+    this.renderFromXmlString = function(selector, xmlString, instanceData, editedListener) {
       return Language()
         .then(function(language) {
           return translateXml(xmlString, language);
         })
         .then(transformXml)
         .then(function(doc) {
-          return renderFromXmls(doc, selector, instanceData);
+          var form = renderFromXmls(doc, selector, instanceData);
+          registerEditedListener(selector, editedListener);
+          return form;
         });
     };
 

--- a/tests/karma/unit/controllers/tasks-content.js
+++ b/tests/karma/unit/controllers/tasks-content.js
@@ -19,7 +19,8 @@ describe('TasksContentCtrl', function() {
       setCancelTarget: function() {},
       setSelected: function() {
         $scope.selected = task;
-      }
+      },
+      enketoStatus: { edited: true }
     };
     render.returns(KarmaUtils.mockPromise());
     inject(function($controller) {
@@ -57,6 +58,7 @@ describe('TasksContentCtrl', function() {
       chai.expect(render.getCall(0).args[0]).to.equal('#task-report');
       chai.expect(render.getCall(0).args[1]).to.equal('myform');
       chai.expect(render.getCall(0).args[2]).to.equal('nothing');
+      chai.expect($scope.enketoStatus.edited).to.equal(false);
       done();
     });
   });

--- a/tests/karma/unit/controllers/tasks-content.js
+++ b/tests/karma/unit/controllers/tasks-content.js
@@ -53,7 +53,7 @@ describe('TasksContentCtrl', function() {
     chai.expect($scope.formId).to.equal('A');
     setTimeout(function() {
       chai.expect(render.callCount).to.equal(1);
-      chai.expect(render.getCall(0).args.length).to.equal(3);
+      chai.expect(render.getCall(0).args.length).to.equal(4);
       chai.expect(render.getCall(0).args[0]).to.equal('#task-report');
       chai.expect(render.getCall(0).args[1]).to.equal('myform');
       chai.expect(render.getCall(0).args[2]).to.equal('nothing');


### PR DESCRIPTION
Enketo has an event that fires when the form content has been updated
by the user. This change leverages that so that the "may lost content"
warning dialog is only shown when the user has actually changed a
value.

This fixes a bug where the warning is shown when the form failed to
render, and also a bug where the warning is shown when the form has no
fields.

medic/medic-webapp#1601
medic/medic-webapp#3045