### PR TITLE
Replaces context field with meta field for xform upload

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -25,6 +25,7 @@ _June 10, 2017_
 - Reporting Rates for Daily Reports. Issue: #1029
 - Prevent duplicates for Daily reports. Issue: #1028
 - Ability to "mark all read". Issue: #682
+- Allow form upload through Form Configuration UI. Issue: #3433
 
 ### Bug fixes
 

--- a/static/js/controllers/configuration-forms.js
+++ b/static/js/controllers/configuration-forms.js
@@ -62,18 +62,18 @@ angular.module('inboxControllers').controller('ConfigurationFormsCtrl',
         return $scope.$apply(); // upload triggered with jQuery
       }
 
-      var contextFiles = $('#forms-upload-xform .context.uploader')[0].files;
-      if (!contextFiles || contextFiles.length === 0) {
-        uploadXFormFinished(new Error('JSON context file not found'));
+      var metaFiles = $('#forms-upload-xform .meta.uploader')[0].files;
+      if (!metaFiles || metaFiles.length === 0) {
+        uploadXFormFinished(new Error('JSON meta file not found'));
         return $scope.$apply(); // upload triggered with jQuery
       }
 
       $q.all([
           FileReader(formFiles[0]),
-          FileReader(contextFiles[0]).then(JsonParse) ])
+          FileReader(metaFiles[0]).then(JsonParse) ])
         .then(function(results) {
           var xml = results[0];
-          var context = results[1];
+          var meta = results[1];
 
           var $xml = $($.parseXML(xml));
           var title = $xml.find('title').text();
@@ -89,10 +89,10 @@ angular.module('inboxControllers').controller('ConfigurationFormsCtrl',
           }
 
           var update = function(doc) {
-            doc.context = context;
             doc.title = title;
             doc.type = 'form';
             doc.internalId = formId;
+            _.extend(doc, meta);
             AddAttachment(doc, 'xml', xml, 'application/xml');
             return doc;
           };
@@ -101,7 +101,7 @@ angular.module('inboxControllers').controller('ConfigurationFormsCtrl',
           DB().get(couchId, { include_attachments:true })
             .catch(function(err) {
               if (err.status === 404) {
-                return { _id:couchId };
+                return { _id: couchId };
               }
               throw err;
             })

--- a/templates/partials/configuration_forms.html
+++ b/templates/partials/configuration_forms.html
@@ -32,7 +32,7 @@
       <ul>
         <li ng-repeat="form in xForms" class="row">
           <div class="col-sm-6">{{form._id}}</div>
-          <div class="col-sm-6">{{form.title}}</div>
+          <div class="col-sm-6">{{form.title | translateFrom}}</div>
         </li>
       </ul>
     </fieldset>

--- a/templates/partials/configuration_forms.html
+++ b/templates/partials/configuration_forms.html
@@ -12,7 +12,7 @@
           <input class="form uploader" type="file" accept="application/xml"/>
         </label>
         <label><span translate>upload.xform.context</span>
-          <input class="context uploader" type="file" accept="application/json"/>
+          <input class="meta uploader" type="file" accept="application/json"/>
         </label>
         <button type="button" class="btn btn-default upload" ng-disabled="xform.uploading">
           <i class="fa fa-arrow-up"></i>


### PR DESCRIPTION
When uploading xforms you can now upload the full meta doc which
means you can set the icon, title, hidden_fields, etc as well as
the context of the form.

This isn't backwards compatible as we should only use meta files
from now on.

medic/medic-webapp#3540