### PR TITLE
Centralise merging lineage into the doc

### DIFF
--- a/static/js/services/lineage-model-generator.js
+++ b/static/js/services/lineage-model-generator.js
@@ -63,13 +63,37 @@ angular.module('inboxServices').factory('LineageModelGenerator',
         });
     };
 
+    var mergeParents = function(doc, lineage) {
+      var current = doc;
+      lineage.forEach(function(hydrated) {
+        if (!current) {
+          return;
+        }
+        if (hydrated) {
+          current.parent = hydrated;
+        }
+        current = current.parent;
+      });
+      return doc;
+    };
+
     return {
-      contact: function(id) {
+
+      /**
+       * Fetch a contact and its lineage by the given uuid. Returns a
+       * contact model, or if options.merge is true the doc with the
+       * lineage inline.
+       */
+      contact: function(id, options) {
+        options = options || {};
         return get(id).then(function(docs) {
           // the first row is the contact
           var doc = docs.shift();
            // everything else is the lineage
           return hydrate(docs).then(function(lineage) {
+            if (options.merge) {
+              return mergeParents(doc, lineage);
+            }
             return {
               _id: id,
               doc: doc,
@@ -78,6 +102,11 @@ angular.module('inboxServices').factory('LineageModelGenerator',
           });
         });
       },
+
+      /**
+       * Fetch a contact and its lineage by the given uuid. Returns a
+       * report model.
+       */
       report: function(id) {
         return get(id).then(function(docs) {
           // the first row is the report

--- a/static/js/services/lineage-model-generator.js
+++ b/static/js/services/lineage-model-generator.js
@@ -91,14 +91,14 @@ angular.module('inboxServices').factory('LineageModelGenerator',
           var doc = docs.shift();
            // everything else is the lineage
           return hydrate(docs).then(function(lineage) {
+            var result = { _id: id };
             if (options.merge) {
-              return mergeParents(doc, lineage);
+              result.doc = mergeParents(doc, lineage);
+            } else {
+              result.doc = doc;
+              result.lineage = lineage;
             }
-            return {
-              _id: id,
-              doc: doc,
-              lineage: lineage
-            };
+            return result;
           });
         });
       },

--- a/static/js/services/select2-search.js
+++ b/static/js/services/select2-search.js
@@ -98,7 +98,10 @@ angular.module('inboxServices').factory('Select2Search',
       };
 
       var getDoc = function(id) {
-        return LineageModelGenerator.contact(id, { merge: true });
+        return LineageModelGenerator.contact(id, { merge: true })
+          .then(function(contact) {
+            return contact && contact.doc;
+          });
       };
 
       var resolveInitialValue = function(selectEl, initialValue) {

--- a/static/js/services/select2-search.js
+++ b/static/js/services/select2-search.js
@@ -98,19 +98,7 @@ angular.module('inboxServices').factory('Select2Search',
       };
 
       var getDoc = function(id) {
-        return LineageModelGenerator.contact(id).then(function(model) {
-          var current = model.doc;
-          model.lineage.forEach(function(hydrated) {
-            if (!current) {
-              return;
-            }
-            if (hydrated) {
-              current.parent = hydrated;
-            }
-            current = current.parent;
-          });
-          return model.doc;
-        });
+        return LineageModelGenerator.contact(id, { merge: true });
       };
 
       var resolveInitialValue = function(selectEl, initialValue) {

--- a/static/js/services/user-contact.js
+++ b/static/js/services/user-contact.js
@@ -1,22 +1,24 @@
 angular.module('inboxServices').factory('UserContact',
   function(
-    DB,
+    LineageModelGenerator,
     UserSettings
   ) {
     'use strict';
     'ngInject';
     return function() {
-      return UserSettings().then(function(user) {
-        if (!user.contact_id) {
-          return;
-        }
-        return DB().get(user.contact_id).catch(function(err) {
-          if (err.status === 404) {
+      return UserSettings()
+        .then(function(user) {
+          if (!user.contact_id) {
+            return;
+          }
+          return LineageModelGenerator.contact(user.contact_id, { merge: true });
+        })
+        .catch(function(err) {
+          if (err.code === 404) {
             return;
           }
           throw err;
         });
-      });
     };
   }
 );

--- a/static/js/services/user-contact.js
+++ b/static/js/services/user-contact.js
@@ -13,6 +13,9 @@ angular.module('inboxServices').factory('UserContact',
           }
           return LineageModelGenerator.contact(user.contact_id, { merge: true });
         })
+        .then(function(contact) {
+          return contact && contact.doc;
+        })
         .catch(function(err) {
           if (err.code === 404) {
             return;

--- a/tests/karma/unit/services/lineage-model-generator.js
+++ b/tests/karma/unit/services/lineage-model-generator.js
@@ -96,7 +96,21 @@ describe('LineageModelGenerator service', () => {
       const contact = { _id: 'a', name: '1', parent: { _id: 'b', parent: { _id: 'c' } } };
       const parent = { _id: 'b', name: '2' };
       const grandparent = { _id: 'c', name: '3' };
-      const expected = { _id: 'a', name: '1', parent: { _id: 'b', name: '2', parent: { _id: 'c', name: '3' } } };
+      const expected = {
+        _id: 'a',
+        doc: {
+          _id: 'a',
+          name: '1',
+          parent: {
+            _id: 'b',
+            name: '2',
+            parent: {
+              _id: 'c',
+              name: '3'
+            }
+          }
+        }
+      };
       dbQuery.returns(Promise.resolve({ rows: [
         { doc: contact },
         { doc: parent },

--- a/tests/karma/unit/services/lineage-model-generator.js
+++ b/tests/karma/unit/services/lineage-model-generator.js
@@ -91,6 +91,21 @@ describe('LineageModelGenerator service', () => {
         chai.expect(model.lineage[1].contact).to.deep.equal(grandparentContact);
       });
     });
+
+    it('merges lineage when merge passed', () => {
+      const contact = { _id: 'a', name: '1', parent: { _id: 'b', parent: { _id: 'c' } } };
+      const parent = { _id: 'b', name: '2' };
+      const grandparent = { _id: 'c', name: '3' };
+      const expected = { _id: 'a', name: '1', parent: { _id: 'b', name: '2', parent: { _id: 'c', name: '3' } } };
+      dbQuery.returns(Promise.resolve({ rows: [
+        { doc: contact },
+        { doc: parent },
+        { doc: grandparent }
+      ] }));
+      return service.contact('a', { merge: true }).then(actual => {
+        chai.expect(actual).to.deep.equal(expected);
+      });
+    });
   });
 
   describe('report', () => {

--- a/tests/karma/unit/services/user-contact.js
+++ b/tests/karma/unit/services/user-contact.js
@@ -4,15 +4,15 @@ describe('UserContact service', function() {
 
   var service,
       UserSettings,
-      get;
+      contact;
 
   beforeEach(function() {
-    get = sinon.stub();
+    contact = sinon.stub();
     UserSettings = sinon.stub();
     module('inboxApp');
     module(function ($provide) {
-      $provide.factory('DB', KarmaUtils.mockDB({ get: get }));
       $provide.value('UserSettings', UserSettings);
+      $provide.value('LineageModelGenerator', { contact: contact });
     });
     inject(function($injector) {
       service = $injector.get('UserContact');
@@ -23,7 +23,7 @@ describe('UserContact service', function() {
     UserSettings.returns(Promise.reject(new Error('boom')));
     service()
       .then(function() {
-        done('Expected error to be thrown');
+        done(new Error('Expected error to be thrown'));
       })
       .catch(function(err) {
         chai.expect(err.message).to.equal('boom');
@@ -43,8 +43,8 @@ describe('UserContact service', function() {
     var err = new Error('not_found');
     err.reason = 'missing';
     err.message = 'missing';
-    err.status = 404;
-    get.returns(Promise.reject(err));
+    err.code = 404;
+    contact.returns(Promise.reject(err));
     return service().then(function(contact) {
       chai.expect(contact).to.equal(undefined);
     });
@@ -52,15 +52,15 @@ describe('UserContact service', function() {
 
   it('returns error from getting contact', function(done) {
     UserSettings.returns(Promise.resolve({ contact_id: 'nobody' }));
-    get.returns(Promise.reject(new Error('boom')));
+    contact.returns(Promise.reject(new Error('boom')));
     service()
       .then(function() {
-        done('Expected error to be thrown');
+        done(new Error('Expected error to be thrown'));
       })
       .catch(function(err) {
         chai.expect(err.message).to.equal('boom');
-        chai.expect(get.callCount).to.equal(1);
-        chai.expect(get.args[0][0]).to.equal('nobody');
+        chai.expect(contact.callCount).to.equal(1);
+        chai.expect(contact.args[0][0]).to.equal('nobody');
         done();
       });
   });
@@ -68,11 +68,11 @@ describe('UserContact service', function() {
   it('returns contact', function() {
     var expected = { _id: 'somebody', name: 'Some Body' };
     UserSettings.returns(Promise.resolve({ contact_id: 'somebody' }));
-    get.returns(Promise.resolve(expected));
-    return service().then(function(contact) {
-      chai.expect(contact).to.deep.equal(expected);
-      chai.expect(get.callCount).to.equal(1);
-      chai.expect(get.args[0][0]).to.equal('somebody');
+    contact.returns(Promise.resolve(expected));
+    return service().then(function(actual) {
+      chai.expect(actual).to.deep.equal(expected);
+      chai.expect(contact.callCount).to.equal(1);
+      chai.expect(contact.args[0][0]).to.equal('somebody');
     });
   });
 

--- a/tests/karma/unit/services/user-contact.js
+++ b/tests/karma/unit/services/user-contact.js
@@ -68,11 +68,12 @@ describe('UserContact service', function() {
   it('returns contact', function() {
     var expected = { _id: 'somebody', name: 'Some Body' };
     UserSettings.returns(Promise.resolve({ contact_id: 'somebody' }));
-    contact.returns(Promise.resolve(expected));
+    contact.returns(Promise.resolve({ doc: expected }));
     return service().then(function(actual) {
       chai.expect(actual).to.deep.equal(expected);
       chai.expect(contact.callCount).to.equal(1);
       chai.expect(contact.args[0][0]).to.equal('somebody');
+      chai.expect(contact.args[0][1].merge).to.equal(true);
     });
   });
 


### PR DESCRIPTION
# Description

Moves the lineage mergine out of Select2Search and adds it behind
an optional parameter on the LineageModelGenerator so it can be
reused by UserContact which prepares data for the TargetGenerator
among others.

medic/medic-webapp#3890

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.