### PR TITLE
Yeshup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ before_script:
   - npm install grunt-cli -g
   - npm --prefix api install
   - ./node_modules/.bin/webdriver-manager update
-  - nohup bash -c "./node_modules/.bin/webdriver-manager start 2>&1 &"
+  - bash -c "./node_modules/.bin/webdriver-manager start 2>&1 &"
   - until nc -z localhost 4444; do sleep 1; done
 
 script:
@@ -67,7 +67,6 @@ script:
     elif [ "$COUCH_VERSION" = 1 ]; then
       node --stack_size=10000 `which grunt` ci1
     fi
-  - cat nohup.out || true
 
 after_success:
  - python ./scripts/ci/travis_after_all.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ before_script:
   - npm install grunt-cli -g
   - npm --prefix api install
   - ./node_modules/.bin/webdriver-manager update
-  - bash -c "./node_modules/.bin/webdriver-manager start 2>&1 &"
+  - ./node_modules/.bin/webdriver-manager start &
   - until nc -z localhost 4444; do sleep 1; done
 
 script:


### PR DESCRIPTION
@garethbowen apparently the `nohup` call was added "to make tests pass locally".  Is this still required?  If it isn't used, I think build failures will be much quicker to diagnose, as test failures should be displayed at the end of the log.  We can confirm that when Travis has built this PR.  If you could confirm if `nohup` is really required locally, that would be great.