### PR TITLE
Add test for enketo translation module

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -343,6 +343,11 @@ module.exports = function(grunt) {
     nodeunit: {
       all: ['tests/nodeunit/unit/**/*.js', '!tests/nodeunit/unit/*/utils.js']
     },
+    mochaTest: {
+      unit: {
+        src: [ 'tests/mocha/unit/**/*.spec.js' ],
+      },
+    },
     ngtemplates: {
       inboxApp: {
         src: [
@@ -505,6 +510,7 @@ module.exports = function(grunt) {
     'minify',
     'karma:unit_ci',
     'nodeunit',
+    'mochaTest:unit',
   ]);
   grunt.registerTask('ci_after', '', [
     'exec:deploy',

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "grunt-couch": "^1.5.1",
     "grunt-exec": "^3.0.0",
     "grunt-karma": "^2.0.0",
+    "grunt-mocha-test": "^0.13.2",
     "grunt-notify": "^0.4.5",
     "grunt-postcss": "^0.8.0",
     "grunt-protractor-runner": "^5.0.0",

--- a/tests/mocha/unit/enketo/translator.spec.js
+++ b/tests/mocha/unit/enketo/translator.spec.js
@@ -1,0 +1,63 @@
+const _ = require('underscore');
+const assert = require('chai').assert;
+
+const translator = require('../../../../static/js/enketo/translator');
+
+describe('enketo translator', () => {
+
+  /*global document:true*/
+  document = {};
+  angular = {
+    element: () => ({
+      injector: () => ({
+        get: () => ({
+          instant: key => key,
+        }),
+      }),
+    }),
+  };
+
+  describe('#t()', () => {
+
+    _.forEach({
+     'some.random.thing': 'enketo.some.random.thing',
+     
+     // Months
+     'date.month.1':  'Jan',
+     'date.month.2':  'Feb',
+     'date.month.3':  'Mar',
+     'date.month.4':  'Apr',
+     'date.month.5':  'May',
+     'date.month.6':  'Jun',
+     'date.month.7':  'Jul',
+     'date.month.8':  'Aug',
+     'date.month.9':  'Sep',
+     'date.month.10': 'Oct',
+     'date.month.11': 'Nov',
+     'date.month.12': 'Dec',
+
+     // Days
+     'date.dayofweek.0': 'Sun',
+     'date.dayofweek.1': 'Mon',
+     'date.dayofweek.2': 'Tue',
+     'date.dayofweek.3': 'Wed',
+     'date.dayofweek.4': 'Thu',
+     'date.dayofweek.5': 'Fri',
+     'date.dayofweek.6': 'Sat',
+     'date.dayofweek.7': 'Sun',
+
+    }, assertPassedThroughAs);
+
+  });
+
+  function assertPassedThroughAs(expected, key) {
+    it(`should pass through ${key} to $translate.instant as ${expected}`, () => {
+      // when
+      const actual = translator.t(key);
+
+      // then
+      assert.equal(actual, expected);
+    });
+  }
+
+});


### PR DESCRIPTION
Follow-on from https://github.com/medic/medic-webapp/pull/3834 - requested tests for the enketo translator.

If we're not interested in using mocha in webapp I can rewrite the tests in nodeunit.