### PR TITLE
[wip] Consider using closure compiler

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -208,7 +208,7 @@ module.exports = function(grunt) {
               'mv static/dist/inbox.js.bak static/dist/inbox.js && ' +
               'java -jar ./closure-compiler-v20171023.jar static/dist/templates.js > static/dist/templates.js.bak 2> build/closure-compiler.log && ' +
               'mv static/dist/templates.js.bak static/dist/templates.js) || ' +
-             'cat build/closure-compiler.log',
+             '(cat build/closure-compiler.log && exit 1)',
       },
       deploy: {
         cmd: 'kanso push $COUCH_URL'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -203,6 +203,12 @@ module.exports = function(grunt) {
       }
     },
     exec: {
+      closureCompiler: {
+        cmd: 'java -jar ./closure-compiler-v20171023.jar --strict_mode_input false static/dist/inbox.js > static/dist/inbox.js.bak 2> build/closure-compiler.log && ' +
+             'mv static/dist/inbox.js.bak static/dist/inbox.js && ' +
+             'java -jar ./closure-compiler-v20171023.jar static/dist/templates.js > static/dist/templates.js.bak 2> build/closure-compiler.log && ' +
+             'mv static/dist/templates.js.bak static/dist/templates.js',
+      },
       deploy: {
         cmd: 'kanso push $COUCH_URL'
       },
@@ -570,6 +576,7 @@ module.exports = function(grunt) {
   // CI tasks
   grunt.registerTask('minify', 'Minify JS and CSS', [
     'uglify',
+    'exec:closureCompiler',
     'cssmin',
     'exec:bundlesize'
   ]);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -575,8 +575,8 @@ module.exports = function(grunt) {
 
   // CI tasks
   grunt.registerTask('minify', 'Minify JS and CSS', [
-    'uglify',
     'exec:closureCompiler',
+    'uglify',
     'cssmin',
     'exec:bundlesize'
   ]);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -204,10 +204,11 @@ module.exports = function(grunt) {
     },
     exec: {
       closureCompiler: {
-        cmd: 'java -jar ./closure-compiler-v20171023.jar --strict_mode_input false static/dist/inbox.js > static/dist/inbox.js.bak 2> build/closure-compiler.log && ' +
-             'mv static/dist/inbox.js.bak static/dist/inbox.js && ' +
-             'java -jar ./closure-compiler-v20171023.jar static/dist/templates.js > static/dist/templates.js.bak 2> build/closure-compiler.log && ' +
-             'mv static/dist/templates.js.bak static/dist/templates.js',
+        cmd: '(java -jar ./closure-compiler-v20171023.jar --strict_mode_input false static/dist/inbox.js > static/dist/inbox.js.bak 2> build/closure-compiler.log && ' +
+              'mv static/dist/inbox.js.bak static/dist/inbox.js && ' +
+              'java -jar ./closure-compiler-v20171023.jar static/dist/templates.js > static/dist/templates.js.bak 2> build/closure-compiler.log && ' +
+              'mv static/dist/templates.js.bak static/dist/templates.js) || ' +
+             'cat build/closure-compiler.log',
       },
       deploy: {
         cmd: 'kanso push $COUCH_URL'


### PR DESCRIPTION
Using closure compiler before the uglify step in our javascript build seems to make `inbox.js` a little smaller (1%):

build options | `inbox.js` / KB | `templates.js` / KB
---|---|---
uglify only (current) | 733.78 | 24.11
cc only | 745.26 | 24.11 | 24.11
cc uglify | 726.13 | 24.1
uglify cc | 745.62 | 24.13

Will be interesting to see if e2e tests pass...

If you use CC in strict mode, it shouldmake things smaller stlll.  However, both libphonenumber and leaflet (included for enketo geopoint inputs, perhaps unnecessarily) violate the strict mode by referencing `arguments.callee` (perhaps dangerously?  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode?redirectlocale=en-US&redirectslug=JavaScript%2FStrict_mode).

This PR (and above data) is using the non-aggressive setting of CC.  With aggressive, we'd lose another 50KB or so of file size, but it wold need a _lot_ of config to make it actually work.

N.B. I'm unsure how much this is worth the effort, and the (long) time it takes CC to run.

# TODO

If this were actually to make it to production, consider:
- [ ] using an npm package to include the closure compiler (create if non existent)
