### PR TITLE
Adds password strength validation 

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,10 @@ _TBC_
 - [#2635](https://github.com/medic/medic-webapp/issues/2635) changes the context available to the configured contact summary script. The `contact` parameter no longer has information about parents. This information is now in an array called `lineage`. More information is available in the [configuration documentation](https://github.com/medic/medic-docs/blob/master/configuration/contact-summary.md).
 - [#3546](https://github.com/medic/medic-webapp/issues/3546) changes the implementation of the `contact_summary` so instead of declaring the output on the last line of the script, now you have to return the output. Usually this is as easy as adding a return on the last line, so `output;` becomes `return output;`. More information is available in the [configuration documentation](https://github.com/medic/medic-docs/blob/master/configuration/contact-summary.md).
 
+### Security
+
+- [#1472](https://github.com/medic/medic-webapp/issues/1472) adds password validation so when creating or updating users the new passwords have to be at least 8 characters long and reasonably complex.
+
 ## 2.12.0
 
 _June 20, 2017_

--- a/package-lock.json
+++ b/package-lock.json
@@ -6305,6 +6305,11 @@
       "integrity": "sha1-Krt1qt453rXMgVzhDmGRFkhQuvA=",
       "dev": true
     },
+    "simple-password-tester": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-password-tester/-/simple-password-tester-1.0.0.tgz",
+      "integrity": "sha512-YgRc3RsOVwHTsdvcrh6yccT8JgCQwy7n/RKmR5zkSpyNWkuZqN7cDGVXNFIYh2/D4faG7RhRHda1fePrqb3qFw=="
+    },
     "sinon": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "pouchdb-browser": "^6.2.0",
     "properties": "^1.2.1",
     "select2": "^4.0.3",
+    "simple-password-tester": "^1.0.0",
     "underscore": "^1.8.3",
     "uuid": "^3.0.1",
     "worker-pouch": "^2.0.0"

--- a/static/js/controllers/edit-user.js
+++ b/static/js/controllers/edit-user.js
@@ -1,3 +1,7 @@
+var passwordTester = require('simple-password-tester'),
+    PASSWORD_MINIMUM_LENGTH = 8,
+    PASSWORD_MINIMUM_SCORE = 50;
+
 (function () {
 
   'use strict';
@@ -9,7 +13,6 @@
       $log,
       $rootScope,
       $scope,
-      $translate,
       $uibModalInstance,
       $window,
       ContactSchema,
@@ -17,6 +20,7 @@
       Select2Search,
       Session,
       SetLanguage,
+      Translate,
       UpdateUser,
       UserSettings
     ) {
@@ -90,9 +94,13 @@
 
       var validateRequired = function(fieldName, fieldDisplayName) {
         if (!$scope.editUserModel[fieldName]) {
-          $scope.errors[fieldName] = $translate.instant('field is required', {
-            field: $translate.instant(fieldDisplayName)
-          });
+          Translate(fieldDisplayName)
+            .then(function(field) {
+              return Translate('field is required', { field: field });
+            })
+            .then(function(value) {
+              $scope.errors[fieldName] = value;
+            });
           return false;
         }
         return true;
@@ -113,7 +121,26 @@
 
       var validateConfirmPasswordMatches = function() {
         if ($scope.editUserModel.password !== $scope.editUserModel.passwordConfirm) {
-          $scope.errors.password = $translate.instant('Passwords must match');
+          Translate('Passwords must match').then(function(value) {
+            $scope.errors.password = value;
+          });
+          return false;
+        }
+        return true;
+      };
+
+      var validatePasswordStrength = function() {
+        var password = $scope.editUserModel.password || '';
+        if (password.length < PASSWORD_MINIMUM_LENGTH) {
+          Translate('password.length.minimum', { minimum: PASSWORD_MINIMUM_LENGTH }).then(function(value) {
+            $scope.errors.password = value;
+          });
+          return false;
+        }
+        if (passwordTester(password) < PASSWORD_MINIMUM_SCORE) {
+          Translate('password.weak').then(function(value) {
+            $scope.errors.password = value;
+          });
           return false;
         }
         return true;
@@ -121,6 +148,7 @@
 
       var validatePasswordFields = function() {
         return validateRequired('password', 'Password') &&
+          validatePasswordStrength() &&
           validateConfirmPasswordMatches();
       };
 

--- a/static/js/services/index.js
+++ b/static/js/services/index.js
@@ -73,6 +73,7 @@
   require('./target-generator');
   require('./tasks-for-contact');
   require('./tour');
+  require('./translate');
   require('./translate-from');
   require('./translation-loader');
   require('./update-facility');

--- a/static/js/services/translate.js
+++ b/static/js/services/translate.js
@@ -1,0 +1,16 @@
+/**
+ * A simple wrapper of $translate which allows for unit test mocking
+ */
+angular.module('inboxServices').service('Translate',
+  function(
+    $translate
+  ) {
+
+    'use strict';
+    'ngInject';
+
+    return function(translationId, interpolateParams) {
+      return $translate(translationId, interpolateParams);
+    };
+  }
+);

--- a/tests/karma/unit/controllers/edit-user.js
+++ b/tests/karma/unit/controllers/edit-user.js
@@ -110,11 +110,11 @@ describe('EditUserCtrl controller', () => {
 
   const mockFacility = (facility_id) => {
       window.$.withArgs('#edit-user-profile [name=facility]')
-        .returns({ val: () => facility_id; });
+        .returns({ val: () => facility_id });
   };
   const mockContact = (contact_id) => {
       window.$.withArgs('#edit-user-profile [name=contact]')
-        .returns({ val: () => contact_id; });
+        .returns({ val: () => contact_id });
   };
 
   describe('initialisation', () => {

--- a/tests/karma/unit/controllers/edit-user.js
+++ b/tests/karma/unit/controllers/edit-user.js
@@ -192,7 +192,7 @@ describe('EditUserCtrl controller', () => {
       });
     });
 
-    it('password must be hard to hack', done => {
+    it('password must be hard to brute force', done => {
       mockEditCurrentUser(userToEdit);
       Translate.withArgs('password.weak').returns(Promise.resolve('hackable'));
       setTimeout(() => {

--- a/tests/karma/unit/controllers/edit-user.js
+++ b/tests/karma/unit/controllers/edit-user.js
@@ -1,8 +1,8 @@
-describe('EditUserCtrl controller', function() {
+describe('EditUserCtrl controller', () => {
 
   'use strict';
 
-  var jQuery,
+  let jQuery,
       mockCreateNewUser,
       mockEditAUser,
       mockEditCurrentUser,
@@ -10,9 +10,10 @@ describe('EditUserCtrl controller', function() {
       translationsDbQuery,
       UpdateUser,
       UserSettings,
+      Translate,
       userToEdit;
 
-  beforeEach(function() {
+  beforeEach(() => {
     module('inboxApp');
 
     translationsDbQuery = sinon.stub();
@@ -33,27 +34,30 @@ describe('EditUserCtrl controller', function() {
       roles: [ 'district-manager' ],
       language: 'zz'
     };
+    Translate = sinon.stub();
 
     jQuery = sinon.stub(window, '$');
     window.$.callThrough();
 
-    module(function($provide) {
-      $provide.factory('$uibModalInstance', function() {
+    module($provide => {
+      $provide.factory('$uibModalInstance', () => {
         return {
           rendered: KarmaUtils.mockPromise(),
-          close: function() {}
+          close: () => {}
         };
       });
-      $provide.factory('processingFunction', function() {
+      $provide.factory('processingFunction', () => {
         return null;
       });
       $provide.factory('DB', KarmaUtils.mockDB({ query: translationsDbQuery }));
       $provide.value('UpdateUser', UpdateUser);
       $provide.value('UserSettings', UserSettings);
+      $provide.value('Translate', Translate);
+
     });
 
-    inject(function($rootScope, $controller) {
-      var createController = function(model) {
+    inject(($rootScope, $controller) => {
+      const createController = model => {
         scope = $rootScope.$new();
         scope.model = model;
         scope.setProcessing = sinon.stub();
@@ -63,10 +67,10 @@ describe('EditUserCtrl controller', function() {
           '$scope': scope,
           '$rootScope': $rootScope,
           'Language': sinon.stub(),
-          'ContactSchema': { getPlaceTypes: function() { return []; } },
+          'ContactSchema': { getPlaceTypes: () => { return []; } },
           'Search': sinon.stub(),
           'Session': {
-            userCtx: function() {
+            userCtx: () => {
               return { name: 'greg' };
             }
           },
@@ -75,13 +79,13 @@ describe('EditUserCtrl controller', function() {
           '$window': {location: {reload: sinon.stub()}}
         });
       };
-      mockEditCurrentUser = (user) => {
+      mockEditCurrentUser = user => {
         UserSettings.returns(KarmaUtils.mockPromise(null, user));
         UpdateUser.returns(KarmaUtils.mockPromise());
         createController();
       };
 
-      mockEditAUser = (user) => {
+      mockEditAUser = user => {
         // Don't mock UserSettings, we're not fetching current user.
         UpdateUser.returns(KarmaUtils.mockPromise());
         createController(user);
@@ -95,7 +99,7 @@ describe('EditUserCtrl controller', function() {
     });
   });
 
-  afterEach(function() {
+  afterEach(() => {
     KarmaUtils.restore(
       UpdateUser,
       UserSettings,
@@ -105,19 +109,19 @@ describe('EditUserCtrl controller', function() {
 
 
   const mockFacility = (facility_id) => {
-      window.$.withArgs('#edit-user-profile [name=facility]').returns(
-        {val: function(){ return facility_id; }});
+      window.$.withArgs('#edit-user-profile [name=facility]')
+        .returns({ val: () => facility_id; });
   };
   const mockContact = (contact_id) => {
-      window.$.withArgs('#edit-user-profile [name=contact]').returns(
-        {val: function(){ return contact_id; }});
+      window.$.withArgs('#edit-user-profile [name=contact]')
+        .returns({ val: () => contact_id; });
   };
 
-  describe('initialisation', function() {
+  describe('initialisation', () => {
 
-    it('edits the given user', function(done) {
+    it('edits the given user', done => {
       mockEditAUser(userToEdit);
-      setTimeout(function() {
+      setTimeout(() => {
         chai.expect(scope.enabledLocales.length).to.equal(2);
         chai.expect(scope.enabledLocales[0].code).to.equal('en');
         chai.expect(scope.enabledLocales[1].code).to.equal('fr');
@@ -140,10 +144,10 @@ describe('EditUserCtrl controller', function() {
       });
     });
 
-    it('when no given user edits the current user', function(done) {
-      var currentUser = userToEdit;
+    it('when no given user edits the current user', done => {
+      const currentUser = userToEdit;
       mockEditCurrentUser(currentUser);
-      setTimeout(function() {
+      setTimeout(() => {
         chai.expect(scope.editUserModel).to.deep.equal({
           id: currentUser._id,
           name: currentUser.name,
@@ -159,82 +163,117 @@ describe('EditUserCtrl controller', function() {
   });
 
   // Note : $scope.updatePassword is only called when editing the current user.
-  // Never when creating a new user, or aditing a non-current user.
-  describe('$scope.updatePassword', function() {
-    it('password must be filled', function(done) {
+  // Never when creating a new user, or editing a non-current user.
+  describe('$scope.updatePassword', () => {
+    it('password must be filled', done => {
       mockEditCurrentUser(userToEdit);
-
-      setTimeout(function() {
+      Translate.withArgs('Password').returns(Promise.resolve('pswd'));
+      Translate.withArgs('field is required', { field: 'pswd' }).returns(Promise.resolve('pswd field must be filled'));
+      setTimeout(() => {
         scope.editUserModel.password = '';
-
         scope.updatePassword();
-        chai.expect(scope.errors).to.have.property('password');
-        done();
+        setTimeout(() => {
+          chai.expect(scope.errors.password).to.equal('pswd field must be filled');
+          done();
+        });
       });
     });
 
-    it('password and passwordConfirm must match', function() {
+    it('password must be long enough', done => {
       mockEditCurrentUser(userToEdit);
-
-      setTimeout(function() {
-        scope.editUserModel.password = 'password';
-        scope.editUser();
-        chai.expect(scope.errors).to.have.property('password');
-
-        scope.editUserModel.passwordConfirm = 'password';
-        scope.editUser();
-        chai.expect(scope.errors).not.to.have.property('password');
+      Translate.withArgs('password.length.minimum', { minimum: 8 }).returns(Promise.resolve('short'));
+      setTimeout(() => {
+        scope.editUserModel.password = '2sml4me';
+        scope.updatePassword();
+        setTimeout(() => {
+          chai.expect(scope.errors.password).to.equal('short');
+          done();
+        });
       });
     });
 
-    it('user is updated with password change', function(done) {
+    it('password must be hard to hack', done => {
       mockEditCurrentUser(userToEdit);
-
-      setTimeout(function() {
+      Translate.withArgs('password.weak').returns(Promise.resolve('hackable'));
+      setTimeout(() => {
         scope.editUserModel.password = 'password';
-        scope.editUserModel.passwordConfirm = 'password';
+        scope.updatePassword();
+        setTimeout(() => {
+          chai.expect(scope.errors.password).to.equal('hackable');
+          done();
+        });
+      });
+    });
+
+    it('error if password and confirm do not match', done => {
+      mockEditCurrentUser(userToEdit);
+      setTimeout(() => {
+        Translate.withArgs('Passwords must match').returns(Promise.resolve('wrong'));
+        const password = '1QrAs$$3%%kkkk445234234234';
+        scope.editUserModel.password = password;
+        scope.editUserModel.passwordConfirm = password + 'a';
+        scope.updatePassword();
+        setTimeout(() => {
+          chai.expect(scope.errors.password).to.equal('wrong');
+          done();
+        });
+      });
+    });
+
+    it('user is updated with password change', done => {
+      mockEditCurrentUser(userToEdit);
+      const password = '1QrAs$$3%%kkkk445234234234';
+
+      setTimeout(() => {
+        scope.editUserModel.password = password;
+        scope.editUserModel.passwordConfirm = password;
 
         scope.updatePassword();
 
-        setTimeout(function() {
+        setTimeout(() => {
           chai.expect(UpdateUser.called).to.equal(true);
-          console.log('args', UpdateUser.getCall(0).args);
           chai.expect(UpdateUser.getCall(0).args[0]).to.equal('user.id');
-          chai.expect(UpdateUser.getCall(0).args[2].password).to.equal('password');
+          chai.expect(UpdateUser.getCall(0).args[2].password).to.equal(password);
           done();
         });
       });
     });
   });
 
-  describe('$scope.editUserSettings', function() {
-    it('name must be present', function() {
+  describe('$scope.editUserSettings', () => {
+    it('name must be present', done => {
       mockEditAUser(userToEdit);
-      scope.editUserModel.name = '';
-
-      scope.editUserSettings();
-      chai.expect(scope.errors).to.have.property('name');
+      Translate.withArgs('User Name').returns(Promise.resolve('uname'));
+      Translate.withArgs('field is required', { field: 'uname' }).returns(Promise.resolve('uname req'));
+      setTimeout(() => {
+        scope.editUserModel.name = '';
+        scope.editUserSettings();
+        setTimeout(() => {
+          chai.expect(scope.errors.name).to.equal('uname req');
+          done();
+        });
+      });
     });
 
-    it('user is updated', function(done) {
+    it('user is updated', done => {
       UpdateUser.returns(KarmaUtils.mockPromise());
       mockEditAUser(userToEdit);
 
       scope.editUserSettings();
 
-      setTimeout(function() {
+      setTimeout(() => {
         chai.expect(UpdateUser.called).to.equal(true);
-        var updateUserArgs = UpdateUser.getCall(0).args;
+        const updateUserArgs = UpdateUser.getCall(0).args;
         chai.expect(updateUserArgs[0]).to.equal('user.id');
 
-        var settingsUpdates = updateUserArgs[1];
+        const settingsUpdates = updateUserArgs[1];
         ['name', 'fullname', 'email', 'phone', 'language']
-          .forEach(function(field) {
+          .forEach(field => {
             chai.expect(settingsUpdates).to.have.property(field);
           });
         // users don't have permission to change their own roles, facility, or contact
         ['roles', 'facility_id', 'contact_id']
-          .forEach(function(field) {
+          .forEach(field => {
             chai.expect(settingsUpdates).to.not.have.property(field);
           });
         chai.expect(settingsUpdates.name).to.equal(scope.editUserModel.name);
@@ -248,59 +287,62 @@ describe('EditUserCtrl controller', function() {
     });
   });
 
-  describe('$scope.editUser', function() {
-    it('name must be present', function() {
+  describe('$scope.editUser', () => {
+    it('name must be present', done => {
       mockEditAUser(userToEdit);
-      scope.editUserModel.name = '';
-
-      scope.editUser();
-
-      chai.expect(scope.errors).to.have.property('name');
+      Translate.withArgs('User Name').returns(Promise.resolve('uname'));
+      Translate.withArgs('field is required', { field: 'uname' }).returns(Promise.resolve('uname req'));
+      setTimeout(() => {
+        scope.editUserModel.name = '';
+        scope.editUser();
+        setTimeout(() => {
+          chai.expect(scope.errors.name).to.equal('uname req');
+          done();
+        });
+      });
     });
 
-    it('password must be filled when creating new user', function() {
+    it('password must be filled when creating new user', done => {
       mockCreateNewUser();
-
-      scope.editUser();
-
-      chai.expect(scope.errors).to.have.property('password');
+      Translate.withArgs('Password').returns(Promise.resolve('pswd'));
+      Translate.withArgs('field is required', { field: 'pswd' }).returns(Promise.resolve('pswd field must be filled'));
+      setTimeout(() => {
+        scope.editUser();
+        setTimeout(() => {
+          chai.expect(scope.errors.password).to.equal('pswd field must be filled');
+          done();
+        });
+      });
     });
 
-    it('password doesn\'t need to be filled when editing user', function() {
+    it('password doesn\'t need to be filled when editing user', done => {
       mockEditAUser(userToEdit);
-      chai.expect(scope.editUserModel).not.to.have.property('password');
-
-      scope.editUser();
-
-      chai.expect(scope.errors).not.to.have.property('password');
+      Translate.returns(Promise.resolve('something'));
+      setTimeout(() => {
+        chai.expect(scope.editUserModel).not.to.have.property('password');
+        scope.editUser();
+        setTimeout(() => {
+          chai.expect(scope.errors).not.to.have.property('password');
+          done();
+        });
+      });
     });
 
-    it('password and passwordConfirm must match when creating new user', function() {
-      mockCreateNewUser();
-      scope.editUserModel.password = 'password';
-
-      scope.editUser();
-
-      chai.expect(scope.errors).to.have.property('password');
-
-      scope.editUserModel.passwordConfirm = 'password';
-      scope.editUser();
-      chai.expect(scope.errors).not.to.have.property('password');
+    it('error if password and confirm do not match when creating new user', done => {
+      mockEditCurrentUser();
+      Translate.withArgs('Passwords must match').returns(Promise.resolve('wrong'));
+      setTimeout(() => {
+        const password = '1QrAs$$3%%kkkk445234234234';
+        scope.editUserModel.password = password;
+        scope.editUser();
+        setTimeout(() => {
+          chai.expect(scope.errors.password).to.equal('wrong');
+          done();
+        });
+      });
     });
 
-    it('password and passwordConfirm must match when editing user', function() {
-      mockEditCurrentUser(userToEdit);
-
-      scope.editUserModel.password = 'password';
-      scope.editUser();
-      chai.expect(scope.errors).to.have.property('password');
-
-      scope.editUserModel.passwordConfirm = 'password';
-      scope.editUser();
-      chai.expect(scope.errors).not.to.have.property('password');
-    });
-
-    it('should not change password when none is supplied', function(done) {
+    it('should not change password when none is supplied', done => {
       // given
       UpdateUser.returns(KarmaUtils.mockPromise());
       mockEditAUser(userToEdit);
@@ -313,55 +355,74 @@ describe('EditUserCtrl controller', function() {
       scope.editUser();
 
       // then
-      setTimeout(function() {
+      setTimeout(() => {
         chai.expect(UpdateUser.called).to.equal(true);
 
-        var userUpdates = UpdateUser.getCall(0).args[2];
+        const userUpdates = UpdateUser.getCall(0).args[2];
         chai.expect(userUpdates).not.to.have.property('password');
 
         done();
       });
     });
 
-    it('must have associated place if user type is restricted user', function() {
+    it('must have associated place if user type is restricted user', done => {
       mockEditAUser(userToEdit);
       scope.editUserModel.type = 'district-manager';
       mockFacility(null);
+      mockContact(userToEdit.contact_id);
+      Translate.withArgs('Facility').returns(Promise.resolve('fac'));
+      Translate.withArgs('field is required', { field: 'fac' }).returns(Promise.resolve('fac req'));
 
       // when
       scope.editUser();
 
       // expect
-      chai.expect(scope.errors).to.have.property('facility_id');
+      setTimeout(() => {
+        chai.expect(scope.errors.facility_id).to.equal('fac req');
+        done();
+      });
     });
 
-    it('must have associated contact if user type is restricted user', function() {
+    it('must have associated contact if user type is restricted user', done => {
       mockEditAUser(userToEdit);
       scope.editUserModel.type = 'district-manager';
+      mockFacility(userToEdit.facility_id);
       mockContact(null);
+      Translate.withArgs('associated.contact').returns(Promise.resolve('con'));
+      Translate.withArgs('field is required', { field: 'con' }).returns(Promise.resolve('con req'));
 
       // when
       scope.editUser();
 
       // expect
-      chai.expect(scope.errors).to.have.property('contact_id');
+      setTimeout(() => {
+        chai.expect(scope.errors.contact_id).to.equal('con req');
+        done();
+      });
     });
 
-    it('must have associated place and contact if user type is restricted user', function() {
+    it('must have associated place and contact if user type is restricted user', done => {
       mockEditAUser(userToEdit);
       scope.editUserModel.type = 'district-manager';
       mockFacility(null);
       mockContact(null);
+      Translate.withArgs('associated.contact').returns(Promise.resolve('con'));
+      Translate.withArgs('field is required', { field: 'con' }).returns(Promise.resolve('con req'));
+      Translate.withArgs('Facility').returns(Promise.resolve('fac'));
+      Translate.withArgs('field is required', { field: 'fac' }).returns(Promise.resolve('fac req'));
 
       // when
       scope.editUser();
 
       // expect
-      chai.expect(scope.errors).to.have.property('facility_id');
-      chai.expect(scope.errors).to.have.property('contact_id');
+      setTimeout(() => {
+        chai.expect(scope.errors.facility_id).to.equal('fac req');
+        chai.expect(scope.errors.contact_id).to.equal('con req');
+        done();
+      });
     });
 
-    it('doesn\'t need associated place and contact if user type is not restricted user', function() {
+    it('doesn\'t need associated place and contact if user type is not restricted user', () => {
       mockEditAUser(userToEdit);
       scope.editUserModel.type = 'some-other-type';
       mockFacility(null);
@@ -375,23 +436,24 @@ describe('EditUserCtrl controller', function() {
       chai.expect(scope.errors).not.to.have.property('contact_id');
     });
 
-    it('user is updated', function() {
+    it('user is updated', () => {
       mockEditAUser(userToEdit);
       mockContact(userToEdit.contact_id);
       mockFacility(userToEdit.facility_id);
-      scope.editUserModel.password = 'new password';
-      scope.editUserModel.passwordConfirm = 'new password';
+      const password = '234lkjsdlf9u)*)(OJKJDfiyer';
+      scope.editUserModel.password = password;
+      scope.editUserModel.passwordConfirm = password;
 
       scope.editUser();
 
       chai.expect(UpdateUser.called).to.equal(true);
-      var updateUserArgs = UpdateUser.getCall(0).args;
+      const updateUserArgs = UpdateUser.getCall(0).args;
 
       chai.expect(updateUserArgs[0]).to.equal('user.id');
 
-      var settingsUpdates = updateUserArgs[1];
+      const settingsUpdates = updateUserArgs[1];
       ['name', 'fullname', 'email', 'phone', 'roles', 'language', 'facility_id', 'contact_id']
-        .forEach(function(field) {
+        .forEach(field => {
           chai.expect(settingsUpdates).to.have.property(field);
         });
       chai.expect(settingsUpdates.name).to.equal(scope.editUserModel.name);
@@ -403,9 +465,9 @@ describe('EditUserCtrl controller', function() {
       chai.expect(settingsUpdates.language).to.equal(scope.editUserModel.language.code);
       chai.expect(settingsUpdates.roles).to.deep.equal(['district-manager', 'kujua_user', 'data_entry', 'district_admin']);
 
-      var userUdates = updateUserArgs[2];
+      const userUdates = updateUserArgs[2];
       ['name', 'password', 'roles', 'facility_id']
-        .forEach(function(field) {
+        .forEach(field => {
           chai.expect(userUdates).to.have.property(field);
         });
       chai.expect(userUdates.name).to.equal(scope.editUserModel.name);

--- a/translations/messages-en.properties
+++ b/translations/messages-en.properties
@@ -905,3 +905,5 @@ forms.xml = XML
 forms.json = JSON
 upload.xform.xml.help = The xform definition in XML.
 upload.xform.meta.help = The meta file in JSON format including the icon, title, context, and so on.
+password.weak = The password is too easy to guess. Include a range of types of characters to increase the score.
+password.length.minimum = The password must be at least {{minimum}} characters long.


### PR DESCRIPTION
# Description

Stops the user entering weak passwords when creating or editing
a user. Weak is defined as being at least 8 characters long and
having sufficient complexity.

medic/medic-webapp#1472

# Review checklist

- [x] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [x] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.