### PR TITLE
Use foreman for managing services in dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ logs
 tests/results
 *.sublime-project
 *.sublime-workspace
+/.env

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,15 @@
+# Please define a .env file with relevant environment variables defined inside
+# as key=value pairs (one per line.
+#
+# Possible variables include:
+#
+# COUCH_URL: url for accessing your couch db instance,
+#   e.g. http://admin:pass@localhost:5984/medic
+# COUCH_NODE_NAME: node name of couch on local host,
+#   e.g. couchdb@localhost
+#
+# Alternatively, these values can be set as normal environment variables.
+
+api: cd api && node server.js
+webapp: grunt dev-no-npm
+sentinel: cd sentinel && node server.js

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "url": "git://github.com/medic/medic-webapp.git"
   },
+  "scripts": {
+    "start": "nf start"
+  },
   "dependencies": {
     "angular": "^1.6.6",
     "angular-cookie": "^4.1.0",
@@ -48,6 +51,7 @@
     "bundlesize": "^0.15.3",
     "chai": "^4.1.2",
     "csv": "^1.1.1",
+    "foreman": "^2.0.0",
     "grunt": "^1.0.0",
     "grunt-angular-templates": "^1.0.3",
     "grunt-appcache": "^0.2.0",


### PR DESCRIPTION
I use [`foreman`](https://www.npmjs.com/package/foreman) for running services in dev.  Now everything's in one repo, it makes sense to store the `Procfile` here.  I thought this might be interesting to others.

On this branch, run `npm start` to run webapp, api and sentinel concurrently.