### PR TITLE
Show relative date tooltips on configuration pages

### DIFF
--- a/static/js/controllers/inbox.js
+++ b/static/js/controllers/inbox.js
@@ -520,7 +520,7 @@ var feedback = require('../modules/feedback'),
             .tooltip({
               placement: 'bottom',
               trigger: 'manual',
-              container: $(this).closest('.inbox-items, .item-content')
+              container: $(this).closest('.inbox-items, .item-content, .page')
             })
             .tooltip('show');
         }

--- a/templates/partials/configuration_upgrade.html
+++ b/templates/partials/configuration_upgrade.html
@@ -25,7 +25,7 @@
         <dt translate>instance.upgrade.deployed_by</dt>
         <dd>{{deployInfo.user}}</dd>
         <dt translate>instance.upgrade.at</dt>
-        <dd ng-bind-html="deployInfo.timestamp | relativeDate"></dd>
+        <dd ng-bind-html="deployInfo.timestamp | simpleDate"></dd>
       </dl>
     </div>
 
@@ -35,7 +35,7 @@
       <ul ng-show="versions.releases.length" class="table table-striped">
         <li ng-repeat="release in versions.releases" class="row">
           <div class="col-xs-5"><code>{{release.id}}</code></div>
-          <div class="col-xs-4" ng-bind-html="release.value.build_time | relativeDate"></div>
+          <div class="col-xs-4" ng-bind-html="release.value.build_time | simpleDate"></div>
           <div class="col-xs-3"><button ng-click="upgrade(release.id)" class="btn btn-primary" translate>upgrade</button></div>
         </li>
       </ul>
@@ -48,7 +48,7 @@
         <ul ng-show="versions.betas.length" class="table table-striped">
           <li ng-repeat="release in versions.betas" class="row">
             <div class="col-xs-5"><code>{{release.id}}</code></div>
-            <div class="col-xs-4" ng-bind-html="release.value.build_time | relativeDate"></div>
+            <div class="col-xs-4" ng-bind-html="release.value.build_time | simpleDate"></div>
             <div class="col-xs-3"><button ng-click="upgrade(release.id)" class="btn btn-primary" translate>upgrade</button></div>
           </li>
         </ul>

--- a/templates/partials/configuration_upgrade.html
+++ b/templates/partials/configuration_upgrade.html
@@ -25,7 +25,7 @@
         <dt translate>instance.upgrade.deployed_by</dt>
         <dd>{{deployInfo.user}}</dd>
         <dt translate>instance.upgrade.at</dt>
-        <dd>{{deployInfo.timestamp | date}}</dd>
+        <dd ng-bind-html="deployInfo.timestamp | relativeDate"></dd>
       </dl>
     </div>
 
@@ -35,7 +35,7 @@
       <ul ng-show="versions.releases.length" class="table table-striped">
         <li ng-repeat="release in versions.releases" class="row">
           <div class="col-xs-5"><code>{{release.id}}</code></div>
-          <div class="col-xs-4" title="{{release.value.build_time}}">{{release.value.build_time | date}}</div>
+          <div class="col-xs-4" ng-bind-html="release.value.build_time | relativeDate"></div>
           <div class="col-xs-3"><button ng-click="upgrade(release.id)" class="btn btn-primary" translate>upgrade</button></div>
         </li>
       </ul>
@@ -48,7 +48,7 @@
         <ul ng-show="versions.betas.length" class="table table-striped">
           <li ng-repeat="release in versions.betas" class="row">
             <div class="col-xs-5"><code>{{release.id}}</code></div>
-            <div class="col-xs-4" title="{{release.value.build_time}}">{{release.value.build_time | date}}</div>
+            <div class="col-xs-4" ng-bind-html="release.value.build_time | relativeDate"></div>
             <div class="col-xs-3"><button ng-click="upgrade(release.id)" class="btn btn-primary" translate>upgrade</button></div>
           </li>
         </ul>


### PR DESCRIPTION
# Description

medic/medic-webapp#3835

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.