### PR TITLE
Make e2e stable

### DIFF
--- a/tests/protractor/e2e/registration-by-sms.js
+++ b/tests/protractor/e2e/registration-by-sms.js
@@ -243,7 +243,7 @@ describe('registration transition', () => {
 
     it('shows content', () => {
       commonElements.goToReports();
-      helper.waitElementToBeVisisble(element(by.css('#reports - list .unfiltered li:first - child')));
+      helper.waitElementToBeVisisble(element(by.css('#reports-list .unfiltered li:first-child')));
       browser.wait(() => element(by.cssContainingText('#reports-list .unfiltered li:first-child h4 span', CAROL.name)).isPresent(), 10000);
 
       element(by.css('#reports-list .unfiltered li:first-child .summary')).click();

--- a/tests/protractor/e2e/registration-by-sms.js
+++ b/tests/protractor/e2e/registration-by-sms.js
@@ -1,5 +1,6 @@
 const utils = require('../utils'),
-      commonElements = require('../page-objects/common/common.po.js');
+      commonElements = require('../page-objects/common/common.po.js'),
+      helper = require('../helper');
 
 describe('registration transition', () => {
 
@@ -242,6 +243,7 @@ describe('registration transition', () => {
 
     it('shows content', () => {
       commonElements.goToReports();
+      helper.waitElementToBeVisisble(element(by.css('#reports - list.unfiltered li:first - child')));
       browser.wait(() => element(by.cssContainingText('#reports-list .unfiltered li:first-child h4 span', CAROL.name)).isPresent(), 10000);
 
       element(by.css('#reports-list .unfiltered li:first-child .summary')).click();

--- a/tests/protractor/e2e/registration-by-sms.js
+++ b/tests/protractor/e2e/registration-by-sms.js
@@ -243,7 +243,7 @@ describe('registration transition', () => {
 
     it('shows content', () => {
       commonElements.goToReports();
-      helper.waitElementToBeVisisble(element(by.css('#reports - list.unfiltered li:first - child')));
+      helper.waitElementToBeVisisble(element(by.css('#reports - list .unfiltered li:first - child')));
       browser.wait(() => element(by.cssContainingText('#reports-list .unfiltered li:first-child h4 span', CAROL.name)).isPresent(), 10000);
 
       element(by.css('#reports-list .unfiltered li:first-child .summary')).click();

--- a/tests/protractor/e2e/sms-gateway.js
+++ b/tests/protractor/e2e/sms-gateway.js
@@ -203,10 +203,10 @@ describe('sms-gateway api', () => {
 
     it('- shows content', () => {
       commonElements.goToReports();
-
       browser.wait(() => {
         return element(by.css('#reports-list li:first-child')).isPresent();
       }, 10000);
+      helper.waitElementToBeVisisble(element(by.css('#reports-list li:first-child')));
       element(by.css('#reports-list li:first-child .heading')).click();
       browser.wait(() => {
         return element(by.css('#reports-content .body .item-summary .icon')).isPresent();
@@ -287,6 +287,7 @@ describe('sms-gateway api', () => {
       browser.wait(() => {
         return element(by.css('#reports-list li:first-child')).isPresent();
       }, 10000);
+      helper.waitElementToBeVisisble(element(by.css('#reports-list li:first-child')));
 
       const desc = element(by.css('#reports-list li:first-child .heading'));
       helper.waitUntilReady(desc);


### PR DESCRIPTION
On clicking report tab, report page takes time to load and the ‘.loading-status ng-hide’ displays first  the spinner then  ‘No reports’ then the reports list finally loads… This has been the root cause of some test failures ( #3509 ). While waiting for related issue to be fixed, I have inserted a `wait for the list to load` line of code in relevant tests. (Screenshot was taken from a Travis job). 
![image](https://user-images.githubusercontent.com/6979995/31323229-a781c6c0-acf0-11e7-96b7-227961fd1a6c.png)

