### PR TITLE
Re-npm install with only prod dependencies when packaging releases

### DIFF
--- a/scripts/ci/after_success.sh
+++ b/scripts/ci/after_success.sh
@@ -13,6 +13,8 @@ if [ -z "$UPLOAD_URL" ]; then
     exit 1;
 fi
 
+rm -rf node_modules && npm install --production
+
 cd sentinel && npm install && cd .. && \
 cd api && npm install && cd ..
 


### PR DESCRIPTION
This looks helpful to me, but maybe shrinkwrap's already doing something clever.