### PR TITLE
Store sentinel meta-data in a _local document

### DIFF
--- a/tests/protractor/utils.js
+++ b/tests/protractor/utils.js
@@ -99,7 +99,7 @@ const revertSettings = () => {
 
 const deleteAll = () => {
   const typesToIgnore = ['translations', 'translations-backup', 'user-settings', 'info'];
-  const idsToIgnore = ['appcache', 'migration-log', 'resources', 'sentinel-meta-data'];
+  const idsToIgnore = ['appcache', 'migration-log', 'resources', '_local/sentinel-meta-data'];
   return request({
     path: path.join('/', constants.DB_NAME, '_all_docs?include_docs=true'),
     method: 'GET'


### PR DESCRIPTION
# Description

This document stores sequence numbers, and so is only relevant on the
specific instance it was created on. Replicating it to another instance
will cause sentinel to behave incorrectly.

medic/medic-webapp#3860

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.