### PR TITLE
Make type a required field when saving users

### DIFF
--- a/static/js/controllers/edit-user.js
+++ b/static/js/controllers/edit-user.js
@@ -179,6 +179,10 @@ var passwordTester = require('simple-password-tester'),
         return hasFacility && hasContact;
       };
 
+      var validateRole = function() {
+        return validateRequired('type', 'User Type');
+      };
+
       var getRoles = function(type, includeAdmin) {
         if (includeAdmin && type === '_admin') {
           return ['_admin'];
@@ -264,7 +268,10 @@ var passwordTester = require('simple-password-tester'),
         $scope.setProcessing();
         $scope.errors = {};
         computeFields();
-        if (validatePasswordForEditUser() && validateName() && validateContactAndFacility()) {
+        if (validateName() &&
+            validateRole() &&
+            validateContactAndFacility() &&
+            validatePasswordForEditUser()) {
           saveEdit('#edit-user-profile', $scope.editUserModel.id, getSettingsUpdates(false), getUserUpdates());
         } else {
           $scope.setError();

--- a/templates/modals/edit_user.html
+++ b/templates/modals/edit_user.html
@@ -35,7 +35,7 @@
       <select id="language" class="form-control" ng-model="editUserModel.language" ng-options="locale.name for locale in enabledLocales track by locale.code"></select>
     </div>
 
-    <div class="form-group" mm-auth="can_configure">
+    <div class="form-group required" mm-auth="can_configure" ng-class="{'has-error': errors.type}">
       <label for="type" translate>User Type</label>
       <input id="name" type="text" class="form-control" ng-model="editUserModel.type" disabled="disabled" ng-if="editUserModel.type === '_admin'" />
       <select id="type" class="form-control" ng-model="editUserModel.type" ng-if="editUserModel.type !== '_admin'">
@@ -50,6 +50,7 @@
           <option value="gateway" translate>usertype.gateway</option>
         </optgroup>
       </select>
+      <span class="help-block">{{errors.type}}</span>
     </div>
 
     <div class="form-group" mm-auth="can_configure" ng-class="{'has-error': errors.facility_id, 'required': editUserModel.type === 'district-manager'}">

--- a/tests/karma/unit/controllers/edit-user.js
+++ b/tests/karma/unit/controllers/edit-user.js
@@ -321,6 +321,8 @@ describe('EditUserCtrl controller', () => {
 
     it('password must be filled when creating new user', done => {
       mockCreateNewUser();
+      scope.editUserModel.name = 'newuser';
+      scope.editUserModel.type = 'data-entry';
       Translate.withArgs('Password').returns(Promise.resolve('pswd'));
       Translate.withArgs('field is required', { field: 'pswd' }).returns(Promise.resolve('pswd field must be filled'));
       setTimeout(() => {
@@ -347,6 +349,8 @@ describe('EditUserCtrl controller', () => {
 
     it('error if password and confirm do not match when creating new user', done => {
       mockEditCurrentUser();
+      scope.editUserModel.name = 'newuser';
+      scope.editUserModel.type = 'data-entry';
       Translate.withArgs('Passwords must match').returns(Promise.resolve('wrong'));
       setTimeout(() => {
         const password = '1QrAs$$3%%kkkk445234234234';

--- a/tests/protractor/e2e/users/add-user.specs.js
+++ b/tests/protractor/e2e/users/add-user.specs.js
@@ -5,13 +5,9 @@ const utils = require('../../utils'),
 
 const addedUser = 'fulltester' + new Date().getTime(),
       fullName = 'Bede Ngaruko',
-      errorMessagePassword = element.all(by.css('span.help-block.ng-binding')).get(3);
+      errorMessagePassword = element(by.css('#password ~ .help-block'));
 
 describe('Add user  : ', () => {
-  afterEach(done => {
-    utils.resetBrowser();
-    done();
-  });
 
   afterAll(utils.afterEach);
 
@@ -75,7 +71,7 @@ describe('Add user  : ', () => {
     addUserModal.fillForm('restricted', 'Not Saved', '%4wbbygxkgdwvdwT65');
     helper.selectDropdownByText(element(by.id('type')), 'Restricted to their place');
     addUserModal.submit();
-    expect(element.all(by.css('span.help-block.ng-binding')).get(1).getText()).toBe('Place is a required field.');
-    expect(element.all(by.css('span.help-block.ng-binding')).get(2).getText()).toBe('Associated contact is a required field.');
+    expect(element(by.css('#facility ~ .help-block')).getText()).toBe('Place is a required field.');
+    expect(element(by.css('#contact ~ .help-block')).getText()).toBe('Associated contact is a required field.');
   });
 });

--- a/tests/protractor/page-objects/common/common.po.js
+++ b/tests/protractor/page-objects/common/common.po.js
@@ -1,14 +1,13 @@
 const helper = require('../../helper'),
-      utils = require('../../utils');
-
-const medicLogo = element(by.className('logo-full'));
-const messagesLink = element(by.id('messages-tab'));
-const tasksLink = element(by.id('tasks-tab'));
-const contactsLink = element(by.id('contacts-tab'));
-const analyticsLink = element(by.id('analytics-tab'));
-const configurationLink = element(by.css('[ui-sref=configuration]'));
-const hamburgerMenu = element(by.className('dropdown options'));
-const logoutButton = $('[ng-click=logout]');
+      utils = require('../../utils'),
+      medicLogo = element(by.className('logo-full')),
+      messagesLink = element(by.id('messages-tab')),
+      tasksLink = element(by.id('tasks-tab')),
+      contactsLink = element(by.id('contacts-tab')),
+      analyticsLink = element(by.id('analytics-tab')),
+      configurationLink = element(by.css('[ui-sref=configuration]')),
+      hamburgerMenu = element(by.className('dropdown options')),
+      logoutButton = $('[ng-click=logout]');
 
 module.exports = {
   getBaseUrl: () => {
@@ -68,6 +67,3 @@ module.exports = {
     logoutButton.click();
   }
 };
-
-
-


### PR DESCRIPTION
# Description

If type isn't set the app behaves very strangely when the user
logs in.

This change also rearranges the order of validations to the order
they appear on screen.

medic/medic-webapp#3904

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.