### PR TITLE
Check for userCtx cookie before bootstrapping

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -93,6 +93,11 @@ _.templateSettings = {
   };
   app.constant('POUCHDB_OPTIONS', POUCHDB_OPTIONS);
 
+  if (window.location.href === 'http://localhost:9876/context.html') {
+    // karma unit testing - do not bootstrap
+    return;
+  }
+
   bootstrapper(POUCHDB_OPTIONS, function(err) {
     if (err) {
       if (err.redirect) {

--- a/static/js/bootstrapper.js
+++ b/static/js/bootstrapper.js
@@ -88,6 +88,7 @@ var utils = require('kujua-utils');
     var userCtx = getUserCtx();
     if (!userCtx) {
       var err = new Error('User must reauthenticate');
+      err.status = 401;
       return redirectToLogin(dbInfo, err, callback);
     }
     if (utils.isUserAdmin(userCtx)) {
@@ -116,7 +117,7 @@ var utils = require('kujua-utils');
           })
           .catch(function(err) {
             if (err.status === 401) {
-              return redirectToLogin(err, dbInfo, callback);
+              return redirectToLogin(dbInfo, err, callback);
             }
             callback(err);
           });

--- a/static/js/services/debug.js
+++ b/static/js/services/debug.js
@@ -25,10 +25,10 @@ angular.module('inboxServices').config([
           var db = pouchDB.debug ? pouchDB : window.PouchDB;
           if (bool) {
             db.debug.enable('*');
-            ipCookie(cookieName, bool, {expires: 360});
+            ipCookie(cookieName, bool, { expires: 360, path: '/' });
           } else {
             db.debug.disable();
-            ipCookie.remove(cookieName);
+            ipCookie.remove(cookieName, { path: '/' });
           }
         };
         set(get()); // initialize

--- a/static/js/services/session.js
+++ b/static/js/services/session.js
@@ -32,7 +32,7 @@ var COOKIE_NAME = 'userCtx',
 
       var navigateToLogin = function() {
         $log.warn('User must reauthenticate');
-        ipCookie.remove(COOKIE_NAME);
+        ipCookie.remove(COOKIE_NAME, { path: '/' });
         waitForAppCache(function() {
           $window.location.href = '/' + Location.dbName + '/login' +
             '?redirect=' + encodeURIComponent($window.location.href);

--- a/tests/nodeunit/unit/bootstrapper.js
+++ b/tests/nodeunit/unit/bootstrapper.js
@@ -14,7 +14,8 @@ var proxyquire = require('proxyquire').noCallThru(),
     pouchDbOptions = {
       local: { auto_compaction: true },
       remote: { skip_setup: true }
-    };
+    },
+    userCtx;
 
 // ignore "Read Only" jshint error for overwriting `document` and `window`
 // jshint -W020
@@ -27,9 +28,7 @@ exports.setUp = function(cb) {
   if (typeof window !== 'undefined') {
     originalWindow = window;
   }
-  document = {
-    cookie: 'userCtx={"name":"jim"};something=true'
-  };
+  document = { cookie: '' };
   window = {
     location: {
       href: 'http://localhost:5988/medic/_design/medic/_rewrite/#/messages'
@@ -38,6 +37,10 @@ exports.setUp = function(cb) {
   };
   $ = sinon.stub().returns({ text:sinon.stub() });
   cb();
+};
+
+var setUserCtxCookie = function(userCtx) {
+  document.cookie = `userCtx=${JSON.stringify(userCtx)};something=true`;
 };
 
 exports.tearDown = function(cb) {
@@ -56,6 +59,7 @@ exports.tearDown = function(cb) {
 // jshint +W020
 
 exports['does nothing for admins'] = function(test) {
+  setUserCtxCookie({ name: 'jim' });
   isAdmin = true;
   bootstrapper(pouchDbOptions, function(err) {
     test.equal(null, err);
@@ -65,6 +69,7 @@ exports['does nothing for admins'] = function(test) {
 };
 
 exports['returns if local db already has client ddoc'] = function(test) {
+  setUserCtxCookie({ name: 'jim' });
   var localGet = sinon.stub();
   pouchDb.returns({ get: localGet });
   localGet.returns(Promise.resolve());
@@ -80,6 +85,7 @@ exports['returns if local db already has client ddoc'] = function(test) {
 };
 
 exports['performs initial replication'] = function(test) {
+  setUserCtxCookie({ name: 'jim' });
   var localGet = sinon.stub();
   var localReplicate = sinon.stub();
   pouchDb.onCall(0).returns({
@@ -113,7 +119,7 @@ exports['performs initial replication'] = function(test) {
   });
 };
 
-exports['handles unauthorized initial replication'] = function(test) {
+exports['returns redirect to login error when no userCtx cookie found'] = function(test) {
   var localGet = sinon.stub();
   var localReplicate = sinon.stub();
   pouchDb.onCall(0).returns({
@@ -132,7 +138,28 @@ exports['handles unauthorized initial replication'] = function(test) {
   });
 };
 
-exports['handles other errors in initial replication'] = function(test) {
+exports['returns redirect to login error when initial replication returns unauthorized'] = function(test) {
+  setUserCtxCookie({ name: 'jim' });
+  var localGet = sinon.stub();
+  var localReplicate = sinon.stub();
+  pouchDb.onCall(0).returns({
+    get: localGet,
+    replicate: { from: localReplicate }
+  });
+  pouchDb.onCall(1).returns({ remote: true });
+  localGet.returns(Promise.reject());
+  var localReplicateResult = Promise.reject({ status: 401 });
+  localReplicateResult.on = function() {};
+  localReplicate.returns(localReplicateResult);
+  bootstrapper(pouchDbOptions, function(err) {
+    test.equal(err.status, 401);
+    test.equal(err.redirect, '/medic/login?redirect=http%3A%2F%2Flocalhost%3A5988%2Fmedic%2F_design%2Fmedic%2F_rewrite%2F%23%2Fmessages');
+    test.done();
+  });
+};
+
+exports['returns other errors in initial replication'] = function(test) {
+  setUserCtxCookie({ name: 'jim' });
   var localGet = sinon.stub();
   var localReplicate = sinon.stub();
   pouchDb.onCall(0).returns({

--- a/tests/nodeunit/unit/bootstrapper.js
+++ b/tests/nodeunit/unit/bootstrapper.js
@@ -14,8 +14,7 @@ var proxyquire = require('proxyquire').noCallThru(),
     pouchDbOptions = {
       local: { auto_compaction: true },
       remote: { skip_setup: true }
-    },
-    userCtx;
+    };
 
 // ignore "Read Only" jshint error for overwriting `document` and `window`
 // jshint -W020


### PR DESCRIPTION
# Description

Previously we checked for the cookie after bootstrapping which
meant if the redirect to the login page was cancelled, for example
by pressing "esc", then the user could access the offline data
without a cookie or session. The navigation can still be cancelled
but the app won't be bootstrapped so the data cannot be easily
accessed.

This change also fixes how we remove cookies so it actually works.

medic/medic-webapp#3239

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.