### PR TITLE
Handle xform location content via HTML navigator.geolocation

### DIFF
--- a/static/js/controllers/contacts-report.js
+++ b/static/js/controllers/contacts-report.js
@@ -70,7 +70,7 @@ angular.module('inboxControllers').controller('ContactsReportCtrl',
 
       $scope.enketoStatus.saving = true;
       $scope.enketoStatus.error = null;
-      Enketo.save($state.params.formId, $scope.form, null, geolocation)
+      Enketo.save($state.params.formId, $scope.form, geolocation)
         .then(function(docs) {
           $log.debug('saved report and associated docs', docs);
           $scope.enketoStatus.saving = false;

--- a/static/js/controllers/contacts-report.js
+++ b/static/js/controllers/contacts-report.js
@@ -8,6 +8,7 @@ angular.module('inboxControllers').controller('ContactsReportCtrl',
     ContactViewModelGenerator,
     DB,
     Enketo,
+    Geolocation,
     Snackbar,
     TranslateFrom,
     XmlForm
@@ -15,6 +16,13 @@ angular.module('inboxControllers').controller('ContactsReportCtrl',
 
     'use strict';
     'ngInject';
+
+    var geolocation;
+    Geolocation()
+      .then(function(position) {
+        geolocation = position;
+      })
+      .catch($log);
 
     var markFormEdited = function() {
       $scope.enketoStatus.edited = true;
@@ -62,7 +70,7 @@ angular.module('inboxControllers').controller('ContactsReportCtrl',
 
       $scope.enketoStatus.saving = true;
       $scope.enketoStatus.error = null;
-      Enketo.save($state.params.formId, $scope.form)
+      Enketo.save($state.params.formId, $scope.form, null, geolocation)
         .then(function(docs) {
           $log.debug('saved report and associated docs', docs);
           $scope.enketoStatus.saving = false;

--- a/static/js/controllers/reports-add.js
+++ b/static/js/controllers/reports-add.js
@@ -8,6 +8,7 @@ angular.module('inboxControllers').controller('ReportsAddCtrl',
     DB,
     Enketo,
     FileReader,
+    Geolocation,
     Snackbar,
     XmlForm
   ) {
@@ -15,8 +16,16 @@ angular.module('inboxControllers').controller('ReportsAddCtrl',
     'ngInject';
     'use strict';
 
+    var geolocation;
+
     var getSelected = function() {
       if ($state.params.formId) { // adding
+        Geolocation()
+          .then(function(position) {
+            geolocation = position;
+          })
+          .catch($log);
+
         return $q.resolve({
           formInternalId: $state.params.formId
         });
@@ -103,7 +112,8 @@ angular.module('inboxControllers').controller('ReportsAddCtrl',
       var model = $scope.selected[0];
       var reportId = model.doc && model.doc._id;
       var formInternalId = model.formInternalId;
-      Enketo.save(formInternalId, $scope.form, reportId)
+
+      Enketo.save(formInternalId, $scope.form, reportId, geolocation)
         .then(function(docs) {
           $log.debug('saved report and associated docs', docs);
           $scope.enketoStatus.saving = false;

--- a/static/js/controllers/reports-add.js
+++ b/static/js/controllers/reports-add.js
@@ -113,7 +113,7 @@ angular.module('inboxControllers').controller('ReportsAddCtrl',
       var reportId = model.doc && model.doc._id;
       var formInternalId = model.formInternalId;
 
-      Enketo.save(formInternalId, $scope.form, reportId, geolocation)
+      Enketo.save(formInternalId, $scope.form, geolocation, reportId)
         .then(function(docs) {
           $log.debug('saved report and associated docs', docs);
           $scope.enketoStatus.saving = false;

--- a/static/js/controllers/tasks-content.js
+++ b/static/js/controllers/tasks-content.js
@@ -84,7 +84,7 @@ angular.module('inboxControllers').controller('TasksContentCtrl',
 
       $scope.enketoStatus.saving = true;
       $scope.enketoStatus.error = null;
-      Enketo.save($scope.formId, $scope.form, null, geolocation)
+      Enketo.save($scope.formId, $scope.form, geolocation)
         .then(function(docs) {
           $log.debug('saved report and associated docs', docs);
           $translate('report.created').then(Snackbar);

--- a/static/js/controllers/tasks-content.js
+++ b/static/js/controllers/tasks-content.js
@@ -6,6 +6,7 @@ angular.module('inboxControllers').controller('TasksContentCtrl',
     $translate,
     DB,
     Enketo,
+    Geolocation,
     TranslateFrom,
     Snackbar,
     XmlForm
@@ -13,6 +14,13 @@ angular.module('inboxControllers').controller('TasksContentCtrl',
 
     'use strict';
     'ngInject';
+
+    var geolocation;
+    Geolocation()
+      .then(function(position) {
+        geolocation = position;
+      })
+      .catch($log);
 
     var hasOneFormAndNoFields = function(task) {
       return Boolean(
@@ -76,7 +84,7 @@ angular.module('inboxControllers').controller('TasksContentCtrl',
 
       $scope.enketoStatus.saving = true;
       $scope.enketoStatus.error = null;
-      Enketo.save($scope.formId, $scope.form)
+      Enketo.save($scope.formId, $scope.form, null, geolocation)
         .then(function(docs) {
           $log.debug('saved report and associated docs', docs);
           $translate('report.created').then(Snackbar);

--- a/static/js/services/enketo-prepopulation-data.js
+++ b/static/js/services/enketo-prepopulation-data.js
@@ -21,7 +21,6 @@ angular.module('inboxServices').service('EnketoPrepopulationData',
           var bindRoot = xml.find('model instance').children().first();
 
           var userRoot = bindRoot.find('>inputs>user');
-          var locationRoot = bindRoot.find('>inputs>meta>location');
 
           if (data) {
             EnketoTranslation.bindJsonToXml(bindRoot, data, function(name) {
@@ -32,17 +31,6 @@ angular.module('inboxServices').service('EnketoPrepopulationData',
 
           if (userRoot.length) {
             EnketoTranslation.bindJsonToXml(userRoot, user);
-          }
-
-          if (locationRoot.length) {
-            var location;
-            if ($window.medicmobile_android) {
-              location = JSON.parse($window.medicmobile_android.getLocation());
-            } else {
-              location = {error: true, message: 'Not on android'};
-            }
-
-            EnketoTranslation.bindJsonToXml(bindRoot.find('inputs>meta>location'), location);
           }
 
           return new XMLSerializer().serializeToString(bindRoot[0]);

--- a/static/js/services/enketo.js
+++ b/static/js/services/enketo.js
@@ -456,7 +456,7 @@ angular.module('inboxServices').service('Enketo',
       });
     };
 
-    this.save = function(formInternalId, form, docId, geolocation) {
+    this.save = function(formInternalId, form, geolocation, docId) {
       return $q.resolve(form.validate())
         .then(function(valid) {
           if (!valid) {

--- a/static/js/services/enketo.js
+++ b/static/js/services/enketo.js
@@ -456,7 +456,7 @@ angular.module('inboxServices').service('Enketo',
       });
     };
 
-    this.save = function(formInternalId, form, docId) {
+    this.save = function(formInternalId, form, docId, geolocation) {
       return $q.resolve(form.validate())
         .then(function(valid) {
           if (!valid) {
@@ -469,6 +469,16 @@ angular.module('inboxServices').service('Enketo',
         })
         .then(function(doc) {
           return xmlToDocs(doc, form.getDataStr());
+        })
+        .then(function(docs) {
+          if (geolocation) {
+            // Only update geolocation if one is provided.  Otherwise, maintain
+            // whatever is already set in the docs.
+            docs.forEach(function(doc) {
+              doc.geolocation = geolocation;
+            });
+          }
+          return docs;
         })
         .then(saveDocs);
     };

--- a/static/js/services/geolocation.js
+++ b/static/js/services/geolocation.js
@@ -1,0 +1,30 @@
+angular.module('inboxServices').service('Geolocation',
+  function(
+    $q
+  ) {
+    'use strict';
+    'ngInject';
+
+    return function(callback) {
+
+      if (!navigator.geolocation) {
+        return callback({
+          code: -1,
+          message: 'Geolocation API unavailable.',
+        });
+      }
+
+      var options = {
+        enableHighAccuracy: true,
+        timeout: 300000, // 5 mins
+        maximumAge: 1200000, // 20 mins
+      };
+
+      return $q(function(resolve, reject) {
+        navigator.geolocation.getCurrentPosition(resolve, reject, options);
+      });
+
+    };
+
+  }
+);

--- a/static/js/services/index.js
+++ b/static/js/services/index.js
@@ -40,6 +40,7 @@
   require('./format-date');
   require('./generate-lucene-query');
   require('./generate-search-requests');
+  require('./geolocation');
   require('./get-contact-summaries');
   require('./get-data-records');
   require('./import-contacts');

--- a/tests/karma/unit/services/enketo-prepopulation-data.js
+++ b/tests/karma/unit/services/enketo-prepopulation-data.js
@@ -245,28 +245,6 @@ describe('EnketoPrepopulationData service', function() {
     rootScope.$digest();
   });
 
-  it('binds location into model on android app', function(done) {
-    var data = {};
-    var user = { name: 'geoff' };
-    var location = { lat: '123', long: '456' };
-    UserSettings.returns(Promise.resolve(user));
-    $window.medicmobile_android = {
-      getLocation: function() {
-        return JSON.stringify(location);
-      }
-    };
-    service(editPersonForm, data)
-      .then(function(actual) {
-        var xml = $($.parseXML(actual));
-        chai.expect(xml.find('inputs > meta > location > lat')[0].innerHTML).to.equal(location.lat);
-        chai.expect(xml.find('inputs > meta > location > long')[0].innerHTML).to.equal(location.long);
-        chai.expect(UserSettings.callCount).to.equal(1);
-        done();
-      })
-      .catch(done);
-    rootScope.$digest();
-  });
-
   it('binds form content into model with custom root node', function(done) {
     var data = { person: { last_name: 'salmon' } };
     var user = { name: 'geoff' };

--- a/tests/karma/unit/services/enketo.js
+++ b/tests/karma/unit/services/enketo.js
@@ -625,7 +625,7 @@ describe('Enketo service', function() {
       dbPut.onCall(2).returns(Promise.resolve({ id: '(generated-in-service)', rev: '1-ghi' }));
       dbGetAttachment.returns(Promise.resolve('<form/>'));
       UserContact.returns(Promise.resolve({ _id: '123', phone: '555' }));
-      return service.save('V', form, null, true).then(function(actual) {
+      return service.save('V', form, true).then(function(actual) {
         const endTime = Date.now() + 1;
 
         chai.expect(form.validate.callCount).to.equal(1);

--- a/tests/karma/unit/services/enketo.js
+++ b/tests/karma/unit/services/enketo.js
@@ -507,7 +507,7 @@ describe('Enketo service', function() {
       }));
       dbPut.returns(Promise.resolve({ id: '6', rev: '2-abc' }));
       dbGetAttachment.returns(Promise.resolve('<form/>'));
-      return service.save('V', form, '6').then(function(actual) {
+      return service.save('V', form, null, '6').then(function(actual) {
         actual = actual[0];
 
         chai.expect(form.validate.callCount).to.equal(1);

--- a/tests/karma/unit/services/enketo.js
+++ b/tests/karma/unit/services/enketo.js
@@ -600,6 +600,81 @@ describe('Enketo service', function() {
       });
     });
 
+    it('creates extra docs with geolocation', function() {
+
+      const startTime = Date.now() - 1;
+
+      form.validate.returns(Promise.resolve(true));
+      var content =
+          `<data>
+            <name>Sally</name>
+            <lmp>10</lmp>
+            <secret_code_name tag="hidden">S4L</secret_code_name>
+            <doc1 db-doc="true">
+              <type>thing_1</type>
+              <some_property_1>some_value_1</some_property_1>
+            </doc1>
+            <doc2 db-doc="true">
+              <type>thing_2</type>
+              <some_property_2>some_value_2</some_property_2>
+            </doc2>
+          </data>`;
+      form.getDataStr.returns(content);
+      dbPut.onCall(0).returns(Promise.resolve({ id: '(generated-in-service)', rev: '1-abc' }));
+      dbPut.onCall(1).returns(Promise.resolve({ id: '(generated-in-service)', rev: '1-def' }));
+      dbPut.onCall(2).returns(Promise.resolve({ id: '(generated-in-service)', rev: '1-ghi' }));
+      dbGetAttachment.returns(Promise.resolve('<form/>'));
+      UserContact.returns(Promise.resolve({ _id: '123', phone: '555' }));
+      return service.save('V', form, null, true).then(function(actual) {
+        const endTime = Date.now() + 1;
+
+        chai.expect(form.validate.callCount).to.equal(1);
+        chai.expect(form.getDataStr.callCount).to.equal(1);
+        chai.expect(dbPut.callCount).to.equal(3);
+        chai.expect(UserContact.callCount).to.equal(1);
+
+        chai.expect(actual.length).to.equal(3);
+
+        var actualReport = actual[0];
+        chai.expect(actualReport._id).to.match(/(\w+-)\w+/);
+        chai.expect(actualReport._rev).to.equal('1-abc');
+        chai.expect(actualReport.fields.name).to.equal('Sally');
+        chai.expect(actualReport.fields.lmp).to.equal('10');
+        chai.expect(actualReport.fields.secret_code_name).to.equal('S4L');
+        chai.expect(actualReport.form).to.equal('V');
+        chai.expect(actualReport.type).to.equal('data_record');
+        chai.expect(actualReport.content_type).to.equal('xml');
+        chai.expect(actualReport.contact._id).to.equal('123');
+        chai.expect(actualReport.from).to.equal('555');
+        chai.expect(actualReport.hidden_fields).to.deep.equal([ 'secret_code_name' ]);
+
+        chai.expect(actualReport.fields.doc1).to.equal(undefined);
+        chai.expect(actualReport.fields.doc2).to.equal(undefined);
+
+        chai.expect(actualReport.geolocation).to.equal(true);
+
+        var actualThing1 = actual[1];
+        chai.expect(actualThing1._id).to.match(/(\w+-)\w+/);
+        chai.expect(actualThing1._rev).to.equal('1-def');
+        chai.expect(actualThing1.reported_date).to.be.above(startTime);
+        chai.expect(actualThing1.reported_date).to.be.below(endTime);
+        chai.expect(actualThing1.some_property_1).to.equal('some_value_1');
+
+        chai.expect(actualThing1.geolocation).to.equal(true);
+
+        var actualThing2 = actual[2];
+        chai.expect(actualThing2._id).to.match(/(\w+-)\w+/);
+        chai.expect(actualThing2._rev).to.equal('1-ghi');
+        chai.expect(actualThing2.reported_date).to.be.above(startTime);
+        chai.expect(actualThing2.reported_date).to.be.below(endTime);
+        chai.expect(actualThing2.some_property_2).to.equal('some_value_2');
+
+        chai.expect(actualThing2.geolocation).to.equal(true);
+
+        chai.expect(_.uniq(_.pluck(actual, '_id')).length).to.equal(3);
+      });
+    });
+
     it('creates extra docs with references', function() {
       form.validate.returns(Promise.resolve(true));
       var content =


### PR DESCRIPTION
Use HTML APIs to add a more comprehensive geolocation object to _all_ docs created when saving a new report.

This replaces the `<inputs><location><lat/><long/>` elements created in previous versions.

Issue: #3781 
