### PR TITLE
Hides collect forms in the UI

### DIFF
--- a/static/js/controllers/configuration-forms-xml.js
+++ b/static/js/controllers/configuration-forms-xml.js
@@ -101,7 +101,7 @@ angular.module('inboxControllers').controller('ConfigurationFormsXmlCtrl',
         .catch(uploadFinished);
     };
 
-    XmlForms('configuration-forms', { ignoreContext:true }, function(err, forms) {
+    XmlForms('configuration-forms', { ignoreContext: true, includeCollect: true }, function(err, forms) {
       if (err) {
         return $log.error('Error fetching XForms for form config page.', err);
       }

--- a/static/js/services/xml-forms.js
+++ b/static/js/services/xml-forms.js
@@ -60,6 +60,10 @@ angular.module('inboxServices').factory('XmlForms',
     };
 
     var filter = function(form, options, user) {
+      if (!options.includeCollect && form.context && form.context.collect) {
+        return false;
+      }
+
       if (options.contactForms !== undefined) {
         var isContactForm = form._id.indexOf('form:contact:') === 0;
         if (options.contactForms !== isContactForm) {

--- a/tests/karma/unit/services/xml-forms.js
+++ b/tests/karma/unit/services/xml-forms.js
@@ -676,4 +676,51 @@ describe('XmlForms service', () => {
       }
     });
   });
+
+  describe('collect forms', () => {
+
+    const collectForm = {
+      id: 'collect',
+      doc: {
+        _id: 'collect',
+        internalId: 'collect',
+        _attachments: { xml: { something: true } },
+        context: { collect: true },
+      }
+    };
+    const enketoForm = {
+      id: 'enketo',
+      doc: {
+        _id: 'enketo',
+        internalId: 'enketo',
+        _attachments: { xml: { something: true } },
+        context: { },
+      }
+    };
+
+    it('are excluded by default', done => {
+      dbQuery.returns(Promise.resolve({ rows: [ collectForm, enketoForm ] }));
+      UserContact.returns(Promise.resolve());
+      const service = $injector.get('XmlForms');
+      service('test', {}, (err, actual) => {
+        chai.expect(err).to.equal(null);
+        chai.expect(actual.length).to.equal(1);
+        chai.expect(actual[0]._id).to.equal('enketo');
+        done();
+      });
+    });
+
+    it('are returned if includeCollect is true', done => {
+      dbQuery.returns(Promise.resolve({ rows: [ collectForm, enketoForm ] }));
+      UserContact.returns(Promise.resolve());
+      const service = $injector.get('XmlForms');
+      service('test', { includeCollect: true }, (err, actual) => {
+        chai.expect(err).to.equal(null);
+        chai.expect(actual.length).to.equal(2);
+        chai.expect(actual[0]._id).to.equal('collect');
+        chai.expect(actual[1]._id).to.equal('enketo');
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
# Description

This updates the XmlForms service to not return forms with
context.collect true. This means users cannot filter by a collect
form which will never have any reports submitted. Furthermore
they cannot attempt to fill in a collect form. The only place
which still shows collect forms is the forms admin page.

medic/medic-webapp#3625

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.