### PR TITLE
Allow for docs to be directly on $scope.selected #3646

### DIFF
--- a/static/js/controllers/reports.js
+++ b/static/js/controllers/reports.js
@@ -79,7 +79,7 @@ angular.module('inboxControllers').controller('ReportsCtrl',
     var setRightActionBar = function() {
       var model = {};
       model.selected = $scope.selected.map(function(s) {
-        return s.doc || s.summary;
+        return s.doc || s.summary || s;
       });
       var doc = !$scope.selectMode &&
                 model.selected &&


### PR DESCRIPTION
# Description

Types. I miss them.

medic/medic-webapp#3646

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.