### PR TITLE
Documentation for silence_for change

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@ _TBD_
 
 - [#3449](https://github.com/medic/medic-webapp/issues/3449) includes a feature which makes it unnecessary to use a `repeat-relevant` node in Enketo forms to workaround a bug which created an empty child. This node should now be removed.
 - [#3629](https://github.com/medic/medic-webapp/issues/3629) added more configurable text to the target widgets. Also, configuring an array of target titles is now deprecated in favor specifying a single translation key. Reconfigure your targets to specify values for `translation_key`, `subtitle_translation_key`, and `percentage_count_translation_key` properties. [Full documentation](https://github.com/medic/medic-docs/blob/master/configuration/targets.md).
+- [#3818](https://github.com/medic/medic-webapp/issues/3818) changed the way groups of scheduled messages are silenced when using `silence_for`. Previously, only the first group found to be in the silence window was silenced. Now, all groups are.
 
 ## 2.13.0
 

--- a/kanso.json
+++ b/kanso.json
@@ -689,7 +689,7 @@
                         "silence_for": {
                             "type": "string",
                             "title": "Silence Window",
-                            "description": "The length of time used to find the next reminder group to clear.  Leave blank to clear all reminder groups.  Supported units: years, months, weeks, days, hours, minutes. e.g. 25 days"
+                            "description": "The length of time used to find reminder groups to clear. Will clear all groups that are within the silence window. Leave blank to clear all reminder groups.  Supported units: years, months, weeks, days, hours, minutes. e.g. 25 days"
                         },
                         "fields": {
                             "title": "Fields",


### PR DESCRIPTION
Actual code change is here:
https://github.com/medic/medic-sentinel/commit/f9b539a7f9a8ddec245307bb216b19d6e7a31fb7

medic/medic-webapp#3818

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.