### PR TITLE
Don't show no more reports when there are reports

### DIFF
--- a/static/js/controllers/messages.js
+++ b/static/js/controllers/messages.js
@@ -15,6 +15,11 @@ angular.module('inboxControllers').controller('MessagesCtrl',
     'use strict';
     'ngInject';
 
+    $scope.allLoaded = false;
+    $scope.messages = [];
+    $scope.selected = null;
+    $scope.loading = true;
+
     var removeDeletedMessages = function(messages) {
       var existingKey;
       var checkExisting = function(updated) {
@@ -62,9 +67,9 @@ angular.module('inboxControllers').controller('MessagesCtrl',
         $scope.loading = true;
       }
       return MessageContacts().then(function(data) {
-        $scope.loading = false;
         options.messages = data;
         setMessages(options);
+        $scope.loading = false;
       });
     };
 
@@ -84,9 +89,6 @@ angular.module('inboxControllers').controller('MessagesCtrl',
       $scope.settingSelected(refreshing);
     };
 
-    $scope.allLoaded = false;
-    $scope.messages = [];
-    $scope.selected = null;
     setMessages();
     updateConversations({ })
       .then(function() {

--- a/static/js/controllers/reports.js
+++ b/static/js/controllers/reports.js
@@ -37,7 +37,7 @@ angular.module('inboxControllers').controller('ReportsCtrl',
     var liveList = LiveList.reports;
 
     var updateLiveList = function(updated) {
-      AddReadStatus.reports(updated).then(function() {
+      return AddReadStatus.reports(updated).then(function() {
         updated.forEach(function(report) {
           liveList.update(report);
         });
@@ -46,6 +46,7 @@ angular.module('inboxControllers').controller('ReportsCtrl',
         if ($state.params.id) {
           liveList.setSelected($state.params.id);
         }
+        return updated;
       });
     };
 
@@ -198,13 +199,13 @@ angular.module('inboxControllers').controller('ReportsCtrl',
       }
 
       Search('reports', $scope.filters, options)
+        .then(updateLiveList)
         .then(function(data) {
           $scope.moreItems = liveList.moreItems = data.length >= options.limit;
           $scope.loading = false;
           $scope.appending = false;
           $scope.error = false;
           $scope.errorSyntax = false;
-          updateLiveList(data);
           if (!$state.params.id &&
               !$scope.isMobile() &&
               !$scope.selected &&


### PR DESCRIPTION
# Description

The reports controller wasn't waiting for the async response
before setting loading to false. The messages controller wasn't
defaulting loading to true so there was a lag before the spinner
was shown.

medic/medic-webapp#3969

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.