### PR TITLE
Conflict view

### DIFF
--- a/ddocs/medic-conflicts/_id
+++ b/ddocs/medic-conflicts/_id
@@ -1,0 +1,1 @@
+_design/medic-conflicts

--- a/ddocs/medic-conflicts/views/conflicts/map.js
+++ b/ddocs/medic-conflicts/views/conflicts/map.js
@@ -1,0 +1,5 @@
+function (doc) {
+  if (doc._conflicts) {
+    emit(doc._conflicts);
+  }
+}

--- a/ddocs/medic-conflicts/views/conflicts/map.js
+++ b/ddocs/medic-conflicts/views/conflicts/map.js
@@ -1,4 +1,4 @@
-function (doc) {
+function(doc) {
   if (doc._conflicts) {
     emit(doc._conflicts);
   }


### PR DESCRIPTION
Add a simple conflict view to allow people to see conflicts. In a
separate ddoc to avoid large view index rebuilds on larger partners.

medic/medic-webapp#3502