### PR TITLE
Update openrosa-xpath-evaluator to support dates with single-digit day and month values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7824,9 +7824,9 @@
       "dev": true
     },
     "openrosa-xpath-evaluator": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/openrosa-xpath-evaluator/-/openrosa-xpath-evaluator-1.4.1.tgz",
-      "integrity": "sha512-IHmSYp80T2B9UIfkBGIrO57V+hZmH18OI7Xxm08uAtShUGzOkGvoxQVUm2Wa8OxT609+KQ9E+OfiABubAJ9e6w=="
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/openrosa-xpath-evaluator/-/openrosa-xpath-evaluator-1.4.2.tgz",
+      "integrity": "sha512-QqBcoER8xCNEQNDYhtL9iiatHrhrDvQy1AIN2GmBdzReE3yJeVIK+JSBwgR9kcZnieKvZbeIbbAPQLHgAm9Ipg=="
     },
     "optimist": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "medic-nootils": "^1.0.3",
     "messageformat": "^1.0.0",
     "moment": "^2.17.1",
-    "openrosa-xpath-evaluator": "^1.4.1",
+    "openrosa-xpath-evaluator": "^1.4.2",
     "pouchdb-browser": "^6.3.4",
     "properties": "^1.2.1",
     "select2": "^4.0.3",


### PR DESCRIPTION
This will need backporting to 2.13