### PR TITLE
Adds the clinic back into lucene index

### DIFF
--- a/lib/fulltext.js
+++ b/lib/fulltext.js
@@ -9,7 +9,7 @@ exports.data_records = {
     var indexField = function(key, value, ret, id) {
       // if field key ends in _date, try to parse as date.
       if (/_date$/.test(key)) {
-        date = new Date(value);
+        var date = new Date(value);
         if (date) {
           ret.add(date, { field: key, type: 'date' });
         } else {
@@ -27,7 +27,6 @@ exports.data_records = {
 
     var ret = new Document(),
         skip = ['type', '_rev', 'refid', 'id'],
-        date,
         type;
 
     // index form fields and _id
@@ -37,9 +36,19 @@ exports.data_records = {
       }
     });
 
-    Object.keys(doc.fields).forEach(function(key) {
-      indexField(key, doc.fields[key], ret, doc._id);
-    });
+    var parent = doc.contact;
+    while(parent) {
+      if (parent._id) {
+        ret.add(parent._id, { field: 'clinic' });
+      }
+      parent = parent.parent;
+    }
+
+    if (doc.fields) {
+      Object.keys(doc.fields).forEach(function(key) {
+        indexField(key, doc.fields[key], ret, doc._id);
+      });
+    }
 
     if (doc.form === 'R') {
       // We don't have an LMP date so add an expected_date field with our best guess.


### PR DESCRIPTION
# Description

Exporting reports filtered by place relies on the "clinic" field
so we need to include it in the lucene index.

Also fixes an exception that's thrown when doc.fields is null.

medic/medic-webapp#3593

# Review checklist

- [x] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [x] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.