### PR TITLE
Watching changes now understands where it left off

### DIFF
--- a/static/js/services/changes.js
+++ b/static/js/services/changes.js
@@ -16,7 +16,6 @@ angular.module('inboxServices').factory('Changes',
   function(
     $log,
     $timeout,
-    $q,
     DB
   ) {
 
@@ -70,11 +69,7 @@ angular.module('inboxServices').factory('Changes',
       .catch(function(err) {
         $log.error('Error initialising watching for db changes', err);
         $log.error('Attempting changes initialisation in ' + (RETRY_MILLIS / 1000) + ' seconds');
-        return $q(function(resolve) {
-          $timeout(function() {
-            resolve(init);
-          }, RETRY_MILLIS);
-        });
+        return $timeout(init, RETRY_MILLIS);
       });
     };
 

--- a/static/js/services/changes.js
+++ b/static/js/services/changes.js
@@ -16,6 +16,7 @@ angular.module('inboxServices').factory('Changes',
   function(
     $log,
     $timeout,
+    $q,
     DB
   ) {
 
@@ -24,8 +25,11 @@ angular.module('inboxServices').factory('Changes',
 
     var callbacks = {};
 
+    var lastSeq;
+
     var notifyAll = function(change) {
       $log.debug('Change notification firing', change);
+      lastSeq = change.seq;
       Object.keys(callbacks).forEach(function(key) {
         var options = callbacks[key];
         if (!options.filter || options.filter(change)) {
@@ -38,28 +42,50 @@ angular.module('inboxServices').factory('Changes',
       });
     };
 
-    var watchChanges = function() {
-      var RETRY_MILLIS = 5000;
+    var RETRY_MILLIS = 5000;
 
+    var watchChanges = function() {
       $log.info('Initiating changes watch');
       DB()
         .changes({
           live: true,
-          since: 'now',
+          since: lastSeq,
           timeout: false,
           include_docs: true
         })
         .on('change', notifyAll)
         .on('error', function(err) {
           $log.error('Error watching for db changes', err);
-          $log.error('Attempting changes reconnection in 5 seconds');
+          $log.error('Attempting changes reconnection in ' + (RETRY_MILLIS / 1000) + ' seconds');
           $timeout(watchChanges, RETRY_MILLIS);
         });
     };
 
-    watchChanges();
+    var init = function() {
+      $log.info('Initiating changes service');
+      return DB().info().then(function(info) {
+        lastSeq = info.update_seq;
+      })
+      .then(watchChanges)
+      .catch(function(err) {
+        $log.error('Error initialising watching for db changes', err);
+        $log.error('Attempting changes initialisation in ' + (RETRY_MILLIS / 1000) + ' seconds');
+        return $q(function(resolve) {
+          $timeout(function() {
+            resolve(init);
+          }, RETRY_MILLIS);
+        });
+      });
+    };
+
+    var initPromise = init();
 
     return function(options) {
+      // Test hook, so we can know when watchChanges is up and running
+      if (!options) {
+        return initPromise;
+      }
+
       callbacks[options.key] = options;
       return {
         unsubscribe: function() {

--- a/tests/karma/unit/services/changes.js
+++ b/tests/karma/unit/services/changes.js
@@ -23,7 +23,6 @@ describe('Changes service', function() {
 
     module('inboxApp');
     module(function ($provide) {
-      $provide.value('$q', Q);
       $provide.value('DB', function() {
         return {
           changes: function(options) {


### PR DESCRIPTION
To avoid losing changes while api is down (eg for an upgrade) record
the last sequence you got up to.

Additionally, record the first sequence instead of letting PouchDB
work it out itself, so that lastSeq always has a start value.

medic/medic-webapp#3783

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.