### PR TITLE
Update resource icons to inline svgs

### DIFF
--- a/static/css/inbox.less
+++ b/static/css/inbox.less
@@ -1390,8 +1390,7 @@ a.fa:hover {
       display: none;
     }
     .fa-stack {
-      height: 50px;
-      margin-top: -5px;
+      height: 20px;
     }
     .mm-icon {
       min-height: 50px;

--- a/static/css/material.less
+++ b/static/css/material.less
@@ -37,9 +37,13 @@
   }
   .meta .heading {
     padding: 20px;
-  }
-  .heading img {
-    width: 60px;
+    display: flex;
+    align-items: center;
+    img,
+    svg {
+      width: 60px;
+      height: 60px;
+    }
   }
   .field-icon {
     margin-right: 10px;
@@ -59,16 +63,13 @@
     text-align: right;
     line-height: 1;
   }
-  .heading-content {
-    display: inline-block;
+  h2 {
+    margin: 0;
   }
   h2,
   .primary-contact {
-    margin-left: 20px;
     display: inline-block;
-  }
-  h2 {
-    margin-top: 0;
+    margin-left: 10px;
   }
   .action-header {
     border-bottom: 3px solid @seperator-color;
@@ -156,13 +157,9 @@
       margin-left: 10px;
       order: 1;
     }
-    .heading-content {
-      display: inherit;
-      margin-left: 60px;
-    }
     h2,
     .primary-contact {
-      display: block;
+      display: inherit;
     }
   }
   #snackbar .snackbar-content {

--- a/static/css/variables.less
+++ b/static/css/variables.less
@@ -14,6 +14,8 @@
 @warning-color: #D19D2E;
 @primary-color: #C78330;
 @unread-color: #007DC6;
+@button-text-color: #333333;
+@button-text-inverse-color: #DDDDDD;
 
 /* tab colours */
 @messages-color: #63A2C6;
@@ -64,19 +66,31 @@
 @font-small: 0.875rem;
 
 .button-text() {
-  color: @grayDark;
+  color: @button-text-color;
   text-shadow: rgba(255, 255, 255, 0.5) 1px 1px 2px;
+  svg path {
+    fill: @button-text-color;
+  }
 }
 
 .button-text-hover() {
   color: @white;
+  svg path {
+    fill: @white;
+  }
 }
 
 .button-text-disabled() {
   color: @label-color;
+  svg path {
+    fill: @label-color;
+  }
 }
 
 .button-text-inverse() {
-  color: #DDDDDD;
+  color: @button-text-inverse-color;
   text-shadow: rgba(0, 0, 0, 0.5) 1px 1px 2px;
+  svg path {
+    fill: @button-text-inverse-color;
+  }
 }

--- a/static/js/filters/resource-icon.js
+++ b/static/js/filters/resource-icon.js
@@ -1,18 +1,9 @@
 angular.module('inboxFilters').filter('resourceIcon',
-  function(ResourceIcons) {
+  function($sce, ResourceIcons) {
     'use strict';
     'ngInject';
     return function(name) {
-      if (!name) {
-        return '';
-      }
-      var src = ResourceIcons.getImg(name);
-      if (src) {
-        src = 'src="' + src + '"';
-      } else {
-        src = '';
-      }
-      return '<img class="resource-icon" title="' + name + '" ' + src + ' />';
+      return $sce.trustAsHtml(ResourceIcons.getImg(name));
     };
   }
 );

--- a/templates/partials/contacts_content.html
+++ b/templates/partials/contacts_content.html
@@ -15,15 +15,13 @@
       <div class="body meta">
         <div class="card">
           <div class="row heading">
-            <div>
-              <span ng-bind-html="selected.icon | resourceIcon"></span>
-              <div class="heading-content">
-                <h2>{{selected.doc.name}}</h2>
-                <div class="primary-contact" ng-if="selected.isPrimaryContact">
-                  <i class="fa fa-star primary" translate translate-attr-title="Primary contact"></i>
-                  <span ng-if="selected.doc.parent.type !== 'clinic'" translate>Primary contact</span>
-                  <span ng-if="selected.doc.parent.type === 'clinic'" translate>clinic.field.contact</span>
-                </div>
+            <span ng-bind-html="selected.icon | resourceIcon"></span>
+            <div class="heading-content">
+              <h2>{{selected.doc.name}}</h2>
+              <div class="primary-contact" ng-if="selected.isPrimaryContact">
+                <i class="fa fa-star primary" translate translate-attr-title="Primary contact"></i>
+                <span ng-if="selected.doc.parent.type !== 'clinic'" translate>Primary contact</span>
+                <span ng-if="selected.doc.parent.type === 'clinic'" translate>clinic.field.contact</span>
               </div>
             </div>
           </div>

--- a/tests/karma/unit/services/resource-icon.js
+++ b/tests/karma/unit/services/resource-icon.js
@@ -29,23 +29,23 @@ describe('ResourceIcons service', function() {
 
   describe('getImg function', function() {
 
-    it('returns undefined when given no name', function(done) {
+    it('returns empty string when given no name', function(done) {
       get.returns(Promise.resolve());
       var service = injector.get('ResourceIcons');
       var actual = service.getImg();
-      chai.expect(actual).to.equal(undefined);
+      chai.expect(actual).to.equal('');
       done();
     });
 
-    it('returns undefined when no doc yet', function(done) {
+    it('returns empty string when no doc yet', function(done) {
       get.returns(Promise.resolve());
       var service = injector.get('ResourceIcons');
       var actual = service.getImg('delivery');
-      chai.expect(actual).to.equal(undefined);
+      chai.expect(actual).to.equal('<span class="resource-icon" title="delivery"></span>');
       done();
     });
 
-    it('returns src when resources doc already cached', function(done) {
+    it('returns img when resources doc already cached', function(done) {
       var resources = {
         resources: {
           child: 'child.png',
@@ -66,12 +66,39 @@ describe('ResourceIcons service', function() {
       var service = injector.get('ResourceIcons');
       setTimeout(function() {
         var actual = service.getImg('child');
-        var expected = 'data:image/png;base64,kiddlywinks';
+        var expected =
+          '<span class="resource-icon" title="child">' +
+            '<img src="data:image/png;base64,kiddlywinks" />' +
+          '</span>';
         chai.expect(actual).to.equal(expected);
         done();
       });
     });
 
+    it('returns inline svg for svg images', function(done) {
+      var data = `<svg  xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <rect x="10" y="10" height="100" width="100" style="stroke:#ff0000; fill: #0000ff"/>
+                  </svg>`;
+      var resources = {
+        resources: {
+          mother: 'mother.png'
+        },
+        _attachments: {
+          'mother.png': {
+            content_type: 'image/svg+xml',
+            data: btoa(data)
+          }
+        }
+      };
+      get.returns(Promise.resolve(resources));
+      var service = injector.get('ResourceIcons');
+      setTimeout(function() {
+        var actual = service.getImg('mother');
+        var expected = '<span class="resource-icon" title="mother">' + data + '</span>';
+        chai.expect(actual).to.equal(expected);
+        done();
+      });
+    });
   });
 
   describe('replacePlaceholders function', function() {
@@ -90,15 +117,15 @@ describe('ResourceIcons service', function() {
       };
       get.returns(Promise.resolve(resources));
       var dom = $('<ul>' +
-                  '<li><img class="resource-icon" title="child"/></li>' +
-                  '<li><img class="resource-icon" title="adult"/></li>' +
-                '</ul>');
+                    '<li><img class="resource-icon" title="child"/></li>' +
+                    '<li><img class="resource-icon" title="adult"/></li>' +
+                  '</ul>');
       var service = injector.get('ResourceIcons');
       service.replacePlaceholders(dom);
       setTimeout(function() {
-        chai.expect(dom.find('.resource-icon[title="child"]').attr('src'))
+        chai.expect(dom.find('.resource-icon[title="child"] img').attr('src'))
           .to.equal('data:image/png;base64,kiddlywinks');
-        chai.expect(dom.find('.resource-icon[title="adult"]').attr('src'))
+        chai.expect(dom.find('.resource-icon[title="adult"] img').attr('src'))
           .to.equal(undefined);
         done();
       });
@@ -142,17 +169,17 @@ describe('ResourceIcons service', function() {
       var service = injector.get('ResourceIcons');
       service.replacePlaceholders(dom);
       setTimeout(function() {
-        chai.expect(dom.find('.resource-icon[title="child"]').attr('src'))
+        chai.expect(dom.find('.resource-icon[title="child"] img').attr('src'))
           .to.equal('data:image/png;base64,kiddlywinks');
-        chai.expect(dom.find('.resource-icon[title="adult"]').attr('src'))
+        chai.expect(dom.find('.resource-icon[title="adult"] img').attr('src'))
           .to.equal(undefined);
 
         Changes.args[0][0].callback(); // invoke the changes listener
         service.replacePlaceholders(dom);
         setTimeout(function() {
-          chai.expect(dom.find('.resource-icon[title="child"]').attr('src'))
+          chai.expect(dom.find('.resource-icon[title="child"] img').attr('src'))
             .to.equal('data:image/png;base64,kiddlywinks');
-          chai.expect(dom.find('.resource-icon[title="adult"]').attr('src'))
+          chai.expect(dom.find('.resource-icon[title="adult"] img').attr('src'))
             .to.equal('data:image/png;base64,coffinstuffer');
           chai.expect(get.callCount).to.equal(2);
           done();


### PR DESCRIPTION
# Description

The ResourceIcons service and resourceIcons filter now detect if
the icon is an svg and inline the xml if it is. This means we can
now apply css styles to the svg which is important, for example,
when we want to use a coloured icon for clinic in the list and the
same icon in white in the action bar.

medic/medic-webapp#3945

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.