### PR TITLE
Call extract lineage on the docs contact and parent

### DIFF
--- a/static/js/controllers/contacts-edit.js
+++ b/static/js/controllers/contacts-edit.js
@@ -331,6 +331,8 @@ angular.module('inboxControllers').controller('ContactsEditCtrl',
 
       return prepareAndAttachSiblingDocs(submitted.doc, original, submitted.siblings)
         .then(function(siblings) {
+          doc.parent = ExtractLineage(doc.parent);
+          doc.contact = ExtractLineage(doc.contact);
           return {
             docId: doc._id,
             preparedDocs: [].concat(repeated, siblings, doc)


### PR DESCRIPTION
# Description

This reduces the doc size by only storing the id of the related
docs rather than inlining the whole doc.

medic/medic-webapp#3785

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.