### PR TITLE
Using `grunt dev`, only rebuild when .rebuild-trigger is touched

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ logs
 
 *.sublime-project
 *.sublime-workspace
+
+/.rebuild-trigger

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -260,36 +260,10 @@ module.exports = function(grunt) {
       options: {
         interval: 1000
       },
-      configFiles: {
-        files: [ 'Gruntfile.js', 'package.json' ],
-        options: {
-          reload: true,
-        }
+      trigger: {
+        files: [ '.rebuild-trigger' ],
+        tasks: ['mmcss', 'mmjs', 'appcache', 'couch-compile', 'deploy']
       },
-      css: {
-        files: ['static/css/**/*'],
-        tasks: ['mmcss', 'appcache', 'deploy']
-      },
-      js: {
-        files: ['templates/**/*', 'static/js/**/*', 'packages/kujua-*/**/*', 'packages/libphonenumber/**/*'],
-        tasks: ['mmjs', 'appcache', 'deploy']
-      },
-      other: {
-        files: ['lib/**/*'],
-        tasks: ['appcache', 'deploy']
-      },
-      compiledddocs: {
-        files: ['ddocs/**/*'],
-        tasks: ['couch-compile', 'deploy']
-      },
-      ddocs: {
-        files: ['kanso.json'],
-        tasks: ['deploy']
-      },
-      translations: {
-        files: ['translations/*'],
-        tasks: ['appcache', 'deploy']
-      }
     },
     notify_hooks: {
       options: {


### PR DESCRIPTION
Usage:

    touch ./rebuild-trigger

-----

# TODO

- [ ] add this as additional watchify config instead of replacing existing
- [ ] add additional grunt target which (1) doesn't npm and (2) only watchifies that file