### PR TITLE
Dropping usage-stats that we don't use anymore

### DIFF
--- a/kanso.json
+++ b/kanso.json
@@ -236,17 +236,6 @@
                 "description": "How to render the contact name in short format? e.g. clinic.name, clinic.contact.name, clinic.parent.name",
                 "default": "clinic.name"
             },
-            "statistics_submission": {
-                "type": "string",
-                "title": "Anonymous Statistics Submission",
-                "description": "Whether and how to submit anonymous statistics. Valid values: 'none', 'web', 'sms', 'both'",
-                "default": "none"
-            },
-            "statistics_submission_number": {
-                "type": "string",
-                "title": "Anonymous Statistics Submission SMS Number",
-                "description": "The phone number to send Anonymous Statistics to."
-            },
             "kujua-reporting": {
                 "title": "Scheduled Reports",
                 "type": "array",

--- a/lib/views.js
+++ b/lib/views.js
@@ -48,19 +48,6 @@ exports.data_records_by_ancestor = {
   }
 };
 
-exports.data_records_by_year_month_form_place = {
-  map: function(doc) {
-    if (doc.type === 'data_record' &&
-        !(doc.errors && doc.errors.length) &&
-        doc.contact &&
-        doc.contact.parent) {
-      var date = new Date(doc.reported_date);
-      emit([date.getFullYear(), date.getMonth(), doc.form, doc.contact.parent._id]);
-    }
-  },
-  reduce: '_count'
-};
-
 exports.delivery_reports_by_district_and_code = {
   map: function(doc) {
     if (doc.type === 'data_record' &&
@@ -79,21 +66,6 @@ exports.delivery_reports_by_district_and_code = {
         emit([placeId, code]);
       }
       emit(['_admin', code]);
-    }
-  },
-  reduce: '_count'
-};
-
-exports.delivery_reports_by_year_month_and_code = {
-  map: function(doc) {
-    if (doc.type === 'data_record' &&
-        doc.form === 'D' &&
-        !(doc.errors && doc.errors.length) &&
-        doc.fields &&
-        doc.fields.delivery_code) {
-      var date = new Date(doc.reported_date);
-      var code = doc.fields.delivery_code.toUpperCase();
-      emit([date.getFullYear(), date.getMonth(), code]);
     }
   },
   reduce: '_count'
@@ -366,14 +338,6 @@ exports.tasks_pending = {
 
     if (pending) {
       emit([doc.reported_date, doc.refid]);
-    }
-  }
-};
-
-exports.usage_stats_by_year_month = {
-  map: function(doc) {
-    if (doc.type === 'usage_stats') {
-      emit([doc.year, doc.month], 1);
     }
   }
 };

--- a/static/js/controllers/guided-setup-modal.js
+++ b/static/js/controllers/guided-setup-modal.js
@@ -66,10 +66,6 @@ angular.module('inboxControllers').controller('GuidedSetupModalCtrl',
       if (val) {
         settings.anc_registration_lmp = val === 'true';
       }
-      val = $('#anonymous-statistics-content .horizontal-options .selected').attr('data-value');
-      if (val) {
-        settings.statistics_submission = val;
-      }
       return UpdateSettings(settings)
         .then(function() {
           $scope.setFinished();
@@ -135,7 +131,6 @@ angular.module('inboxControllers').controller('GuidedSetupModalCtrl',
                 $('#language-preference-content .locale a[data-value="' + res.locale + '"]').trigger('click');
                 $('#language-preference-content .locale-outgoing a[data-value="' + res.locale_outgoing + '"]').trigger('click');
                 $('#registration-form-content a[data-value=' + res.anc_registration_lmp + ']').trigger('click');
-                $('#anonymous-statistics-content a[data-value=' + res.statistics_submission + ']').trigger('click');
               });
             }
           })

--- a/templates/modals/guided_setup.html
+++ b/templates/modals/guided_setup.html
@@ -127,40 +127,6 @@
           </div>
         </div>
       </div>
-
-      <!-- 5. Anonymous statistics -->
-      <div class="panel panel-default">
-        <div class="panel-heading" role="tab" id="anonymous-statistics-heading">
-          <h4 class="panel-title">
-            <a class="collapsed" data-toggle="collapse" data-parent="#accordion" href="#anonymous-statistics-content" aria-expanded="false" aria-controls="anonymous-statistics-content" target="_self">
-              <span class="count">
-                <span class="number">5</span>
-                <i class="fa fa-check"></i>
-              </span><span translate>setup.statistics.title</span>
-              <span class="value"></span>
-            </a>
-          </h4>
-        </div>
-        <div id="anonymous-statistics-content" class="anonymous-statistics-content panel-collapse collapse" role="tabpanel" aria-labelledby="anonymous-statistics-heading">
-          <div class="panel-body">
-            <p translate>setup.statistics.description</p>
-            <p class="horizontal-options">
-              <a href="#" data-value="sms">
-                <span class="rectangle" translate>Submit via sms</span>
-              </a>
-              <a href="#" data-value="both">
-                <span class="rectangle" translate>Submit via either</span>
-              </a>
-              <a href="#" data-value="web">
-                <span class="rectangle" translate>Submit via web</span>
-              </a>
-              <a href="#" data-value="none">
-                <span class="rectangle" translate>No submission</span>
-              </a>
-            </p>
-          </div>
-        </div>
-      </div>
     </div>
   </div>
 </mm-modal>


### PR DESCRIPTION
Including three (3!) views that were only used by this feature.

medic/medic-webapp#3950

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.