### PR TITLE
Removing migration note

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,7 +7,6 @@ _August 1, 2017_
 ### Migration notes
 - [#2635](https://github.com/medic/medic-webapp/issues/2635) changes the context available to the configured contact summary script. The `contact` parameter no longer has information about parents. This information is now in an array called `lineage`. More information is available in the [configuration documentation](https://github.com/medic/medic-docs/blob/master/configuration/contact-summary.md).
 - [#3546](https://github.com/medic/medic-webapp/issues/3546) changes the implementation of the `contact_summary` so instead of declaring the output on the last line of the script, now you have to return the output. Usually this is as easy as adding a return on the last line, so `output;` becomes `return output;`. More information is available in the [configuration documentation](https://github.com/medic/medic-docs/blob/master/configuration/contact-summary.md).
-- [#3419](https://github.com/medic/medic-webapp/issues/3419) exposes the person contact to message templates used by registration forms, to allow the patient's name to be referred to in situations where the initial patient creation did not occur via a registration (ie they were created in the UI). To ensure correct messages use `{{person.name}}` in registration messages instead of `{{patient_name}}`.
 
 ### Features
 


### PR DESCRIPTION
We're not actually going to support this we've now decided. Instead,
just use patient_name like always

medic/medic-webapp#3838

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.