### PR TITLE
 Delete user continues if couch user not found

### DIFF
--- a/static/js/services/update-user.js
+++ b/static/js/services/update-user.js
@@ -128,6 +128,12 @@ var _ = require('underscore');
 
       return function(user) {
         return deleteCouchUser(user._id)
+          .catch(function(err) {
+            if (err.status !== 404) {
+              throw err;
+            }
+            // CouchDB user already deleted - attempt to delete the medic user
+          })
           .then(function() {
             return deleteMedicUser(user._id);
           })

--- a/tests/karma/unit/services/delete-user.js
+++ b/tests/karma/unit/services/delete-user.js
@@ -54,14 +54,14 @@ describe('DeleteUser service', function() {
         starsign: 'aries',
         _deleted: true
       })
-      .respond(404, 'Not found');
+      .respond(401, 'Unauthorized');
 
     service({ _id: 'org.couchdb.user:gareth', name: 'gareth' })
       .then(function() {
         done(new Error('expected error to be thrown'));
       })
       .catch(function(err) {
-        chai.expect(err.data).to.equal('Not found');
+        chai.expect(err.data).to.equal('Unauthorized');
         chai.expect(cacheRemove.callCount).to.equal(0);
         done();
       });
@@ -89,6 +89,38 @@ describe('DeleteUser service', function() {
         _deleted: true
       })
       .respond({ success: true });
+
+    get.returns(KarmaUtils.mockPromise(null, { _id: 'org.couchdb.user:gareth' }));
+    DeleteDocs.returns(KarmaUtils.mockPromise());
+
+    setTimeout(function() {
+      rootScope.$apply(); // needed to resolve the promises
+      httpBackend.flush();
+      setTimeout(function() {
+        rootScope.$apply();
+        httpBackend.flush();
+      });
+    });
+
+    return service({ _id: 'org.couchdb.user:gareth', name: 'gareth' })
+      .then(function() {
+        chai.expect(get.callCount).to.equal(1);
+        chai.expect(get.args[0][0]).to.equal('org.couchdb.user:gareth');
+
+        chai.expect(DeleteDocs.callCount).to.equal(1);
+        chai.expect(DeleteDocs.args[0][0]._id).to.equal('org.couchdb.user:gareth');
+
+        chai.expect(cacheRemove.callCount).to.equal(2);
+        chai.expect(cacheRemove.args[0][0]).to.equal('/_users/org.couchdb.user%3Agareth');
+        chai.expect(cacheRemove.args[1][0]).to.equal('/_users/_all_docs?include_docs=true');
+      });
+  });
+
+  it('deletes medic user if couch user not found - #3788', function() {
+
+    httpBackend
+      .expect('GET', '/_users/org.couchdb.user%3Agareth')
+      .respond(404, 'Not found');
 
     get.returns(KarmaUtils.mockPromise(null, { _id: 'org.couchdb.user:gareth' }));
     DeleteDocs.returns(KarmaUtils.mockPromise());

--- a/tests/karma/unit/services/delete-user.js
+++ b/tests/karma/unit/services/delete-user.js
@@ -90,8 +90,8 @@ describe('DeleteUser service', function() {
       })
       .respond({ success: true });
 
-    get.returns(KarmaUtils.mockPromise(null, { _id: 'org.couchdb.user:gareth' }));
-    DeleteDocs.returns(KarmaUtils.mockPromise());
+    get.returns(Promise.resolve({ _id: 'org.couchdb.user:gareth' }));
+    DeleteDocs.returns(Promise.resolve());
 
     setTimeout(function() {
       rootScope.$apply(); // needed to resolve the promises
@@ -122,8 +122,8 @@ describe('DeleteUser service', function() {
       .expect('GET', '/_users/org.couchdb.user%3Agareth')
       .respond(404, 'Not found');
 
-    get.returns(KarmaUtils.mockPromise(null, { _id: 'org.couchdb.user:gareth' }));
-    DeleteDocs.returns(KarmaUtils.mockPromise());
+    get.returns(Promise.resolve({ _id: 'org.couchdb.user:gareth' }));
+    DeleteDocs.returns(Promise.resolve());
 
     setTimeout(function() {
       rootScope.$apply(); // needed to resolve the promises


### PR DESCRIPTION
# Description

There are two documents for each user - the couchdb doc in the
_users database, and the settings doc in the medic database. When
deleting we delete both. If the couchdb user is not found the
service errored out making it impossible to delete the medic user
through the UI. Now the service continues if the couch user delete
404s.

medic/medic-webapp#3788

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.