### PR TITLE
Fail after_success script if any command fails

### DIFF
--- a/scripts/ci/after_success.sh
+++ b/scripts/ci/after_success.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 MAX=50
 COUNT=0


### PR DESCRIPTION
Currently the script seems to carry on deploying broken binaries if e.g. `npm install` fails for api or sentinel.