### PR TITLE
Loads contact icons from resources not font awesome

### DIFF
--- a/static/css/content-list.less
+++ b/static/css/content-list.less
@@ -52,9 +52,6 @@
       align-self: start;
       margin-right: 5px;
       margin-top: 5px;
-      .fa {
-        color: @ok-color;
-      }
       img {
         max-height: 30px;
         max-width: 30px;

--- a/static/css/material.less
+++ b/static/css/material.less
@@ -31,12 +31,8 @@
   .meta .heading {
     padding: 20px;
   }
-  .main-icon {
+  .heading img {
     width: 60px;
-    font-size: 60px;
-    text-align: center;
-    color: @contacts-color;
-    vertical-align: middle;
   }
   .field-icon {
     float: left;
@@ -147,8 +143,7 @@
       border-left: 0;
       border-right: 0;
     }
-    .main-icon {
-      vertical-align: inherit;
+    .heading img {
       float: left;
     }
     .field-icon {

--- a/static/js/directives/content-row.js
+++ b/static/js/directives/content-row.js
@@ -17,10 +17,7 @@ angular.module('inboxDirectives').directive('mmContentRow', function() {
       read: '=',
 
       // string: (optional) the id of the resource icon to render
-      resourceIcon: '=',
-
-      // string: (optional) the class of the font awesome icon to render
-      fontIcon: '=',
+      icon: '=',
 
       // date: (optional) the date to show on the row
       date: '=',

--- a/static/js/services/contact-schema.js
+++ b/static/js/services/contact-schema.js
@@ -11,7 +11,7 @@ var RAW_SCHEMAS = [
     type: 'district_hospital',
     isPlace: true,
     schema: {
-      icon: 'fa-building',
+      icon: 'district_hospital',
       addButtonLabel: 'contact.type.district_hospital.new',
       label: 'contact.type.district_hospital',
       pluralLabel: 'contact.type.district_hospital.plural',
@@ -35,7 +35,7 @@ var RAW_SCHEMAS = [
     type: 'health_center',
     isPlace: true,
     schema: {
-      icon: 'fa-hospital-o',
+      icon: 'health_center',
       addButtonLabel: 'contact.type.health_center.new',
       label: 'contact.type.health_center',
       pluralLabel: 'contact.type.health_center.plural',
@@ -63,7 +63,7 @@ var RAW_SCHEMAS = [
     type: 'clinic',
     isPlace: true,
     schema: {
-      icon: 'fa-group',
+      icon: 'clinic',
       addButtonLabel: 'contact.type.clinic.new',
       label: 'contact.type.clinic',
       pluralLabel: 'contact.type.clinic.plural',
@@ -93,7 +93,7 @@ var RAW_SCHEMAS = [
     type: 'person',
     isPlace: false,
     schema: {
-      icon: 'fa-user',
+      icon: 'person',
       addButtonLabel: 'contact.type.person.new',
       label: 'contact.type.person',
       pluralLabel: 'contact.type.person.plural',

--- a/static/js/services/live-list.js
+++ b/static/js/services/live-list.js
@@ -55,7 +55,7 @@ angular.module('inboxServices').factory('LiveListConfig',
           var scope = $scope.$new();
           scope.id = contact._id;
           scope.route = 'contacts';
-          scope.fontIcon = ContactSchema.get(contact.type).icon;
+          scope.icon = ContactSchema.get(contact.type).icon;
           scope.heading = contact.name;
           scope.primary = contact.home;
           scope.simprintsTier = contact.simprints && contact.simprints.tierNumber;
@@ -98,7 +98,7 @@ angular.module('inboxServices').factory('LiveListConfig',
           scope.id = report._id;
           var form = _.findWhere($scope.forms, { code: report.form });
           scope.route = 'reports';
-          scope.resourceIcon = form && form.icon;
+          scope.icon = form && form.icon;
           scope.heading = report.contact || report.from;
           scope.date = report.reported_date;
           scope.summary = form ? TranslateFrom(form.name) : report.form;
@@ -156,7 +156,7 @@ angular.module('inboxServices').factory('LiveListConfig',
           scope.route = 'tasks';
           scope.date = task.date;
           scope.overdue = Date.parse(task.date) < startOfToday;
-          scope.resourceIcon = task.icon;
+          scope.icon = task.icon;
           scope.heading = task.contact && task.contact.name;
           scope.summary = TranslateFrom(task.title, task);
           scope.warning = TranslateFrom(task.priorityLabel, task);

--- a/templates/partials/actionbar.html
+++ b/templates/partials/actionbar.html
@@ -52,7 +52,7 @@
         <div class="actions dropup">
           <a class="mm-icon mm-icon-inverse mm-icon-caption" ng-show="actionBar.left.userChildPlace.type" ui-sref="contacts.addChild({ type: actionBar.left.userChildPlace.type, parent_id: actionBar.left.userFacilityId })">
             <span class="fa-stack">
-              <i class="fa {{actionBar.left.userChildPlace.icon}} fa-stack-1x"></i>
+              <i ng-bind-html="actionBar.left.userChildPlace.icon | resourceIcon"></i>
               <i class="fa fa-plus fa-stack-1x"></i>
             </span>
             <p translate>{{actionBar.left.addPlaceLabel}}</p>
@@ -139,7 +139,7 @@
 
           <a class="mm-icon mm-icon-inverse mm-icon-caption" ng-show="actionBar.right.selected[0].child.type" ui-sref="contacts.addChild({ type: actionBar.right.selected[0].child.type, parent_id: actionBar.right.selected[0]._id })">
             <span class="fa-stack">
-              <i class="fa {{actionBar.right.selected[0].child.icon}} fa-stack-1x"></i>
+              <i ng-bind-html="actionBar.right.selected[0].child.icon | resourceIcon"></i>
               <i class="fa fa-plus fa-stack-1x"></i>
             </span>
             <p translate>{{actionBar.right.selected[0].child.addPlaceLabel}}</p>
@@ -147,7 +147,7 @@
 
           <a class="mm-icon mm-icon-inverse mm-icon-caption" ng-show="actionBar.right.selected[0].type !== 'person'" ui-sref="contacts.addChild({ type: 'person', parent_id: actionBar.right.selected[0]._id })">
             <span class="fa-stack">
-              <i class="fa fa-user fa-stack-1x"></i>
+              <i ng-bind-html="'person' | resourceIcon"></i>
               <i class="fa fa-plus fa-stack-1x"></i>
             </span>
             <p translate>action.person.add</p>

--- a/templates/partials/contacts_content.html
+++ b/templates/partials/contacts_content.html
@@ -16,7 +16,7 @@
         <div class="card">
           <div class="row heading">
             <div>
-              <i class="fa main-icon {{selected.icon}}"></i>
+              <span ng-bind-html="selected.icon | resourceIcon"></span>
               <div class="heading-content">
                 <h2>{{selected.doc.name}}</h2>
                 <div class="primary-contact" ng-if="selected.isPrimaryContact">
@@ -123,7 +123,7 @@
             <mm-content-row ng-repeat="task in selected.tasks | filter:filterTasks as filteredTasks"
               id="task._id"
               route="'tasks'"
-              resource-icon="task.icon"
+              icon="task.icon"
               date="task.date"
               overdue="task.isLate"
               hide-time="true"
@@ -155,7 +155,7 @@
             <mm-content-row ng-repeat="report in selected.reports | filter:filterReports as filteredReports track by report._id"
               id="report._id"
               route="'reports'"
-              resource-icon="report | formIconName:forms"
+              icon="report | formIconName:forms"
               date="report.reported_date"
               heading="selected.doc.type === 'person' ? (report | summary:forms) : (report.fields.place_name ? report.fields.place_name : report.fields.patient_name)"
               summary="selected.doc.type === 'person' ? '' : (report | summary:forms)"

--- a/templates/partials/content_row_list_item.html
+++ b/templates/partials/content_row_list_item.html
@@ -1,8 +1,7 @@
 <li data-record-id="{{id}}" class="content-row {{selected ? 'selected' : ''}} {{primary ? 'primary' : ''}} {{unread ? 'unread' : ''}}">
   <a href="#{{route}}/{{id}}">
     <div><input type="checkbox"></div>
-    <div class="icon {{resourceIcon ? '' : 'ng-hide'}}" ng-bind-html="resourceIcon | resourceIcon"></div>
-    <div class="icon {{fontIcon ? '' : 'ng-hide'}}"><i class="fa fa-fw {{fontIcon}}"></i></div>
+    <div class="icon {{icon ? '' : 'ng-hide'}}" ng-bind-html="icon | resourceIcon"></div>
     <div class="content">
       <div class="heading">
         <h4>

--- a/tests/karma/unit/services/contact-schema.js
+++ b/tests/karma/unit/services/contact-schema.js
@@ -48,7 +48,7 @@ describe('ContactSchema service', function() {
           label: 'contact.type.person',
           pluralLabel: 'contact.type.person.plural',
           addButtonLabel: 'contact.type.person.new',
-          icon: 'fa-user',
+          icon: 'person',
           fields: {
             name: {
               type: 'string',
@@ -83,7 +83,7 @@ describe('ContactSchema service', function() {
           label: 'contact.type.district_hospital',
           pluralLabel: 'contact.type.district_hospital.plural',
           addButtonLabel: 'contact.type.district_hospital.new',
-          icon: 'fa-building',
+          icon: 'district_hospital',
           fields: {
             name: {
               type: 'string',
@@ -112,7 +112,7 @@ describe('ContactSchema service', function() {
           label: 'contact.type.health_center',
           pluralLabel: 'contact.type.health_center.plural',
           addButtonLabel: 'contact.type.health_center.new',
-          icon: 'fa-hospital-o',
+          icon: 'health_center',
           fields: {
             name: {
               type: 'string',
@@ -145,7 +145,7 @@ describe('ContactSchema service', function() {
           label: 'contact.type.clinic',
           pluralLabel: 'contact.type.clinic.plural',
           addButtonLabel: 'contact.type.clinic.new',
-          icon: 'fa-group',
+          icon: 'clinic',
           fields: {
             name: {
               type: 'string',


### PR DESCRIPTION
# Description

Uses the static resources doc rather than the font awesome fonts
which means we have more flexibility and also makes the icons
configurable.

medic/medic-webapp#3945

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.