### PR TITLE
Hydrate the contacts of parents

### DIFF
--- a/tests/karma/unit/services/lineage-model-generator.js
+++ b/tests/karma/unit/services/lineage-model-generator.js
@@ -3,13 +3,16 @@ describe('LineageModelGenerator service', () => {
   'use strict';
 
   let service,
-      dbQuery;
+      dbQuery,
+      dbAllDocs;
 
   beforeEach(() => {
     module('inboxApp');
     module($provide => {
       dbQuery = sinon.stub();
-      $provide.factory('DB', KarmaUtils.mockDB({ query: dbQuery }));
+      dbAllDocs = sinon.stub();
+      $provide.value('$q', Q); // bypass $q so we don't have to digest
+      $provide.factory('DB', KarmaUtils.mockDB({ query: dbQuery, allDocs: dbAllDocs }));
     });
     inject(_LineageModelGenerator_ => service = _LineageModelGenerator_);
   });
@@ -17,7 +20,7 @@ describe('LineageModelGenerator service', () => {
   describe('contact', () => {
 
     it('handles not found', () => {
-      dbQuery.returns(KarmaUtils.mockPromise(null, { rows: [] }));
+      dbQuery.returns(Promise.resolve({ rows: [] }));
       return service.contact('a').then(model => {
         chai.expect(model._id).to.equal('a');
         chai.expect(model.doc).to.equal(undefined);
@@ -26,7 +29,7 @@ describe('LineageModelGenerator service', () => {
 
     it('handles no lineage', () => {
       const contact = { _id: 'a', _rev: '1' };
-      dbQuery.returns(KarmaUtils.mockPromise(null, { rows: [
+      dbQuery.returns(Promise.resolve({ rows: [
         { doc: contact }
       ] }));
       return service.contact('a').then(model => {
@@ -39,24 +42,56 @@ describe('LineageModelGenerator service', () => {
       const contact = { _id: 'a', _rev: '1' };
       const parent = { _id: 'b', _rev: '1' };
       const grandparent = { _id: 'c', _rev: '1' };
-      dbQuery.returns(KarmaUtils.mockPromise(null, { rows: [
+      dbQuery.returns(Promise.resolve({ rows: [
         { doc: contact },
         { doc: parent },
         { doc: grandparent }
       ] }));
       return service.contact('a').then(model => {
+        chai.expect(dbQuery.callCount).to.equal(1);
+        chai.expect(dbQuery.args[0][0]).to.equal('medic-client/docs_by_id_lineage');
+        chai.expect(dbQuery.args[0][1]).to.deep.equal({
+          startkey: [ 'a' ],
+          endkey: [ 'a', {} ],
+          include_docs: true
+        });
         chai.expect(model._id).to.equal('a');
         chai.expect(model.doc).to.deep.equal(contact);
         chai.expect(model.lineage).to.deep.equal([ parent, grandparent ]);
       });
     });
 
+    it('hydrates lineage contacts - #3812', () => {
+      const contact = { _id: 'a', _rev: '1', contact: { _id: 'x' } };
+      const parent = { _id: 'b', _rev: '1', contact: { _id: 'd' } };
+      const grandparent = { _id: 'c', _rev: '1', contact: { _id: 'e' } };
+      const parentContact = { _id: 'd', name: 'donny' };
+      const grandparentContact = { _id: 'e', name: 'erica' };
+      dbQuery.returns(Promise.resolve({ rows: [
+        { doc: contact },
+        { doc: parent },
+        { doc: grandparent }
+      ] }));
+      dbAllDocs.returns(Promise.resolve({ rows: [
+        { doc: parentContact },
+        { doc: grandparentContact }
+      ] }));
+      return service.contact('a').then(model => {
+        chai.expect(dbAllDocs.callCount).to.equal(1);
+        chai.expect(dbAllDocs.args[0][0]).to.deep.equal({
+          keys: [ 'd', 'e' ],
+          include_docs: true
+        });
+        chai.expect(model.lineage[0].contact).to.deep.equal(parentContact);
+        chai.expect(model.lineage[1].contact).to.deep.equal(grandparentContact);
+      });
+    });
   });
 
   describe('report', () => {
 
     it('handles not found', () => {
-      dbQuery.returns(KarmaUtils.mockPromise(null, { rows: [] }));
+      dbQuery.returns(Promise.resolve({ rows: [] }));
       return service.report('a').then(model => {
         chai.expect(model._id).to.equal('a');
         chai.expect(model.doc).to.equal(undefined);
@@ -65,7 +100,7 @@ describe('LineageModelGenerator service', () => {
 
     it('handles no lineage', () => {
       const report = { _id: 'a', _rev: '1' };
-      dbQuery.returns(KarmaUtils.mockPromise(null, { rows: [
+      dbQuery.returns(Promise.resolve({ rows: [
         { doc: report }
       ] }));
       return service.report('a').then(model => {
@@ -79,7 +114,7 @@ describe('LineageModelGenerator service', () => {
       const contact = { _id: 'b', _rev: '1' };
       const parent = { _id: 'c', _rev: '1' };
       const grandparent = { _id: 'd', _rev: '1' };
-      dbQuery.returns(KarmaUtils.mockPromise(null, { rows: [
+      dbQuery.returns(Promise.resolve({ rows: [
         { doc: report },
         { doc: contact },
         { doc: parent },
@@ -90,6 +125,34 @@ describe('LineageModelGenerator service', () => {
         chai.expect(model.doc).to.deep.equal(report);
         chai.expect(model.contact).to.deep.equal(contact);
         chai.expect(model.lineage).to.deep.equal([ parent, grandparent ]);
+      });
+    });
+
+    it('hydrates lineage contacts - #3812', () => {
+      const report = { _id: 'a', _rev: '1', contact: { _id: 'x' } };
+      const contact = { _id: 'b', _rev: '1', contact: { _id: 'y' } };
+      const parent = { _id: 'c', _rev: '1', contact: { _id: 'e' } };
+      const grandparent = { _id: 'd', _rev: '1', contact: { _id: 'f' } };
+      const parentContact = { _id: 'e', name: 'erica' };
+      const grandparentContact = { _id: 'f', name: 'frank' };
+      dbQuery.returns(Promise.resolve({ rows: [
+        { doc: report },
+        { doc: contact },
+        { doc: parent },
+        { doc: grandparent }
+      ] }));
+      dbAllDocs.returns(Promise.resolve({ rows: [
+        { doc: parentContact },
+        { doc: grandparentContact }
+      ] }));
+      return service.report('a').then(model => {
+        chai.expect(dbAllDocs.callCount).to.equal(1);
+        chai.expect(dbAllDocs.args[0][0]).to.deep.equal({
+          keys: [ 'e', 'f' ],
+          include_docs: true
+        });
+        chai.expect(model.lineage[0].contact).to.deep.equal(parentContact);
+        chai.expect(model.lineage[1].contact).to.deep.equal(grandparentContact);
       });
     });
 


### PR DESCRIPTION
# Description

This means wherever the lineage model generator is used we can now
access the details of the contact of a parent. For example, it's
useful to know the name and phone number of the contacts of the
parents when filling in forms.

medic/medic-webapp#3812

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.