### PR TITLE
Throw an error when document not found

### DIFF
--- a/static/js/controllers/contacts-content.js
+++ b/static/js/controllers/contacts-content.js
@@ -87,7 +87,7 @@ angular.module('inboxControllers').controller('ContactsContentCtrl',
           getTasks();
         })
         .catch(function(err) {
-          if (err.error === 'not_found') {
+          if (err.code === 404) {
             $translate('error.404.title').then(Snackbar);
           }
           $scope.clearSelected();

--- a/static/js/controllers/messages-content.js
+++ b/static/js/controllers/messages-content.js
@@ -49,6 +49,17 @@ angular.module('inboxControllers').controller('MessagesContentCtrl',
       }
     };
 
+    var getContact = function(id) {
+      return LineageModelGenerator.contact(id)
+        .catch(function(err) {
+          if (err.code === 404) {
+            // might be an unknown contact so do the best we can
+            return { name: id };
+          }
+          throw err;
+        });
+    };
+
     var selectContact = function(id, options) {
       options = options || {};
       if (!id) {
@@ -63,7 +74,7 @@ angular.module('inboxControllers').controller('MessagesContentCtrl',
         $scope.setLoadingContent(id);
       }
       $q.all([
-        LineageModelGenerator.contact(id),
+        getContact(id),
         MessageContacts({ id: id })
       ])
         .then(function(results) {

--- a/static/js/services/lineage-model-generator.js
+++ b/static/js/services/lineage-model-generator.js
@@ -24,6 +24,11 @@ angular.module('inboxServices').factory('LineageModelGenerator',
           include_docs: true
         })
         .then(function(result) {
+          if (!result.rows.length) {
+            var err = new Error('Document not found');
+            err.code = 404;
+            throw err;
+          }
           return result.rows.map(function(row) {
             return row && row.doc;
           });

--- a/tests/karma/unit/services/lineage-model-generator.js
+++ b/tests/karma/unit/services/lineage-model-generator.js
@@ -19,12 +19,17 @@ describe('LineageModelGenerator service', () => {
 
   describe('contact', () => {
 
-    it('handles not found', () => {
+    it('handles not found', done => {
       dbQuery.returns(Promise.resolve({ rows: [] }));
-      return service.contact('a').then(model => {
-        chai.expect(model._id).to.equal('a');
-        chai.expect(model.doc).to.equal(undefined);
-      });
+      service.contact('a')
+        .then(() => {
+          done(new Error('expected error to be thrown'));
+        })
+        .catch(err => {
+          chai.expect(err.message).to.equal('Document not found');
+          chai.expect(err.code).to.equal(404);
+          done();
+        });
     });
 
     it('handles no lineage', () => {
@@ -90,12 +95,17 @@ describe('LineageModelGenerator service', () => {
 
   describe('report', () => {
 
-    it('handles not found', () => {
+    it('handles not found', done => {
       dbQuery.returns(Promise.resolve({ rows: [] }));
-      return service.report('a').then(model => {
-        chai.expect(model._id).to.equal('a');
-        chai.expect(model.doc).to.equal(undefined);
-      });
+      service.report('a')
+        .then(() => {
+          done(new Error('expected error to be thrown'));
+        })
+        .catch(err => {
+          chai.expect(err.message).to.equal('Document not found');
+          chai.expect(err.code).to.equal(404);
+          done();
+        });
     });
 
     it('handles no lineage', () => {


### PR DESCRIPTION
# Description

The lineage model generator was returning an empty model when the
document with the given ID was not found. This caused uncaught
errors and made it less obvious to the user what was going wrong.
This change throws a 404 error which can be interpreted by the
caller and displayed to the user in some useful way.

medic/medic-webapp#3718

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.