### PR TITLE
Inner docs should have correct lineages

### DIFF
--- a/static/js/services/contact-save.js
+++ b/static/js/services/contact-save.js
@@ -31,10 +31,13 @@ angular.module('inboxServices').service('ContactSave',
 
       return prepareAndAttachSiblingDocs(schema, submitted.doc, original, submitted.siblings)
         .then(function(siblings) {
-          siblings.concat(doc).map(function(item) {
+          var extract = function(item) {
             item.parent = item.parent && ExtractLineage(item.parent);
             item.contact = item.contact && ExtractLineage(item.contact);
-          });
+          };
+
+          siblings.forEach(extract);
+          extract(doc);
 
           // This must be done after prepareAndAttachSiblingDocs, as it relies
           // on the doc's parents being attached.

--- a/tests/karma/unit/services/contact-save.js
+++ b/tests/karma/unit/services/contact-save.js
@@ -115,7 +115,7 @@ describe('ContactSave service', () => {
     const type = 'some-contact-type';
 
     EnketoTranslation.contactRecordToJs.returns({
-      doc: { _id: 'main1', type: 'main', sis: 'NEW', },
+      doc: { _id: 'main1', type: 'main', sis: 'NEW', contact: 'this-would-be-the-chw-id'},
       siblings: {
         sis: { _id: 'sis1', type: 'sister', parent: 'PARENT', },
       },
@@ -124,7 +124,10 @@ describe('ContactSave service', () => {
       },
     });
 
-    ExtractLineage.returnsArg(0);
+    ExtractLineage.callsFake(contact => {
+      contact.extracted = true;
+      return contact;
+    });
 
     bulkDocs.returns(Promise.resolve());
 
@@ -139,9 +142,11 @@ describe('ContactSave service', () => {
 
         assert.equal(savedDocs[0]._id, 'kid1');
         assert.equal(savedDocs[0].parent._id, 'main1');
+        assert.equal(savedDocs[0].parent.extracted, true);
 
         assert.equal(savedDocs[1]._id, 'sis1');
         assert.equal(savedDocs[1].parent._id, 'main1');
+        assert.equal(savedDocs[1].parent.extracted, true);
 
         assert.equal(savedDocs[2]._id, 'main1');
 


### PR DESCRIPTION
1. Siblings (in the case of a family form, the head of household)
already get their parent lineage mostly correct, because they attach the
doc as the parent, (see the if (child) block in
prepareAndAttachSiblingDocs()) which then later on (see the promiseChain
in the same function) get loaded from CouchDB with its whole hierarchy.
However, they still need to extract the lineage to clean it up

2. Repeated docs preperation was moved until *after*
prepareAndAttachSiblings was run, so that the doc they prepare against
has its parents loaded correctly (the same state the siblings rely on)

NB: this is really gross. It relies on non-obvious ordering. I've added
comments, but we should consider reworking this

medic/medic-webapp#3840

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.