### PR TITLE
Don't show the snackbar except on user action

### DIFF
--- a/static/js/controllers/contacts-content.js
+++ b/static/js/controllers/contacts-content.js
@@ -77,7 +77,7 @@ angular.module('inboxControllers').controller('ContactsContentCtrl',
         });
     };
 
-    var selectContact = function(id) {
+    var selectContact = function(id, silent) {
       $scope.setLoadingContent(id);
       return ContactViewModelGenerator(id)
         .then(function(model) {
@@ -87,7 +87,7 @@ angular.module('inboxControllers').controller('ContactsContentCtrl',
           getTasks();
         })
         .catch(function(err) {
-          if (err.code === 404) {
+          if (err.code === 404 && !silent) {
             $translate('error.404.title').then(Snackbar);
           }
           $scope.clearSelected();
@@ -106,7 +106,7 @@ angular.module('inboxControllers').controller('ContactsContentCtrl',
       }
       return getHomePlaceId().then(function(id) {
         if (id) {
-          return selectContact(id);
+          return selectContact(id, true);
         }
       });
     });
@@ -124,14 +124,14 @@ angular.module('inboxControllers').controller('ContactsContentCtrl',
                          $scope.selected.doc.parent._id;
           if (parentId) {
             // select the parent
-            selectContact(parentId);
+            selectContact(parentId, true);
           } else {
             // top level contact deleted - clear selection
             $scope.clearSelected();
           }
         } else {
           // refresh the updated contact
-          selectContact(change.id);
+          selectContact(change.id, true);
         }
       }
     });


### PR DESCRIPTION
# Description

Instead of showing the snackbar any time the contact isn't found,
only show it when it's not found and the user was trying to select
it. This means the snackbar won't show on background changes or a
badly configured facility_id.

medic/medic-webapp#3718

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.