### PR TITLE
Avoid selecting multiple elements in webdriver tests

### DIFF
--- a/tests/protractor/e2e/submit-enketo-form.js
+++ b/tests/protractor/e2e/submit-enketo-form.js
@@ -102,10 +102,10 @@ describe('Submit Enketo form', () => {
 
     // refresh - live list only updates on changes but changes are disabled for e2e
     browser.driver.navigate().refresh();
-    helper.waitElementToBeClickable(element(by.css('.action-container .general-actions .fa-plus')));
+    const addButton = element(by.css('.action-container .general-actions:not(.ng-hide) .fa-plus'));
+    helper.waitElementToBeClickable(addButton);
 
     // select form
-    const addButton = element(by.css('.action-container .general-actions .fa-plus'));
     browser.wait(() => {
       return addButton.isPresent();
     }, 10000);


### PR DESCRIPTION
# Description
When selecting elements for webdriver tests, if your selector selects several, the first will be used and the other dropped. This can cause a selection of the wrong element.
medic/medic-webapp#3691

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.