### PR TITLE
Uses exact matching for form field

### DIFF
--- a/lib/fulltext.js
+++ b/lib/fulltext.js
@@ -1,5 +1,5 @@
 exports.data_records = {
-  analyzer: 'perfield:{default:"standard",form:"simple"}',
+  analyzer: 'perfield:{default:"standard"}',
   index: function(doc) {
 
     if (doc.type !== 'data_record') {
@@ -17,6 +17,10 @@ exports.data_records = {
         }
       } else if (typeof value === 'number') {
         ret.add(value, { field: key, type: 'int' });
+      } else if (key === 'form') {
+        ret.add(value);
+        // string type forces an exact case insensitive match
+        ret.add(value, { field: key, type: 'string' });
       } else if (typeof value === 'string') {
         ret.add(value);
         ret.add(value, {


### PR DESCRIPTION
# Description

The default "text" type splits fields by non-word characters
which means "pregnancy_visit" matches "pregnancy" and forms
are returned when they shouldn't be. Using "string" foces it
to match exactly (except for case).

medic/medic-webapp#3615

# Review checklist

- [x] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [x] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.