### PR TITLE
Show time for today instead of relative date

### DIFF
--- a/static/js/filters/date.js
+++ b/static/js/filters/date.js
@@ -17,29 +17,37 @@ var _ = require('underscore'),
   var getRelativeDateString = function(date, options) {
     if (options.age) {
       return options.FormatDate.age(date);
+    } else if (!options.withoutTime && moment(date).isSame(moment(), 'day')) {
+      return options.FormatDate.time(date);
+    } else {
+      return options.FormatDate.relative(date, options);
     }
-    return options.FormatDate.relative(date, options);
   };
 
   var getRelativeDate = function(date, options) {
     options = options || {};
     _.defaults(options, { prefix: '', suffix: '' });
+
     if (!date) {
       return '<span>' + options.prefix + options.suffix + '</span>';
     }
+
     var momentDate = moment(date);
     var absolute = getAbsoluteDateString(momentDate, options);
     var relative = getRelativeDateString(momentDate, options);
     var classes = ['relative-date'];
     var now = moment();
+
     if (options.withoutTime) {
       now = now.startOf('day');
     }
+
     if (momentDate.isBefore(now)) {
       classes.push('past');
     } else {
       classes.push('future');
     }
+
     return options.prefix +
            '<span class="' + classes.join(' ') + '" title="' + absolute + '">' +
              '<span class="relative-date-content">' + relative + '</span>' +

--- a/static/js/services/format-date.js
+++ b/static/js/services/format-date.js
@@ -19,7 +19,7 @@ var moment = require('moment');
       var config = {
         date: 'DD-MMM-YYYY',
         datetime: 'DD-MMM-YYYY HH:mm:ss',
-        time: 'h:mm A',
+        time: MomentLocaleData().longDateFormat('LT'),
         ageBreaks: [
           { unit: 'years', key: { singular: 'y', plural: 'yy' }, min: 1 },
           { unit: 'months', key: { singular: 'M', plural: 'MM' }, min: 1 },

--- a/static/js/services/format-date.js
+++ b/static/js/services/format-date.js
@@ -19,6 +19,7 @@ var moment = require('moment');
       var config = {
         date: 'DD-MMM-YYYY',
         datetime: 'DD-MMM-YYYY HH:mm:ss',
+        time: 'h:mm A',
         ageBreaks: [
           { unit: 'years', key: { singular: 'y', plural: 'yy' }, min: 1 },
           { unit: 'months', key: { singular: 'M', plural: 'MM' }, min: 1 },
@@ -90,9 +91,12 @@ var moment = require('moment');
         },
         age: function(date) {
           return relativeDate(date);
+        },
+        time: function(date) {
+          return format(date, 'time');
         }
       };
     }
   );
-  
-}()); 
+
+}());

--- a/tests/karma/unit/filters/relative-date.js
+++ b/tests/karma/unit/filters/relative-date.js
@@ -13,6 +13,9 @@ describe('relativeDate filter', function() {
           return 'day 0';
         },
         relative: function() {
+          return 'somerelativetime';
+        },
+        time: function() {
           return 'sometime';
         }
       });
@@ -31,11 +34,20 @@ describe('relativeDate filter', function() {
   });
 
   it('should render date', function() {
+    //                   some time in the past
+    scope.date = moment('2017-10-10T10:10:10.100').valueOf();
+    var element = compile('<div ng-bind-html="date | relativeDate"></div>')(scope);
+    scope.$digest();
+    chai.expect(element.find('span').attr('title')).to.equal('day 0');
+    chai.expect(element.text()).to.equal('somerelativetime');
+  });
+
+  it('should render a time when the date is today', () => {
+    //           today
     scope.date = moment().valueOf();
     var element = compile('<div ng-bind-html="date | relativeDate"></div>')(scope);
     scope.$digest();
     chai.expect(element.find('span').attr('title')).to.equal('day 0');
     chai.expect(element.text()).to.equal('sometime');
   });
-
 });

--- a/tests/karma/unit/services/format-date.js
+++ b/tests/karma/unit/services/format-date.js
@@ -170,4 +170,13 @@ describe('FormatDate service', function() {
 
   });
 
+  describe('time', () => {
+    it('returns just the time of a given date', done => {
+      const now = moment();
+      const time = now.format('h:mm A');
+      var actual = service.time(now);
+      chai.expect(actual).to.equal(time);
+      done();
+    });
+  });
 });

--- a/tests/karma/unit/services/format-date.js
+++ b/tests/karma/unit/services/format-date.js
@@ -2,33 +2,36 @@ describe('FormatDate service', function() {
 
   'use strict';
 
+  var sandbox = sinon.sandbox.create();
+
   var service,
       translateInstant,
       relativeTime,
       pastFuture;
 
+  var LONG_DATE_FORMAT = 'h:mm A';
+
   beforeEach(function() {
     module('inboxApp');
-    relativeTime = sinon.stub();
-    pastFuture = sinon.stub();
+    relativeTime = sandbox.stub();
+    pastFuture = sandbox.stub();
     module(function($provide) {
       $provide.value('Settings', KarmaUtils.nullPromise());
       $provide.value('MomentLocaleData', function() {
         return {
           relativeTime: relativeTime,
-          pastFuture: pastFuture
+          pastFuture: pastFuture,
+          longDateFormat: function() { return LONG_DATE_FORMAT; }
         };
       });
     });
     inject(function(_FormatDate_, _$translate_) {
       service = _FormatDate_;
-      translateInstant = sinon.stub(_$translate_, 'instant');
+      translateInstant = sandbox.stub(_$translate_, 'instant');
     });
   });
 
-  afterEach(function() {
-    KarmaUtils.restore(translateInstant, relativeTime, pastFuture);
-  });
+  afterEach(function() { sandbox.restore(); });
 
   describe('age', function() {
 
@@ -173,7 +176,7 @@ describe('FormatDate service', function() {
   describe('time', () => {
     it('returns just the time of a given date', done => {
       const now = moment();
-      const time = now.format('h:mm A');
+      const time = now.format(LONG_DATE_FORMAT);
       var actual = service.time(now);
       chai.expect(actual).to.equal(time);
       done();


### PR DESCRIPTION
Modifies our relative date logic so that if the date is today, show the
time (10:10 AM) instead. Dates later or earlier than today will show
relative values as normal (3 days ago).

medic/medic-webapp#3613

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.