### PR TITLE
Enable the changes feed for e2e tests

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -83,9 +83,6 @@ _.templateSettings = {
     $compileProvider.debugInfoEnabled(isDevelopment);
   });
 
-  // Protractor waits for requests to complete so we have to disable
-  // long polling requests.
-  app.constant('E2ETESTING', window.location.href.indexOf('e2eTesting=true') !== -1);
   app.constant('APP_CONFIG', {
     name: '@@APP_CONFIG.name',
     version: '@@APP_CONFIG.version'

--- a/static/js/services/changes.js
+++ b/static/js/services/changes.js
@@ -16,8 +16,7 @@ angular.module('inboxServices').factory('Changes',
   function(
     $log,
     $timeout,
-    DB,
-    E2ETESTING
+    DB
   ) {
 
     'use strict';
@@ -58,11 +57,7 @@ angular.module('inboxServices').factory('Changes',
         });
     };
 
-    // Longpoll requests like changes hangs protractor testing as it waits
-    // for all requests to finish.
-    if (!E2ETESTING) {
-      watchChanges();
-    }
+    watchChanges();
 
     return function(options) {
       callbacks[options.key] = options;

--- a/templates/modals/version_update.html
+++ b/templates/modals/version_update.html
@@ -1,4 +1,5 @@
 <mm-modal
+  id="'update-available'"
   status="status"
   title-key="'version.update.title'"
   submit-key="'Update'"

--- a/tests/protractor/conf.js
+++ b/tests/protractor/conf.js
@@ -5,7 +5,7 @@ const utils = require('./utils'),
   modules = [];
 
 const getLoginUrl = () => {
-  const redirectUrl = encodeURIComponent(`/${constants.DB_NAME}/_design/medic/_rewrite/#/messages?e2eTesting=true`);
+  const redirectUrl = encodeURIComponent(`/${constants.DB_NAME}/_design/medic/_rewrite/#/messages`);
   return `http://${constants.API_HOST}:${constants.API_PORT}/${constants.DB_NAME}/login?redirect=${redirectUrl}`;
 };
 

--- a/tests/protractor/e2e/auditing.js
+++ b/tests/protractor/e2e/auditing.js
@@ -37,7 +37,6 @@ describe('Auditing', () => {
 
   let savedUuid;
   beforeEach(done=> {
-    browser.ignoreSynchronization = true;
     utils.saveDoc(message)
       .then(doc=> {
         savedUuid = doc.id;

--- a/tests/protractor/e2e/bulk-delete.js
+++ b/tests/protractor/e2e/bulk-delete.js
@@ -58,7 +58,6 @@ describe('Bulk delete reports', () => {
 
   const savedUuids = [];
   beforeEach(done => {
-    browser.ignoreSynchronization = true;
     protractor.promise
       .all(docs.map(utils.saveDoc))
       .then(results => {
@@ -67,10 +66,7 @@ describe('Bulk delete reports', () => {
         });
         done();
       })
-      .catch(err => {
-        console.error('Error saving docs', err);
-        done();
-      });
+      .catch(done.fail);
   });
 
   afterEach(utils.afterEach);
@@ -78,7 +74,6 @@ describe('Bulk delete reports', () => {
   it('reports', () => {
     element(by.id('reports-tab')).click();
 
-    browser.wait(() => element(by.css('#reports-list')), 10000, 'Refresh completes');
     browser.wait(() => element(by.css('#reports-list li:first-child')).isPresent(), 10000, 'There should be at least one report in the LHS');
 
     // start select mode

--- a/tests/protractor/e2e/bulk-delete.js
+++ b/tests/protractor/e2e/bulk-delete.js
@@ -78,8 +78,6 @@ describe('Bulk delete reports', () => {
   it('reports', () => {
     element(by.id('reports-tab')).click();
 
-    // refresh - live list only updates on changes but changes are disabled for e2e
-    browser.driver.navigate().refresh();
     browser.wait(() => element(by.css('#reports-list')), 10000, 'Refresh completes');
     browser.wait(() => element(by.css('#reports-list li:first-child')).isPresent(), 10000, 'There should be at least one report in the LHS');
 
@@ -145,15 +143,11 @@ describe('Bulk delete reports', () => {
     browser.wait(protractor.ExpectedConditions.elementToBeClickable(confirmButton), 5000);
     confirmButton.click();
 
-    // refresh - live list only updates on changes but changes are disabled for e2e
-    browser.sleep(1000);
-    browser.driver.navigate().refresh();
     browser.wait(() => {
-      return element(by.css('#reports-list li:first-child')).isPresent();
+      return element.all(by.css('#reports-list li')).count().then(utils.countOf(1));
     }, 10000);
 
     // make sure the reports are deleted
-    expect(element.all(by.css('#reports-list li')).count()).toBe(1);
     expect(element.all(by.css('#reports-list li[data-record-id="' + savedUuids[1] + '"]')).count()).toBe(1);
 
   });

--- a/tests/protractor/e2e/contact-summary.js
+++ b/tests/protractor/e2e/contact-summary.js
@@ -120,26 +120,15 @@ describe('Contact summary info', () => {
   const DOCS = [ALICE, BOB_PLACE, CAROL, DAVID, PREGNANCY, VISIT];
 
   beforeEach(done => {
-    browser.ignoreSynchronization = true;
     utils.updateSettings({ contact_summary: SCRIPT })
       .then(() => {
         return protractor.promise.all(DOCS.map(utils.saveDoc));
       })
       .then(done)
-      .catch(done);
+      .catch(done.fail);
   });
 
-  afterEach(done => {
-    utils.afterEach()
-      .catch(() => { })
-      .then(() => {
-        browser.driver.navigate().refresh();
-        browser.wait(() => {
-          return element(by.id('contacts-tab')).isPresent();
-        }, 10000);
-        done();
-      });
-  });
+  afterEach(utils.afterEach);
 
   const selectContact = term => {
     element(by.id('contacts-tab')).click();
@@ -152,12 +141,6 @@ describe('Contact summary info', () => {
   };
 
   it('contact summary', () => {
-
-    // select contact
-    browser.driver.navigate().refresh();
-    browser.wait(() => {
-      return element(by.id('contacts-tab')).isPresent();
-    }, 10000);
     selectContact('carol');
 
     // assert the summary card has the right fields

--- a/tests/protractor/e2e/contacts/create-new-district.specs.js
+++ b/tests/protractor/e2e/contacts/create-new-district.specs.js
@@ -1,9 +1,8 @@
 const commonElements = require('../../page-objects/common/common.po.js'),
-  contactPage = require('../../page-objects/contacts/contacts.po.js');
+      contactPage = require('../../page-objects/contacts/contacts.po.js');
 
 describe('Add new district tests : ', () => {
   it('should open new place form', () => {
-    browser.driver.navigate().refresh();
     commonElements.goToPeople();
     expect(commonElements.isAt('contacts-list'));
     expect(browser.getCurrentUrl()).toEqual(commonElements.getBaseUrl() + 'contacts/');

--- a/tests/protractor/e2e/docs-by-replication-key-view.js
+++ b/tests/protractor/e2e/docs-by-replication-key-view.js
@@ -168,7 +168,7 @@ describe('view docs_by_replication_key', () => {
       err => {
         if (err) {
           console.error(err);
-          return done(err);
+          return done.fail(err);
         }
         console.log('…done');
 

--- a/tests/protractor/e2e/forms/submit-delivery-form.specs.js
+++ b/tests/protractor/e2e/forms/submit-delivery-form.specs.js
@@ -1,7 +1,7 @@
 const helper = require('../../helper'),
-  deliveryReport = require('../../page-objects/forms/delivery-report.po.js'),
-  common = require('../../page-objects/common/common.po.js'),
-  utils = require('../../utils');
+      deliveryReport = require('../../page-objects/forms/delivery-report.po.js'),
+      common = require('../../page-objects/common/common.po.js'),
+      utils = require('../../utils');
 
 describe('Submit Delivery Report', () => {
 
@@ -58,7 +58,6 @@ describe('Submit Delivery Report', () => {
   const noteToCHW = 'Good news, Jack! Jack () has delivered at the health facility. We will alert you when it is time to refer them for PNC. Please monitor them for danger signs. Thank you!';
 
   beforeAll(done =>{
-    browser.ignoreSynchronization = true;
     deliveryReport.configureForm(done);
     utils.seedTestData(done, contactId, docs);
   });
@@ -70,11 +69,8 @@ describe('Submit Delivery Report', () => {
 
   afterAll(utils.afterEach);
 
-
   it('open delivery form', () => {
     common.goToReports();
-    // refresh - live list only updates on changes but changes are disabled for e2e
-    browser.driver.navigate().refresh();
     browser.wait(() => {
       return element(by.css('.action-container .general-actions:not(.ng-hide) .fa-plus')).isPresent();
     }, 10000);

--- a/tests/protractor/e2e/forms/submit-delivery-form.specs.js
+++ b/tests/protractor/e2e/forms/submit-delivery-form.specs.js
@@ -75,6 +75,8 @@ describe('Submit Delivery Report', () => {
       return element(by.css('.action-container .general-actions:not(.ng-hide) .fa-plus')).isPresent();
     }, 10000);
 
+    browser.sleep(1000); // let the refresh work - #3691
+
     // select form
     const addButton = element(by.css('.action-container .general-actions:not(.ng-hide) .fa-plus'));
     browser.wait(() => {

--- a/tests/protractor/e2e/registration-by-sms.js
+++ b/tests/protractor/e2e/registration-by-sms.js
@@ -194,16 +194,9 @@ describe('registration transition', () => {
     });
   };
 
-  // refresh after changing settings so the new settings are loaded
-  const refresh = () => {
-    browser.driver.navigate().refresh();
-    return browser.wait(() => element(by.id('reports-tab')).isPresent(), 10000);
-  };
-
   describe('submits new sms messages', () => {
 
     beforeEach(done => {
-      browser.ignoreSynchronization = true;
       const body = {
         messages: [{
           from: PHONE,
@@ -214,17 +207,11 @@ describe('registration transition', () => {
       utils.updateSettings(CONFIG)
         .then(() => protractor.promise.all(DOCS.map(utils.saveDoc)))
         .then(() => submit(body))
-        .then(() => refresh)
         .then(done)
-        .catch(done);
+        .catch(done.fail);
     });
 
-    afterEach(done => {
-      utils.afterEach()
-        .then(refresh)
-        .then(done)
-        .catch(done);
-    });
+    afterEach(utils.afterEach);
 
     const checkItemSummary = () => {
       const summaryElement = element(by.css('#reports-content .item-summary'));
@@ -251,10 +238,6 @@ describe('registration transition', () => {
     };
 
     it('shows content', () => {
-      // wait for sentinel to do its thing
-      // TODO find a better way to wait
-      browser.sleep(1000);
-      refresh();
       element(by.id('reports-tab')).click();
       browser.wait(() => element(by.cssContainingText('#reports-list .unfiltered li:first-child .name', CAROL.name)).isPresent(), 10000);
 

--- a/tests/protractor/e2e/report-date-filter.js
+++ b/tests/protractor/e2e/report-date-filter.js
@@ -86,7 +86,6 @@ describe('Filters reports', () => {
 
   const savedUuids = [];
   beforeEach(done => {
-    browser.ignoreSynchronization = true;
     protractor.promise
       .all(reports.map(utils.saveDoc))
       .then(results => {
@@ -95,10 +94,7 @@ describe('Filters reports', () => {
         });
         done();
       })
-      .catch(err => {
-        console.error('Error saving docs', err);
-        done();
-      });
+      .catch(done.fail);
   });
 
   afterEach(utils.afterEach);
@@ -106,8 +102,6 @@ describe('Filters reports', () => {
   it('by date', () => {
     element(by.id('reports-tab')).click();
 
-    // refresh - live list only updates on changes but changes are disabled for e2e
-    browser.driver.navigate().refresh();
     browser.wait(() => {
       return element(by.css('#reports-list li:first-child')).isPresent();
     }, 10000);

--- a/tests/protractor/e2e/send-message.js
+++ b/tests/protractor/e2e/send-message.js
@@ -39,12 +39,10 @@ describe('Send message', () => {
   const CONTACTS = [ALICE, BOB_PLACE, CAROL, DAVID];
 
   beforeAll(done => {
-    console.log('beforeAll for send-message');
-    browser.ignoreSynchronization = true;
     protractor.promise
       .all(CONTACTS.map(utils.saveDoc))
       .then(done)
-      .catch(done);
+      .catch(done.fail);
   });
 
   afterEach(done => {

--- a/tests/protractor/e2e/sms-gateway.js
+++ b/tests/protractor/e2e/sms-gateway.js
@@ -140,7 +140,6 @@ describe('sms-gateway api', () => {
   describe('- gateway submits new WT sms messages', () => {
 
     beforeEach(done => {
-      browser.ignoreSynchronization = true;
       const body = {
         messages: [{
           from: '+64271234567',
@@ -148,14 +147,11 @@ describe('sms-gateway api', () => {
           id: 'a'
         }]
       };
-      pollSmsApi(body).then(done).catch(done);
+      pollSmsApi(body).then(done).catch(done.fail);
     });
 
     it('- shows content', () => {
       element(by.id('messages-tab')).click();
-
-      // refresh - live list only updates on changes but changes are disabled for e2e
-      browser.driver.navigate().refresh();
 
       // LHS
       browser.wait(() => {
@@ -183,8 +179,6 @@ describe('sms-gateway api', () => {
     let savedDoc;
 
     beforeEach(done => {
-      browser.ignoreSynchronization = true;
-
       utils.saveDoc(report)
         .then(result => {
           savedDoc = result.id;
@@ -195,20 +189,17 @@ describe('sms-gateway api', () => {
               { id: messageId3, status: 'FAILED', reason: 'Insufficient credit' }
             ]
           };
-          pollSmsApi(body).then(done).catch(done);
+          pollSmsApi(body).then(done).catch(done.fail);
         })
-        .catch(done);
+        .catch(done.fail);
     });
 
     afterEach(done => {
-      utils.deleteDoc(savedDoc).then(done).catch(done);
+      utils.deleteDoc(savedDoc).then(done).catch(done.fail);
     });
 
     it('- shows content', () => {
       element(by.id('reports-tab')).click();
-
-      // refresh - live list only updates on changes but changes are disabled for e2e
-      browser.driver.navigate().refresh();
 
       browser.wait(() => {
         return element(by.css('#reports-list li:first-child')).isPresent();
@@ -237,8 +228,6 @@ describe('sms-gateway api', () => {
     let response;
 
     beforeEach(done => {
-      browser.ignoreSynchronization = true;
-
       const reportWithTwoMessagesToSend = JSON.parse(JSON.stringify(report));
       // First scheduled message is in forwarded-to-gateway state.
       reportWithTwoMessagesToSend.scheduled_tasks[0].state = 'forwarded-to-gateway';
@@ -258,7 +247,7 @@ describe('sms-gateway api', () => {
     });
 
     afterEach(done => {
-      utils.deleteDoc(savedDoc).then(done).catch(done);
+      utils.deleteDoc(savedDoc).then(done).catch(done.fail);
     });
 
     it('- returns list and updates state', () => {
@@ -292,9 +281,6 @@ describe('sms-gateway api', () => {
       expect(response.messages[1].content).toBe(messageContent2);
 
       element(by.id('reports-tab')).click();
-
-      // refresh - live list only updates on changes but changes are disabled for e2e
-      browser.driver.navigate().refresh();
 
       browser.wait(() => {
         return element(by.css('#reports-list li:first-child')).isPresent();

--- a/tests/protractor/e2e/submit-enketo-form.js
+++ b/tests/protractor/e2e/submit-enketo-form.js
@@ -23,7 +23,6 @@ describe('Submit Enketo form', () => {
   </h:html>`;
 
   const contactId = '3b3d50d275280d2568cd36281d00348b';
-  //const userSettingsDocId = `org.couchdb.user:${auth.user}`;
 
   const docs = [
     {
@@ -90,19 +89,11 @@ describe('Submit Enketo form', () => {
     utils.seedTestData(done, contactId, docs);
   });
 
-  afterEach(done => {
-    utils.resetBrowser();
-    done();
-  });
-
-  afterAll(utils.afterEach);
+  afterEach(utils.afterEach);
 
   it('submits on reports tab', () => {
     element(by.id('reports-tab')).click();
 
-    // refresh - live list only updates on changes but changes are disabled for e2e
-    browser.driver.navigate().refresh();
-    browser.sleep(1000); // let the refresh work - #3691
     const addButton = element(by.css('.action-container .general-actions:not(.ng-hide) .fa-plus'));
     helper.waitElementToBeClickable(addButton);
     // select form

--- a/tests/protractor/e2e/submit-enketo-form.js
+++ b/tests/protractor/e2e/submit-enketo-form.js
@@ -93,6 +93,7 @@ describe('Submit Enketo form', () => {
 
   it('submits on reports tab', () => {
     element(by.id('reports-tab')).click();
+    browser.sleep(1000); // let the refresh work - #3691
 
     const addButton = element(by.css('.action-container .general-actions:not(.ng-hide) .fa-plus'));
     helper.waitElementToBeClickable(addButton);

--- a/tests/protractor/helper.js
+++ b/tests/protractor/helper.js
@@ -83,7 +83,6 @@ module.exports = {
 
   setBrowserParams: ()=> {
     browser.driver.manage().window().setSize(browser.params.screenWidth, browser.params.screenHeight);
-    browser.ignoreSynchronization = true;
   },
 
   isTextDisplayed: text=> {

--- a/tests/protractor/page-objects/forms/delivery-report.po.js
+++ b/tests/protractor/page-objects/forms/delivery-report.po.js
@@ -1102,9 +1102,7 @@ module.exports = {
   },
 
   selectPatientName: (name) => {
-    browser.driver.navigate().refresh();
     helper.waitElementToBeClickable(element(by.css('button.btn.btn-primary.next-page')));
-
     element(by.css('.selection')).click();
     const search = element(by.css('.select2-search__field'));
     search.click();

--- a/tests/protractor/utils.js
+++ b/tests/protractor/utils.js
@@ -141,7 +141,7 @@ const refreshToGetNewSettings = () => {
     })
     .then(() => {
       return browser.wait(protractor.ExpectedConditions.elementToBeClickable(element(by.id('contacts-tab'))), 10000);
-    })
+    });
 };
 
 const revertDb = () => {

--- a/tests/protractor/utils.js
+++ b/tests/protractor/utils.js
@@ -1,14 +1,13 @@
 const _ = require('underscore'),
-  auth = require('./auth')(),
-  constants = require('./constants'),
-  http = require('http'),
-  path = require('path');
+      auth = require('./auth')(),
+      constants = require('./constants'),
+      http = require('http'),
+      path = require('path'),
+      // The app_settings and update_settings modules are on the main ddoc.
+      mainDdocName = 'medic',
+      userSettingsDocId = `org.couchdb.user:${auth.user}`;
 
-const originalSettings = {};
-
-// The app_settings and update_settings modules are on the main ddoc.
-const mainDdocName = 'medic';
-const userSettingsDocId = `org.couchdb.user:${auth.user}`;
+let originalSettings;
 
 const request = (options, debug) =>  {
   const deferred = protractor.promise.defer();
@@ -32,7 +31,7 @@ const request = (options, debug) =>  {
       try {
         body = JSON.parse(body);
         if (body.error) {
-          deferred.reject(new Error('Request failed: ' + options.path + ',\n  body: ' + JSON.stringify(options.body) + '\n  response: ' + JSON.stringify(body)));
+          deferred.reject(new Error(`Request failed: ${options.path},\n  body: ${JSON.stringify(options.body)}\n  response: ${JSON.stringify(body)}`));
         } else {
           deferred.fulfill(body);
         }
@@ -55,45 +54,46 @@ const request = (options, debug) =>  {
   return deferred.promise;
 };
 
-const updateSettingsForDdoc = (updates, ddocName) =>  {
-  if (originalSettings[ddocName]) {
-    throw new Error('A previous test did not call revertSettings on ' + ddocName);
+const updateSettings = updates =>  {
+  if (originalSettings) {
+    throw new Error('A previous test did not call revertSettings');
   }
   return request({
-    path: path.join('/', constants.DB_NAME, '_design', mainDdocName, '_rewrite/app_settings', ddocName),
+    path: path.join('/', constants.DB_NAME, '_design', mainDdocName, '_rewrite/app_settings', mainDdocName),
     method: 'GET'
   }).then(result =>  {
-    originalSettings[ddocName] = result.settings;
+    originalSettings = result.settings;
 
-    // Make sure all updated fields are present in originalSettings[ddocName], to enable reverting later.
+    // Make sure all updated fields are present in originalSettings, to enable reverting later.
     Object.keys(updates).forEach(updatedField =>  {
-      if (!_.has(originalSettings[ddocName], updatedField)) {
-        originalSettings[ddocName][updatedField] = null;
+      if (!_.has(originalSettings, updatedField)) {
+        originalSettings[updatedField] = null;
       }
     });
     return;
   }).then(() =>  {
     return request({
-      path: path.join('/', constants.DB_NAME, '_design', mainDdocName, '_rewrite/update_settings', ddocName, '?replace=1'),
+      path: path.join('/', constants.DB_NAME, '_design', mainDdocName, '_rewrite/update_settings', mainDdocName, '?replace=1'),
       method: 'PUT',
       body: JSON.stringify(updates)
     });
   });
 };
 
-const revertSettingsForDdoc = ddocName =>  {
-  if (!originalSettings[ddocName]) {
-    return Promise.resolve();
+const revertSettings = () =>  {
+  if (!originalSettings) {
+    return Promise.resolve(false);
   }
 
-  console.log(`Reverting settings for ${ddocName}`);
+  console.log(`Reverting settings`);
 
   return request({
-    path: path.join('/', constants.DB_NAME, '_design', mainDdocName, '_rewrite/update_settings', ddocName, '?replace=1'),
+    path: path.join('/', constants.DB_NAME, '_design', mainDdocName, '_rewrite/update_settings', mainDdocName, '?replace=1'),
     method: 'PUT',
-    body: JSON.stringify(originalSettings[ddocName])
+    body: JSON.stringify(originalSettings)
   }).then(() =>  {
-    delete originalSettings[ddocName];
+    originalSettings = null;
+    return true;
   });
 };
 
@@ -128,6 +128,33 @@ const deleteAll = () => {
     });
 };
 
+const refreshToGetNewSettings = () => {
+  // wait for the updates to replicate
+  return browser.wait(protractor.ExpectedConditions.elementToBeClickable(element(by.css('#update-available .submit'))), 10000)
+    .then(() => {
+      element(by.css('#update-available .submit')).click();
+    })
+    .catch(() => {
+      // sometimes there's a double update which causes the dialog to be redrawn
+      // retry with the new dialog
+      element(by.css('#update-available .submit')).click();
+    })
+    .then(() => {
+      return browser.wait(protractor.ExpectedConditions.elementToBeClickable(element(by.id('contacts-tab'))), 10000);
+    })
+};
+
+const revertDb = () => {
+  return revertSettings().then(needsRefresh => {
+    return deleteAll().then(() => {
+      // only need to refresh if the settings were changed
+      if (needsRefresh) {
+        return refreshToGetNewSettings();
+      }
+    });
+  });
+};
+
 module.exports = {
 
   request: request,
@@ -152,14 +179,14 @@ module.exports = {
 
   getDoc: id =>  {
     return request({
-      path: '/' + constants.DB_NAME + '/' + id,
+      path: `/${constants.DB_NAME}/${id}`,
       method: 'GET'
     });
   },
 
   getAuditDoc: id =>  {
     return request({
-      path: '/' + constants.DB_NAME + '-audit/' + id + '-audit',
+      path: `/${constants.DB_NAME}-audit/${id}-audit`,
       method: 'GET'
     });
   },
@@ -177,21 +204,11 @@ module.exports = {
     // Note that API will be copying changes to medic over to medic-client, so change
     // medic-client first (api does nothing) and medic after (api copies changes over to
     // medic-client, but the changes are already there.)
-    return updateSettingsForDdoc(updates, 'medic-client')
-      .then(() =>  {
-        return updateSettingsForDdoc(updates, 'medic');
-      });
-  },
-
-  revertSettings: () =>  {
-    return revertSettingsForDdoc('medic-client')
-      .then(() =>  {
-        return revertSettingsForDdoc('medic');
-      });
+    return updateSettings(updates)
+      .then(refreshToGetNewSettings);
   },
 
   seedTestData: (done, contactId, documents) => {
-    browser.ignoreSynchronization = true;
     protractor.promise
       .all(documents.map(module.exports.saveDoc))
       .then(() => module.exports.getDoc(userSettingsDocId))
@@ -200,7 +217,7 @@ module.exports = {
         return module.exports.saveDoc(user);
       })
       .then(done)
-      .catch(done);
+      .catch(done.fail);
   },
 
   /**
@@ -208,8 +225,7 @@ module.exports = {
    * and also returns a promise - pick one!
    */
   afterEach: done => {
-    return module.exports.revertSettings()
-      .then(deleteAll)
+    return revertDb()
       .then(() => {
         if (done) {
           done();
@@ -217,9 +233,8 @@ module.exports = {
       })
       .catch(err => {
         if (done) {
-          done(err);
+          done.fail(err);
         } else {
-          console.error('Error deleting all docs');
           throw err;
         }
       });


### PR DESCRIPTION
# Description

This means we don't need to refresh as much as the changes feed updates the UI without any refresh. It also means we test more code because we're now testing the UI is updated automatically.

Also uses `done.fail` which actually fails the test and returns the error message so it's easier to debug when something goes wrong.

medic/medic-webapp#3696

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.