### PR TITLE
Improved facility filter logic

### DIFF
--- a/static/js/controllers/reports.js
+++ b/static/js/controllers/reports.js
@@ -18,6 +18,7 @@ angular.module('inboxControllers').controller('ReportsCtrl',
     ReportViewModelGenerator,
     Search,
     SearchFilters,
+    Session,
     Tour,
     TranslateFrom
   ) {
@@ -339,6 +340,9 @@ angular.module('inboxControllers').controller('ReportsCtrl',
         $scope.search();
       });
     };
+
+    $scope.isAdmin = Session.isAdmin();
+
     $scope.resetFilterModel = function() {
       if ($scope.selectMode && $scope.selected && $scope.selected.length) {
         // can't filter when in select mode

--- a/static/js/services/place-hierarchy.js
+++ b/static/js/services/place-hierarchy.js
@@ -52,24 +52,13 @@ angular.module('inboxServices').factory('PlaceHierarchy',
       });
     };
 
-    // This works because our current hierarchy model only allows you to
-    // have one parent. Because you only have one parent, if you are a
-    // restricted user whose parent lineage contains stubs, all stubs will
-    // only have one child.
-    //
-    // CHW example:
-    //   district_hospital [stub]
-    //    \-> health_center [stub]
-    //         \-> clinic [real, CHW sits here]
-    //
-    //  District Manager example:
-    //   district_hospital [stub]
-    //    \-> health_center [real, DM sits here]
-    //         |-> clinic
-    //         |-> clinic
-    //         |-> clinic
+    // For restricted users. Hoist the highest place they have access to, to the
+    // top of the tree.
     var firstNonStubNode = function(children) {
-      if (children[0] && children[0].doc.stub) {
+      // Only hoist if there is one child. This will be the case for CHWs. There
+      // may be situations where the first child is a stub but there are more
+      // children, in which case we want to expose that in the UI.
+      if (children.length === 1 && children[0].doc.stub) {
         return firstNonStubNode(children[0].children);
       } else {
         return children;

--- a/templates/partials/filters/facility.html
+++ b/templates/partials/filters/facility.html
@@ -1,4 +1,4 @@
-<span id="facilityDropdown" class="filter dropdown mm-dropdown multidropdown" data-label-no-filter="All facilities" data-filter-label="Number of facilities" ng-show="facilities.length" ng-class="{ 'disabled': selectMode && selected.length }">
+<span id="facilityDropdown" class="filter dropdown mm-dropdown multidropdown" data-label-no-filter="All facilities" data-filter-label="Number of facilities" ng-show="facilities.length && (facilities.length > 1 || facilities[0].children.length)" ng-class="{ 'disabled': selectMode && selected.length }">
   <span id="facility" class="mm-button" data-toggle="dropdown">
     <span class="mm-button-icon">
       <span class="fa fa-hospital-o"></span>

--- a/templates/partials/filters/facility_items.html
+++ b/templates/partials/filters/facility_items.html
@@ -1,4 +1,4 @@
-<a role="menuitem" tabindex="-1" data-value="{{::facility.doc._id}}" class="{{:: 'indent-' + facilityDepth}}">{{::facility.doc.name}}</a>
+<a role="menuitem" tabindex="-1" data-value="{{::facility.doc._id}}" class="{{:: 'indent-' + facilityDepth}}">{{::facility.doc.name || ((isAdmin ? 'facility.deleted' : 'facility.unavailable') | translate)}}</a>
 <ul class="mm-dropdown-submenu">
   <li role="presentation" ng-repeat="facility in ::facility.children | orderBy:'doc.name'" ng-include="::'templates/partials/filters/facility_items.html'" ng-init="facilityDepth = facilityDepth + 1"></li>
 </ul>

--- a/templates/partials/filters/facility_items.html
+++ b/templates/partials/filters/facility_items.html
@@ -1,4 +1,4 @@
-<a role="menuitem" tabindex="-1" data-value="{{::facility.doc._id}}" class="{{:: 'indent-' + facilityDepth}}">{{::facility.doc.name || ((isAdmin ? 'facility.deleted' : 'facility.unavailable') | translate)}}</a>
+<a role="menuitem" tabindex="-1" data-value="{{::facility.doc._id}}" class="{{:: 'indent-' + facilityDepth}}">{{::facility.doc.name || ((isAdmin ? 'place.deleted' : 'place.unavailable') | translate)}}</a>
 <ul class="mm-dropdown-submenu">
   <li role="presentation" ng-repeat="facility in ::facility.children | orderBy:'doc.name'" ng-include="::'templates/partials/filters/facility_items.html'" ng-init="facilityDepth = facilityDepth + 1"></li>
 </ul>

--- a/tests/karma/unit/controllers/reports.js
+++ b/tests/karma/unit/controllers/reports.js
@@ -68,24 +68,25 @@ describe('ReportsCtrl controller', () => {
     createController = () => {
       return $controller('ReportsCtrl', {
         '$scope': scope,
-        'UserDistrict': UserDistrict,
-        'Changes': Changes,
-        'MarkRead': MarkRead,
-        'Search': Search,
-        'Verified': {},
-        'DeleteDocs': {},
-        'UpdateFacility': {},
-        'MessageState': {},
-        'EditGroup': {},
-        'FormatDataRecord': FormatDataRecord,
-        'Settings': KarmaUtils.nullPromise(),
-        'DB': KarmaUtils.mockDB({ get: get, post: post })(),
-        'LiveList': LiveList,
-        'ReportViewModelGenerator': {},
         'AddReadStatus': () => {},
-        'Tour': () => {},
+        'Changes': Changes,
+        'DB': KarmaUtils.mockDB({ get: get, post: post })(),
+        'DeleteDocs': {},
+        'EditGroup': {},
+        'Export': () => {},
+        'FormatDataRecord': FormatDataRecord,
+        'LiveList': LiveList,
+        'MarkRead': MarkRead,
+        'MessageState': {},
+        'ReportViewModelGenerator': {},
+        'Search': Search,
         'SearchFilters': () => {},
-        'Export': () => {}
+        'Settings': KarmaUtils.nullPromise(),
+        'Session': {isAdmin: () => {}},
+        'Tour': () => {},
+        'UpdateFacility': {},
+        'UserDistrict': UserDistrict,
+        'Verified': {}
       });
     };
   }));

--- a/tests/karma/unit/services/place-hierarchy.js
+++ b/tests/karma/unit/services/place-hierarchy.js
@@ -1,4 +1,4 @@
-describe.skip('PlaceHierarchy service', () => {
+describe('PlaceHierarchy service', () => {
 
   'use strict';
 
@@ -52,7 +52,7 @@ describe.skip('PlaceHierarchy service', () => {
     const b = { _id: 'b', parent: { _id: 'c' } };
     const c = { _id: 'c' };
     const d = { _id: 'd', parent: { _id: 'b', parent: { _id: 'c' } } };
-    const e = { _id: 'e', parent: { _id: 'x' } }; // unknown parent is ignored
+    const e = { _id: 'e', parent: { _id: 'x' } };
     const f = { _id: 'f' };
     Contacts.returns(Promise.resolve([ a, b, c, d, e, f ]));
     return service().then(actual => {
@@ -76,6 +76,16 @@ describe.skip('PlaceHierarchy service', () => {
               ]
             }
           ]
+        },
+        {
+          doc: {
+            _id: 'x',
+            stub: true
+          },
+          children: [{
+            doc: e,
+            children: []
+          }]
         },
         {
           doc: f,

--- a/tests/karma/unit/services/place-hierarchy.js
+++ b/tests/karma/unit/services/place-hierarchy.js
@@ -85,7 +85,6 @@ describe('PlaceHierarchy service', () => {
     });
   });
 
-
   it('pulls the hierarchy level from config', () => {
     Contacts.returns(Promise.resolve([]));
     settings.place_hierarchy_types = ['a', 'b', 'c'];
@@ -93,5 +92,7 @@ describe('PlaceHierarchy service', () => {
       chai.expect(Contacts.args[0][0]).to.deep.equal(settings.place_hierarchy_types);
     });
   });
+
+  it('supports partial hierarchies that have parent stubs');
 
 });

--- a/tests/karma/unit/services/place-hierarchy.js
+++ b/tests/karma/unit/services/place-hierarchy.js
@@ -1,4 +1,4 @@
-describe('PlaceHierarchy service', () => {
+describe.skip('PlaceHierarchy service', () => {
 
   'use strict';
 

--- a/translations/messages-en.properties
+++ b/translations/messages-en.properties
@@ -969,3 +969,5 @@ No\ submission = Do not share impact data
 Submit\ via\ web = Internet only
 Submit\ via\ sms = SMS only
 Submit\ via\ either = Try internet first, then SMS
+facility.deleted = [deleted]
+facility.unavailable = [unavailable]

--- a/translations/messages-en.properties
+++ b/translations/messages-en.properties
@@ -969,5 +969,5 @@ No\ submission = Do not share impact data
 Submit\ via\ web = Internet only
 Submit\ via\ sms = SMS only
 Submit\ via\ either = Try internet first, then SMS
-facility.deleted = [deleted]
-facility.unavailable = [unavailable]
+place.deleted = [deleted]
+place.unavailable = [unavailable]


### PR DESCRIPTION
Change the stub removal rules so that you hoist the children of a stub up a
level in cases where there is only one parent stub to a collection of children.
This means restricted users will have the parents they are unable to see hidden,
but we won't just throw away arbitrary trees of facilities because there is a
stub at some level.

Changed the UI so that if it has to display a stub facility it says [deleted]
for admins (because we know it's deleted) and [unavailable] for restricted
users, because it may be deleted, or we may just not have permissions to see it.

medic/medic-webapp#3902

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.