### PR TITLE
Hides form title in CSS instead of removing from form

### DIFF
--- a/scripts/upload_xform.sh
+++ b/scripts/upload_xform.sh
@@ -162,17 +162,12 @@ echo "[$0] Upload response: $revResponse"
 rev=$(jq -r .rev <<< "$revResponse")
 check_rev
 
-# Upload a temp file with the title stripped
-sed '/<h:title>/d' "$XFORM_PATH" > "$XFORM_PATH.$$.tmp"
-
 echo "[$SELF] Uploading form xml: id: $ID, rev: $rev..."
 revResponse=$(curl -# -f -X PUT -H "Content-Type: text/xml" \
-    --data-binary "@${XFORM_PATH}.$$.tmp" \
+    --data-binary "@${XFORM_PATH}" \
     "${docUrl}/xml?rev=${rev}")
 echo "revResponse: $revResponse"
 rev=$(jq -r .rev <<< "$revResponse")
-
-rm "$XFORM_PATH.$$.tmp"
 
 while [ $# -gt 0 ]; do
     attachment="$1"

--- a/static/css/enketo/medic.less
+++ b/static/css/enketo/medic.less
@@ -269,6 +269,9 @@
 
 @media (max-width: 767px) {
   .enketo {
+    #form-title {
+      display: none;
+    }
     .option-wrapper > label:not(.filler) {
       padding-top: 10px;
       padding-bottom: 10px;


### PR DESCRIPTION
The upload_xform script was removing the title from the xform
definition so it wouldn't show in the UI. This broken medic-collect
integration which relies on the title being present.

This change leaves the title in the form. It is replaced during
render with the translated version from the doc. This is hidden on
mobile where the title is displayed in the title bar instead.

medic/medic-webapp#3390