### PR TITLE
Refactor to not use array.find

### DIFF
--- a/static/js/services/contact-view-model-generator.js
+++ b/static/js/services/contact-view-model-generator.js
@@ -194,11 +194,7 @@ angular.module('inboxServices').factory('ContactViewModelGenerator',
         if (report.fields && !report.fields.patient_name) {
           var patientId = report.fields.patient_id ||
                           report.patient_id;
-
-          var patient = contacts.find(function(contact) {
-            return contact.patient_id === patientId;
-          });
-
+          var patient = _.findWhere(contacts, { patient_id: patientId });
           if (patient) {
             report.fields.patient_name = patient.name;
           }

--- a/tests/karma/unit/services/contact-view-model-generator.js
+++ b/tests/karma/unit/services/contact-view-model-generator.js
@@ -266,6 +266,21 @@ describe('ContactViewModelGenerator service', () => {
       });
     });
 
+    it('adds patient name to reports', () => {
+      childPerson.patient_id = '12345';
+      const report1 = { _id: 'ab', fields: { patient_id: childPerson.patient_id } };
+      const report2 = { _id: 'cd', fields: { patient_id: childPerson.patient_id, patient_name: 'Jack' } };
+      stubSearch(null, [ report1, report2 ]);
+      return runReportsTest([childPerson, childPerson2]).then(model => {
+        chai.expect(search.callCount).to.equal(1);
+        chai.expect(model.reports.length).to.equal(2);
+        chai.expect(model.reports[0]._id).to.equal('ab');
+        chai.expect(model.reports[0].fields.patient_name).to.equal(childPerson.name);
+        chai.expect(model.reports[1]._id).to.equal('cd');
+        chai.expect(model.reports[1].fields.patient_name).to.equal('Jack'); // don't add if name already defined
+      });
+    });
+
     it('sorts reports by reported_date, not by parent vs. child', () => {
       const expectedReports = [
         { _id: 'aa', reported_date: 123 },


### PR DESCRIPTION
# Description

array.find is not defined in Chrome 30 so use underscore instead.

medic/medic-webapp#3855

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.