### PR TITLE
Remote bottom margin for last material card on screen

### DIFF
--- a/static/css/material.less
+++ b/static/css/material.less
@@ -7,6 +7,9 @@
     padding-top: 0;
     padding-bottom: 0;
     clear: both;
+    &:last-child {
+      margin-bottom: 0;
+    }
     a.cell {
       display: inline-block;
       width: 100%;


### PR DESCRIPTION
Issue #4012

This feels hacky...  It might be safer for future material design stuff to be more explicit about _where_ this child should be, e.g. `.item-content.material > .card:last-child`?