### PR TITLE
Update openrosa-xpath-evaluator with better support for [] statements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5371,9 +5371,9 @@
       "dev": true
     },
     "openrosa-xpath-evaluator": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/openrosa-xpath-evaluator/-/openrosa-xpath-evaluator-1.2.2.tgz",
-      "integrity": "sha1-ruhxyQok5c6sOkw0ebqWeX9Hkd8="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/openrosa-xpath-evaluator/-/openrosa-xpath-evaluator-1.3.0.tgz",
+      "integrity": "sha1-VZod/wiruZrhPIEYetGjjlDCAnM="
     },
     "optimist": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "medic-nootils": "^1.0.3",
     "messageformat": "^1.0.0",
     "moment": "^2.17.1",
-    "openrosa-xpath-evaluator": "^1.2.2",
+    "openrosa-xpath-evaluator": "^1.3.0",
     "pouchdb-browser": "^6.2.0",
     "properties": "^1.2.1",
     "select2": "^4.0.3",


### PR DESCRIPTION
I think this needs an update to `package-lock.json` too.  What's the correct way to do that?