### PR TITLE
Run CI on master branch against latest master of submodules

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,12 @@ _TBC_
 
 - [#1472](https://github.com/medic/medic-webapp/issues/1472) adds password validation so when creating or updating users the new passwords have to be at least 8 characters long and reasonably complex.
 
+### Continuous Integration
+
+- [#3621](https://github.com/medic/medic-webapp/pull/3621) Automatically update
+  to master branches of `api` and `sentinel` submodules before running CI in
+  Travis.
+
 ## 2.12.0
 
 _June 20, 2017_

--- a/scripts/ci/setup.sh
+++ b/scripts/ci/setup.sh
@@ -6,6 +6,9 @@ ARGS+='this.dependencies_included = true;'
 # Process append to the version string if pre-release
 if [ "$TRAVIS_BRANCH" == "master" ]; then
     ARGS+="this.version += \"-alpha.$TRAVIS_BUILD_NUMBER\";"
+    # Run CI against latest master of submodules if this is master
+    git submodule update --remote api
+    git submodule update --remote sentinel
 elif [[ "$TRAVIS_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(rc|beta)\.[0-9]+$ ]]; then
     ARGS+="this.version = \"$TRAVIS_TAG\";"
 fi


### PR DESCRIPTION
# Description

Update submodules to latest master before running tests.  Example build where you can see latest master is checked out: https://travis-ci.org/medic/medic-webapp/jobs/250756289#L3985

Travis also does a `git submodule update --recursive` after git clone here https://travis-ci.org/medic/medic-webapp/jobs/250756289#L487 if we could add some logic there to check the travis branch string and append `--remote` that could work too.

Related: https://github.com/medic/medic-webapp/issues/3359

# Review checklist

- [x] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [x] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.