### PR TITLE
Fully resolve home place

### DIFF
--- a/static/js/controllers/contacts.js
+++ b/static/js/controllers/contacts.js
@@ -19,8 +19,8 @@ var _ = require('underscore'),
       Changes,
       ContactSchema,
       ContactSummary,
-      DB,
       Export,
+      GetDataRecords,
       LiveList,
       Search,
       SearchFilters,
@@ -44,23 +44,14 @@ var _ = require('underscore'),
         return UserSettings()
           .then(function(userSettings) {
             if (userSettings.facility_id) {
-              return DB().query(
-                'medic-client/doc_summaries_by_id',
-                { key: userSettings.facility_id }
-              );
+              return GetDataRecords(userSettings.facility_id);
             }
           })
-          .then(function(results) {
-            var firstRow = results &&
-                           results.rows &&
-                           results.rows.length &&
-                           results.rows[0];
-            if (firstRow) {
-              var summary = firstRow.value;
-              summary._id = firstRow.id;
+          .then(function(summary) {
+            if (summary) {
               summary.home = true;
-              return summary;
             }
+            return summary;
           });
       };
 

--- a/tests/karma/unit/controllers/contacts.js
+++ b/tests/karma/unit/controllers/contacts.js
@@ -15,9 +15,9 @@ describe('Contacts controller', () => {
       person,
       scope,
       userSettings,
-      userFaciltyQuery,
       searchResults,
       searchService,
+      getDataRecords,
       typeLabel,
       xmlForms,
       $rootScope;
@@ -61,8 +61,8 @@ describe('Contacts controller', () => {
     forms = 'forms';
     xmlForms.callsArgWith(2, null, forms); // call the callback
     userSettings = KarmaUtils.promiseService(null, { facility_id: district._id });
-    userFaciltyQuery = KarmaUtils.promiseService(null, { rows: [{ id: district._id, value: district }] });
     contactsLiveList = deadList();
+    getDataRecords = KarmaUtils.promiseService(null, district);
     searchResults = [];
 
     createController = () => {
@@ -78,12 +78,7 @@ describe('Contacts controller', () => {
         '$timeout': work => work(),
         '$translate': key => KarmaUtils.mockPromise(null, key + 'translated'),
         'ContactSchema': contactSchema,
-        'DB': () => {
-          return {
-            get: KarmaUtils.promiseService(null, district),
-            query: userFaciltyQuery
-          };
-        },
+        'GetDataRecords': getDataRecords,
         'LiveList': { contacts: contactsLiveList },
         'Search': searchService,
         'SearchFilters': { freetext: sinon.stub(), reset: sinon.stub()},
@@ -103,10 +98,6 @@ describe('Contacts controller', () => {
       });
     };
   }));
-
-  afterEach(() => {
-    KarmaUtils.restore();
-  });
 
   it('sets title', () => {
     return createController().getSetupPromiseForTesting()
@@ -230,7 +221,8 @@ describe('Contacts controller', () => {
     });
 
     it('when user doesn\'t have facility_id', () => {
-      userSettings = userFaciltyQuery = KarmaUtils.promiseService(null, {});
+      userSettings = KarmaUtils.promiseService(null, {});
+      getDataRecords = KarmaUtils.promiseService();
       return createController().getSetupPromiseForTesting().then(() => {
         assert(scope.setLeftActionBar.called);
       });


### PR DESCRIPTION
# Description

The home place was showing the primary contact's UUID instead of
name. This change makes the home place code use the same service
as the rest of the list so it renders consistently.

medic/medic-webapp#3723

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.