### PR TITLE
Stop kanso from building node modules (api and sentinel)

### DIFF
--- a/kanso.json
+++ b/kanso.json
@@ -48,8 +48,7 @@
         "app-settings": ">=0.0.2",
         "url": null,
         "querystring": null,
-        "duality": null,
-        "kanso-gardener": null
+        "duality": null
     },
     "postprocessors": {
         "bundle_templates": "scripts/bundle_templates"


### PR DESCRIPTION
# Description

The node modules are packaged in CI for releases and is rarely ever used in dev.  It slows down the dev build step significantly, in my setup `grunt deploy` improves from 59s to 11s.

https://github.com/medic/medic-webapp/issues/2678

# Review checklist

- [x] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.