### PR TITLE
Make disabled labels in enketo forms hidden

### DIFF
--- a/static/css/inbox.less
+++ b/static/css/inbox.less
@@ -762,6 +762,9 @@ a.fa:hover {
       }
 
       label {
+        &:disabled {
+          display: none;
+        }
         display: block;
         margin: 0;
       }


### PR DESCRIPTION
Issue #4010

Fix feels hacky.  @garethbowen do you remember why the fix for https://github.com/medic/medic-webapp/issues/3521 changed the css for the `.messages .item-content` as well as for `.tasks .item-content?