### PR TITLE
Use overflow auto to get content to line up nicely

### DIFF
--- a/static/css/theme.less
+++ b/static/css/theme.less
@@ -145,6 +145,7 @@ ul {
     float: left;
   }
   .detail {
+    overflow: auto;
     .time,
     .status {
       float: right;


### PR DESCRIPTION
# Description

The default overflow wraps text under the icon, but using auto
causes the text to align vertically.

medic/medic-webapp#3758

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.