### PR TITLE
3891 bump xpath evaluator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7681,9 +7681,9 @@
       "dev": true
     },
     "openrosa-xpath-evaluator": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/openrosa-xpath-evaluator/-/openrosa-xpath-evaluator-1.3.0.tgz",
-      "integrity": "sha1-VZod/wiruZrhPIEYetGjjlDCAnM="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/openrosa-xpath-evaluator/-/openrosa-xpath-evaluator-1.3.2.tgz",
+      "integrity": "sha512-gQNbhVGgPqB7wKXIAslEWbMISXg8rXwDdZcWQ94CMIOIqqcNBLHqNf6KhkiYNbkP3FF5DXamZ46Pm5ipC9suOg=="
     },
     "optimist": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "medic-nootils": "^1.0.3",
     "messageformat": "^1.0.0",
     "moment": "^2.17.1",
-    "openrosa-xpath-evaluator": "^1.3.0",
+    "openrosa-xpath-evaluator": "^1.3.2",
     "pouchdb-browser": "^6.2.0",
     "properties": "^1.2.1",
     "select2": "^4.0.3",


### PR DESCRIPTION
# Description

Bumps the dependency to the latest 1.3 release to get some bug
fixes.

medic/medic-webapp#3891

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.