### PR TITLE
Document limit of 100 for num_reports_threshold in multi_report_alerts

### DIFF
--- a/kanso.json
+++ b/kanso.json
@@ -410,7 +410,7 @@
                         "num_reports_threshold": {
                             "type": "integer",
                             "title": "Threshold in number of reports",
-                            "description": "Number of counted reports that will trigger the message sending. E.g. \"3\" (3 reports of either cholera or diarrhea)"
+                            "description": "Number of counted reports that will trigger the message sending. Should be less than 100. E.g. \"3\" (3 reports of either cholera or diarrhea)"
                         },
                         "time_window_in_days": {
                             "type": "integer",


### PR DESCRIPTION

# Description
If num_reports_threshold gets too big we could get some memory problems when generating messages for the alert. 100 is really conservative.
medic/medic-webapp#3725

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.