### PR TITLE
Enable delete all button in select mode on mobile

### DIFF
--- a/templates/partials/actionbar.html
+++ b/templates/partials/actionbar.html
@@ -12,7 +12,7 @@
             <span class="fa fa-square-o"></span>
             <p translate>select.mode.deselect.all</p>
           </a>
-          <a class="mm-icon mm-icon-inverse mm-icon-caption delete-all" mm-auth="can_bulk_delete_reports" ng-click="deleteDoc(actionBar.selected)" ng-class="{'mm-icon-disabled': !actionBar.selected.length}">
+          <a class="mm-icon mm-icon-inverse mm-icon-caption delete-all" mm-auth="can_bulk_delete_reports" ng-click="deleteDoc(actionBar.right.selected)" ng-class="{'mm-icon-disabled': !actionBar.right.selected.length}">
             <span class="fa fa-trash-o"></span>
             <p translate>select.mode.delete.all</p>
           </a>


### PR DESCRIPTION
# Description

The delete all button should be enabled when one or more records
are selected.

medic/medic-webapp#3808

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.