### PR TITLE
Document change of config for multi_forms_alert : recipients are specified per report.

### DIFF
--- a/kanso.json
+++ b/kanso.json
@@ -433,7 +433,7 @@
                                 "rows": 3
                             },
                             "title": "Message",
-                            "description": "Text that will be sent out in the alert. Available template fields : alertName, numReportsThreshold, timeWindowInDays, countedReports. You can refer to the latest report as countedReports.0 (not countedReports[0] as in usual javascript! This is specific to the templates we use.), the previous counted report as countedReports.1, etc. E.g. \"{{alertName}} alert! {{countedReports.length}} reports in {{timeWindowInDays}} days, reported at {{countedReports.0.contact.parent.name}}. Reported by {{countedReports.0.contact.name}}, {{countedReports.1.contact.name}}, {{countedReports.2.contact.name}}.\""
+                            "description": "Text that will be sent out in the alert. You can refer to alertName, numReportsThreshold, timeWindowInDays, numCountedReports (total number of reports within the time window) and newReports (the counted reports which haven't been messaged about yet). Refer to the latest report as newReports.0 (not newReports[0] as in usual javascript! This is specific to the templates we use.), the previous report as newReports.1, etc. E.g. \"{{numCountedReports}} patients with {{alertName}} in {{timeWindowInDays}} days reported at {{countedReports.0.contact.parent.name}}. . New reports from: {{newReports.0.contact.name}}, {{newReports.1.contact.name}}, {{newReports.2.contact.name}}.\""
                         },
                         "recipients": {
                             "type": "array",

--- a/kanso.json
+++ b/kanso.json
@@ -438,7 +438,7 @@
                         "recipients": {
                             "type": "array",
                             "title": "Recipients for the alerts",
-                            "description": "The phone numbers to receive alerts. You can use international format phone numbers (e.g. \"+254777888999\") or an expression to fetch phone fields in the countedReports (e.g. \"countedReports[0].contact.parent.contact.phone\" for the Primary Contact of the parent place of the sender. E.g.2: \"countedReports.map((report) => report.contact.phone)\" for the senders of the countedReports.)",
+                            "description": "The phone numbers to receive alerts. You can use international format phone numbers (e.g. \"+254777888999\") or an expression to fetch phone fields in each countedReport (e.g. \"countedReport.contact.parent.contact.phone\" for the Primary Contact of the parent place of the sender.",
                             "items": {
                                 "type": "string"
                             }


### PR DESCRIPTION

# Description

Specify recipients in config per countedReport, instead of using the countedReports array. It allows for batching.
medic/medic-webapp#3678

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.