### PR TITLE
Returns correct http codes

### DIFF
--- a/packages/app-settings/app-settings/updates.js
+++ b/packages/app-settings/app-settings/updates.js
@@ -11,10 +11,15 @@
 exports.update_config = function (ddoc, req) {
 
     var replace = req.query && req.query.replace;
+    var result = _process(ddoc, req.body, replace);
 
     return [
         ddoc,
-        JSON.stringify(_process(ddoc, req.body, replace))
+        {
+            headers: { "Content-Type" : "application/json" },
+            body: JSON.stringify(result),
+            code: result.code
+        }
     ];
 
 };
@@ -29,6 +34,7 @@ var _process = function (ddoc, body, replace) {
     if (!ddoc) {
         return {
             success: false,
+            code: 404,
             error: 'Design document not found'
         };
     }
@@ -44,6 +50,7 @@ var _process = function (ddoc, body, replace) {
     } catch(e) {
         return {
             success: false,
+            code: 400,
             error: 'Request body must be valid JSON'
         };
     }

--- a/packages/kujua-sms/kujua-sms/updates.js
+++ b/packages/kujua-sms/kujua-sms/updates.js
@@ -217,7 +217,7 @@ var add_json = exports.add_json = function(doc, request) {
         data = JSON.parse(req.body);
     } catch(e) {
         kutils.logger.error(req.body);
-        return [null, getErrorResponse('Error: request body not valid JSON.')];
+        return [null, getErrorResponse('Error: request body not valid JSON.', 400)];
     }
 
     // use locale if passed in via query param
@@ -235,7 +235,7 @@ var add_json = exports.add_json = function(doc, request) {
 
     // require form definition
     if (!def) {
-        return [null, getErrorResponse('Form not found: ' + options.form)];
+        return [null, getErrorResponse('Form not found: ' + options.form, 404)];
     }
 
     // For now only save string and number fields, ignore the others.

--- a/tests/nodeunit/unit/kujua-sms/updates.js
+++ b/tests/nodeunit/unit/kujua-sms/updates.js
@@ -462,19 +462,20 @@ exports['creates record with empty message field'] = function(test) {
     test.done();
 };
 
-exports['JSON POST: return 500 error if form not found'] = function(test) {
+exports['JSON POST: return 404 error if form not found'] = function(test) {
     var req = {
-        body: '{ "_meta: { "form: "foo" } }'
+        body: '{ "_meta": { "form": "foo" } }'
     };
     var ret = updates.add(null, req),
         resp_body = JSON.parse(ret[1].body);
     test.same(ret[0], null);
     test.same(resp_body.payload.success, false);
-    test.same(ret[1].code, 500);
+    test.same(resp_body.payload.error, 'Form not found: FOO');
+    test.same(ret[1].code, 404);
     test.done();
 };
 
-exports['JSON POST: return 500 error if JSON parse fails'] = function(test) {
+exports['JSON POST: return 400 error if JSON parse fails'] = function(test) {
     var req = {
         body: 'bad json'
     };
@@ -482,7 +483,7 @@ exports['JSON POST: return 500 error if JSON parse fails'] = function(test) {
         resp_body = JSON.parse(ret[1].body);
     test.same(ret[0], null);
     test.same(resp_body.payload.success, false);
-    test.same(ret[1].code, 500);
+    test.same(ret[1].code, 400);
     test.done();
 };
 


### PR DESCRIPTION
# Description

The couch updates endpoints were always returning 200 status even
if the operation failed. This change returns 200, 400, or 404 as
appropriate so it's more obvious when a request fails.

medic/medic-webapp#3674

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.