### PR TITLE
3698 more than one

### DIFF
--- a/tests/protractor/e2e/auditing.js
+++ b/tests/protractor/e2e/auditing.js
@@ -90,7 +90,7 @@ describe('Auditing', () => {
     // delete the message
     newMessage.click();
     element(by.css('#message-content ul li[data-record-id="' + savedUuid + '"] .fa-trash-o')).click();
-    const confirmButton = element(by.css('#delete-confirm .submit'));
+    const confirmButton = element(by.css('#delete-confirm .submit:not(.ng-hide)'));
     browser.wait(protractor.ExpectedConditions.elementToBeClickable(confirmButton), 5000);
     confirmButton.click();
 

--- a/tests/protractor/e2e/bulk-delete.js
+++ b/tests/protractor/e2e/bulk-delete.js
@@ -141,7 +141,7 @@ describe('Bulk delete reports', () => {
 
     // delete all selected
     element(by.css('.action-container .detail-actions .delete-all')).click();
-    const confirmButton = element(by.css('#delete-confirm .submit'));
+    const confirmButton = element(by.css('#delete-confirm .submit:not(.ng-hide)'));
     browser.wait(protractor.ExpectedConditions.elementToBeClickable(confirmButton), 5000);
     confirmButton.click();
 

--- a/tests/protractor/e2e/forms/submit-delivery-form.specs.js
+++ b/tests/protractor/e2e/forms/submit-delivery-form.specs.js
@@ -76,11 +76,11 @@ describe('Submit Delivery Report', () => {
     // refresh - live list only updates on changes but changes are disabled for e2e
     browser.driver.navigate().refresh();
     browser.wait(() => {
-      return element(by.css('.action-container .general-actions .fa-plus')).isPresent();
+      return element(by.css('.action-container .general-actions:not(.ng-hide) .fa-plus')).isPresent();
     }, 10000);
 
     // select form
-    const addButton = element(by.css('.action-container .general-actions .fa-plus'));
+    const addButton = element(by.css('.action-container .general-actions:not(.ng-hide) .fa-plus'));
     browser.wait(() => {
       return addButton.isPresent();
     }, 10000);

--- a/tests/protractor/e2e/send-message.js
+++ b/tests/protractor/e2e/send-message.js
@@ -123,7 +123,7 @@ describe('Send message', () => {
   };
 
   const sendMessage = () => {
-    element(by.css('#send-message a.btn.submit')).click();
+    element(by.css('#send-message a.btn.submit:not(.ng-hide)')).click();
 
     browser.wait(() => {
       return element(by.css('#send-message')).isDisplayed()

--- a/tests/protractor/page-objects/forms/delivery-report.po.js
+++ b/tests/protractor/page-objects/forms/delivery-report.po.js
@@ -1157,16 +1157,16 @@ module.exports = {
 
   //summary page
   getOutcomeText: () => {
-    return element(by.css('[data-value=" /delivery/group_delivery_summary/display_delivery_outcome "]'))
+    return element(by.css('[lang="en"] [data-value=" /delivery/group_delivery_summary/display_delivery_outcome "]'))
       .getInnerHtml();
   },
 
   getDeliveryLocationSummaryText: () => {
-    return element(by.css('[data-value=" /delivery/group_summary/r_delivery_location "]'))
+    return element(by.css('[lang="en"] [data-value=" /delivery/group_summary/r_delivery_location "]'))
       .getInnerHtml();
   },
 
   getFollowUpMessage: () => {
-    return element(by.css('[data-value=" /delivery/group_note/g_chw_sms "]')).getInnerHtml();
+    return element(by.css('[lang="en"] [data-value=" /delivery/group_note/g_chw_sms "]')).getInnerHtml();
   },
 };

--- a/tests/protractor/page-objects/users/add-user-modal.po.js
+++ b/tests/protractor/page-objects/users/add-user-modal.po.js
@@ -31,7 +31,7 @@ const getConfirmPasswordField = () => {
   return element(by.id('password-confirm'));
 };
 const getSubmitButton = () => {
-  return element(by.className('btn submit btn-primary'));
+  return element(by.css('.btn.submit.btn-primary:not(.ng-hide)'));
 };
 
 const getCancelButton = () => {


### PR DESCRIPTION
# Description

When selecting elements for webdriver tests, if your selector selects several, the first will be used and the other dropped. This can cause a selection of the wrong element.
medic/medic-webapp#3698

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.