### PR TITLE
Add a refresh of the page at start of test to remove parasite modals.…

### DIFF
--- a/tests/protractor/e2e/contacts/create-new-district.specs.js
+++ b/tests/protractor/e2e/contacts/create-new-district.specs.js
@@ -3,6 +3,7 @@ const commonElements = require('../../page-objects/common/common.po.js'),
 
 describe('Add new district tests : ', () => {
   it('should open new place form', () => {
+    browser.driver.navigate().refresh();
     commonElements.goToPeople();
     expect(commonElements.isAt('contacts-list'));
     expect(browser.getCurrentUrl()).toEqual(commonElements.getBaseUrl() + 'contacts/');


### PR DESCRIPTION
# Description

Clicking the contacts-tab is hitting a modal. Adding a refresh of the page to clean up old modals.
medic/medic-webapp#3689

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.