### PR TITLE
Delay db query to avoid uncaught exception

### DIFF
--- a/static/js/controllers/inbox.js
+++ b/static/js/controllers/inbox.js
@@ -288,6 +288,10 @@ var feedback = require('../modules/feedback'),
             $log.error('Error fetching read status', err);
           });
       };
+      // wait for db.info to avoid uncaught exceptions: #3754
+      DB().info().then(function() {
+        $scope.updateUnreadCount();
+      });
       Changes({
         key: 'inbox-read-status',
         filter: function(change) {

--- a/templates/inbox.html
+++ b/templates/inbox.html
@@ -20,7 +20,7 @@
     <ng-include src="'templates/partials/actionbar.html'"></ng-include>
 
     <div class="container-fluid">
-      <ng-include src="'templates/partials/header.html'" onload="updateUnreadCount()"></ng-include>
+      <ng-include src="'templates/partials/header.html'"></ng-include>
       <div class="row content" ui-view></div>
     </div>
 

--- a/tests/karma/unit/controllers/inbox.js
+++ b/tests/karma/unit/controllers/inbox.js
@@ -20,7 +20,10 @@ describe('InboxCtrl controller', () => {
         return { path: 'localhost' };
       });
       $provide.value('DB', () => {
-        return { query: KarmaUtils.nullPromise() };
+        return {
+          query: KarmaUtils.nullPromise(),
+          info: KarmaUtils.nullPromise()
+        };
       });
       $provide.value('WatchDesignDoc', sinon.stub());
       $provide.value('DBSync', sinon.stub());


### PR DESCRIPTION
# Description

Due to a bug in worker-pouch or possibly Chrome if we query the DB
too quickly and the query throws then we get an uncaught exception
in the log. Querying info() first means the code executes only once
the database is ready.

medic/medic-webapp#3754

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.