### PR TITLE
Removing legacy mockPromise usage

### DIFF
--- a/tests/karma/unit/controllers/analytics.js
+++ b/tests/karma/unit/controllers/analytics.js
@@ -43,7 +43,7 @@ describe('AnalyticsCtrl controller', function() {
   });
 
   it('set up controller with no modules', function(done) {
-    AnalyticsModules.returns(KarmaUtils.mockPromise(null, []));
+    AnalyticsModules.returns(Promise.resolve([]));
     stateIs.returns(false);
     createController('anc');
     scope.$digest();
@@ -54,7 +54,7 @@ describe('AnalyticsCtrl controller', function() {
   });
 
   it('renders specified module', function(done) {
-    AnalyticsModules.returns(KarmaUtils.mockPromise(null, [
+    AnalyticsModules.returns(Promise.resolve([
       { state: 'reporting' },
       { state: 'anc' }
     ]));
@@ -68,7 +68,7 @@ describe('AnalyticsCtrl controller', function() {
   });
 
   it('jumps to child state if single module present', function(done) {
-    AnalyticsModules.returns(KarmaUtils.mockPromise(null, [
+    AnalyticsModules.returns(Promise.resolve([
       { state: 'anc' }
     ]));
     stateIs.returns(true);
@@ -82,7 +82,7 @@ describe('AnalyticsCtrl controller', function() {
   });
 
   it('does not jump to child state if multiple modules present', function(done) {
-    AnalyticsModules.returns(KarmaUtils.mockPromise(null, [
+    AnalyticsModules.returns(Promise.resolve([
       { state: 'reporting' },
       { state: 'anc' }
     ]));

--- a/tests/karma/unit/controllers/contacts-content.js
+++ b/tests/karma/unit/controllers/contacts-content.js
@@ -31,7 +31,7 @@ describe('ContactsContentCtrl', () => {
       children: { persons: childRows }
     };
     contactViewModelGenerator.withArgs(doc._id)
-      .returns(KarmaUtils.mockPromise(null, model));
+      .returns(Promise.resolve(model));
   };
 
   const stubTasksForContact = tasks => {

--- a/tests/karma/unit/controllers/contacts.js
+++ b/tests/karma/unit/controllers/contacts.js
@@ -67,7 +67,7 @@ describe('Contacts controller', () => {
 
     createController = () => {
       searchService = sinon.stub();
-      searchService.returns(KarmaUtils.mockPromise(null, searchResults));
+      searchService.returns(Promise.resolve(searchResults));
 
       return $controller('ContactsCtrl', {
         '$element': sinon.stub(),
@@ -77,7 +77,7 @@ describe('Contacts controller', () => {
         '$q': Q,
         '$state': { includes: sinon.stub() },
         '$timeout': work => work(),
-        '$translate': key => KarmaUtils.mockPromise(null, key + 'translated'),
+        '$translate': key => Promise.resolve(key + 'translated'),
         'ContactSchema': contactSchema,
         'GetDataRecords': getDataRecords,
         'LiveList': { contacts: contactsLiveList },
@@ -89,7 +89,7 @@ describe('Contacts controller', () => {
         'UserSettings': userSettings,
         'XmlForms': xmlForms,
         'ContactSummary': () => {
-          return KarmaUtils.mockPromise(null, {});
+          return Promise.resolve({});
         },
         'Changes': () => {
           return { unsubscribe: () => {} };

--- a/tests/karma/unit/controllers/edit-translation-messages.js
+++ b/tests/karma/unit/controllers/edit-translation-messages.js
@@ -73,7 +73,7 @@ describe('EditTranslationMessagesCtrl controller', function() {
       ]
     };
     createController();
-    Settings.returns(KarmaUtils.mockPromise(null, {
+    Settings.returns(Promise.resolve({
       forms: [
         {
           registration: {

--- a/tests/karma/unit/controllers/edit-translation.js
+++ b/tests/karma/unit/controllers/edit-translation.js
@@ -80,7 +80,7 @@ describe('EditTranslationCtrl controller', function() {
         { doc: { code: 'es', values: { 'title.key': 'Hola', 'bye': 'Hasta luego' } } }
       ]
     };
-    bulkDocs.returns(KarmaUtils.mockPromise());
+    bulkDocs.returns(Promise.resolve());
     createController();
     scope.model.values.en = 'Hello';
     scope.model.values.fr = 'Bienvenue';
@@ -107,7 +107,7 @@ describe('EditTranslationCtrl controller', function() {
         { doc: { code: 'es', newValue: '', values: { 'title.key': 'Hola', 'bye': 'Hasta luego' } } }
       ]
     };
-    bulkDocs.returns(KarmaUtils.mockPromise());
+    bulkDocs.returns(Promise.resolve());
     createController();
     scope.model.key = 'somethingelse';
     scope.model.values.en = 'a';

--- a/tests/karma/unit/controllers/edit-user.js
+++ b/tests/karma/unit/controllers/edit-user.js
@@ -17,7 +17,7 @@ describe('EditUserCtrl controller', () => {
     module('inboxApp');
 
     translationsDbQuery = sinon.stub();
-    translationsDbQuery.returns(KarmaUtils.mockPromise(null, { rows: [
+    translationsDbQuery.returns(Promise.resolve({ rows: [
       { value: { code: 'en' } },
       { value: { code: 'fr' } }
     ] }));
@@ -42,7 +42,7 @@ describe('EditUserCtrl controller', () => {
     module($provide => {
       $provide.factory('$uibModalInstance', () => {
         return {
-          rendered: KarmaUtils.mockPromise(),
+          rendered: Promise.resolve(),
           close: () => {}
         };
       });
@@ -80,20 +80,20 @@ describe('EditUserCtrl controller', () => {
         });
       };
       mockEditCurrentUser = user => {
-        UserSettings.returns(KarmaUtils.mockPromise(null, user));
-        UpdateUser.returns(KarmaUtils.mockPromise());
+        UserSettings.returns(Promise.resolve(user));
+        UpdateUser.returns(Promise.resolve());
         createController();
       };
 
       mockEditAUser = user => {
         // Don't mock UserSettings, we're not fetching current user.
-        UpdateUser.returns(KarmaUtils.mockPromise());
+        UpdateUser.returns(Promise.resolve());
         createController(user);
       };
 
       mockCreateNewUser = () => {
         // Don't mock UserSettings, we're not fetching current user.
-        UpdateUser.returns(KarmaUtils.mockPromise());
+        UpdateUser.returns(Promise.resolve());
         createController({});
       };
     });
@@ -270,7 +270,7 @@ describe('EditUserCtrl controller', () => {
     });
 
     it('user is updated', done => {
-      UpdateUser.returns(KarmaUtils.mockPromise());
+      UpdateUser.returns(Promise.resolve());
       mockEditAUser(userToEdit);
 
       scope.editUserSettings();
@@ -361,7 +361,7 @@ describe('EditUserCtrl controller', () => {
 
     it('should not change password when none is supplied', done => {
       // given
-      UpdateUser.returns(KarmaUtils.mockPromise());
+      UpdateUser.returns(Promise.resolve());
       mockEditAUser(userToEdit);
       mockContact(userToEdit.contact_id);
       mockFacility(userToEdit.facility_id);

--- a/tests/karma/unit/controllers/inbox.js
+++ b/tests/karma/unit/controllers/inbox.js
@@ -43,7 +43,7 @@ describe('InboxCtrl controller', () => {
         // ConfirmModal : Always return as if user clicked delete. This ignores the DeleteDocs
         // altogether. The calling of the processingFunction is tested in
         // modal.js, not here.
-        stubModal.returns(KarmaUtils.mockPromise());
+        stubModal.returns(Promise.resolve());
         return stubModal;
       });
       $provide.value('ReadMessages', sinon.stub());
@@ -116,7 +116,7 @@ describe('InboxCtrl controller', () => {
 
   it('doesn\'t deleteContact if user cancels modal', () => {
     stubModal.reset();
-    stubModal.returns(KarmaUtils.mockPromise({err: 'user cancelled'}));
+    stubModal.returns(Promise.reject({err: 'user cancelled'}));
 
     scope.deleteDoc(dummyId);
 

--- a/tests/karma/unit/controllers/medic-reporter-modal.js
+++ b/tests/karma/unit/controllers/medic-reporter-modal.js
@@ -31,20 +31,20 @@ describe('MedicReporterModalCtrl', function() {
       $provide.factory('UserContact', function() {
         userNumber = 12345;
         userContact = sinon.stub();
-        userContact.returns(KarmaUtils.mockPromise(null, {phone: userNumber}));
+        userContact.returns(Promise.resolve({phone: userNumber}));
         return userContact;
       });
 
       $provide.factory('$http', function() {
         http = { head: sinon.stub() };
-        http.head.returns(KarmaUtils.mockPromise(null, 'happy'));
+        http.head.returns(Promise.resolve('happy'));
         return http;
       });
 
       $provide.factory('Language', function() {
         userLocale = 'sw';
         language = sinon.stub();
-        language.returns(KarmaUtils.mockPromise(null, userLocale));
+        language.returns(Promise.resolve(userLocale));
         return language;
       });
 
@@ -55,13 +55,13 @@ describe('MedicReporterModalCtrl', function() {
 
       $provide.factory('Settings', function() {
         settings = sinon.stub();
-        settings.returns(KarmaUtils.mockPromise(null, { muvuku_webapp_url: settingsUri }));
+        settings.returns(Promise.resolve({ muvuku_webapp_url: settingsUri }));
         return settings;
       });
 
       $provide.factory('MergeUriParameters', function() {
         merge = sinon.stub();
-        merge.returns(KarmaUtils.mockPromise(null, mergedUri));
+        merge.returns(Promise.resolve(mergedUri));
         return merge;
       });
 
@@ -107,7 +107,7 @@ describe('MedicReporterModalCtrl', function() {
 
   it('Does not display medic-reporter if no auth', function(done) {
     var err = { status: 403 };
-    http.head.returns(KarmaUtils.mockPromise(err));
+    http.head.returns(Promise.reject(err));
 
     runTest(done, function() {
       chai.expect(scope.setError.called).to.equal(true);

--- a/tests/karma/unit/controllers/reports.js
+++ b/tests/karma/unit/controllers/reports.js
@@ -95,8 +95,8 @@ describe('ReportsCtrl controller', () => {
   });
 
   it('verifies the given report', done => {
-    get.returns(KarmaUtils.mockPromise(null, { _id: 'def', name: 'hello' }));
-    post.returns(KarmaUtils.mockPromise());
+    get.returns(Promise.resolve({ _id: 'def', name: 'hello' }));
+    post.returns(Promise.resolve());
     createController();
     scope.selected[0] = {
       _id: 'abc',
@@ -116,8 +116,8 @@ describe('ReportsCtrl controller', () => {
 
   it('when selecting a report, it sets the phone number in the actionbar', done => {
     const phone = 12345;
-    get.returns(KarmaUtils.mockPromise(null, { _id: 'def', name: 'hello', phone: phone }));
-    post.returns(KarmaUtils.mockPromise());
+    get.returns(Promise.resolve({ _id: 'def', name: 'hello', phone: phone }));
+    post.returns(Promise.resolve());
     createController();
     scope.setSelected({ doc: {
       _id: 'abc',

--- a/tests/karma/unit/controllers/tasks-content.js
+++ b/tests/karma/unit/controllers/tasks-content.js
@@ -22,7 +22,7 @@ describe('TasksContentCtrl', function() {
       },
       enketoStatus: { edited: true }
     };
-    render.returns(KarmaUtils.mockPromise());
+    render.returns(Promise.resolve());
     inject(function($controller) {
       createController = function() {
         $controller('TasksContentCtrl', {
@@ -48,7 +48,7 @@ describe('TasksContentCtrl', function() {
         content: 'nothing'
       }]
     };
-    XmlForm.returns(KarmaUtils.mockPromise(null, { id: 'myform', doc: { title: 'My Form' } }));
+    XmlForm.returns(Promise.resolve({ id: 'myform', doc: { title: 'My Form' } }));
     createController();
     watchCallback();
     chai.expect($scope.formId).to.equal('A');

--- a/tests/karma/unit/controllers/user-language-modal.js
+++ b/tests/karma/unit/controllers/user-language-modal.js
@@ -18,17 +18,17 @@ describe('UserLanguageModalCtrl controller', function() {
     scope.setFinished = sinon.stub();
     scope.setError = sinon.stub();
     stubSetLanguage = sinon.stub();
-    stubSetLanguage.returns(KarmaUtils.mockPromise());
+    stubSetLanguage.returns(Promise.resolve());
     stubLanguage = sinon.stub();
-    stubLanguage.returns(KarmaUtils.mockPromise(null, 'ab'));
+    stubLanguage.returns(Promise.resolve('ab'));
     stubLanguages = sinon.stub();
-    stubLanguages.returns(KarmaUtils.mockPromise(null, [
+    stubLanguages.returns(Promise.resolve([
       { code: 'en', name: 'English' },
       { code: 'sw', name: 'Swahili' }
     ]));
     spyUibModalInstance = {close: sinon.spy(), dismiss: sinon.spy()};
     stubUpdateUser = sinon.stub();
-    stubUpdateUser.returns(KarmaUtils.mockPromise());
+    stubUpdateUser.returns(Promise.resolve());
 
     createController = function() {
       return $controller('UserLanguageModalCtrl', {
@@ -100,7 +100,7 @@ describe('UserLanguageModalCtrl controller', function() {
   it('displays error when saving error', function(done) {
     createController();
     stubUpdateUser.reset();
-    stubUpdateUser.returns(KarmaUtils.mockPromise({err: 'oh noes language is all wrong'}));
+    stubUpdateUser.returns(Promise.reject({err: 'oh noes language is all wrong'}));
 
     setTimeout(function() {
       scope.submit().then(function() {
@@ -116,7 +116,7 @@ describe('UserLanguageModalCtrl controller', function() {
   it('resets language when saving error', function(done) {
     createController();
     stubUpdateUser.reset();
-    stubUpdateUser.returns(KarmaUtils.mockPromise({err: 'oh noes language is all wrong'}));
+    stubUpdateUser.returns(Promise.reject({err: 'oh noes language is all wrong'}));
     setTimeout(function() {
       var initialLang = scope.selectedLanguage;
       scope.submit().then(function() {
@@ -129,7 +129,7 @@ describe('UserLanguageModalCtrl controller', function() {
 
   it('does nothing when no language selected', function(done) {
     stubUpdateUser.reset();
-    stubLanguage.returns(KarmaUtils.mockPromise());
+    stubLanguage.returns(Promise.resolve());
     createController();
     setTimeout(function() {
       scope.submit()

--- a/tests/karma/unit/directives/auth.js
+++ b/tests/karma/unit/directives/auth.js
@@ -20,7 +20,7 @@ describe('auth directive', function() {
   });
 
   it('should be shown when auth does not error', function(done) {
-    Auth.returns(KarmaUtils.mockPromise());
+    Auth.returns(Promise.resolve());
     var element = compile('<a mm-auth="can_do_stuff">')(scope);
     scope.$digest();
     setTimeout(function() {
@@ -32,7 +32,7 @@ describe('auth directive', function() {
   });
 
   it('should be hidden when auth errors', function(done) {
-    Auth.returns(KarmaUtils.mockPromise('boom'));
+    Auth.returns(Promise.reject('boom'));
     var element = compile('<a mm-auth="can_do_stuff">')(scope);
     scope.$digest();
     setTimeout(function() {
@@ -44,7 +44,7 @@ describe('auth directive', function() {
   });
 
   it('splits comma separated permissions', function(done) {
-    Auth.returns(KarmaUtils.mockPromise());
+    Auth.returns(Promise.resolve());
     var element = compile('<a mm-auth="can_do_stuff,!can_not_do_stuff">')(scope);
     scope.$digest();
     setTimeout(function() {

--- a/tests/karma/unit/enketo/phone-widget.js
+++ b/tests/karma/unit/enketo/phone-widget.js
@@ -50,7 +50,7 @@ describe('phone-widget', function() {
   }
 
   it('is placed in dom', function() {
-    settings.returns(KarmaUtils.mockPromise(null, {}));
+    settings.returns(Promise.resolve({}));
     buildHtml();
     new phoneWidget.widget($(phoneWidget.selector)[0], {}, settings);
 
@@ -66,7 +66,7 @@ describe('phone-widget', function() {
   });
 
   it('formats input', function() {
-    settings.returns(KarmaUtils.mockPromise(null, {}));
+    settings.returns(Promise.resolve({}));
     buildHtml();
     new phoneWidget.widget($(phoneWidget.selector)[0], {}, settings);
     var input = inputSelector(inputName);
@@ -78,7 +78,7 @@ describe('phone-widget', function() {
   });
 
   it('still formats if no settings are found', function() {
-    settings.returns(KarmaUtils.mockPromise(null, {}));
+    settings.returns(Promise.resolve({}));
     buildHtml();
     new phoneWidget.widget($(phoneWidget.selector)[0], {}, settings);
 
@@ -91,7 +91,7 @@ describe('phone-widget', function() {
   });
 
   it('doesn\'t format invalid input', function() {
-    settings.returns(KarmaUtils.mockPromise(null, {}));
+    settings.returns(Promise.resolve({}));
     buildHtml();
     new phoneWidget.widget($(phoneWidget.selector)[0], {}, settings);
 
@@ -105,7 +105,7 @@ describe('phone-widget', function() {
   });
 
   it('keeps formatted input', function() {
-    settings.returns(KarmaUtils.mockPromise(null, {}));
+    settings.returns(Promise.resolve({}));
     buildHtml();
     new phoneWidget.widget($(phoneWidget.selector)[0], {}, settings);
 
@@ -119,7 +119,7 @@ describe('phone-widget', function() {
   });
 
   it('doesn\'t modify non-phone fields', function() {
-    settings.returns(KarmaUtils.mockPromise(null, {}));
+    settings.returns(Promise.resolve({}));
     buildHtml('other');
     new phoneWidget.widget($(phoneWidget.selector)[0], {}, settings);
 

--- a/tests/karma/unit/services/add-read-status.js
+++ b/tests/karma/unit/services/add-read-status.js
@@ -28,7 +28,7 @@ describe('AddReadStatus service', () => {
     });
 
     it('sets the read status', () => {
-      allDocs.returns(KarmaUtils.mockPromise(null, {
+      allDocs.returns(Promise.resolve({
         rows: [
           { id: 'a', key: 'a', value: { rev: 'x' } },
           { key: 'b', error: 'not_found' },
@@ -69,7 +69,7 @@ describe('AddReadStatus service', () => {
     });
 
     it('sets the read status', () => {
-      allDocs.returns(KarmaUtils.mockPromise(null, {
+      allDocs.returns(Promise.resolve({
         rows: [
           { id: 'a', key: 'a', value: { rev: 'x' } },
           { key: 'b', error: 'not_found' },

--- a/tests/karma/unit/services/app-info.js
+++ b/tests/karma/unit/services/app-info.js
@@ -25,7 +25,7 @@ describe('AppInfo service', function() {
   });
 
   it('returns errors', function(done) {
-    Settings.returns(KarmaUtils.mockPromise('boom'));
+    Settings.returns(Promise.reject('boom'));
     service()
       .then(function() {
         done('SHOULD NOT GET HERE');
@@ -38,7 +38,7 @@ describe('AppInfo service', function() {
   });
 
   it('gets the form', function(done) {
-    Settings.returns(KarmaUtils.mockPromise(null, {
+    Settings.returns(Promise.resolve({
       forms: {
         a: { id: 'a' },
         b: { id: 'b' }
@@ -57,7 +57,7 @@ describe('AppInfo service', function() {
   });
 
   it('formats the date', function(done) {
-    Settings.returns(KarmaUtils.mockPromise(null, {
+    Settings.returns(Promise.resolve({
       date_format: 'YYYY'
     }));
     service()
@@ -76,7 +76,7 @@ describe('AppInfo service', function() {
 
   it('translates the key', function(done) {
     var expected = 'kia ora';
-    Settings.returns(KarmaUtils.mockPromise(null, {}));
+    Settings.returns(Promise.resolve({}));
     var translate = sinon.stub($translate, 'instant').returns(expected);
     service()
       .then(function(appinfo) {

--- a/tests/karma/unit/services/auth.js
+++ b/tests/karma/unit/services/auth.js
@@ -57,7 +57,7 @@ describe('Auth service', function() {
 
   it('rejects when settings errors', function(done) {
     userCtx.returns({ roles: [ 'district_admin' ] });
-    Settings.returns(KarmaUtils.mockPromise('boom'));
+    Settings.returns(Promise.reject('boom'));
     service([ 'can_backup_facilities' ])
       .catch(function(err) {
         chai.expect(err).to.equal('boom');
@@ -68,7 +68,7 @@ describe('Auth service', function() {
 
   it('rejects when perm is empty string', function(done) {
     userCtx.returns({ roles: [ 'district_admin' ] });
-    Settings.returns(KarmaUtils.mockPromise(null, { permissions: [
+    Settings.returns(Promise.resolve({ permissions: [
       { name: 'can_backup_facilities', roles: ['national_admin'] },
       { name: 'can_export_messages', roles: [ 'national_admin', 'district_admin', 'analytics' ] }
     ] }));
@@ -89,7 +89,7 @@ describe('Auth service', function() {
 
     it('rejects when unknown permission', function(done) {
       userCtx.returns({ roles: [ 'district_admin' ] });
-      Settings.returns(KarmaUtils.mockPromise(null, { permissions: [
+      Settings.returns(Promise.resolve({ permissions: [
         { name: 'can_backup_facilities', roles: ['national_admin'] },
         { name: 'can_export_messages', roles: [ 'national_admin', 'district_admin', 'analytics' ] }
       ] }));
@@ -105,7 +105,7 @@ describe('Auth service', function() {
 
     it('resolves when !unknown permission', function(done) {
       userCtx.returns({ roles: [ 'district_admin' ] });
-      Settings.returns(KarmaUtils.mockPromise(null, { permissions: [
+      Settings.returns(Promise.resolve({ permissions: [
         { name: 'can_backup_facilities', roles: ['national_admin'] },
         { name: 'can_export_messages', roles: [ 'national_admin', 'district_admin', 'analytics' ] }
       ] }));
@@ -119,7 +119,7 @@ describe('Auth service', function() {
 
   it('rejects when user does not have permission', function(done) {
     userCtx.returns({ roles: [ 'district_admin' ] });
-    Settings.returns(KarmaUtils.mockPromise(null, { permissions: [
+    Settings.returns(Promise.resolve({ permissions: [
       { name: 'can_backup_facilities', roles: ['national_admin'] },
       { name: 'can_export_messages', roles: [ 'national_admin', 'district_admin', 'analytics' ] }
     ] }));
@@ -135,7 +135,7 @@ describe('Auth service', function() {
 
   it('rejects when user does not have all permissions', function(done) {
     userCtx.returns({ roles: [ 'district_admin' ] });
-    Settings.returns(KarmaUtils.mockPromise(null, { permissions: [
+    Settings.returns(Promise.resolve({ permissions: [
       { name: 'can_backup_facilities', roles: ['national_admin'] },
       { name: 'can_export_messages', roles: [ 'national_admin', 'district_admin', 'analytics' ] }
     ] }));
@@ -151,7 +151,7 @@ describe('Auth service', function() {
 
   it('resolves when user has all permissions', function(done) {
     userCtx.returns({ roles: [ 'national_admin' ] });
-    Settings.returns(KarmaUtils.mockPromise(null, { permissions: [
+    Settings.returns(Promise.resolve({ permissions: [
       { name: 'can_backup_facilities', roles: ['national_admin'] },
       { name: 'can_export_messages', roles: [ 'national_admin', 'district_admin', 'analytics' ] }
     ] }));
@@ -175,7 +175,7 @@ describe('Auth service', function() {
 
   it('rejects when user has one of the !permissions', function(done) {
     userCtx.returns({ roles: [ 'analytics' ] });
-    Settings.returns(KarmaUtils.mockPromise(null, { permissions: [
+    Settings.returns(Promise.resolve({ permissions: [
       { name: 'can_backup_facilities', roles: ['national_admin'] },
       { name: 'can_export_messages', roles: [ 'national_admin', 'district_admin', 'analytics' ] }
     ] }));
@@ -191,7 +191,7 @@ describe('Auth service', function() {
 
   it('resolves when user has none of the !permissions', function(done) {
     userCtx.returns({ roles: [ 'analytics' ] });
-    Settings.returns(KarmaUtils.mockPromise(null, { permissions: [
+    Settings.returns(Promise.resolve({ permissions: [
       { name: 'can_backup_facilities', roles: ['national_admin'] },
       { name: 'can_export_messages', roles: [ 'national_admin', 'district_admin', 'analytics' ] }
     ] }));

--- a/tests/karma/unit/services/contact-summary.js
+++ b/tests/karma/unit/services/contact-summary.js
@@ -26,7 +26,7 @@ describe('ContactSummary service', () => {
   });
 
   it('returns empty when no script configured', () => {
-    Settings.returns(KarmaUtils.mockPromise(null, { contact_summary: '' }));
+    Settings.returns(Promise.resolve({ contact_summary: '' }));
     const contact = {};
     const reports = [];
     return service(contact, reports).then(actual => {
@@ -40,7 +40,7 @@ describe('ContactSummary service', () => {
                       { label: "Notes", value: "Hello " + contact.name },
                       { label: "Num reports", value: reports.length }
                     ] };`;
-    Settings.returns(KarmaUtils.mockPromise(null, { contact_summary: script }));
+    Settings.returns(Promise.resolve({ contact_summary: script }));
     const contact = { name: 'jack' };
     const reports = [ { _id: 1 }, { _id: 2} ];
     return service(contact, reports).then(actual => {
@@ -57,7 +57,7 @@ describe('ContactSummary service', () => {
     const script = `return { fields: [
                       { label: "Notes", value: "Hello", filter: "reversify" }
                     ] };`;
-    Settings.returns(KarmaUtils.mockPromise(null, { contact_summary: script }));
+    Settings.returns(Promise.resolve({ contact_summary: script }));
     const contact = {};
     const reports = [];
     return service(contact, reports).then(actual => {

--- a/tests/karma/unit/services/contact-view-model-generator.js
+++ b/tests/karma/unit/services/contact-view-model-generator.js
@@ -21,11 +21,11 @@ describe('ContactViewModelGenerator service', () => {
         childPlaceIcon = 'fa-mushroom';
 
   const stubDbGet = (err, doc) => {
-    dbGet.withArgs(doc._id).returns(KarmaUtils.mockPromise(err, doc));
+    dbGet.withArgs(doc._id).returns(KarmaUtils.promise(err, doc));
   };
 
   const stubLineageModelGenerator = (err, contact, lineage) => {
-    lineageModelGenerator.contact.returns(KarmaUtils.mockPromise(err, {
+    lineageModelGenerator.contact.returns(KarmaUtils.promise(err, {
       _id: contact && contact._id,
       doc: contact,
       lineage: lineage
@@ -45,13 +45,13 @@ describe('ContactViewModelGenerator service', () => {
     });
     var ids = docs.map(child => child.doc.contact && child.doc.contact._id).filter(id => !!id);
     dbQuery.withArgs('medic-client/contacts_by_parent', options)
-      .returns(KarmaUtils.mockPromise(err, { rows: docs }));
+      .returns(KarmaUtils.promise(err, { rows: docs }));
     dbAllDocs.withArgs({ keys: ids, include_docs: true })
-      .returns(KarmaUtils.mockPromise(err, { rows: contacts }));
+      .returns(KarmaUtils.promise(err, { rows: contacts }));
   };
 
   const stubSearch = (err, reports) => {
-    search.returns(KarmaUtils.mockPromise(err, reports));
+    search.returns(KarmaUtils.promise(err, reports));
   };
 
   beforeEach(() => {

--- a/tests/karma/unit/services/contacts.js
+++ b/tests/karma/unit/services/contacts.js
@@ -29,7 +29,7 @@ describe('Contacts service', function() {
   });
 
   it('returns errors from request', function(done) {
-    dbQuery.returns(KarmaUtils.mockPromise('boom'));
+    dbQuery.returns(Promise.reject('boom'));
     service({})
       .then(function() {
         done(new Error('expected error to be thrown'));
@@ -41,7 +41,7 @@ describe('Contacts service', function() {
   });
 
   it('returns zero when no facilities', function() {
-    dbQuery.returns(KarmaUtils.mockPromise(null, { rows: [] }));
+    dbQuery.returns(Promise.resolve({ rows: [] }));
     return service({}).then(function(actual) {
       chai.expect(actual).to.deep.equal([]);
     });
@@ -132,8 +132,8 @@ describe('Contacts service', function() {
       }
     };
 
-    dbQuery.withArgs('medic-client/contacts_by_type', {include_docs: true, key: ['clinic']}).returns(KarmaUtils.mockPromise(null, { rows: [ { doc: clinicA }, { doc: clinicB } ] }));
-    dbQuery.withArgs('medic-client/contacts_by_type', {include_docs: true, key: ['health_center']}).returns(KarmaUtils.mockPromise(null, { rows: [ { doc: healthCenter } ] }));
+    dbQuery.withArgs('medic-client/contacts_by_type', {include_docs: true, key: ['clinic']}).returns(Promise.resolve({ rows: [ { doc: clinicA }, { doc: clinicB } ] }));
+    dbQuery.withArgs('medic-client/contacts_by_type', {include_docs: true, key: ['health_center']}).returns(Promise.resolve({ rows: [ { doc: healthCenter } ] }));
 
     return service({ types: ['clinic'] }).then(function(actual) {
       chai.expect(actual).to.deep.equal([ clinicA, clinicB ]);

--- a/tests/karma/unit/services/count-unread-records.js
+++ b/tests/karma/unit/services/count-unread-records.js
@@ -18,7 +18,7 @@ describe('CountUnreadRecords service', () => {
   });
 
   it('returns zero when no data_records', () => {
-    query.returns(KarmaUtils.mockPromise(null, { rows: [] }));
+    query.returns(Promise.resolve({ rows: [] }));
     return service().then(actual => {
       chai.expect(actual).to.deep.equal({
         report: 0,
@@ -28,11 +28,11 @@ describe('CountUnreadRecords service', () => {
   });
 
   it('returns all data_records when none read', () => {
-    query.onCall(0).returns(KarmaUtils.mockPromise(null, { rows: [
+    query.onCall(0).returns(Promise.resolve({ rows: [
       { key: 'report', value: 13 },
       { key: 'message', value: 5 }
     ] }));
-    query.onCall(1).returns(KarmaUtils.mockPromise(null, { rows: [] }));
+    query.onCall(1).returns(Promise.resolve({ rows: [] }));
     return service().then(actual => {
       chai.expect(actual).to.deep.equal({
         report: 13,
@@ -42,11 +42,11 @@ describe('CountUnreadRecords service', () => {
   });
 
   it('returns total', () => {
-    query.onCall(0).returns(KarmaUtils.mockPromise(null, { rows: [
+    query.onCall(0).returns(Promise.resolve({ rows: [
       { key: 'report', value: 13 },
       { key: 'message', value: 5 }
     ] }));
-    query.onCall(1).returns(KarmaUtils.mockPromise(null, { rows: [
+    query.onCall(1).returns(Promise.resolve({ rows: [
       { key: 'report', value: 3 }
     ] }));
     return service().then(actual => {

--- a/tests/karma/unit/services/db-sync.js
+++ b/tests/karma/unit/services/db-sync.js
@@ -54,11 +54,11 @@ describe('DBSync service', () => {
 
   it('initiates sync for non-admin', () => {
     isAdmin.returns(false);
-    to.returns(KarmaUtils.mockPromise());
-    from.returns(KarmaUtils.mockPromise());
-    Auth.returns(KarmaUtils.mockPromise());
+    to.returns(Promise.resolve());
+    from.returns(Promise.resolve());
+    Auth.returns(Promise.resolve());
     userCtx.returns({ name: 'mobile', roles: [ 'district-manager' ] });
-    allDocs.returns(KarmaUtils.mockPromise(null, { rows: [
+    allDocs.returns(Promise.resolve({ rows: [
       { id: 'm' },
       { id: 'e' },
       { id: 'd' },
@@ -87,11 +87,11 @@ describe('DBSync service', () => {
 
   it('does not sync to remote if user lacks "can_edit" permission', () => {
     isAdmin.returns(false);
-    to.returns(KarmaUtils.mockPromise());
-    from.returns(KarmaUtils.mockPromise());
-    Auth.returns(KarmaUtils.mockPromise('unauthorized'));
+    to.returns(Promise.resolve());
+    from.returns(Promise.resolve());
+    Auth.returns(Promise.reject('unauthorized'));
     userCtx.returns({ name: 'mobile', roles: [ 'district-manager' ] });
-    allDocs.returns(KarmaUtils.mockPromise(null, { rows: [
+    allDocs.returns(Promise.resolve({ rows: [
       { id: 'm' },
       { id: 'e' },
       { id: 'd' },
@@ -116,11 +116,11 @@ describe('DBSync service', () => {
 
     before(() => {
       isAdmin.returns(false);
-      to.returns(KarmaUtils.mockPromise());
-      from.returns(KarmaUtils.mockPromise());
-      Auth.returns(KarmaUtils.mockPromise());
+      to.returns(Promise.resolve());
+      from.returns(Promise.resolve());
+      Auth.returns(Promise.resolve());
       userCtx.returns({ name: 'mobile', roles: [ 'district-manager' ] });
-      allDocs.returns(KarmaUtils.mockPromise(null, { rows: [] }));
+      allDocs.returns(Promise.resolve({ rows: [] }));
       return service().then(() => {
         chai.expect(to.callCount).to.equal(1);
         filterFunction = to.args[0][1].filter;

--- a/tests/karma/unit/services/delete-docs.js
+++ b/tests/karma/unit/services/delete-docs.js
@@ -24,7 +24,7 @@ describe('DeleteDocs service', function() {
   });
 
   it('returns bulkDocs errors', function(done) {
-    bulkDocs.returns(KarmaUtils.mockPromise('errcode2'));
+    bulkDocs.returns(Promise.reject('errcode2'));
     service({ _id: 'xyz' })
       .then(function() {
         done('expected error to be thrown');
@@ -55,8 +55,8 @@ describe('DeleteDocs service', function() {
         _id: 'b'
       }
     };
-    get.returns(KarmaUtils.mockPromise(null, clinic));
-    bulkDocs.returns(KarmaUtils.mockPromise(null,
+    get.returns(Promise.resolve(clinic));
+    bulkDocs.returns(Promise.resolve(
       // person is not deleted, but clinic is edited just fine. Oops.
       [
         { id: person._id, error:'conflict' },
@@ -107,7 +107,7 @@ describe('DeleteDocs service', function() {
         _id: 'b'
       }
     };
-    get.returns(KarmaUtils.mockPromise(null, clinic));
+    get.returns(Promise.resolve(clinic));
     service([ person, clinic ])
       .then(function() {
         done(new Error('expected error to be thrown'));
@@ -118,7 +118,7 @@ describe('DeleteDocs service', function() {
   });
 
   it('marks the record deleted', function() {
-    bulkDocs.returns(KarmaUtils.mockPromise());
+    bulkDocs.returns(Promise.resolve());
     var record = {
       _id: 'xyz',
       _rev: '123',
@@ -138,7 +138,7 @@ describe('DeleteDocs service', function() {
   });
 
   it('marks multiple records deleted', function() {
-    bulkDocs.returns(KarmaUtils.mockPromise());
+    bulkDocs.returns(Promise.resolve());
     var record1 = {
       _id: 'xyz',
       _rev: '123',
@@ -187,8 +187,8 @@ describe('DeleteDocs service', function() {
         _id: 'b'
       }
     };
-    get.returns(KarmaUtils.mockPromise(null, clinic));
-    bulkDocs.returns(KarmaUtils.mockPromise());
+    get.returns(Promise.resolve(clinic));
+    bulkDocs.returns(Promise.resolve());
     return service(person).then(function() {
       chai.expect(get.callCount).to.equal(1);
       chai.expect(get.args[0][0]).to.equal(clinic._id);
@@ -218,8 +218,8 @@ describe('DeleteDocs service', function() {
         _id: 'b'
       }
     };
-    get.returns(KarmaUtils.mockPromise(null, clinic));
-    bulkDocs.returns(KarmaUtils.mockPromise());
+    get.returns(Promise.resolve(clinic));
+    bulkDocs.returns(Promise.resolve());
     return service(person).then(function() {
       chai.expect(get.callCount).to.equal(1);
       chai.expect(get.args[0][0]).to.equal(clinic._id);
@@ -243,8 +243,8 @@ describe('DeleteDocs service', function() {
         _id: 'b'
       }
     };
-    get.returns(KarmaUtils.mockPromise(null, clinic));
-    bulkDocs.returns(KarmaUtils.mockPromise());
+    get.returns(Promise.resolve(clinic));
+    bulkDocs.returns(Promise.resolve());
     return service(person).then(function() {
       chai.expect(get.callCount).to.equal(1);
       chai.expect(get.args[0][0]).to.equal(clinic._id);
@@ -273,8 +273,8 @@ describe('DeleteDocs service', function() {
       }
     };
     var docs = [ person ];
-    get.returns(KarmaUtils.mockPromise(null, clinic));
-    bulkDocs.returns(KarmaUtils.mockPromise());
+    get.returns(Promise.resolve(clinic));
+    bulkDocs.returns(Promise.resolve());
     return service(docs).then(function() {
       chai.expect(docs.length).to.equal(1);
       chai.expect(bulkDocs.args[0][0].length).to.equal(2);

--- a/tests/karma/unit/services/download-url.js
+++ b/tests/karma/unit/services/download-url.js
@@ -23,35 +23,35 @@ describe('DownloadUrl service', function() {
   });
 
   it('builds url for messages', function() {
-    Language.returns(KarmaUtils.mockPromise(null, 'en'));
+    Language.returns(Promise.resolve('en'));
     return service(null, 'messages').then(function(actual) {
       chai.expect(actual).to.equal('/api/v1/export/messages?format=xml&locale=en');
     });
   });
 
   it('builds url for audit', function() {
-    Language.returns(KarmaUtils.mockPromise(null, 'en'));
+    Language.returns(Promise.resolve('en'));
     return service(null, 'audit').then(function(actual) {
       chai.expect(actual).to.equal('/api/v1/export/audit?format=xml&locale=en');
     });
   });
 
   it('builds url for feedback', function() {
-    Language.returns(KarmaUtils.mockPromise(null, 'en'));
+    Language.returns(Promise.resolve('en'));
     return service(null, 'feedback').then(function(actual) {
       chai.expect(actual).to.equal('/api/v1/export/feedback?format=xml&locale=en');
     });
   });
 
   it('builds url for logs', function() {
-    Language.returns(KarmaUtils.mockPromise(null, 'en'));
+    Language.returns(Promise.resolve('en'));
     return service(null, 'logs').then(function(actual) {
       chai.expect(actual).to.equal('/api/v1/export/logs?format=zip&locale=en');
     });
   });
 
   it('builds url for forms', function() {
-    Language.returns(KarmaUtils.mockPromise(null, 'en'));
+    Language.returns(Promise.resolve('en'));
     GenerateLuceneQuery.returns({ query: 'form:P' });
     return service(null, 'reports').then(function(actual) {
       chai.expect(decodeURIComponent(actual))
@@ -60,7 +60,7 @@ describe('DownloadUrl service', function() {
   });
 
   it('builds url for contacts backup', function() {
-    Language.returns(KarmaUtils.mockPromise(null, 'en'));
+    Language.returns(Promise.resolve('en'));
     GenerateLuceneQuery.returns({ query: 'district:2' });
     return service(null, 'contacts').then(function(actual) {
       chai.expect(decodeURIComponent(actual))

--- a/tests/karma/unit/services/edit-group.js
+++ b/tests/karma/unit/services/edit-group.js
@@ -23,7 +23,7 @@ describe('EditGroup service', function() {
   });
 
   it('returns get errors', function(done) {
-    get.returns(KarmaUtils.mockPromise('db messed up'));
+    get.returns(Promise.reject('db messed up'));
     var group = {};
     service('123', group)
       .catch(function(err) {
@@ -43,7 +43,7 @@ describe('EditGroup service', function() {
     var group = {
       rows: [ { group: 1, state: 'muted' } ]
     };
-    get.returns(KarmaUtils.mockPromise(null, doc));
+    get.returns(Promise.resolve(doc));
     service('123', group).then(function(actual) {
       chai.expect(actual).to.deep.equal(doc);
       done();
@@ -58,8 +58,8 @@ describe('EditGroup service', function() {
         { group: 3 }
       ]
     };
-    get.returns(KarmaUtils.mockPromise(null, doc));
-    put.returns(KarmaUtils.mockPromise('audit borked'));
+    get.returns(Promise.resolve(doc));
+    put.returns(Promise.reject('audit borked'));
     var group = {
       number: 1,
       rows: [ { group: 1, state: 'scheduled' } ]
@@ -86,8 +86,8 @@ describe('EditGroup service', function() {
         { group: 2, state: 'muted', due: '6', messages: [ { message: 'f' } ] }
       ]
     };
-    get.returns(KarmaUtils.mockPromise(null, doc));
-    put.returns(KarmaUtils.mockPromise());
+    get.returns(Promise.resolve(doc));
+    put.returns(Promise.resolve());
     service('123', group).then(function(actual) {
       chai.expect(actual.scheduled_tasks.length).to.equal(4);
 
@@ -131,8 +131,8 @@ describe('EditGroup service', function() {
         { group: 2, state: 'scheduled', due: '7', messages: [ { message: 'g' } ], deleted: true }
       ]
     };
-    get.returns(KarmaUtils.mockPromise(null, doc));
-    put.returns(KarmaUtils.mockPromise());
+    get.returns(Promise.resolve(doc));
+    put.returns(Promise.resolve());
     service('123', group).then(function(actual) {
       chai.expect(actual.scheduled_tasks.length).to.equal(1);
       chai.expect(actual.scheduled_tasks[0].group).to.equal(2);
@@ -158,8 +158,8 @@ describe('EditGroup service', function() {
         { group: 2, state: 'scheduled', due: '7', messages: [ { message: 'g' } ], added: true }
       ]
     };
-    get.returns(KarmaUtils.mockPromise(null, doc));
-    put.returns(KarmaUtils.mockPromise());
+    get.returns(Promise.resolve(doc));
+    put.returns(Promise.resolve());
     service('123', group).then(function(actual) {
       chai.expect(actual.scheduled_tasks.length).to.equal(2);
 
@@ -192,8 +192,8 @@ describe('EditGroup service', function() {
         { group: 2, state: 'scheduled', due: '7', messages: [ { message: 'g' } ], added: true }
       ]
     };
-    get.returns(KarmaUtils.mockPromise(null, doc));
-    put.returns(KarmaUtils.mockPromise());
+    get.returns(Promise.resolve(doc));
+    put.returns(Promise.resolve());
     service('123', group).then(function(actual) {
       chai.expect(actual.scheduled_tasks.length).to.equal(1);
 

--- a/tests/karma/unit/services/enketo-prepopulation-data.js
+++ b/tests/karma/unit/services/enketo-prepopulation-data.js
@@ -171,7 +171,7 @@ describe('EnketoPrepopulationData service', function() {
   it('rejects when user settings fails', function(done) {
     var model = '';
     var data = {};
-    UserSettings.returns(KarmaUtils.mockPromise('phail'));
+    UserSettings.returns(Promise.reject('phail'));
     service(model, data)
       .then(function() {
         done('Expected fail');
@@ -187,7 +187,7 @@ describe('EnketoPrepopulationData service', function() {
   it('binds user details into model', function(done) {
     var data = {};
     var user = { name: 'geoff' };
-    UserSettings.returns(KarmaUtils.mockPromise(null, user));
+    UserSettings.returns(Promise.resolve(user));
     service(editPersonForm, data)
       .then(function(actual) {
         var xml = $($.parseXML(actual));
@@ -202,7 +202,7 @@ describe('EnketoPrepopulationData service', function() {
   it('binds form content into model', function(done) {
     var data = { person: { last_name: 'salmon' } };
     var user = { name: 'geoff' };
-    UserSettings.returns(KarmaUtils.mockPromise(null, user));
+    UserSettings.returns(Promise.resolve(user));
     service(editPersonFormWithoutInputs, data)
       .then(function(actual) {
         var xml = $($.parseXML(actual));
@@ -217,7 +217,7 @@ describe('EnketoPrepopulationData service', function() {
   it('binds form content into generated form model', function(done) {
     var data = { person: { name: 'sally' } };
     var user = { name: 'geoff' };
-    UserSettings.returns(KarmaUtils.mockPromise(null, user));
+    UserSettings.returns(Promise.resolve(user));
     service(generatedForm, data)
       .then(function(actual) {
         var xml = $($.parseXML(actual));
@@ -232,7 +232,7 @@ describe('EnketoPrepopulationData service', function() {
   it('binds user details and form content into model', function(done) {
     var data = { person: { last_name: 'salmon' } };
     var user = { name: 'geoff' };
-    UserSettings.returns(KarmaUtils.mockPromise(null, user));
+    UserSettings.returns(Promise.resolve(user));
     service(editPersonForm, data)
       .then(function(actual) {
         var xml = $($.parseXML(actual));
@@ -249,7 +249,7 @@ describe('EnketoPrepopulationData service', function() {
     var data = {};
     var user = { name: 'geoff' };
     var location = { lat: '123', long: '456' };
-    UserSettings.returns(KarmaUtils.mockPromise(null, user));
+    UserSettings.returns(Promise.resolve(user));
     $window.medicmobile_android = {
       getLocation: function() {
         return JSON.stringify(location);
@@ -270,7 +270,7 @@ describe('EnketoPrepopulationData service', function() {
   it('binds form content into model with custom root node', function(done) {
     var data = { person: { last_name: 'salmon' } };
     var user = { name: 'geoff' };
-    UserSettings.returns(KarmaUtils.mockPromise(null, user));
+    UserSettings.returns(Promise.resolve(user));
     service(pregnancyForm, data)
       .then(function(actual) {
         var xml = $($.parseXML(actual));

--- a/tests/karma/unit/services/enketo.js
+++ b/tests/karma/unit/services/enketo.js
@@ -94,7 +94,7 @@ describe('Enketo service', function() {
       init: enketoInit
     });
 
-    XmlForm.returns(KarmaUtils.mockPromise(null, { id: 'abc' }));
+    XmlForm.returns(Promise.resolve({ id: 'abc' }));
 
     module(function($provide) {
       $provide.factory('DB', KarmaUtils.mockDB({
@@ -123,7 +123,7 @@ describe('Enketo service', function() {
     inject(function(_Enketo_) {
       service = _Enketo_;
     });
-    Language.returns(KarmaUtils.mockPromise(null, 'en'));
+    Language.returns(Promise.resolve('en'));
     TranslateFrom.returns('translated');
   });
 
@@ -134,7 +134,7 @@ describe('Enketo service', function() {
   describe('render', function() {
 
     it('renders error when user does not have associated contact', function(done) {
-      UserContact.returns(KarmaUtils.mockPromise());
+      UserContact.returns(Promise.resolve());
       service
         .render(null, 'not-defined')
         .then(function() {
@@ -147,13 +147,13 @@ describe('Enketo service', function() {
     });
 
     it('return error when form initialisation fails', function(done) {
-      UserContact.returns(KarmaUtils.mockPromise(null, { contact_id: '123' }));
-      dbGet.returns(KarmaUtils.mockPromise(null, mockEnketoDoc('myform')));
-      dbGetAttachment.returns(KarmaUtils.mockPromise(null, 'xml'));
+      UserContact.returns(Promise.resolve({ contact_id: '123' }));
+      dbGet.returns(Promise.resolve(mockEnketoDoc('myform')));
+      dbGetAttachment.returns(Promise.resolve('xml'));
       transform
-        .onFirstCall().returns(KarmaUtils.mockPromise(null, $('<div>my form</div>')))
-        .onSecondCall().returns(KarmaUtils.mockPromise(null, VISIT_MODEL));
-      EnketoPrepopulationData.returns(KarmaUtils.mockPromise(null, '<xml></xml>'));
+        .onFirstCall().returns(Promise.resolve($('<div>my form</div>')))
+        .onSecondCall().returns(Promise.resolve(VISIT_MODEL));
+      EnketoPrepopulationData.returns(Promise.resolve('<xml></xml>'));
       var expected = [ 'nope', 'still nope' ];
       enketoInit.returns(expected);
       service
@@ -169,15 +169,15 @@ describe('Enketo service', function() {
     });
 
     it('return form when everything works', function() {
-      UserContact.returns(KarmaUtils.mockPromise(null, { contact_id: '123' }));
-      dbGet.returns(KarmaUtils.mockPromise(null, mockEnketoDoc('myform')));
-      dbGetAttachment.returns(KarmaUtils.mockPromise(null, 'xmlblob'));
+      UserContact.returns(Promise.resolve({ contact_id: '123' }));
+      dbGet.returns(Promise.resolve(mockEnketoDoc('myform')));
+      dbGetAttachment.returns(Promise.resolve('xmlblob'));
       enketoInit.returns([]);
-      FileReader.returns(KarmaUtils.mockPromise(null, '<some-blob name="xml"/>'));
-      EnketoPrepopulationData.returns(KarmaUtils.mockPromise(null, '<xml></xml>'));
+      FileReader.returns(Promise.resolve('<some-blob name="xml"/>'));
+      EnketoPrepopulationData.returns(Promise.resolve('<xml></xml>'));
       transform
-        .onFirstCall().returns(KarmaUtils.mockPromise(null, $('<div>my form</div>')))
-        .onSecondCall().returns(KarmaUtils.mockPromise(null, VISIT_MODEL));
+        .onFirstCall().returns(Promise.resolve($('<div>my form</div>')))
+        .onSecondCall().returns(Promise.resolve(VISIT_MODEL));
       return service.render($('<div></div>'), 'ok').then(function() {
         chai.expect(UserContact.callCount).to.equal(1);
         chai.expect(EnketoPrepopulationData.callCount).to.equal(2);
@@ -191,18 +191,18 @@ describe('Enketo service', function() {
     });
 
     it('replaces img src with obj urls', function() {
-      UserContact.returns(KarmaUtils.mockPromise(null, { contact_id: '123' }));
-      dbGet.returns(KarmaUtils.mockPromise(null, mockEnketoDoc('myform')));
+      UserContact.returns(Promise.resolve({ contact_id: '123' }));
+      dbGet.returns(Promise.resolve(mockEnketoDoc('myform')));
       transform
-        .onFirstCall().returns(KarmaUtils.mockPromise(null, '<div><img src="jr://myimg"></div>'))
-        .onSecondCall().returns(KarmaUtils.mockPromise(null, VISIT_MODEL));
+        .onFirstCall().returns(Promise.resolve('<div><img src="jr://myimg"></div>'))
+        .onSecondCall().returns(Promise.resolve(VISIT_MODEL));
       dbGetAttachment
-        .onFirstCall().returns(KarmaUtils.mockPromise(null, 'xmlblob'))
-        .onSecondCall().returns(KarmaUtils.mockPromise(null, 'myobjblob'));
+        .onFirstCall().returns(Promise.resolve('xmlblob'))
+        .onSecondCall().returns(Promise.resolve('myobjblob'));
       createObjectURL.returns('myobjurl');
       enketoInit.returns([]);
-      FileReader.returns(KarmaUtils.mockPromise(null, '<some-blob name="xml"/>'));
-      EnketoPrepopulationData.returns(KarmaUtils.mockPromise(null, '<xml></xml>'));
+      FileReader.returns(Promise.resolve('<some-blob name="xml"/>'));
+      EnketoPrepopulationData.returns(Promise.resolve('<xml></xml>'));
       var wrapper = $('<div><div class="container"></div><form></form></div>');
       return service.render(wrapper, 'ok').then(function() {
         // need to wait for async get attachment to complete
@@ -220,17 +220,17 @@ describe('Enketo service', function() {
     });
 
     it('leaves img wrapped if failed to load', function() {
-      UserContact.returns(KarmaUtils.mockPromise(null, { contact_id: '123' }));
-      dbGet.returns(KarmaUtils.mockPromise(null, mockEnketoDoc('myform')));
+      UserContact.returns(Promise.resolve({ contact_id: '123' }));
+      dbGet.returns(Promise.resolve(mockEnketoDoc('myform')));
       transform
-        .onFirstCall().returns(KarmaUtils.mockPromise(null, '<div><img src="jr://myimg"></div>'))
-        .onSecondCall().returns(KarmaUtils.mockPromise(null, VISIT_MODEL));
+        .onFirstCall().returns(Promise.resolve('<div><img src="jr://myimg"></div>'))
+        .onSecondCall().returns(Promise.resolve(VISIT_MODEL));
       dbGetAttachment
-        .onFirstCall().returns(KarmaUtils.mockPromise(null, 'xmlblob'))
-        .onSecondCall().returns(KarmaUtils.mockPromise('not found'));
+        .onFirstCall().returns(Promise.resolve('xmlblob'))
+        .onSecondCall().returns(Promise.reject('not found'));
       enketoInit.returns([]);
-      FileReader.returns(KarmaUtils.mockPromise(null, '<some-blob name="xml"/>'));
-      EnketoPrepopulationData.returns(KarmaUtils.mockPromise(null, '<xml></xml>'));
+      FileReader.returns(Promise.resolve('<some-blob name="xml"/>'));
+      EnketoPrepopulationData.returns(Promise.resolve('<xml></xml>'));
       var wrapper = $('<div><div class="container"></div><form></form></div>');
       return service.render(wrapper, 'ok').then(function() {
         var img = wrapper.find('img').first();
@@ -245,15 +245,15 @@ describe('Enketo service', function() {
 
     it('passes xml instance data through to Enketo', function() {
       var data = '<data><patient_id>123</patient_id></data>';
-      UserContact.returns(KarmaUtils.mockPromise(null, { contact_id: '123' }));
-      dbGet.returns(KarmaUtils.mockPromise(null, mockEnketoDoc('myform')));
-      dbGetAttachment.returns(KarmaUtils.mockPromise(null, 'xmlblob'));
+      UserContact.returns(Promise.resolve({ contact_id: '123' }));
+      dbGet.returns(Promise.resolve(mockEnketoDoc('myform')));
+      dbGetAttachment.returns(Promise.resolve('xmlblob'));
       enketoInit.returns([]);
-      FileReader.returns(KarmaUtils.mockPromise(null, '<some-blob name="xml"/>'));
-      EnketoPrepopulationData.returns(KarmaUtils.mockPromise(null, data));
+      FileReader.returns(Promise.resolve('<some-blob name="xml"/>'));
+      EnketoPrepopulationData.returns(Promise.resolve(data));
       transform
-        .onFirstCall().returns(KarmaUtils.mockPromise(null, $('<div>my form</div>')))
-        .onSecondCall().returns(KarmaUtils.mockPromise(null, 'my model'));
+        .onFirstCall().returns(Promise.resolve($('<div>my form</div>')))
+        .onSecondCall().returns(Promise.resolve('my model'));
       return service.render($('<div></div>'), 'ok', data).then(function() {
         chai.expect(EnketoForm.callCount).to.equal(1);
         chai.expect(EnketoForm.args[0][1].modelStr).to.equal('my model');
@@ -263,19 +263,19 @@ describe('Enketo service', function() {
 
     it('passes json instance data through to Enketo', function() {
       var data = '<data><patient_id>123</patient_id></data>';
-      UserContact.returns(KarmaUtils.mockPromise(null, {
+      UserContact.returns(Promise.resolve({
         _id: '456',
         contact_id: '123',
         facility_id: '789'
       }));
-      dbGet.returns(KarmaUtils.mockPromise(null, mockEnketoDoc('myform')));
-      dbGetAttachment.returns(KarmaUtils.mockPromise(null, 'xmlblob'));
+      dbGet.returns(Promise.resolve(mockEnketoDoc('myform')));
+      dbGetAttachment.returns(Promise.resolve('xmlblob'));
       enketoInit.returns([]);
-      FileReader.returns(KarmaUtils.mockPromise(null, '<some-blob name="xml"/>'));
-      EnketoPrepopulationData.returns(KarmaUtils.mockPromise(null, data));
+      FileReader.returns(Promise.resolve('<some-blob name="xml"/>'));
+      EnketoPrepopulationData.returns(Promise.resolve(data));
       transform
-        .onFirstCall().returns(KarmaUtils.mockPromise(null, $('<div>my form</div>')))
-        .onSecondCall().returns(KarmaUtils.mockPromise(null, VISIT_MODEL));
+        .onFirstCall().returns(Promise.resolve($('<div>my form</div>')))
+        .onSecondCall().returns(Promise.resolve(VISIT_MODEL));
       var instanceData = {
         inputs: {
           patient_id: 123,
@@ -291,19 +291,19 @@ describe('Enketo service', function() {
 
     it('passes contact summary data to enketo', function() {
       var data = '<data><patient_id>123</patient_id></data>';
-      UserContact.returns(KarmaUtils.mockPromise(null, {
+      UserContact.returns(Promise.resolve({
         _id: '456',
         contact_id: '123',
         facility_id: '789'
       }));
-      dbGet.returns(KarmaUtils.mockPromise(null, mockEnketoDoc('myform')));
-      dbGetAttachment.returns(KarmaUtils.mockPromise(null, 'xmlblob'));
+      dbGet.returns(Promise.resolve(mockEnketoDoc('myform')));
+      dbGetAttachment.returns(Promise.resolve('xmlblob'));
       enketoInit.returns([]);
-      FileReader.returns(KarmaUtils.mockPromise(null, '<some-blob name="xml"/>'));
-      EnketoPrepopulationData.returns(KarmaUtils.mockPromise(null, data));
+      FileReader.returns(Promise.resolve('<some-blob name="xml"/>'));
+      EnketoPrepopulationData.returns(Promise.resolve(data));
       transform
-        .onFirstCall().returns(KarmaUtils.mockPromise(null, $('<div>my form</div>')))
-        .onSecondCall().returns(KarmaUtils.mockPromise(null, VISIT_MODEL_WITH_CONTACT_SUMMARY));
+        .onFirstCall().returns(Promise.resolve($('<div>my form</div>')))
+        .onSecondCall().returns(Promise.resolve(VISIT_MODEL_WITH_CONTACT_SUMMARY));
       var instanceData = {
         contact: {
           _id: 'fffff',
@@ -339,19 +339,19 @@ describe('Enketo service', function() {
 
     it('handles arrays and escaping characters', function() {
       var data = '<data><patient_id>123</patient_id></data>';
-      UserContact.returns(KarmaUtils.mockPromise(null, {
+      UserContact.returns(Promise.resolve({
         _id: '456',
         contact_id: '123',
         facility_id: '789'
       }));
-      dbGet.returns(KarmaUtils.mockPromise(null, mockEnketoDoc('myform')));
-      dbGetAttachment.returns(KarmaUtils.mockPromise(null, 'xmlblob'));
+      dbGet.returns(Promise.resolve(mockEnketoDoc('myform')));
+      dbGetAttachment.returns(Promise.resolve('xmlblob'));
       enketoInit.returns([]);
-      FileReader.returns(KarmaUtils.mockPromise(null, '<some-blob name="xml"/>'));
-      EnketoPrepopulationData.returns(KarmaUtils.mockPromise(null, data));
+      FileReader.returns(Promise.resolve('<some-blob name="xml"/>'));
+      EnketoPrepopulationData.returns(Promise.resolve(data));
       transform
-        .onFirstCall().returns(KarmaUtils.mockPromise(null, $('<div>my form</div>')))
-        .onSecondCall().returns(KarmaUtils.mockPromise(null, VISIT_MODEL_WITH_CONTACT_SUMMARY));
+        .onFirstCall().returns(Promise.resolve($('<div>my form</div>')))
+        .onSecondCall().returns(Promise.resolve(VISIT_MODEL_WITH_CONTACT_SUMMARY));
       var instanceData = {
         contact: {
           _id: 'fffff'
@@ -382,19 +382,19 @@ describe('Enketo service', function() {
 
     it('does not get contact summary when the form has no instance for it', function() {
       var data = '<data><patient_id>123</patient_id></data>';
-      UserContact.returns(KarmaUtils.mockPromise(null, {
+      UserContact.returns(Promise.resolve({
         _id: '456',
         contact_id: '123',
         facility_id: '789'
       }));
-      dbGet.returns(KarmaUtils.mockPromise(null, mockEnketoDoc('myform')));
-      dbGetAttachment.returns(KarmaUtils.mockPromise(null, 'xmlblob'));
+      dbGet.returns(Promise.resolve(mockEnketoDoc('myform')));
+      dbGetAttachment.returns(Promise.resolve('xmlblob'));
       enketoInit.returns([]);
-      FileReader.returns(KarmaUtils.mockPromise(null, '<some-blob name="xml"/>'));
-      EnketoPrepopulationData.returns(KarmaUtils.mockPromise(null, data));
+      FileReader.returns(Promise.resolve('<some-blob name="xml"/>'));
+      EnketoPrepopulationData.returns(Promise.resolve(data));
       transform
-        .onFirstCall().returns(KarmaUtils.mockPromise(null, $('<div>my form</div>')))
-        .onSecondCall().returns(KarmaUtils.mockPromise(null, VISIT_MODEL));
+        .onFirstCall().returns(Promise.resolve($('<div>my form</div>')))
+        .onSecondCall().returns(Promise.resolve(VISIT_MODEL));
       var instanceData = {
         contact: {
           _id: 'fffff'
@@ -416,7 +416,7 @@ describe('Enketo service', function() {
   describe('save', function() {
 
     it('rejects on invalid form', function(done) {
-      form.validate.returns(KarmaUtils.mockPromise(null, false));
+      form.validate.returns(Promise.resolve(false));
       service.save('V', form).catch(function(actual) {
         chai.expect(actual.message).to.equal('Form is invalid');
         chai.expect(form.validate.callCount).to.equal(1);
@@ -425,13 +425,13 @@ describe('Enketo service', function() {
     });
 
     it('creates report', function() {
-      form.validate.returns(KarmaUtils.mockPromise(null, true));
+      form.validate.returns(Promise.resolve(true));
       var content = '<doc><name>Sally</name><lmp>10</lmp></doc>';
       form.getDataStr.returns(content);
-      dbPut.returns(KarmaUtils.mockPromise(null, { id: '(generated-in-service)', rev: '1-abc' }));
-      dbGetAttachment.returns(KarmaUtils.mockPromise(null, '<form/>'));
-      UserContact.returns(KarmaUtils.mockPromise(null, { _id: '123', phone: '555' }));
-      UserSettings.returns(KarmaUtils.mockPromise(null, { name: 'Jim' }));
+      dbPut.returns(Promise.resolve({ id: '(generated-in-service)', rev: '1-abc' }));
+      dbGetAttachment.returns(Promise.resolve('<form/>'));
+      UserContact.returns(Promise.resolve({ _id: '123', phone: '555' }));
+      UserSettings.returns(Promise.resolve({ name: 'Jim' }));
       return service.save('V', form).then(function(actual) {
         actual = actual[0];
 
@@ -459,7 +459,7 @@ describe('Enketo service', function() {
     });
 
     it('creates report with hidden fields', function() {
-      form.validate.returns(KarmaUtils.mockPromise(null, true));
+      form.validate.returns(Promise.resolve(true));
       var content =
         `<doc>
           <name>Sally</name>
@@ -467,9 +467,9 @@ describe('Enketo service', function() {
           <secret_code_name tag="hidden">S4L</secret_code_name>
         </doc>`;
       form.getDataStr.returns(content);
-      dbPut.returns(KarmaUtils.mockPromise(null, { id: '(generated-in-service)', rev: '1-abc' }));
-      dbGetAttachment.returns(KarmaUtils.mockPromise(null, '<form/>'));
-      UserContact.returns(KarmaUtils.mockPromise(null, { _id: '123', phone: '555' }));
+      dbPut.returns(Promise.resolve({ id: '(generated-in-service)', rev: '1-abc' }));
+      dbGetAttachment.returns(Promise.resolve('<form/>'));
+      UserContact.returns(Promise.resolve({ _id: '123', phone: '555' }));
       return service.save('V', form).then(function(actual) {
         actual = actual[0];
 
@@ -492,10 +492,10 @@ describe('Enketo service', function() {
     });
 
     it('updates report', function() {
-      form.validate.returns(KarmaUtils.mockPromise(null, true));
+      form.validate.returns(Promise.resolve(true));
       var content = '<doc><name>Sally</name><lmp>10</lmp></doc>';
       form.getDataStr.returns(content);
-      dbGet.returns(KarmaUtils.mockPromise(null, {
+      dbGet.returns(Promise.resolve({
         _id: '6',
         _rev: '1-abc',
         form: 'V',
@@ -505,8 +505,8 @@ describe('Enketo service', function() {
         type: 'data_record',
         reported_date: 500,
       }));
-      dbPut.returns(KarmaUtils.mockPromise(null, { id: '6', rev: '2-abc' }));
-      dbGetAttachment.returns(KarmaUtils.mockPromise(null, '<form/>'));
+      dbPut.returns(Promise.resolve({ id: '6', rev: '2-abc' }));
+      dbGetAttachment.returns(Promise.resolve('<form/>'));
       return service.save('V', form, '6').then(function(actual) {
         actual = actual[0];
 
@@ -535,7 +535,7 @@ describe('Enketo service', function() {
 
       const startTime = Date.now() - 1;
 
-      form.validate.returns(KarmaUtils.mockPromise(null, true));
+      form.validate.returns(Promise.resolve(true));
       var content =
           `<data>
             <name>Sally</name>
@@ -551,11 +551,11 @@ describe('Enketo service', function() {
             </doc2>
           </data>`;
       form.getDataStr.returns(content);
-      dbPut.onCall(0).returns(KarmaUtils.mockPromise(null, { id: '(generated-in-service)', rev: '1-abc' }));
-      dbPut.onCall(1).returns(KarmaUtils.mockPromise(null, { id: '(generated-in-service)', rev: '1-def' }));
-      dbPut.onCall(2).returns(KarmaUtils.mockPromise(null, { id: '(generated-in-service)', rev: '1-ghi' }));
-      dbGetAttachment.returns(KarmaUtils.mockPromise(null, '<form/>'));
-      UserContact.returns(KarmaUtils.mockPromise(null, { _id: '123', phone: '555' }));
+      dbPut.onCall(0).returns(Promise.resolve({ id: '(generated-in-service)', rev: '1-abc' }));
+      dbPut.onCall(1).returns(Promise.resolve({ id: '(generated-in-service)', rev: '1-def' }));
+      dbPut.onCall(2).returns(Promise.resolve({ id: '(generated-in-service)', rev: '1-ghi' }));
+      dbGetAttachment.returns(Promise.resolve('<form/>'));
+      UserContact.returns(Promise.resolve({ _id: '123', phone: '555' }));
       return service.save('V', form).then(function(actual) {
         const endTime = Date.now() + 1;
 
@@ -601,7 +601,7 @@ describe('Enketo service', function() {
     });
 
     it('creates extra docs with references', function() {
-      form.validate.returns(KarmaUtils.mockPromise(null, true));
+      form.validate.returns(Promise.resolve(true));
       var content =
           `<data>
             <name>Sally</name>
@@ -626,11 +626,11 @@ describe('Enketo service', function() {
             <my_child_02 db-doc-ref="/data/doc2"/>
           </data>`;
       form.getDataStr.returns(content);
-      dbPut.onCall(0).returns(KarmaUtils.mockPromise(null, { id: '(generated-in-service)', rev: '1-abc' }));
-      dbPut.onCall(1).returns(KarmaUtils.mockPromise(null, { id: '(generated-in-service)', rev: '1-def' }));
-      dbPut.onCall(2).returns(KarmaUtils.mockPromise(null, { id: '(generated-in-service)', rev: '1-ghi' }));
-      dbGetAttachment.returns(KarmaUtils.mockPromise(null, '<form/>'));
-      UserContact.returns(KarmaUtils.mockPromise(null, { _id: '123', phone: '555' }));
+      dbPut.onCall(0).returns(Promise.resolve({ id: '(generated-in-service)', rev: '1-abc' }));
+      dbPut.onCall(1).returns(Promise.resolve({ id: '(generated-in-service)', rev: '1-def' }));
+      dbPut.onCall(2).returns(Promise.resolve({ id: '(generated-in-service)', rev: '1-ghi' }));
+      dbGetAttachment.returns(Promise.resolve('<form/>'));
+      UserContact.returns(Promise.resolve({ _id: '123', phone: '555' }));
       return service.save('V', form).then(function(actual) {
         chai.expect(form.validate.callCount).to.equal(1);
         chai.expect(form.getDataStr.callCount).to.equal(1);
@@ -682,7 +682,7 @@ describe('Enketo service', function() {
     });
 
     it('creates extra docs with repeats', function() {
-      form.validate.returns(KarmaUtils.mockPromise(null, true));
+      form.validate.returns(Promise.resolve(true));
       var content =
           `<data xmlns:jr="http://openrosa.org/javarosa">
             <name>Sally</name>
@@ -705,12 +705,12 @@ describe('Enketo service', function() {
             </repeat_doc>
           </data>`;
       form.getDataStr.returns(content);
-      dbPut.onCall(0).returns(KarmaUtils.mockPromise(null, { id: '(generated-in-service)', rev: '1-abc' }));
-      dbPut.onCall(1).returns(KarmaUtils.mockPromise(null, { id: '(generated-in-service)', rev: '1-xxx' }));
-      dbPut.onCall(2).returns(KarmaUtils.mockPromise(null, { id: '(generated-in-service)', rev: '2-xxx' }));
-      dbPut.onCall(3).returns(KarmaUtils.mockPromise(null, { id: '(generated-in-service)', rev: '3-xxx' }));
-      dbGetAttachment.returns(KarmaUtils.mockPromise(null, '<form/>'));
-      UserContact.returns(KarmaUtils.mockPromise(null, { _id: '123', phone: '555' }));
+      dbPut.onCall(0).returns(Promise.resolve({ id: '(generated-in-service)', rev: '1-abc' }));
+      dbPut.onCall(1).returns(Promise.resolve({ id: '(generated-in-service)', rev: '1-xxx' }));
+      dbPut.onCall(2).returns(Promise.resolve({ id: '(generated-in-service)', rev: '2-xxx' }));
+      dbPut.onCall(3).returns(Promise.resolve({ id: '(generated-in-service)', rev: '3-xxx' }));
+      dbGetAttachment.returns(Promise.resolve('<form/>'));
+      UserContact.returns(Promise.resolve({ _id: '123', phone: '555' }));
       return service.save('V', form).then(function(actual) {
         chai.expect(form.validate.callCount).to.equal(1);
         chai.expect(form.getDataStr.callCount).to.equal(1);

--- a/tests/karma/unit/services/get-contact-summaries.js
+++ b/tests/karma/unit/services/get-contact-summaries.js
@@ -30,7 +30,7 @@ describe('GetContactSummaries service', () => {
       contact: 'a',
       lineage: [ 'b', 'c' ]
     }];
-    query.returns(KarmaUtils.mockPromise(null, { rows: [] }));
+    query.returns(Promise.resolve({ rows: [] }));
     return service(given).then(actual => {
       chai.expect(actual).to.deep.equal(given);
     });
@@ -46,7 +46,7 @@ describe('GetContactSummaries service', () => {
       { id: 'c', value: { name: 'charlie', colour: 'green' } },
       { id: 'd', value: { name: 'dannie' } }
     ];
-    query.returns(KarmaUtils.mockPromise(null, { rows: summaries }));
+    query.returns(Promise.resolve({ rows: summaries }));
     return service(given).then(actual => {
       chai.expect(actual[0].contact).to.equal('arnie');
       chai.expect(actual[0].lineage.length).to.equal(2);

--- a/tests/karma/unit/services/get-data-records.js
+++ b/tests/karma/unit/services/get-data-records.js
@@ -35,7 +35,7 @@ describe('GetDataRecords service', () => {
   describe('summaries', () => {
 
     it('db errors', () => {
-      query.returns(KarmaUtils.mockPromise('missing'));
+      query.returns(Promise.reject('missing'));
       return service('5')
         .then(() => {
           throw new Error('expected error to be thrown');
@@ -44,8 +44,8 @@ describe('GetDataRecords service', () => {
     });
 
     it('no result', () => {
-      query.returns(KarmaUtils.mockPromise(null, { rows: [] }));
-      GetContactSummaries.returns(KarmaUtils.mockPromise(null, [ ]));
+      query.returns(Promise.resolve({ rows: [] }));
+      GetContactSummaries.returns(Promise.resolve([ ]));
       return service('5').then(actual => {
         chai.expect(actual).to.equal(null);
         chai.expect(query.callCount).to.equal(1);
@@ -62,7 +62,7 @@ describe('GetDataRecords service', () => {
         contact: 'jim',
         lineage: [ 'area', 'center' ]
       };
-      query.returns(KarmaUtils.mockPromise(null, { rows: [
+      query.returns(Promise.resolve({ rows: [
         {
           id: '5',
           value: {
@@ -72,7 +72,7 @@ describe('GetDataRecords service', () => {
           }
         }
       ] }));
-      GetContactSummaries.returns(KarmaUtils.mockPromise(null, [ expected ]));
+      GetContactSummaries.returns(Promise.resolve([ expected ]));
       return service('5').then(actual => {
         chai.expect(actual).to.deep.equal(expected);
         chai.expect(query.callCount).to.equal(1);
@@ -95,12 +95,12 @@ describe('GetDataRecords service', () => {
         { _id: '6', name: 'six' },
         { _id: '7', name: 'seven' }
       ];
-      query.returns(KarmaUtils.mockPromise(null, { rows: [
+      query.returns(Promise.resolve({ rows: [
         { id: '5', value: { name: 'five' } },
         { id: '6', value: { name: 'six' } },
         { id: '7', value: { name: 'seven' } }
       ] }));
-      GetContactSummaries.returns(KarmaUtils.mockPromise(null, expected));
+      GetContactSummaries.returns(Promise.resolve(expected));
       return service([ '5', '6', '7' ]).then(actual => {
         chai.expect(actual).to.deep.equal(expected);
         chai.expect(query.callCount).to.equal(1);
@@ -115,7 +115,7 @@ describe('GetDataRecords service', () => {
   describe('details', () => {
 
     it('db errors', () => {
-      allDocs.returns(KarmaUtils.mockPromise('missing'));
+      allDocs.returns(Promise.reject('missing'));
       return service('5', { include_docs: true })
         .then(() => {
           throw new Error('expected error to be thrown');
@@ -124,7 +124,7 @@ describe('GetDataRecords service', () => {
     });
 
     it('no result', () => {
-      allDocs.returns(KarmaUtils.mockPromise(null, { rows: [] }));
+      allDocs.returns(Promise.resolve({ rows: [] }));
       return service('5', { include_docs: true }).then(actual => {
         chai.expect(actual).to.equal(null);
         chai.expect(allDocs.callCount).to.equal(1);
@@ -134,7 +134,7 @@ describe('GetDataRecords service', () => {
     });
 
     it('single result', () => {
-      allDocs.returns(KarmaUtils.mockPromise(null, { rows: [
+      allDocs.returns(Promise.resolve({ rows: [
         { doc: { _id: '5', name: 'five' } }
       ] }));
       return service('5', { include_docs: true }).then(actual => {
@@ -146,7 +146,7 @@ describe('GetDataRecords service', () => {
     });
 
     it('multiple results', () => {
-      allDocs.returns(KarmaUtils.mockPromise(null, { rows: [
+      allDocs.returns(Promise.resolve({ rows: [
         { doc: { _id: '5', name: 'five' } },
         { doc: { _id: '6', name: 'six' } },
         { doc: { _id: '7', name: 'seven' } }

--- a/tests/karma/unit/services/import-contacts.js
+++ b/tests/karma/unit/services/import-contacts.js
@@ -55,7 +55,7 @@ describe('ImportContacts service', function() {
     $httpBackend
       .expect('HEAD', 'BASEURL/_db/1')
       .respond(404);
-    put.returns(KarmaUtils.mockPromise('boom'));
+    put.returns(Promise.reject('boom'));
     service([{ _id: 1 }], true)
       .then(function() {
         done(new Error('Expected error to be thrown'));
@@ -78,8 +78,8 @@ describe('ImportContacts service', function() {
       .expect('HEAD', 'BASEURL/_db/2')
       .respond(404);
     put
-      .onFirstCall().returns(KarmaUtils.mockPromise(null, { _id: 1, _rev: 1 }))
-      .onSecondCall().returns(KarmaUtils.mockPromise(null, { _id: 2, _rev: 1 }));
+      .onFirstCall().returns(Promise.resolve({ _id: 1, _rev: 1 }))
+      .onSecondCall().returns(Promise.resolve({ _id: 2, _rev: 1 }));
     var contact1 = { _id: 1 };
     var contact2 = { _id: 2 };
 
@@ -109,8 +109,8 @@ describe('ImportContacts service', function() {
       .expect('HEAD', 'BASEURL/_db/2')
       .respond(200, '', { ETag: 'def' });
     put
-      .onFirstCall().returns(KarmaUtils.mockPromise(null, { _id: 1, _rev: 1 }))
-      .onSecondCall().returns(KarmaUtils.mockPromise(null, { _id: 2, _rev: 1 }));
+      .onFirstCall().returns(Promise.resolve({ _id: 1, _rev: 1 }))
+      .onSecondCall().returns(Promise.resolve({ _id: 2, _rev: 1 }));
 
     service([{ _id: 1 }, { _id: 2 }], true)
       .then(function() {
@@ -138,8 +138,8 @@ describe('ImportContacts service', function() {
       .expect('HEAD', 'BASEURL/_db/2')
       .respond(200, '', { ETag: 'def' });
     put
-      .onFirstCall().returns(KarmaUtils.mockPromise(null, { _id: 1, _rev: 1 }))
-      .onSecondCall().returns(KarmaUtils.mockPromise(null, { _id: 2, _rev: 1 }));
+      .onFirstCall().returns(Promise.resolve({ _id: 1, _rev: 1 }))
+      .onSecondCall().returns(Promise.resolve({ _id: 2, _rev: 1 }));
 
     service([{ _id: 1 }, { _id: 2 }], false)
       .then(function() {
@@ -165,10 +165,10 @@ describe('ImportContacts service', function() {
     $httpBackend
       .expect('HEAD', 'BASEURL/_db/2')
       .respond(404);
-    put.onCall(0).returns(KarmaUtils.mockPromise(null, { _id: 1, _rev: 1 }));
-    put.onCall(1).returns(KarmaUtils.mockPromise(null, { }));
-    put.onCall(2).returns(KarmaUtils.mockPromise(null, { _id: 4, _rev: 1 }));
-    put.onCall(3).returns(KarmaUtils.mockPromise(null, { }));
+    put.onCall(0).returns(Promise.resolve({ _id: 1, _rev: 1 }));
+    put.onCall(1).returns(Promise.resolve({ }));
+    put.onCall(2).returns(Promise.resolve({ _id: 4, _rev: 1 }));
+    put.onCall(3).returns(Promise.resolve({ }));
     var contact1 = { _id: 1, contact: { name: 'john', phone: '+123' } };
     var contact2 = { _id: 2, contact: { _id: 3, name: 'jack', phone: '+123' } };
 

--- a/tests/karma/unit/services/import-properties.js
+++ b/tests/karma/unit/services/import-properties.js
@@ -42,8 +42,8 @@ describe('ImportProperties service', function() {
         'Goodbye': 'bye'
       }
     };
-    Settings.returns(KarmaUtils.mockPromise(null, {}));
-    put.returns(KarmaUtils.mockPromise(null, {}));
+    Settings.returns(Promise.resolve({}));
+    put.returns(Promise.resolve({}));
     setTimeout(function() {
       rootScope.$digest();
       setTimeout(function() {
@@ -74,8 +74,8 @@ describe('ImportProperties service', function() {
         'Hello': 'hello'
       }
     };
-    Settings.returns(KarmaUtils.mockPromise(null, {}));
-    put.returns(KarmaUtils.mockPromise(null, {}));
+    Settings.returns(Promise.resolve({}));
+    put.returns(Promise.resolve({}));
     setTimeout(function() {
       rootScope.$digest();
       setTimeout(function() {
@@ -104,9 +104,9 @@ describe('ImportProperties service', function() {
                   'registrations[0].messages[0] = MESSAGE 1\n' +
                   'registrations[0].validations.list[0] = VALIDATION 1\n' +
                   'registrations[0].validations.list[1] = VALIDATION 2';
-    Settings.returns(KarmaUtils.mockPromise(null, settings()));
-    UpdateSettings.returns(KarmaUtils.mockPromise());
-    put.returns(KarmaUtils.mockPromise(null, {}));
+    Settings.returns(Promise.resolve(settings()));
+    UpdateSettings.returns(Promise.resolve());
+    put.returns(Promise.resolve({}));
     setTimeout(function() {
       rootScope.$digest();
       setTimeout(function() {
@@ -126,13 +126,13 @@ describe('ImportProperties service', function() {
                   'registrations[0].validations.list[0] = VALIDATION 1\n' +
                   'registrations[0].validations.list[1] = VALIDATION 2\n' +
                   'registrations[0].validations.list[2] =  ';
-    Settings.returns(KarmaUtils.mockPromise(null, settings(s => {
+    Settings.returns(Promise.resolve(settings(s => {
       s.registrations[0].validations.list[2] = {
         translation_key: 'test.translation.key',
       };
     })));
-    UpdateSettings.returns(KarmaUtils.mockPromise());
-    put.returns(KarmaUtils.mockPromise(null, {}));
+    UpdateSettings.returns(Promise.resolve());
+    put.returns(Promise.resolve({}));
     setTimeout(() => {
       rootScope.$digest();
       setTimeout(() => {

--- a/tests/karma/unit/services/json-forms.js
+++ b/tests/karma/unit/services/json-forms.js
@@ -20,7 +20,7 @@ describe('JsonForms service', function() {
   });
 
   it('returns zero when no forms', function(done) {
-    Settings.returns(KarmaUtils.mockPromise(null, { forms: {} }));
+    Settings.returns(Promise.resolve({ forms: {} }));
     service()
       .then(function(actual) {
         chai.expect(actual).to.deep.equal([]);
@@ -30,7 +30,7 @@ describe('JsonForms service', function() {
   });
 
   it('returns forms with old style labels', function(done) {
-    Settings.returns(KarmaUtils.mockPromise(null, { forms: {
+    Settings.returns(Promise.resolve({ forms: {
       A: { meta: { code: 'A', label: 'First',  icon: 'a' } },
       B: { meta: { code: 'B', label: 'Second', icon: 'b' } },
       C: { meta: { code: 'C', label: 'Third',  icon: 'c' } },
@@ -50,7 +50,7 @@ describe('JsonForms service', function() {
   });
 
   it('handles forms with no label', function(done) {
-    Settings.returns(KarmaUtils.mockPromise(null, { forms: {
+    Settings.returns(Promise.resolve({ forms: {
       A: { meta: { code: 'A' } },
       B: { meta: { code: 'B', icon: 'b' } },
       C: { meta: { code: 'C', label: 'Third' } },

--- a/tests/karma/unit/services/language.js
+++ b/tests/karma/unit/services/language.js
@@ -26,7 +26,7 @@ describe('Language service', function() {
 
   it('uses the language configured in user', function(done) {
     ipCookie.returns(null);
-    UserSettings.returns(KarmaUtils.mockPromise(null, { language: 'latin' }));
+    UserSettings.returns(Promise.resolve({ language: 'latin' }));
     service().then(function(actual) {
       chai.expect(actual).to.equal('latin');
       chai.expect(UserSettings.callCount).to.equal(1);
@@ -42,8 +42,8 @@ describe('Language service', function() {
 
   it('uses the language configured in settings', function(done) {
     ipCookie.returns(null);
-    UserSettings.returns(KarmaUtils.mockPromise(null, { }));
-    Settings.returns(KarmaUtils.mockPromise(null, { locale: 'yiddish' }));
+    UserSettings.returns(Promise.resolve({ }));
+    Settings.returns(Promise.resolve({ locale: 'yiddish' }));
     service().then(function(actual) {
       chai.expect(actual).to.equal('yiddish');
       chai.expect(UserSettings.callCount).to.equal(1);
@@ -59,8 +59,8 @@ describe('Language service', function() {
 
   it('defaults', function(done) {
     ipCookie.returns(null);
-    UserSettings.returns(KarmaUtils.mockPromise(null, { }));
-    Settings.returns(KarmaUtils.mockPromise(null, { }));
+    UserSettings.returns(Promise.resolve({ }));
+    Settings.returns(Promise.resolve({ }));
     service().then(function(actual) {
       chai.expect(actual).to.equal('en');
       chai.expect(UserSettings.callCount).to.equal(1);

--- a/tests/karma/unit/services/mark-read.js
+++ b/tests/karma/unit/services/mark-read.js
@@ -34,7 +34,7 @@ describe('MarkRead service', () => {
   it('marks messages read', () => {
     const given = [ { _id: 'xyz' } ];
     const expected = [ { _id: 'read:message:xyz' } ];
-    bulkDocs.returns(KarmaUtils.mockPromise());
+    bulkDocs.returns(Promise.resolve());
     return service(given).then(() => {
       chai.expect(db.args[0][0].meta).to.equal(true);
       chai.expect(bulkDocs.args[0][0]).to.deep.equal(expected);
@@ -44,7 +44,7 @@ describe('MarkRead service', () => {
   it('marks reports read', () => {
     const given = [ { _id: 'xyz', form: 'P' } ];
     const expected = [ { _id: 'read:report:xyz' } ];
-    bulkDocs.returns(KarmaUtils.mockPromise());
+    bulkDocs.returns(Promise.resolve());
     return service(given).then(() => {
       chai.expect(db.args[0][0].meta).to.equal(true);
       chai.expect(bulkDocs.args[0][0]).to.deep.equal(expected);
@@ -54,7 +54,7 @@ describe('MarkRead service', () => {
   it('ignores conflicts when marking a document read thats already read', () => {
     const given = [ { _id: 'xyz' } ];
     const conflictResult = { ok: false, id: 'read:message:xyz', rev: '1' };
-    bulkDocs.returns(KarmaUtils.mockPromise(null, [ conflictResult ]));
+    bulkDocs.returns(Promise.resolve([ conflictResult ]));
     return service(given).then(() => {
       chai.expect(bulkDocs.callCount).to.equal(1);
     });
@@ -63,7 +63,7 @@ describe('MarkRead service', () => {
   it('returns bulkDocs errors', done => {
     const given = { _id: 'xyz' };
     const expected = 'errcode2';
-    bulkDocs.returns(KarmaUtils.mockPromise(expected));
+    bulkDocs.returns(Promise.reject(expected));
     service([given]).catch(err => {
       chai.expect(err).to.equal(expected);
       done();
@@ -81,7 +81,7 @@ describe('MarkRead service', () => {
       { _id: 'read:message:b' }
     ];
 
-    bulkDocs.returns(KarmaUtils.mockPromise());
+    bulkDocs.returns(Promise.resolve());
 
     return service(given).then(() => {
       chai.expect(bulkDocs.args[0][0]).to.deep.equal(expected);

--- a/tests/karma/unit/services/message-contacts.js
+++ b/tests/karma/unit/services/message-contacts.js
@@ -30,9 +30,9 @@ describe('MessageContacts service', () => {
         { name: 'alistair', from: 'a', key: 'a', read: false },
         { name: 'britney' , from: 'b', key: 'b', read: true },
       ];
-      query.returns(KarmaUtils.mockPromise(null, { rows: given }));
-      getContactSummaries.returns(KarmaUtils.mockPromise(null, expected));
-      allDocs.returns(KarmaUtils.mockPromise(null, { rows: [ {}, { value: 'a' } ] }));
+      query.returns(Promise.resolve({ rows: given }));
+      getContactSummaries.returns(Promise.resolve(expected));
+      allDocs.returns(Promise.resolve({ rows: [ {}, { value: 'a' } ] }));
       return service({}).then(actual => {
         chai.expect(actual).to.deep.equal(expected);
         chai.expect(getContactSummaries.args[0][0]).to.deep.equal([
@@ -43,7 +43,7 @@ describe('MessageContacts service', () => {
     });
 
     it('returns errors from db query', done => {
-      query.returns(KarmaUtils.mockPromise('server error'));
+      query.returns(Promise.reject('server error'));
       service({})
         .then(() => {
           done(new Error('exception expected'));
@@ -62,8 +62,8 @@ describe('MessageContacts service', () => {
       const given = [ { id: 'a' }, { id: 'b' } ];
       const read = [ { }, { value: 'y' } ];
       const expected = [ { id: 'a', read: false }, { id: 'b', read: true } ];
-      query.returns(KarmaUtils.mockPromise(null, { rows: given }));
-      allDocs.returns(KarmaUtils.mockPromise(null, { rows: read }));
+      query.returns(Promise.resolve({ rows: given }));
+      allDocs.returns(Promise.resolve({ rows: read }));
       return service({ id: 'abc' }).then(actual => {
         chai.expect(actual).to.deep.equal(expected);
       });
@@ -73,15 +73,15 @@ describe('MessageContacts service', () => {
       const given = [ { id: 'a' }, { id: 'b' } ];
       const read = [ { value: 'x' }, { } ];
       const expected = [ { id: 'a', read: true }, { id: 'b', read: false } ];
-      query.returns(KarmaUtils.mockPromise(null, { rows: given }));
-      allDocs.returns(KarmaUtils.mockPromise(null, { rows: read }));
+      query.returns(Promise.resolve({ rows: given }));
+      allDocs.returns(Promise.resolve({ rows: read }));
       return service({ id: 'abc', skip: 45 }).then(actual => {
         chai.expect(actual).to.deep.equal(expected);
       });
     });
 
     it('returns errors from db query', done => {
-      query.returns(KarmaUtils.mockPromise('server error'));
+      query.returns(Promise.reject('server error'));
       service({ id: 'abc' })
         .then(() => {
           done(new Error('expected exception'));

--- a/tests/karma/unit/services/message-state.js
+++ b/tests/karma/unit/services/message-state.js
@@ -52,7 +52,7 @@ describe('MessageState service', function() {
   });
 
   it('set returns get errors', function(done) {
-    get.returns(KarmaUtils.mockPromise('db messed up'));
+    get.returns(Promise.reject('db messed up'));
     service.set('123', 2, 'scheduled', 'muted').catch(function(err) {
       chai.expect(err).to.equal('db messed up');
       done();
@@ -67,7 +67,7 @@ describe('MessageState service', function() {
         { group: 3, state: 'sent' }
       ]
     };
-    get.returns(KarmaUtils.mockPromise(null, doc));
+    get.returns(Promise.resolve(doc));
     service.set('123', 2, 'scheduled', 'muted').then(function() {
       done();
     });
@@ -81,8 +81,8 @@ describe('MessageState service', function() {
         { group: 3, state: 'sent' }
       ]
     };
-    get.returns(KarmaUtils.mockPromise(null, doc));
-    put.returns(KarmaUtils.mockPromise('save borked'));
+    get.returns(Promise.resolve(doc));
+    put.returns(Promise.reject('save borked'));
     service.set('123', 2, 'muted', 'scheduled').catch(function(err) {
       chai.expect(err).to.equal('save borked');
       done();
@@ -99,8 +99,8 @@ describe('MessageState service', function() {
         { group: 3, state: 'sent' }
       ]
     };
-    get.returns(KarmaUtils.mockPromise(null, doc));
-    put.returns(KarmaUtils.mockPromise());
+    get.returns(Promise.resolve(doc));
+    put.returns(Promise.resolve());
     service.set('123', 2, 'muted', 'scheduled').then(function() {
       chai.expect(get.args[0][0]).to.equal('123');
       var actual = put.args[0][0];

--- a/tests/karma/unit/services/place-hierarchy.js
+++ b/tests/karma/unit/services/place-hierarchy.js
@@ -29,7 +29,7 @@ describe('PlaceHierarchy service', function() {
   });
 
   it('returns errors from Contacts service', function(done) {
-    Contacts.returns(KarmaUtils.mockPromise('boom'));
+    Contacts.returns(Promise.reject('boom'));
     service()
       .then(function() {
         done(new Error('error expected'));
@@ -41,7 +41,7 @@ describe('PlaceHierarchy service', function() {
   });
 
   it('builds empty hierarchy when no facilities', function() {
-    Contacts.returns(KarmaUtils.mockPromise(null, []));
+    Contacts.returns(Promise.resolve([]));
     return service().then(function(actual) {
       chai.expect(actual.length).to.equal(0);
     });
@@ -54,7 +54,7 @@ describe('PlaceHierarchy service', function() {
     var d = { _id: 'd', parent: { _id: 'b', parent: { _id: 'c' } } };
     var e = { _id: 'e', parent: { _id: 'x' } }; // unknown parent is ignored
     var f = { _id: 'f' };
-    Contacts.returns(KarmaUtils.mockPromise(null, [ a, b, c, d, e, f ]));
+    Contacts.returns(Promise.resolve([ a, b, c, d, e, f ]));
     return service().then(function(actual) {
       chai.expect(actual).to.deep.equal([
         {

--- a/tests/karma/unit/services/resource-icon.js
+++ b/tests/karma/unit/services/resource-icon.js
@@ -30,7 +30,7 @@ describe('ResourceIcons service', function() {
   describe('getImg function', function() {
 
     it('returns undefined when given no name', function(done) {
-      get.returns(KarmaUtils.mockPromise());
+      get.returns(Promise.resolve());
       var service = injector.get('ResourceIcons');
       var actual = service.getImg();
       chai.expect(actual).to.equal(undefined);
@@ -38,7 +38,7 @@ describe('ResourceIcons service', function() {
     });
 
     it('returns undefined when no doc yet', function(done) {
-      get.returns(KarmaUtils.mockPromise());
+      get.returns(Promise.resolve());
       var service = injector.get('ResourceIcons');
       var actual = service.getImg('delivery');
       chai.expect(actual).to.equal(undefined);
@@ -62,7 +62,7 @@ describe('ResourceIcons service', function() {
           }
         }
       };
-      get.returns(KarmaUtils.mockPromise(null, resources));
+      get.returns(Promise.resolve(resources));
       var service = injector.get('ResourceIcons');
       setTimeout(function() {
         var actual = service.getImg('child');
@@ -88,7 +88,7 @@ describe('ResourceIcons service', function() {
           }
         }
       };
-      get.returns(KarmaUtils.mockPromise(null, resources));
+      get.returns(Promise.resolve(resources));
       var dom = $('<ul>' +
                   '<li><img class="resource-icon" title="child"/></li>' +
                   '<li><img class="resource-icon" title="adult"/></li>' +
@@ -133,8 +133,8 @@ describe('ResourceIcons service', function() {
         }
       };
       get
-        .onFirstCall().returns(KarmaUtils.mockPromise(null, resources1))
-        .onSecondCall().returns(KarmaUtils.mockPromise(null, resources2));
+        .onFirstCall().returns(Promise.resolve(resources1))
+        .onSecondCall().returns(Promise.resolve(resources2));
       var dom = $('<ul>' +
                   '<li><img class="resource-icon" title="child"/></li>' +
                   '<li><img class="resource-icon" title="adult"/></li>' +

--- a/tests/karma/unit/services/rules-engine.js
+++ b/tests/karma/unit/services/rules-engine.js
@@ -235,14 +235,14 @@ describe('RulesEngine service', function() {
   };
 
   it('returns search errors', function(done) {
-    Search.returns(KarmaUtils.mockPromise('boom'));
-    Settings.returns(KarmaUtils.mockPromise(null, {
+    Search.returns(Promise.reject('boom'));
+    Settings.returns(Promise.resolve({
       tasks: {
         rules: rules,
         schedules: schedules
       }
     }));
-    UserContact.returns(KarmaUtils.mockPromise(null, { name: 'Jim' }));
+    UserContact.returns(Promise.resolve({ name: 'Jim' }));
     var service = getService();
     service.listen('test', 'task', function(err) {
       chai.expect(err).to.equal('boom');
@@ -252,8 +252,8 @@ describe('RulesEngine service', function() {
   });
 
   it('returns settings errors', function(done) {
-    Settings.returns(KarmaUtils.mockPromise('boom'));
-    UserContact.returns(KarmaUtils.mockPromise(null, { name: 'Jim' }));
+    Settings.returns(Promise.reject('boom'));
+    UserContact.returns(Promise.resolve({ name: 'Jim' }));
     var service = getService();
     service.listen('test', 'task', function(err) {
       chai.expect(err).to.equal('boom');
@@ -263,8 +263,8 @@ describe('RulesEngine service', function() {
   });
 
   it('returns empty when settings returns no config', function(done) {
-    Settings.returns(KarmaUtils.mockPromise(null, {}));
-    UserContact.returns(KarmaUtils.mockPromise(null, { name: 'Jim' }));
+    Settings.returns(Promise.resolve({}));
+    UserContact.returns(Promise.resolve({ name: 'Jim' }));
     var service = getService();
     service.listen('test', 'task', function(err, actual) {
       chai.expect(Search.callCount).to.equal(0);
@@ -276,15 +276,15 @@ describe('RulesEngine service', function() {
 
   it('generates tasks when given registrations', function(done) {
 
-    Search.onFirstCall().returns(KarmaUtils.mockPromise(null, dataRecords));
-    Search.onSecondCall().returns(KarmaUtils.mockPromise(null, contacts));
-    Settings.returns(KarmaUtils.mockPromise(null, {
+    Search.onFirstCall().returns(Promise.resolve(dataRecords));
+    Search.onSecondCall().returns(Promise.resolve(contacts));
+    Settings.returns(Promise.resolve({
       tasks: {
         rules: rules,
         schedules: schedules
       }
     }));
-    UserContact.returns(KarmaUtils.mockPromise(null, { name: 'Jim' }));
+    UserContact.returns(Promise.resolve({ name: 'Jim' }));
 
     var expectations = {
       '1-visit-1': {
@@ -397,15 +397,15 @@ describe('RulesEngine service', function() {
       name: 'Jenny',
       patient_id: '12345'
     };
-    Search.onFirstCall().returns(KarmaUtils.mockPromise(null, [ dataRecord ]));
-    Search.onSecondCall().returns(KarmaUtils.mockPromise(null, [ contact ]));
-    Settings.returns(KarmaUtils.mockPromise(null, {
+    Search.onFirstCall().returns(Promise.resolve([ dataRecord ]));
+    Search.onSecondCall().returns(Promise.resolve([ contact ]));
+    Settings.returns(Promise.resolve({
       tasks: {
         rules: rules,
         schedules: schedules
       }
     }));
-    UserContact.returns(KarmaUtils.mockPromise(null, { name: 'Jim' }));
+    UserContact.returns(Promise.resolve({ name: 'Jim' }));
 
     var expectations = {
       '1-visit-1': {
@@ -457,15 +457,15 @@ describe('RulesEngine service', function() {
 
   it('caches tasks', function(done) {
 
-    Search.onFirstCall().returns(KarmaUtils.mockPromise(null, dataRecords));
-    Search.onSecondCall().returns(KarmaUtils.mockPromise(null, contacts));
-    Settings.returns(KarmaUtils.mockPromise(null, {
+    Search.onFirstCall().returns(Promise.resolve(dataRecords));
+    Search.onSecondCall().returns(Promise.resolve(contacts));
+    Settings.returns(Promise.resolve({
       tasks: {
         rules: rules,
         schedules: schedules
       }
     }));
-    UserContact.returns(KarmaUtils.mockPromise(null, { name: 'Jim' }));
+    UserContact.returns(Promise.resolve({ name: 'Jim' }));
 
     var service = getService();
     var expected = {};
@@ -505,15 +505,15 @@ describe('RulesEngine service', function() {
       { _id: 1, name: 'Jenny' }
     ];
 
-    Search.onFirstCall().returns(KarmaUtils.mockPromise(null, dataRecords));
-    Search.onSecondCall().returns(KarmaUtils.mockPromise(null, contacts));
-    Settings.returns(KarmaUtils.mockPromise(null, {
+    Search.onFirstCall().returns(Promise.resolve(dataRecords));
+    Search.onSecondCall().returns(Promise.resolve(contacts));
+    Settings.returns(Promise.resolve({
       tasks: {
         rules: rules,
         schedules: schedules
       }
     }));
-    UserContact.returns(KarmaUtils.mockPromise(null, { name: 'Jim' }));
+    UserContact.returns(Promise.resolve({ name: 'Jim' }));
 
     var callbackCount = 0;
     var service = getService();
@@ -560,15 +560,15 @@ describe('RulesEngine service', function() {
       { _id: 1, name: 'Jenny' }
     ];
 
-    Search.onFirstCall().returns(KarmaUtils.mockPromise(null, dataRecords));
-    Search.onSecondCall().returns(KarmaUtils.mockPromise(null, contacts));
-    Settings.returns(KarmaUtils.mockPromise(null, {
+    Search.onFirstCall().returns(Promise.resolve(dataRecords));
+    Search.onSecondCall().returns(Promise.resolve(contacts));
+    Settings.returns(Promise.resolve({
       tasks: {
         rules: rules,
         schedules: schedules
       }
     }));
-    UserContact.returns(KarmaUtils.mockPromise(null, { name: 'Jim' }));
+    UserContact.returns(Promise.resolve({ name: 'Jim' }));
 
     var callbackCount = 0;
     var service = getService();
@@ -613,15 +613,15 @@ describe('RulesEngine service', function() {
 
     var newContact = { _id: 4, name: 'Sarah' };
 
-    Search.onFirstCall().returns(KarmaUtils.mockPromise(null, dataRecords));
-    Search.onSecondCall().returns(KarmaUtils.mockPromise(null, contacts));
-    Settings.returns(KarmaUtils.mockPromise(null, {
+    Search.onFirstCall().returns(Promise.resolve(dataRecords));
+    Search.onSecondCall().returns(Promise.resolve(contacts));
+    Settings.returns(Promise.resolve({
       tasks: {
         rules: rules,
         schedules: schedules
       }
     }));
-    UserContact.returns(KarmaUtils.mockPromise(null, { name: 'Jim' }));
+    UserContact.returns(Promise.resolve({ name: 'Jim' }));
 
     var callbackCount = 0;
     var service = getService();
@@ -671,15 +671,15 @@ describe('RulesEngine service', function() {
       { _id: 1, name: 'Jenny' }
     ];
 
-    Search.onFirstCall().returns(KarmaUtils.mockPromise(null, dataRecords));
-    Search.onSecondCall().returns(KarmaUtils.mockPromise(null, contacts));
-    Settings.returns(KarmaUtils.mockPromise(null, {
+    Search.onFirstCall().returns(Promise.resolve(dataRecords));
+    Search.onSecondCall().returns(Promise.resolve(contacts));
+    Settings.returns(Promise.resolve({
       tasks: {
         rules: rules,
         schedules: schedules
       }
     }));
-    UserContact.returns(KarmaUtils.mockPromise(null, { name: 'Jim' }));
+    UserContact.returns(Promise.resolve({ name: 'Jim' }));
 
     var callbackCount = 0;
     var service = getService();
@@ -728,15 +728,15 @@ describe('RulesEngine service', function() {
       { _id: 'some_uuid', name: 'Jenny', patient_id: 1 }
     ];
 
-    Search.onFirstCall().returns(KarmaUtils.mockPromise(null, dataRecords));
-    Search.onSecondCall().returns(KarmaUtils.mockPromise(null, contacts));
-    Settings.returns(KarmaUtils.mockPromise(null, {
+    Search.onFirstCall().returns(Promise.resolve(dataRecords));
+    Search.onSecondCall().returns(Promise.resolve(contacts));
+    Settings.returns(Promise.resolve({
       tasks: {
         rules: rules,
         schedules: schedules
       }
     }));
-    UserContact.returns(KarmaUtils.mockPromise(null, { name: 'Jim' }));
+    UserContact.returns(Promise.resolve({ name: 'Jim' }));
 
     var callbackCount = 0;
     var service = getService();
@@ -778,15 +778,15 @@ describe('RulesEngine service', function() {
       { _id: 1, name: 'Jenny' }
     ];
 
-    Search.onFirstCall().returns(KarmaUtils.mockPromise(null, dataRecords));
-    Search.onSecondCall().returns(KarmaUtils.mockPromise(null, contacts));
-    Settings.returns(KarmaUtils.mockPromise(null, {
+    Search.onFirstCall().returns(Promise.resolve(dataRecords));
+    Search.onSecondCall().returns(Promise.resolve(contacts));
+    Settings.returns(Promise.resolve({
       tasks: {
         rules: rules,
         schedules: schedules
       }
     }));
-    UserContact.returns(KarmaUtils.mockPromise(null, { name: 'Jim' }));
+    UserContact.returns(Promise.resolve({ name: 'Jim' }));
 
     var callbackCount = 0;
     var service = getService();
@@ -828,15 +828,15 @@ describe('RulesEngine service', function() {
       { _id: 1, name: 'Jenny' }
     ];
 
-    Search.onFirstCall().returns(KarmaUtils.mockPromise(null, dataRecords));
-    Search.onSecondCall().returns(KarmaUtils.mockPromise(null, contacts));
-    Settings.returns(KarmaUtils.mockPromise(null, {
+    Search.onFirstCall().returns(Promise.resolve(dataRecords));
+    Search.onSecondCall().returns(Promise.resolve(contacts));
+    Settings.returns(Promise.resolve({
       tasks: {
         rules: rules,
         schedules: schedules
       }
     }));
-    UserContact.returns(KarmaUtils.mockPromise(null, { name: 'Jim' }));
+    UserContact.returns(Promise.resolve({ name: 'Jim' }));
 
     var callbackCount = 0;
     var service = getService();

--- a/tests/karma/unit/services/scheduled-forms.js
+++ b/tests/karma/unit/services/scheduled-forms.js
@@ -23,7 +23,7 @@ describe('ScheduledForms service', function() {
   });
 
   it('returns error when Settings errors', function(done) {
-    Settings.returns(KarmaUtils.mockPromise('boom'));
+    Settings.returns(Promise.reject('boom'));
     service()
       .then(function() {
         done(new Error('expected go boom'));
@@ -35,7 +35,7 @@ describe('ScheduledForms service', function() {
   });
 
   it('returns empty if no scheduled forms', function(done) {
-    Settings.returns(KarmaUtils.mockPromise(null, {}));
+    Settings.returns(Promise.resolve({}));
     service()
       .then(function(actual) {
         chai.expect(actual).to.deep.equal([]);
@@ -45,7 +45,7 @@ describe('ScheduledForms service', function() {
   });
 
   it('returns empty if no reporting config', function(done) {
-    Settings.returns(KarmaUtils.mockPromise(null, {
+    Settings.returns(Promise.resolve({
       forms: { R: 'registration', D: 'delivery' }
     }));
     service()
@@ -57,7 +57,7 @@ describe('ScheduledForms service', function() {
   });
 
   it('returns multiple forms', function(done) {
-    Settings.returns(KarmaUtils.mockPromise(null, {
+    Settings.returns(Promise.resolve({
       forms: { R: 'registration', D: 'delivery', F: 'flag' },
       'kujua-reporting': [ { code: 'R' }, { code: 'X' }, { code: 'D' } ]
     }));

--- a/tests/karma/unit/services/search.js
+++ b/tests/karma/unit/services/search.js
@@ -37,7 +37,7 @@ describe('Search service', function() {
           descending: true
         }
       }]);
-      dbQuery.returns(KarmaUtils.mockPromise('boom'));
+      dbQuery.returns(Promise.reject('boom'));
       return service('reports', {})
         .then(function() {
           throw new Error('expected error to be thrown');
@@ -57,8 +57,8 @@ describe('Search service', function() {
           descending: true
         }
       }]);
-      dbQuery.returns(KarmaUtils.mockPromise(null, { rows: [] }));
-      GetDataRecords.returns(KarmaUtils.mockPromise(null, []));
+      dbQuery.returns(Promise.resolve({ rows: [] }));
+      GetDataRecords.returns(Promise.resolve([]));
       return service('reports', {})
         .then(function(actual) {
           chai.expect(actual.length).to.equal(0);
@@ -76,8 +76,8 @@ describe('Search service', function() {
           descending: true
         }
       }]);
-      dbQuery.returns(KarmaUtils.mockPromise(null, { rows: [ { id: 3 }, { id: 4 } ] }));
-      GetDataRecords.returns(KarmaUtils.mockPromise(null, expected));
+      dbQuery.returns(Promise.resolve({ rows: [ { id: 3 }, { id: 4 } ] }));
+      GetDataRecords.returns(Promise.resolve(expected));
       return service('reports', {})
         .then(function(actual) {
           chai.expect(actual).to.deep.equal(expected);
@@ -94,8 +94,8 @@ describe('Search service', function() {
     it('returns results when one filter', function() {
       var expected = [ { id: 'a' }, { id: 'b' } ];
       GenerateSearchRequests.returns([ { view: 'get_stuff', params: { key: [ 'a' ] } } ]);
-      dbQuery.returns(KarmaUtils.mockPromise(null, { rows: [ { id: 'a', value: 1 }, { id: 'b', value: 2 } ] }));
-      GetDataRecords.returns(KarmaUtils.mockPromise(null, expected));
+      dbQuery.returns(Promise.resolve({ rows: [ { id: 'a', value: 1 }, { id: 'b', value: 2 } ] }));
+      GetDataRecords.returns(Promise.resolve(expected));
       return service('reports', {}, { limit: 10, skip: 5 })
         .then(function(actual) {
           chai.expect(actual).to.deep.equal(expected);
@@ -111,8 +111,8 @@ describe('Search service', function() {
     it('removes duplicates before pagination', function() {
       var expected = [ { id: 'a' }, { id: 'b' } ];
       GenerateSearchRequests.returns([ { view: 'get_stuff', params: { key: [ 'a' ] } } ]);
-      dbQuery.returns(KarmaUtils.mockPromise(null, { rows: [ { id: 'a', value: 1 }, { id: 'b', value: 2 }, { id: 'a', value: 1 } ] }));
-      GetDataRecords.returns(KarmaUtils.mockPromise(null, expected));
+      dbQuery.returns(Promise.resolve({ rows: [ { id: 'a', value: 1 }, { id: 'b', value: 2 }, { id: 'a', value: 1 } ] }));
+      GetDataRecords.returns(Promise.resolve(expected));
       return service('reports', {})
         .then(function(actual) {
           chai.expect(actual).to.deep.equal(expected);
@@ -137,9 +137,9 @@ describe('Search service', function() {
         { view: 'get_stuff', params: { key: [ 'a' ] } },
         { view: 'get_moar_stuff', params: { key: [ 'b' ] } }
       ]);
-      dbQuery.onCall(0).returns(KarmaUtils.mockPromise(null, viewResult));
-      dbQuery.onCall(1).returns(KarmaUtils.mockPromise(null, viewResult));
-      GetDataRecords.returns(KarmaUtils.mockPromise(null, []));
+      dbQuery.onCall(0).returns(Promise.resolve(viewResult));
+      dbQuery.onCall(1).returns(Promise.resolve(viewResult));
+      GetDataRecords.returns(Promise.resolve([]));
       return service('reports', {}, { limit: 10 })
         .then(function(actual) {
           chai.expect(actual).to.deep.equal([]);
@@ -161,9 +161,9 @@ describe('Search service', function() {
         { view: 'get_stuff', params: { key: [ 'a' ] } },
         { view: 'get_moar_stuff', params: { key: [ 'b' ] } }
       ]);
-      dbQuery.onCall(0).returns(KarmaUtils.mockPromise(null, viewResult));
-      dbQuery.onCall(1).returns(KarmaUtils.mockPromise(null, viewResult));
-      GetDataRecords.returns(KarmaUtils.mockPromise(null, []));
+      dbQuery.onCall(0).returns(Promise.resolve(viewResult));
+      dbQuery.onCall(1).returns(Promise.resolve(viewResult));
+      GetDataRecords.returns(Promise.resolve([]));
       return service('reports', {}, { skip: 10 })
         .then(function(actual) {
           chai.expect(actual).to.deep.equal([]);
@@ -181,9 +181,9 @@ describe('Search service', function() {
         { view: 'get_stuff', params: { key: [ 'a' ] } },
         { view: 'get_moar_stuff', params: { key: [ 'b' ] } }
       ]);
-      dbQuery.onCall(0).returns(KarmaUtils.mockPromise(null, viewResult));
-      dbQuery.onCall(1).returns(KarmaUtils.mockPromise(null, viewResult));
-      GetDataRecords.returns(KarmaUtils.mockPromise(null, []));
+      dbQuery.onCall(0).returns(Promise.resolve(viewResult));
+      dbQuery.onCall(1).returns(Promise.resolve(viewResult));
+      GetDataRecords.returns(Promise.resolve([]));
       return service('reports', {}, { skip: 14, limit: 5 })
         .then(function(actual) {
           chai.expect(actual).to.deep.equal([]);
@@ -198,9 +198,9 @@ describe('Search service', function() {
         { view: 'get_stuff', params: { key: [ 'a' ] } },
         { view: 'get_moar_stuff', params: { startkey: [ {} ] } }
       ]);
-      dbQuery.onCall(0).returns(KarmaUtils.mockPromise(null, { rows: [ { id: 'a', value: 1 }, { id: 'b', value: 2 }, { id: 'c', value: 3 } ] }));
-      dbQuery.onCall(1).returns(KarmaUtils.mockPromise(null, { rows: [ { id: 'a', value: 1 }, { id: 'b', value: 2 }, { id: 'd', value: 4 } ] }));
-      GetDataRecords.returns(KarmaUtils.mockPromise(null, expected));
+      dbQuery.onCall(0).returns(Promise.resolve({ rows: [ { id: 'a', value: 1 }, { id: 'b', value: 2 }, { id: 'c', value: 3 } ] }));
+      dbQuery.onCall(1).returns(Promise.resolve({ rows: [ { id: 'a', value: 1 }, { id: 'b', value: 2 }, { id: 'd', value: 4 } ] }));
+      GetDataRecords.returns(Promise.resolve(expected));
       return service('reports', {})
         .then(function(actual) {
           chai.expect(actual).to.deep.equal(expected);
@@ -220,8 +220,8 @@ describe('Search service', function() {
         { view: 'get_stuff', params: { key: [ 'a' ] } },
         { view: 'get_moar_stuff', params: { startkey: [ {} ] } }
       ]);
-      dbQuery.onCall(0).returns(KarmaUtils.mockPromise(null, { rows: [ { id: 'a', value: 1 }, { id: 'b', value: 2 }, { id: 'c', value: 3 } ] }));
-      dbQuery.onCall(1).returns(KarmaUtils.mockPromise('boom'));
+      dbQuery.onCall(0).returns(Promise.resolve({ rows: [ { id: 'a', value: 1 }, { id: 'b', value: 2 }, { id: 'c', value: 3 } ] }));
+      dbQuery.onCall(1).returns(Promise.reject('boom'));
       return service('reports', {})
         .then(function() {
           throw new Error('expected error to be thrown');
@@ -235,8 +235,8 @@ describe('Search service', function() {
 
     it('does not get when no ids', function() {
       GenerateSearchRequests.returns([ { view: 'get_stuff', params: { key: [ 'a' ] } } ]);
-      dbQuery.returns(KarmaUtils.mockPromise(null, { rows: []}));
-      GetDataRecords.returns(KarmaUtils.mockPromise(null, []));
+      dbQuery.returns(Promise.resolve({ rows: []}));
+      GetDataRecords.returns(Promise.resolve([]));
       return service('reports', {})
         .then(function(actual) {
           chai.expect(actual).to.deep.equal([]);
@@ -254,8 +254,8 @@ describe('Search service', function() {
     it('debounces if the same query is executed twice', function(done) {
       var expected = [ { id: 'a' } ];
       GenerateSearchRequests.returns([ { view: 'get_stuff', params: { } } ]);
-      dbQuery.returns(KarmaUtils.mockPromise(null, { rows: [ { id: 'a', value: 1 } ] }));
-      GetDataRecords.returns(KarmaUtils.mockPromise(null, expected));
+      dbQuery.returns(Promise.resolve({ rows: [ { id: 'a', value: 1 } ] }));
+      GetDataRecords.returns(Promise.resolve(expected));
       service('reports', {})
         .then(function(actual) {
           chai.expect(actual).to.deep.equal(expected);
@@ -270,8 +270,8 @@ describe('Search service', function() {
     it('does not debounce if the same query is executed twice with the force option', function() {
       var expected = [ { id: 'a' } ];
       GenerateSearchRequests.returns([ { view: 'get_stuff', params: { } } ]);
-      dbQuery.returns(KarmaUtils.mockPromise(null, { rows: [ { id: 'a', value: 1 } ] }));
-      GetDataRecords.returns(KarmaUtils.mockPromise(null, expected));
+      dbQuery.returns(Promise.resolve({ rows: [ { id: 'a', value: 1 } ] }));
+      GetDataRecords.returns(Promise.resolve(expected));
       var firstReturned = false;
       service('reports', {})
         .then(function(actual) {
@@ -290,11 +290,11 @@ describe('Search service', function() {
         .onCall(0).returns([ { view: 'get_stuff', params: { id: 'a' } } ])
         .onCall(1).returns([ { view: 'get_stuff', params: { id: 'b' } } ]);
       dbQuery
-        .onCall(0).returns(KarmaUtils.mockPromise(null, { rows: [ { id: 'a', value: 1 } ] }))
-        .onCall(1).returns(KarmaUtils.mockPromise(null, { rows: [ { id: 'b', value: 2 } ] }));
+        .onCall(0).returns(Promise.resolve({ rows: [ { id: 'a', value: 1 } ] }))
+        .onCall(1).returns(Promise.resolve({ rows: [ { id: 'b', value: 2 } ] }));
       GetDataRecords
-        .onFirstCall().returns(KarmaUtils.mockPromise(null, [ { id: 'a' } ]))
-        .onSecondCall().returns(KarmaUtils.mockPromise(null, [ { id: 'b' } ]));
+        .onFirstCall().returns(Promise.resolve([ { id: 'a' } ]))
+        .onSecondCall().returns(Promise.resolve([ { id: 'b' } ]));
       var firstReturned = false;
       service('reports', { freetext: 'first' })
         .then(function(actual) {
@@ -313,8 +313,8 @@ describe('Search service', function() {
     it('does not debounce subsequent queries', function() {
       var expected = [ { id: 'a' } ];
       GenerateSearchRequests.returns([ { view: 'get_stuff', params: { } } ]);
-      dbQuery.returns(KarmaUtils.mockPromise(null, { rows: [ { id: 'a', value: 1 } ] }));
-      GetDataRecords.returns(KarmaUtils.mockPromise(null, expected));
+      dbQuery.returns(Promise.resolve({ rows: [ { id: 'a', value: 1 } ] }));
+      GetDataRecords.returns(Promise.resolve(expected));
       return service('reports', {})
         .then(function(actual) {
           chai.expect(actual).to.deep.equal(expected);
@@ -347,9 +347,9 @@ describe('Search service', function() {
         { view: 'get_stuff', params: { key: [ 'a' ] } },
         { view: 'get_moar_stuff', params: { key: [ 'b' ] } }
       ]);
-      dbQuery.onCall(0).returns(KarmaUtils.mockPromise(null, viewResult));
-      dbQuery.onCall(1).returns(KarmaUtils.mockPromise(null, viewResult));
-      GetDataRecords.returns(KarmaUtils.mockPromise(null, []));
+      dbQuery.onCall(0).returns(Promise.resolve(viewResult));
+      dbQuery.onCall(1).returns(Promise.resolve(viewResult));
+      GetDataRecords.returns(Promise.resolve([]));
       return service('contacts', {}, { limit: 10 })
         .then(function(actual) {
           chai.expect(actual).to.deep.equal([]);
@@ -371,9 +371,9 @@ describe('Search service', function() {
         { view: 'get_stuff', params: { key: [ 'a' ] } },
         { view: 'get_moar_stuff', params: { key: [ 'b' ] } }
       ]);
-      dbQuery.onCall(0).returns(KarmaUtils.mockPromise(null, viewResult));
-      dbQuery.onCall(1).returns(KarmaUtils.mockPromise(null, viewResult));
-      GetDataRecords.returns(KarmaUtils.mockPromise(null, []));
+      dbQuery.onCall(0).returns(Promise.resolve(viewResult));
+      dbQuery.onCall(1).returns(Promise.resolve(viewResult));
+      GetDataRecords.returns(Promise.resolve([]));
       return service('contacts', {}, { skip: 10 })
         .then(function(actual) {
           chai.expect(actual).to.deep.equal([]);
@@ -390,9 +390,9 @@ describe('Search service', function() {
         union: true,
         paramSets: [ { key: [ 'a' ] }, { key: [ 'b' ] } ]
       } ]);
-      dbQuery.onCall(0).returns(KarmaUtils.mockPromise(null, { rows: [ { id: 'a', value: 1 }, { id: 'b', value: 2 } ] }));
-      dbQuery.onCall(1).returns(KarmaUtils.mockPromise(null, { rows: [ { id: 'b', value: 2 }, { id: 'c', value: 3 } ] }));
-      GetDataRecords.returns(KarmaUtils.mockPromise(null, expected));
+      dbQuery.onCall(0).returns(Promise.resolve({ rows: [ { id: 'a', value: 1 }, { id: 'b', value: 2 } ] }));
+      dbQuery.onCall(1).returns(Promise.resolve({ rows: [ { id: 'b', value: 2 }, { id: 'c', value: 3 } ] }));
+      GetDataRecords.returns(Promise.resolve(expected));
       return service('contacts', {})
         .then(function(actual) {
           chai.expect(actual).to.deep.equal(expected);

--- a/tests/karma/unit/services/send-message.js
+++ b/tests/karma/unit/services/send-message.js
@@ -22,7 +22,7 @@ describe('SendMessage service', function() {
       }));
       $provide.value('$q', Q); // bypass $q so we don't have to digest
       $provide.value('UserSettings', function() {
-        return KarmaUtils.mockPromise(null, { phone: '+5551', name: 'jack' });
+        return Promise.resolve({ phone: '+5551', name: 'jack' });
       });
       $provide.value('Settings', Settings);
     });
@@ -50,7 +50,7 @@ describe('SendMessage service', function() {
     if (!Array.isArray(docs)) {
       docs = [docs];
     }
-    return KarmaUtils.mockPromise(null, {
+    return Promise.resolve({
       rows: docs.map(function(doc) {return {doc: doc};})
     });
   }
@@ -66,8 +66,8 @@ describe('SendMessage service', function() {
 
   it('create doc for one recipient', function(done) {
 
-    post.returns(KarmaUtils.mockPromise());
-    Settings.returns(KarmaUtils.mockPromise(null, {}));
+    post.returns(Promise.resolve());
+    Settings.returns(Promise.resolve({}));
 
     var recipient = {
       _id: 'abc',
@@ -95,8 +95,8 @@ describe('SendMessage service', function() {
 
   it('create doc for non-contact recipient from select2', function(done) {
 
-    post.returns(KarmaUtils.mockPromise());
-    Settings.returns(KarmaUtils.mockPromise(null, {}));
+    post.returns(Promise.resolve());
+    Settings.returns(Promise.resolve({}));
 
     var recipient = {
       selected: false,
@@ -125,7 +125,7 @@ describe('SendMessage service', function() {
   it('normalizes phone numbers', function(done) {
     // Note : only valid phone numbers can be normalized.
 
-    post.returns(KarmaUtils.mockPromise());
+    post.returns(Promise.resolve());
 
     var phoneNumber = '700123456';
     var recipient = {
@@ -135,7 +135,7 @@ describe('SendMessage service', function() {
       }
     };
     allDocs.returns(mockAllDocs(recipient));
-    Settings.returns(KarmaUtils.mockPromise(null, {
+    Settings.returns(Promise.resolve({
       default_country_code: 254
     }));
 
@@ -154,8 +154,8 @@ describe('SendMessage service', function() {
 
   it('create doc for multiple recipients', function(done) {
 
-    post.returns(KarmaUtils.mockPromise());
-    Settings.returns(KarmaUtils.mockPromise(null, {}));
+    post.returns(Promise.resolve());
+    Settings.returns(Promise.resolve({}));
 
     var recipients = [
       {
@@ -198,8 +198,8 @@ describe('SendMessage service', function() {
 
   it('create doc for everyoneAt recipients', function(done) {
 
-    post.returns(KarmaUtils.mockPromise());
-    Settings.returns(KarmaUtils.mockPromise(null, {}));
+    post.returns(Promise.resolve());
+    Settings.returns(Promise.resolve({}));
 
     var recipients = [
       {
@@ -271,8 +271,8 @@ describe('SendMessage service', function() {
 
   it('returns post errors', function(done) {
 
-    post.returns(KarmaUtils.mockPromise('errcode2'));
-    Settings.returns(KarmaUtils.mockPromise(null, {}));
+    post.returns(Promise.reject('errcode2'));
+    Settings.returns(Promise.resolve({}));
 
     var recipient = {
       _id: 'abc',

--- a/tests/karma/unit/services/settings.js
+++ b/tests/karma/unit/services/settings.js
@@ -34,7 +34,7 @@ describe('Settings service', function() {
         isTrue: true,
         isString: 'hello'
       };
-      get.returns(KarmaUtils.mockPromise(null, { app_settings: expected }));
+      get.returns(Promise.resolve({ app_settings: expected }));
       service()
         .then(function(actual) {
           chai.expect(actual.isTrue).to.equal(expected.isTrue);
@@ -48,7 +48,7 @@ describe('Settings service', function() {
     });
 
     it('returns errors', function(done) {
-      get.returns(KarmaUtils.mockPromise('Not found'));
+      get.returns(Promise.reject('Not found'));
       service()
         .then(function() {
           done('Unexpected resolution of promise.');

--- a/tests/karma/unit/services/target-generator.js
+++ b/tests/karma/unit/services/target-generator.js
@@ -31,8 +31,8 @@ describe('TargetGenerator service', function() {
   });
 
   it('returns settings errors', function(done) {
-    Settings.returns(KarmaUtils.mockPromise('boom'));
-    UserContact.returns(KarmaUtils.mockPromise());
+    Settings.returns(Promise.reject('boom'));
+    UserContact.returns(Promise.resolve());
     injector.get('TargetGenerator')(function(err) {
       chai.expect(err).to.equal('boom');
       done();
@@ -40,8 +40,8 @@ describe('TargetGenerator service', function() {
   });
 
   it('returns empty array when no targets are configured', function(done) {
-    Settings.returns(KarmaUtils.mockPromise(null, {}));
-    UserContact.returns(KarmaUtils.mockPromise());
+    Settings.returns(Promise.resolve({}));
+    UserContact.returns(Promise.resolve());
     RulesEngine.listen.callsArgWith(2, null, []);
     injector.get('TargetGenerator')(function(err, actual) {
       chai.expect(actual).to.deep.equal([]);
@@ -50,8 +50,8 @@ describe('TargetGenerator service', function() {
   });
 
   it('returns task generator errors', function(done) {
-    Settings.returns(KarmaUtils.mockPromise(null, { tasks: { targets: { items: [] } } }));
-    UserContact.returns(KarmaUtils.mockPromise());
+    Settings.returns(Promise.resolve({ tasks: { targets: { items: [] } } }));
+    UserContact.returns(Promise.resolve());
     RulesEngine.listen.callsArgWith(2, 'boom');
     injector.get('TargetGenerator')(function(err) {
       chai.expect(err).to.equal('boom');
@@ -60,8 +60,8 @@ describe('TargetGenerator service', function() {
   });
 
   it('returns empty when no targets are emitted', function(done) {
-    Settings.returns(KarmaUtils.mockPromise(null, { tasks: { targets: { items: [] } } }));
-    UserContact.returns(KarmaUtils.mockPromise());
+    Settings.returns(Promise.resolve({ tasks: { targets: { items: [] } } }));
+    UserContact.returns(Promise.resolve());
     RulesEngine.listen.callsArgWith(2, null, []);
     injector.get('TargetGenerator')(function(err, actual) {
       chai.expect(actual).to.deep.equal([]);
@@ -70,10 +70,10 @@ describe('TargetGenerator service', function() {
   });
 
   it('ignores unconfigured targets', function(done) {
-    Settings.returns(KarmaUtils.mockPromise(null, { tasks: { targets: { items: [
+    Settings.returns(Promise.resolve({ tasks: { targets: { items: [
       { id: 'known' }
     ] } } }));
-    UserContact.returns(KarmaUtils.mockPromise());
+    UserContact.returns(Promise.resolve());
     RulesEngine.listen.callsArgWith(2, null, [
       { _id: '1', type: 'unknown' }
     ]);
@@ -85,10 +85,10 @@ describe('TargetGenerator service', function() {
   });
 
   it('calculates the target count', function(done) {
-    Settings.returns(KarmaUtils.mockPromise(null, { tasks: { targets: { items: [
+    Settings.returns(Promise.resolve({ tasks: { targets: { items: [
       { id: 'report', type: 'count' }
     ] } } }));
-    UserContact.returns(KarmaUtils.mockPromise());
+    UserContact.returns(Promise.resolve());
     RulesEngine.listen.callsArgWith(2, null, [
       { _id: '1', type: 'report', date: now, pass: true },
       { _id: '2', type: 'report', date: now, pass: false },
@@ -104,10 +104,10 @@ describe('TargetGenerator service', function() {
   });
 
   it('ignores old target instances', function(done) {
-    Settings.returns(KarmaUtils.mockPromise(null, { tasks: { targets: { items: [
+    Settings.returns(Promise.resolve({ tasks: { targets: { items: [
       { id: 'report', type: 'count' }
     ] } } }));
-    UserContact.returns(KarmaUtils.mockPromise());
+    UserContact.returns(Promise.resolve());
     RulesEngine.listen.callsArgWith(2, null, [
       { _id: '1', type: 'report', pass: true, date: now },
       { _id: '2', type: 'report', pass: true, date: 0 },
@@ -123,10 +123,10 @@ describe('TargetGenerator service', function() {
   });
 
   it('calculates the target percent', function(done) {
-    Settings.returns(KarmaUtils.mockPromise(null, { tasks: { targets: { items: [
+    Settings.returns(Promise.resolve({ tasks: { targets: { items: [
       { id: 'report', type: 'percent' }
     ] } } }));
-    UserContact.returns(KarmaUtils.mockPromise());
+    UserContact.returns(Promise.resolve());
     RulesEngine.listen.callsArgWith(2, null, [
       { _id: '1', type: 'report', date: now, pass: true },
       { _id: '2', type: 'report', date: 0, pass: false },
@@ -143,10 +143,10 @@ describe('TargetGenerator service', function() {
   });
 
   it('handles divison by zero in percent', function(done) {
-    Settings.returns(KarmaUtils.mockPromise(null, { tasks: { targets: { items: [
+    Settings.returns(Promise.resolve({ tasks: { targets: { items: [
       { id: 'report', type: 'percent' }
     ] } } }));
-    UserContact.returns(KarmaUtils.mockPromise());
+    UserContact.returns(Promise.resolve());
     RulesEngine.listen.callsArgWith(2, null, [
       { _id: '1', type: 'report', pass: true, date: 0 } // too old to be relevant, so not included in count
     ]);
@@ -160,11 +160,11 @@ describe('TargetGenerator service', function() {
   });
 
   it('calculates multiple targets', function(done) {
-    Settings.returns(KarmaUtils.mockPromise(null, { tasks: { targets: { items: [
+    Settings.returns(Promise.resolve({ tasks: { targets: { items: [
       { id: 'report', type: 'count' },
       { id: 'registration', type: 'percent' }
     ] } } }));
-    UserContact.returns(KarmaUtils.mockPromise());
+    UserContact.returns(Promise.resolve());
     RulesEngine.listen.callsArgWith(2, null, [
       { _id: '1', type: 'report', pass: true, date: now },
       { _id: '2', type: 'report', pass: true, date: now },
@@ -200,10 +200,10 @@ describe('TargetGenerator service', function() {
   };
 
   it('deals with deleted instances', function(done) {
-    Settings.returns(KarmaUtils.mockPromise(null, { tasks: { targets: { items: [
+    Settings.returns(Promise.resolve({ tasks: { targets: { items: [
       { id: 'report', type: 'count' }
     ] } } }));
-    UserContact.returns(KarmaUtils.mockPromise());
+    UserContact.returns(Promise.resolve());
     var callbackCount = 0;
     injector.get('TargetGenerator')(function(err, actual) {
       if (callbackCount === 0) {
@@ -238,10 +238,10 @@ describe('TargetGenerator service', function() {
   });
 
   it('updates for new emissions', function(done) {
-    Settings.returns(KarmaUtils.mockPromise(null, { tasks: { targets: { items: [
+    Settings.returns(Promise.resolve({ tasks: { targets: { items: [
       { id: 'report', type: 'count' }
     ] } } }));
-    UserContact.returns(KarmaUtils.mockPromise());
+    UserContact.returns(Promise.resolve());
     var callbackCount = 0;
     injector.get('TargetGenerator')(function(err, actual) {
       if (callbackCount === 0) {
@@ -274,10 +274,10 @@ describe('TargetGenerator service', function() {
   });
 
   it('duplicate instances are updated', function(done) {
-    Settings.returns(KarmaUtils.mockPromise(null, { tasks: { targets: { items: [
+    Settings.returns(Promise.resolve({ tasks: { targets: { items: [
       { id: 'report', type: 'count' }
     ] } } }));
-    UserContact.returns(KarmaUtils.mockPromise());
+    UserContact.returns(Promise.resolve());
     var callbackCount = 0;
     injector.get('TargetGenerator')(function(err, actual) {
       if (callbackCount === 0) {
@@ -315,12 +315,12 @@ describe('TargetGenerator service', function() {
   });
 
   it('excludes targets for which the expression fails', function(done) {
-    Settings.returns(KarmaUtils.mockPromise(null, { tasks: { targets: { items: [
+    Settings.returns(Promise.resolve({ tasks: { targets: { items: [
       { id: 'none',  type: 'count' },
       { id: 'true',  type: 'count', context: 'user.name === "geoff"' },
       { id: 'false', type: 'count', context: 'user.name === "jeff"' }
     ] } } }));
-    UserContact.returns(KarmaUtils.mockPromise(null, { name: 'geoff' }));
+    UserContact.returns(Promise.resolve({ name: 'geoff' }));
     RulesEngine.listen.callsArgWith(2, null, [
       { _id: '1', type: 'none', date: now, pass: true },
       { _id: '2', type: 'true', date: now, pass: true },
@@ -339,10 +339,10 @@ describe('TargetGenerator service', function() {
   });
 
   it('updates targets that are no longer relevant - #3207', function(done) {
-    Settings.returns(KarmaUtils.mockPromise(null, { tasks: { targets: { items: [
+    Settings.returns(Promise.resolve({ tasks: { targets: { items: [
       { id: 'report', type: 'count' }
     ] } } }));
-    UserContact.returns(KarmaUtils.mockPromise());
+    UserContact.returns(Promise.resolve());
     var callbackCount = 0;
     injector.get('TargetGenerator')(function(err, actual) {
       if (callbackCount === 0) {

--- a/tests/karma/unit/services/translation-loader.js
+++ b/tests/karma/unit/services/translation-loader.js
@@ -27,7 +27,7 @@ describe('TranslationLoader service', function() {
   it('returns error when db throws error', function(done) {
     var options = { key: 'err' };
     var expected = { status: 503 };
-    DBGet.returns(KarmaUtils.mockPromise(expected));
+    DBGet.returns(Promise.reject(expected));
     service(options)
       .then(function() {
         done(new Error('expected error to be thrown'));
@@ -40,7 +40,7 @@ describe('TranslationLoader service', function() {
 
   it('returns empty when no translation document', function() {
     var options = { key: 'notfound' };
-    DBGet.returns(KarmaUtils.mockPromise({ status: 404 }));
+    DBGet.returns(Promise.reject({ status: 404 }));
     return service(options).then(function(actual) {
       chai.expect(actual).to.deep.equal({});
       chai.expect(Settings.callCount).to.equal(0);
@@ -55,7 +55,7 @@ describe('TranslationLoader service', function() {
       prawn: 'shrimp',
       bbq: 'barbie'
     };
-    DBGet.returns(KarmaUtils.mockPromise(null, { values: expected }));
+    DBGet.returns(Promise.resolve({ values: expected }));
     return service(options).then(function(actual) {
       chai.expect(actual).to.deep.equal(expected);
       chai.expect(Settings.callCount).to.equal(0);
@@ -71,8 +71,8 @@ describe('TranslationLoader service', function() {
       prawn: 'prawn',
       bbq: 'grill'
     };
-    Settings.returns(KarmaUtils.mockPromise(null, settings));
-    DBGet.returns(KarmaUtils.mockPromise(null, { values: expected }));
+    Settings.returns(Promise.resolve(settings));
+    DBGet.returns(Promise.resolve({ values: expected }));
     return service(options).then(function(actual) {
       chai.expect(actual).to.deep.equal(expected);
       chai.expect(Settings.callCount).to.equal(1);
@@ -88,8 +88,8 @@ describe('TranslationLoader service', function() {
       prawn: 'prawn',
       bbq: 'barbeque'
     };
-    Settings.returns(KarmaUtils.mockPromise(null, settings));
-    DBGet.returns(KarmaUtils.mockPromise(null, { values: expected }));
+    Settings.returns(Promise.resolve(settings));
+    DBGet.returns(Promise.resolve({ values: expected }));
     return service(options).then(function(actual) {
       chai.expect(actual).to.deep.equal(expected);
       chai.expect(Settings.callCount).to.equal(1);
@@ -108,7 +108,7 @@ describe('TranslationLoader service', function() {
       prawn: '-prawn-',
       bbq: '-barbeque-'
     };
-    DBGet.returns(KarmaUtils.mockPromise(null, { values: doc }));
+    DBGet.returns(Promise.resolve({ values: doc }));
     return service(options).then(function(actual) {
       chai.expect(actual).to.deep.equal(expected);
       chai.expect(Settings.callCount).to.equal(0);

--- a/tests/karma/unit/services/update-facility.js
+++ b/tests/karma/unit/services/update-facility.js
@@ -33,7 +33,7 @@ describe('UpdateFacility service', function() {
       ]
     };
     var facility = { _id: 'xyz' };
-    var expected = { 
+    var expected = {
       _id: 'abc',
       _rev: 1,
       errors: [
@@ -45,9 +45,9 @@ describe('UpdateFacility service', function() {
     };
 
     get
-      .onFirstCall().returns(KarmaUtils.mockPromise(null, message))
-      .onSecondCall().returns(KarmaUtils.mockPromise(null, facility));
-    put.returns(KarmaUtils.mockPromise(null, { _id: message._id, _rev: 2 }));
+      .onFirstCall().returns(Promise.resolve(message))
+      .onSecondCall().returns(Promise.resolve(facility));
+    put.returns(Promise.resolve({ _id: message._id, _rev: 2 }));
 
     return service('abc', 'xyz')
       .then(function() {
@@ -58,8 +58,8 @@ describe('UpdateFacility service', function() {
 
   it('returns db errors', function(done) {
     get
-      .onFirstCall().returns(KarmaUtils.mockPromise('errcode1'))
-      .onSecondCall().returns(KarmaUtils.mockPromise(null, {}));
+      .onFirstCall().returns(Promise.reject('errcode1'))
+      .onSecondCall().returns(Promise.resolve({}));
     service('abc', 'xyz')
       .then(function() {
         done(new Error('expected error to be thrown'));
@@ -72,8 +72,8 @@ describe('UpdateFacility service', function() {
 
   it('returns db errors from second call', function(done) {
     get
-      .onFirstCall().returns(KarmaUtils.mockPromise(null, {}))
-      .onSecondCall().returns(KarmaUtils.mockPromise('errcode2'));
+      .onFirstCall().returns(Promise.resolve({}))
+      .onSecondCall().returns(Promise.reject('errcode2'));
     service('abc', 'xyz')
       .then(function() {
         done(new Error('expected error to be thrown'));
@@ -86,9 +86,9 @@ describe('UpdateFacility service', function() {
 
   it('returns save errors', function(done) {
     get
-      .onFirstCall().returns(KarmaUtils.mockPromise(null, {}))
-      .onSecondCall().returns(KarmaUtils.mockPromise(null, {}));
-    put.returns(KarmaUtils.mockPromise('errcode3'));
+      .onFirstCall().returns(Promise.resolve({}))
+      .onSecondCall().returns(Promise.resolve({}));
+    put.returns(Promise.reject('errcode3'));
     service('abc', 'xyz')
       .then(function() {
         done(new Error('expected error to be thrown'));

--- a/tests/karma/unit/services/update-user.js
+++ b/tests/karma/unit/services/update-user.js
@@ -69,7 +69,7 @@ describe('UpdateUser service', function() {
       .expect('PUT', '/_users/org.couchdb.user%3Asally', JSON.stringify(expectedUser))
       .respond(201, '');
 
-    put.returns(KarmaUtils.mockPromise());
+    put.returns(Promise.resolve());
 
     service(null, settings, user);
 
@@ -122,13 +122,13 @@ describe('UpdateUser service', function() {
       .expect('PUT', '/_users/org.couchdb.user%3Ajerome', JSON.stringify(expectedUser))
       .respond(201, '');
 
-    get.returns(KarmaUtils.mockPromise(null, {
+    get.returns(Promise.resolve({
       _id: 'org.couchdb.user:jerome',
       type: 'user-settings',
       name: 'jerome',
       favcolour: 'teal'
     }));
-    put.returns(KarmaUtils.mockPromise());
+    put.returns(Promise.resolve());
 
     service('org.couchdb.user:jerome', settings, user);
 
@@ -228,13 +228,13 @@ describe('UpdateUser service', function() {
       starsign: 'libra'
     };
 
-    get.returns(KarmaUtils.mockPromise(null, {
+    get.returns(Promise.resolve({
       _id: 'org.couchdb.user:jerome',
       type: 'user-settings',
       name: 'jerome',
       favcolour: 'teal'
     }));
-    put.returns(KarmaUtils.mockPromise());
+    put.returns(Promise.resolve());
 
     setTimeout(function() {
       scope.$apply(); // needed to resolve the promises

--- a/tests/karma/unit/services/user-contact.js
+++ b/tests/karma/unit/services/user-contact.js
@@ -20,7 +20,7 @@ describe('UserContact service', function() {
   });
 
   it('returns error from user settings', function(done) {
-    UserSettings.returns(KarmaUtils.mockPromise(new Error('boom')));
+    UserSettings.returns(Promise.reject(new Error('boom')));
     service()
       .then(function() {
         done('Expected error to be thrown');
@@ -32,27 +32,27 @@ describe('UserContact service', function() {
   });
 
   it('returns null when no configured contact', function() {
-    UserSettings.returns(KarmaUtils.mockPromise(null, {}));
+    UserSettings.returns(Promise.resolve({}));
     return service().then(function(contact) {
       chai.expect(contact).to.equal(undefined);
     });
   });
 
   it('returns null when configured contact not in the database', function() {
-    UserSettings.returns(KarmaUtils.mockPromise(null, { contact_id: 'not-found' }));
+    UserSettings.returns(Promise.resolve({ contact_id: 'not-found' }));
     var err = new Error('not_found');
     err.reason = 'missing';
     err.message = 'missing';
     err.status = 404;
-    get.returns(KarmaUtils.mockPromise(err));
+    get.returns(Promise.reject(err));
     return service().then(function(contact) {
       chai.expect(contact).to.equal(undefined);
     });
   });
 
   it('returns error from getting contact', function(done) {
-    UserSettings.returns(KarmaUtils.mockPromise(null, { contact_id: 'nobody' }));
-    get.returns(KarmaUtils.mockPromise(new Error('boom')));
+    UserSettings.returns(Promise.resolve({ contact_id: 'nobody' }));
+    get.returns(Promise.reject(new Error('boom')));
     service()
       .then(function() {
         done('Expected error to be thrown');
@@ -67,8 +67,8 @@ describe('UserContact service', function() {
 
   it('returns contact', function() {
     var expected = { _id: 'somebody', name: 'Some Body' };
-    UserSettings.returns(KarmaUtils.mockPromise(null, { contact_id: 'somebody' }));
-    get.returns(KarmaUtils.mockPromise(null, expected));
+    UserSettings.returns(Promise.resolve({ contact_id: 'somebody' }));
+    get.returns(Promise.resolve(expected));
     return service().then(function(contact) {
       chai.expect(contact).to.deep.equal(expected);
       chai.expect(get.callCount).to.equal(1);

--- a/tests/karma/unit/services/user-district.js
+++ b/tests/karma/unit/services/user-district.js
@@ -79,8 +79,8 @@ describe('UserDistrict service', function() {
       facility_id: 'x'
     };
 
-    get.onCall(0).returns(KarmaUtils.mockPromise(null, user));
-    get.onCall(1).returns(KarmaUtils.mockPromise(null, { type: 'district_hospital' }));
+    get.onCall(0).returns(Promise.resolve(user));
+    get.onCall(1).returns(Promise.resolve({ type: 'district_hospital' }));
 
     return service()
       .then(function(actual) {
@@ -105,7 +105,7 @@ describe('UserDistrict service', function() {
       roles: ['district_admin']
     };
 
-    get.onCall(0).returns(KarmaUtils.mockPromise(null, user));
+    get.onCall(0).returns(Promise.resolve(user));
 
     return service()
       .then(function() {
@@ -133,9 +133,9 @@ describe('UserDistrict service', function() {
 
     var err404 = {status: 404, name: 'not_found', message: 'missing', error: true, reason: 'missing'};
 
-    get.onCall(0).returns(KarmaUtils.mockPromise(null, user));
-    get.onCall(1).returns(KarmaUtils.mockPromise(err404));
-    get.onCall(2).returns(KarmaUtils.mockPromise(err404));
+    get.onCall(0).returns(Promise.resolve(user));
+    get.onCall(1).returns(Promise.reject(err404));
+    get.onCall(2).returns(Promise.reject(err404));
 
     return service()
       .then(function() {

--- a/tests/karma/unit/services/user-settings.js
+++ b/tests/karma/unit/services/user-settings.js
@@ -40,7 +40,7 @@ describe('UserSettings service', function() {
 
   it('gets from local db', function() {
     userCtx.returns({ name: 'jack' });
-    get.returns(KarmaUtils.mockPromise(null, { id: 'j' }));
+    get.returns(Promise.resolve({ id: 'j' }));
     return service()
       .then(function(actual) {
         chai.expect(actual.id).to.equal('j');
@@ -53,8 +53,8 @@ describe('UserSettings service', function() {
   it('gets from remote db', function() {
     userCtx.returns({ name: 'jack' });
     get
-      .onCall(0).returns(KarmaUtils.mockPromise({ code: 404 }))
-      .onCall(1).returns(KarmaUtils.mockPromise(null, { id: 'j' }));
+      .onCall(0).returns(Promise.reject({ code: 404 }))
+      .onCall(1).returns(Promise.resolve({ id: 'j' }));
     return service()
       .then(function(actual) {
         chai.expect(actual.id).to.equal('j');
@@ -68,8 +68,8 @@ describe('UserSettings service', function() {
   it('errors if remote db errors', function(done) {
     userCtx.returns({ name: 'jack' });
     get
-      .onCall(0).returns(KarmaUtils.mockPromise({ code: 404 }))
-      .onCall(1).returns(KarmaUtils.mockPromise({ code: 503, message: 'nope' }));
+      .onCall(0).returns(Promise.reject({ code: 404 }))
+      .onCall(1).returns(Promise.reject({ code: 503, message: 'nope' }));
     service()
       .then(function() {
         done(new Error('expected error to be thrown'));

--- a/tests/karma/unit/services/z-score.js
+++ b/tests/karma/unit/services/z-score.js
@@ -40,7 +40,7 @@ describe('ZScore service', function() {
       var configDoc = {
         charts: []
       };
-      dbGet.returns(KarmaUtils.mockPromise(null, configDoc));
+      dbGet.returns(Promise.resolve(configDoc));
       return service(options).then(function(scores) {
         chai.expect(scores.weightForAge).to.equal(undefined);
       });
@@ -57,7 +57,7 @@ describe('ZScore service', function() {
           data: {}
         }]
       };
-      dbGet.returns(KarmaUtils.mockPromise(null, configDoc));
+      dbGet.returns(Promise.resolve(configDoc));
       return service(options).then(function(scores) {
         chai.expect(scores.weightForAge).to.equal(undefined);
       });
@@ -74,7 +74,7 @@ describe('ZScore service', function() {
           data: {}
         }]
       };
-      dbGet.returns(KarmaUtils.mockPromise(null, configDoc));
+      dbGet.returns(Promise.resolve(configDoc));
       return service(options).then(function(scores) {
         chai.expect(scores.weightForAge).to.equal(undefined);
       });
@@ -91,7 +91,7 @@ describe('ZScore service', function() {
           data: {}
         }]
       };
-      dbGet.returns(KarmaUtils.mockPromise(null, configDoc));
+      dbGet.returns(Promise.resolve(configDoc));
       return service(options).then(function(scores) {
         chai.expect(scores.weightForAge).to.equal(undefined);
       });
@@ -103,7 +103,7 @@ describe('ZScore service', function() {
         weight: 25,
         age: 1
       };
-      dbGet.returns(KarmaUtils.mockPromise(null, CONFIG_DOC));
+      dbGet.returns(Promise.resolve(CONFIG_DOC));
       return service(options).then(function(scores) {
         chai.expect(scores.weightForAge).to.equal(1);
         chai.expect(dbGet.callCount).to.equal(1);
@@ -117,7 +117,7 @@ describe('ZScore service', function() {
         weight: 25.753,
         age: 1
       };
-      dbGet.returns(KarmaUtils.mockPromise(null, CONFIG_DOC));
+      dbGet.returns(Promise.resolve(CONFIG_DOC));
       return service(options).then(function(scores) {
         // round to 3dp to ignore tiny errors caused by floats
         var actual = (scores.weightForAge * 1000) / 1000;
@@ -131,7 +131,7 @@ describe('ZScore service', function() {
         weight: 25.7,
         age: 1
       };
-      dbGet.returns(KarmaUtils.mockPromise(null, CONFIG_DOC));
+      dbGet.returns(Promise.resolve(CONFIG_DOC));
       return service(options).then(function(scores) {
         chai.expect(scores.weightForAge).to.equal(undefined);
       });
@@ -154,7 +154,7 @@ describe('ZScore service', function() {
           }
         }]
       };
-      dbGet.returns(KarmaUtils.mockPromise(null, configDoc));
+      dbGet.returns(Promise.resolve(configDoc));
       return service(options).then(function(scores) {
         chai.expect(scores.weightForAge).to.equal(undefined);
       });
@@ -166,7 +166,7 @@ describe('ZScore service', function() {
         weight: 25.7,
         age: 5
       };
-      dbGet.returns(KarmaUtils.mockPromise(null, CONFIG_DOC));
+      dbGet.returns(Promise.resolve(CONFIG_DOC));
       return service(options).then(function(scores) {
         chai.expect(scores.weightForAge).to.equal(undefined);
       });
@@ -178,7 +178,7 @@ describe('ZScore service', function() {
         weight: 19,
         age: 1
       };
-      dbGet.returns(KarmaUtils.mockPromise(null, CONFIG_DOC));
+      dbGet.returns(Promise.resolve(CONFIG_DOC));
       return service(options).then(function(scores) {
         chai.expect(scores.weightForAge).to.equal(-4);
       });
@@ -190,7 +190,7 @@ describe('ZScore service', function() {
         weight: 29,
         age: 1
       };
-      dbGet.returns(KarmaUtils.mockPromise(null, CONFIG_DOC));
+      dbGet.returns(Promise.resolve(CONFIG_DOC));
       return service(options).then(function(scores) {
         chai.expect(scores.weightForAge).to.equal(4);
       });
@@ -220,7 +220,7 @@ describe('ZScore service', function() {
         height: 56.1,
         age: 1
       };
-      dbGet.returns(KarmaUtils.mockPromise(null, CONFIG_DOC));
+      dbGet.returns(Promise.resolve(CONFIG_DOC));
       return service(options).then(function(scores) {
         chai.expect(scores.heightForAge).to.equal(1.5);
         chai.expect(dbGet.callCount).to.equal(1);
@@ -251,7 +251,7 @@ describe('ZScore service', function() {
         height: 45.1,
         weight: 26.5
       };
-      dbGet.returns(KarmaUtils.mockPromise(null, CONFIG_DOC));
+      dbGet.returns(Promise.resolve(CONFIG_DOC));
       return service(options).then(function(scores) {
         chai.expect(scores.weightForHeight).to.equal(2.5);
         chai.expect(dbGet.callCount).to.equal(1);
@@ -300,7 +300,7 @@ describe('ZScore service', function() {
         height: 83,
         weight: 11.704545
       };
-      dbGet.returns(KarmaUtils.mockPromise(null, CONFIG_DOC));
+      dbGet.returns(Promise.resolve(CONFIG_DOC));
       return service(options).then(function(scores) {
         chai.expect(scores.heightForAge).to.equal(-3.424135113048216);
         chai.expect(scores.weightForAge).to.equal(-1.6321967559943587);

--- a/tests/karma/utils.js
+++ b/tests/karma/utils.js
@@ -26,23 +26,9 @@ window.KarmaUtils = {
   // A service that returns a promise,
   // to mock out e.g. UserSettings().then(function(promiseResult) { ... })
   promiseService: function(err, promiseResult) {
-    return function() {
-      return KarmaUtils.mockPromise(err, promiseResult);
-    };
+    return () => KarmaUtils.promise(err, promiseResult);
   },
-  mockPromise: function(err, payload) {
-    var result = new Promise(function(resolve, reject) {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(payload);
-      }
-    });
-    result.on = function() {
-      return result;
-    };
-    return result;
-  },
+  promise: (err, payload) => err ? Promise.reject(err) : Promise.resolve(payload),
   // a promise than never resolves or rejects
   nullPromise: function() {
     return function() {


### PR DESCRIPTION
# Description

We used to have to use a 3rd party promise library. This is no longer
the case. Remove the now-pointless redirection.

Note that it does still have some minor value, in being a utility to
correctly reject or resolve (err, payload) dynamically, so we have
kept it for just that and renamed it from 'mockPromise' to 'promise'.

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.