### PR TITLE
Set the cancel target after setting selected

### DIFF
--- a/static/js/controllers/contacts-report.js
+++ b/static/js/controllers/contacts-report.js
@@ -20,12 +20,16 @@ angular.module('inboxControllers').controller('ContactsReportCtrl',
       $scope.enketoStatus.edited = true;
     };
 
-    var setSelected = function(contact) {
+    var setCancelTarget = function() {
       $scope.setCancelTarget(function() {
         $state.go('contacts.detail', { id: $state.params.id });
       });
+    };
+
+    var setSelected = function(contact) {
       return ContactViewModelGenerator(contact._id)
-        .then($scope.setSelected);
+        .then($scope.setSelected)
+        .then(setCancelTarget);
     };
 
     var render = function(contact) {
@@ -78,9 +82,7 @@ angular.module('inboxControllers').controller('ContactsReportCtrl',
     $scope.loadingForm = true;
     $scope.setRightActionBar();
     $scope.setShowContent(true);
-    $scope.setCancelTarget(function() {
-      $state.go('contacts.detail', { id: $state.params.id });
-    });
+    setCancelTarget();
     DB()
       .get($state.params.id)
       .then(render)


### PR DESCRIPTION
# Description

Setting selected clears the cancel target so we need to wait for it
to finish before setting the cancel target.

medic/medic-webapp#3797

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.