### PR TITLE
Register change listener on meta db

### DIFF
--- a/static/js/services/add-read-status.js
+++ b/static/js/services/add-read-status.js
@@ -13,6 +13,10 @@ angular.module('inboxServices').factory('AddReadStatus',
       });
     };
 
+    var docExists = function(row) {
+      return !!(row.value && !row.value.deleted);
+    };
+
     var addRead = function(type, models) {
       if (!models.length) {
         return $q.resolve(models);
@@ -22,7 +26,7 @@ angular.module('inboxServices').factory('AddReadStatus',
         .allDocs({ keys: keys })
         .then(function(response) {
           for (var i = 0; i < models.length; i++) {
-            models[i].read = !!response.rows[i].value;
+            models[i].read = docExists(response.rows[i]);
           }
           return models;
         });

--- a/tests/karma/unit/services/add-read-status.js
+++ b/tests/karma/unit/services/add-read-status.js
@@ -31,19 +31,22 @@ describe('AddReadStatus service', () => {
       allDocs.returns(Promise.resolve({
         rows: [
           { id: 'a', key: 'a', value: { rev: 'x' } },
-          { key: 'b', error: 'not_found' },
-          { id: 'c', key: 'c', value: { rev: 'y' } },
+          { key: 'b', error: 'not_found' }, // read doc never existed
+          { id: 'c', key: 'c', value: { rev: 'y', deleted: true } }, // read doc has been deleted
+          { id: 'd', key: 'd', value: { rev: 'z' } }
         ]
       }));
       const given = [
         { id: 'a' },  // supports no underscore prefix
         { _id: 'b' }, // AND works with underscore prefix
-        { _id: 'c' }
+        { _id: 'c' },
+        { _id: 'd' }
       ];
       const expected = [
         { id: 'a', read: true },
         { _id: 'b', read: false },
-        { _id: 'c', read: true }
+        { _id: 'c', read: false },
+        { _id: 'd', read: true }
       ];
       return service.reports(given).then(actual => {
         chai.expect(actual).to.deep.equal(expected);
@@ -51,7 +54,8 @@ describe('AddReadStatus service', () => {
         chai.expect(allDocs.args[0][0].keys).to.deep.equal([
           'read:report:a',
           'read:report:b',
-          'read:report:c'
+          'read:report:c',
+          'read:report:d'
         ]);
       });
     });

--- a/tests/karma/unit/services/unread-records.js
+++ b/tests/karma/unit/services/unread-records.js
@@ -101,8 +101,39 @@ describe('UnreadRecords service', () => {
       let call = 0;
       service((err, actual) => {
         if (call === 0) {
-          chai.expect(Changes.callCount).to.equal(1);
+          chai.expect(Changes.callCount).to.equal(2); // one for medic and one for meta
           Changes.args[0][0].callback({ id: 'abc' });
+        } else if (call === 1) {
+          chai.expect(query.callCount).to.equal(4);
+          chai.expect(actual).to.deep.equal({
+            report: 11,
+            message: 5
+          });
+          done();
+        }
+        call++;
+      });
+    });
+
+    it('updates the count if the meta db is updated', done => {
+      query.onCall(0).returns(Promise.resolve({ rows: [
+        { key: 'report', value: 13 },
+        { key: 'message', value: 5 }
+      ] }));
+      query.onCall(1).returns(Promise.resolve({ rows: [
+        { key: 'report', value: 3 }
+      ] }));
+      query.onCall(2).returns(Promise.resolve({ rows: [
+        { key: 'report', value: 14 },
+        { key: 'message', value: 5 }
+      ] }));
+      query.onCall(3).returns(Promise.resolve({ rows: [
+        { key: 'report', value: 3 }
+      ] }));
+      let call = 0;
+      service((err, actual) => {
+        if (call === 0) {
+          Changes.args[1][0].callback({ id: 'abc' });
         } else if (call === 1) {
           chai.expect(query.callCount).to.equal(4);
           chai.expect(actual).to.deep.equal({
@@ -142,7 +173,7 @@ describe('UnreadRecords service', () => {
           return done(err);
         }
         if (call === 0) {
-          chai.expect(Changes.callCount).to.equal(1);
+          chai.expect(Changes.callCount).to.equal(2);
           Changes.args[0][0].callback({
             deleted: true,
             id: 'abc',
@@ -182,7 +213,7 @@ describe('UnreadRecords service', () => {
           return done(err);
         }
         if (call === 0) {
-          chai.expect(Changes.callCount).to.equal(1);
+          chai.expect(Changes.callCount).to.equal(2);
           Changes.args[0][0].callback({
             deleted: true,
             id: 'abc',


### PR DESCRIPTION
# Description

Without the listener admins don't see the updated status bubbles
until they refresh the page. This also extends the Changes service
to be able to register listeners on the meta db.

Finally it also fixes a bug where the reports list was styling
reports with deleted read docs as read rather than unread.

medic/medic-webapp#3944

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.