### PR TITLE
Polyfill outerHTML function

### DIFF
--- a/static/js/services/enketo.js
+++ b/static/js/services/enketo.js
@@ -361,6 +361,14 @@ angular.module('inboxServices').service('Enketo',
           ._couchId;
       }
 
+      // Chrome 30 doesn't support $xml.outerHTML: #3880
+      function getOuterHTML(xml) {
+        if (xml.outerHTML) {
+          return xml.outerHTML;
+        }
+        return $('<temproot>').append($(xml).clone()).html();
+      }
+
       var recordDoc = $.parseXML(record);
       var $record = $($(recordDoc).children()[0]);
       mapOrAssignId($record[0], doc._id || uuid());
@@ -376,13 +384,13 @@ angular.module('inboxServices').service('Enketo',
       });
 
       var docsToStore = $record.find('[db-doc=true]').map(function() {
-        var docToStore = EnketoTranslation.reportRecordToJs(this.outerHTML);
+        var docToStore = EnketoTranslation.reportRecordToJs(getOuterHTML(this));
         docToStore._id = getId(xpathPath(this));
         docToStore.reported_date = Date.now();
         return docToStore;
       }).get();
 
-      record = $record[0].outerHTML;
+      record = getOuterHTML($record[0]);
 
       AddAttachment(doc, REPORT_ATTACHMENT_NAME, record, 'application/xml');
       doc._id = getId('/*');


### PR DESCRIPTION
# Description

The version of the browser on the Tecno doesn't have the outerHTML
function for xml nodes. This change detects if it's missing and uses
a workaround if it is.

medic/medic-webapp#3880

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.