### PR TITLE
Add boilerplate GitHub issue template PHI warning

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,3 @@
 
-**Important**: This is a public repository. Anyone in the world can
-see what's posted here. If you are posting screenshots or log files,
-please **carefully examine them for** the presence of any kind of
-**protected health information** (PHI). Images or logs containing
-PHI _must_ be posted in fully-redacted form, with no visible PHI.
+**Important**: This is a public repository. Anyone in the world can see what's posted here. If you are posting screenshots or log files, please **carefully examine them for** the presence of any kind of **protected health information** (PHI). Images or logs containing PHI _must_ be posted in fully-redacted form, with no visible PHI.
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,7 @@
+
+**Important**: This is a public repository. Anyone in the world can
+see what's posted here. If you are posting screenshots or log files,
+please **carefully examine them for** the presence of any kind of
+**protected health information** (PHI). Images or logs containing
+PHI _must_ be posted in fully-redacted form, with no visible PHI.
+


### PR DESCRIPTION
A proposal: add a proactive reminder to protect the confidentiality of patient and health worker PII; this reminder will automatically appear in every issue. This reminder would be deleted as a rule prior to the issue being filed, so as not to cause clutter.