### PR TITLE
Don't write remote checkpoints

### DIFF
--- a/tests/karma/unit/services/db-sync.js
+++ b/tests/karma/unit/services/db-sync.js
@@ -73,9 +73,11 @@ describe('DBSync service', () => {
       chai.expect(from.args[0][1].live).to.equal(true);
       chai.expect(from.args[0][1].retry).to.equal(true);
       chai.expect(from.args[0][1].doc_ids).to.deep.equal(['m','e','d','i','c']);
+      chai.expect(from.args[0][1].checkpoint).to.equal('target');
       chai.expect(to.callCount).to.equal(1);
       chai.expect(to.args[0][1].live).to.equal(true);
       chai.expect(to.args[0][1].retry).to.equal(true);
+      chai.expect(to.args[0][1].checkpoint).to.equal('source');
       const backoff = to.args[0][1].back_off_function;
       chai.expect(backoff(0)).to.equal(1000);
       chai.expect(backoff(2000)).to.equal(4000);


### PR DESCRIPTION
# Description

By default pouchdb writes checkpoints locally and remotely when
a document is replicated. The checkpoint is so the next replication
can pick up where this one left off. For us this means lots of
checkpoints being replicated over slow connections.

This change keeps the checkpoints in the local database but removes
them on the remote database.

medic/medic-webapp#3644

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.