### PR TITLE
Removes the help pages implementation

### DIFF
--- a/ddocs/medic-client/views/help_pages/map.js
+++ b/ddocs/medic-client/views/help_pages/map.js
@@ -1,5 +1,0 @@
-function(doc) {
-  if (doc.type === 'help' && doc._id.indexOf('help:') === 0) {
-    emit(doc._id.substring(5), doc.title);
-  }
-}

--- a/static/js/controllers/about.js
+++ b/static/js/controllers/about.js
@@ -1,14 +1,10 @@
-var _ = require('underscore');
-
 angular.module('inboxControllers').controller('AboutCtrl',
   function (
     $interval,
-    $q,
     $log,
     $scope,
     DB,
     Debug,
-    Language,
     Session
   ) {
     'use strict';
@@ -59,19 +55,5 @@ angular.module('inboxControllers').controller('AboutCtrl',
     }).catch(function (err) {
       $log.error('Failed to fetch DB info', err);
     });
-
-    $scope.help_loading = true;
-
-    var helpPageGet = DB().query('medic-client/help_pages');
-
-    $q.all([ helpPageGet, Language() ])
-      .then(function(results) {
-        var helpPageRes = results[0];
-        var lang = results[1];
-        $scope.help_loading = false;
-        $scope.help_pages = _.map(helpPageRes.rows, function(row) {
-          return { id: row.key, title: row.value[lang] || row.value.en };
-        });
-      });
   }
 );

--- a/templates/partials/about.html
+++ b/templates/partials/about.html
@@ -76,16 +76,6 @@
       </dl>
     </div>
 
-    <div ng-hide="help_pages.length === 0">
-      <h3 translate>Help</h3>
-      <ul>
-        <li ng-repeat="page in help_pages">
-          <a ui-sref="help({ page: page.id })">{{page.title}}</a>
-        </li>
-      </ul>
-      <div class="loader" ng-show="help_loading"></div>
-    </div>
-
     <div>
       <h3 translate>debug.mode</h3>
       <p translate>debug.mode.description</p>


### PR DESCRIPTION
This removes the concept of help pages which were intended to be
in-app user documentation but has never been implemented. We can
add it back if we decide to implement it one day.

medic/medic-webapp#1895