### PR TITLE
Clarity, correct unsubscribe

### DIFF
--- a/static/js/services/changes.js
+++ b/static/js/services/changes.js
@@ -46,7 +46,7 @@ angular.module('inboxServices').factory('Changes',
       db.lastSeq = change.seq;
       Object.keys(db.callbacks).forEach(function(key) {
         var options = db.callbacks[key];
-        if (!options || !options.filter || options.filter(change)) {
+        if (!options.filter || options.filter(change)) {
           try {
             options.callback(change);
           } catch(e) {
@@ -109,7 +109,7 @@ angular.module('inboxServices').factory('Changes',
 
       return {
         unsubscribe: function() {
-          db.callbacks[options.key] = null;
+          delete db.callbacks[options.key];
         }
       };
     };

--- a/tests/karma/unit/services/changes.js
+++ b/tests/karma/unit/services/changes.js
@@ -3,7 +3,8 @@ describe('Changes service', function() {
   'use strict';
 
   var service,
-      changesCalls;
+      changesCalls,
+      log;
 
   var onProvider = function(db) {
     return {
@@ -19,6 +20,13 @@ describe('Changes service', function() {
       medic: { callCount: 0, callOptions: null, callbacks: {} },
       meta:  { callCount: 0, callOptions: null, callbacks: {} }
     };
+
+    log = {
+      debug: sinon.stub(),
+      info: sinon.stub(),
+      error: sinon.stub()
+    };
+
 
     module('inboxApp');
     module(function ($provide) {
@@ -43,6 +51,7 @@ describe('Changes service', function() {
       $provide.value('$timeout', function(fn) {
         return fn();
       });
+      $provide.value('$log', log);
     });
     inject(function(_Changes_) {
       service = _Changes_;
@@ -207,6 +216,7 @@ describe('Changes service', function() {
 
     changesCalls.medic.callbacks.change({ id: 'x', changes: [ { rev: '2-abc' } ] });
 
+    chai.expect(log.error.callCount).to.equal(0);
     chai.expect(changesCalls.medic.callCount).to.equal(1);
     chai.expect(changesCalls.meta.callCount).to.equal(1);
 


### PR DESCRIPTION
Don't let !options be a possible path to an if statement that then
expects options to exist.

Correct unsubscribe so that it completely removes the callback item.

medic/medic-webapp#3985

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.