### PR TITLE
Reduces select2 update binding scope

### DIFF
--- a/static/js/enketo/widgets/db-object-widget.js
+++ b/static/js/enketo/widgets/db-object-widget.js
@@ -77,14 +77,15 @@ define( function( require, exports, module ) {
         var selected = $this.select2('data');
         var doc = selected && selected[0] && selected[0].doc;
         if (doc) {
-            var form = $this.closest('form.or');
+            // find the nearest repeat section, or form if not in a repeat
+            var parent = $this.closest('.or-repeat,form.or');
             var field = $this.attr('name');
             var objectRoot = field.substring(0, field.lastIndexOf('/'));
-            updateFields(form, doc, objectRoot, field);
+            updateFields(parent, doc, objectRoot, field);
         }
     };
 
-    var updateFields = function(form, doc, objectRoot, keyPath) {
+    var updateFields = function(parent, doc, objectRoot, keyPath) {
         Object.keys(doc).forEach(function(key) {
             var path = objectRoot + '/' + key;
             if (path === keyPath) {
@@ -98,9 +99,9 @@ define( function( require, exports, module ) {
             }
             if (_.isObject(value)) {
                 // recursively set fields for children
-                return updateFields(form, value, path, keyPath);
+                return updateFields(parent, value, path, keyPath);
             }
-            form.find('[name="' + path + '"]')
+            parent.find('[name="' + path + '"]')
                 .val(value)
                 .trigger('change');
         });


### PR DESCRIPTION
# Description

When the selected db object is changed in a select2 widget we
attempt to bind to other fields defined by that object. This
allows form configurations that can interrogate other fields
on the object.

The bug was that when binding the code matched all the fields in
all the selects, rather than just the fields in this repeat
section.

medic/medic-webapp#3430

# Review checklist

- [x] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [x] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.