### PR TITLE
Hide contact when not found

### DIFF
--- a/static/js/services/get-contact-summaries.js
+++ b/static/js/services/get-contact-summaries.js
@@ -11,7 +11,7 @@ angular.module('inboxServices').factory('GetContactSummaries',
 
     var findContactName = function(response, id) {
       var parent = _.findWhere(response.rows, { id: id });
-      return parent && parent.value.name || id;
+      return (parent && parent.value && parent.value.name) || null;
     };
 
     var replaceContactIdsWithNames = function(summaries, response) {

--- a/tests/karma/unit/services/get-contact-summaries.js
+++ b/tests/karma/unit/services/get-contact-summaries.js
@@ -46,13 +46,15 @@ describe('GetContactSummaries service', () => {
       { id: 'c', value: { name: 'charlie', colour: 'green' } },
       { id: 'd', value: { name: 'dannie' } }
     ];
-    const expected = [
-      { contact: 'arnie', lineage: [ 'b', 'charlie' ] },
-      { contact: 'dannie' }
-    ];
     query.returns(KarmaUtils.mockPromise(null, { rows: summaries }));
     return service(given).then(actual => {
-      chai.expect(actual).to.deep.equal(expected);
+      console.log('actual', JSON.stringify(actual));
+      chai.expect(actual[0].contact).to.equal('arnie');
+      chai.expect(actual[0].lineage.length).to.equal(2);
+      chai.expect(actual[0].lineage[0]).to.equal(null);
+      chai.expect(actual[0].lineage[1]).to.equal('charlie');
+      chai.expect(actual[1].contact).to.equal('dannie');
+      chai.expect(actual[1].lineage).to.equal(undefined);
       chai.expect(query.callCount).to.equal(1);
       chai.expect(query.args[0][0]).to.equal('medic-client/doc_summaries_by_id');
       chai.expect(query.args[0][1]).to.deep.equal({ keys: ['a', 'b', 'c', 'd' ] });


### PR DESCRIPTION
# Description

Before this change when a document had a contact or parent that
wasn't found in the database we defaulted to showing the UUID
because that's all the information we had available. This is a
common situation for restricted users who don't replicate the whole
tree.

Now the parent is hidden altogether so the only names shown are of
contacts you can view.

medic/medic-webapp#3752
medic/medic-webapp#3769

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.