### PR TITLE
Make disabled labels in enketo forms hidden again

### DIFF
--- a/static/css/inbox.less
+++ b/static/css/inbox.less
@@ -761,15 +761,14 @@ a.fa:hover {
         }
       }
 
-      label {
-        display: block;
-        margin: 0;
-      }
-
       .missing p {
         color: @lightgrey;
       }
 
+    }
+    label {
+      display: block;
+      margin: 0;
     }
     .task-list > li {
       margin-top: 10px;


### PR DESCRIPTION
Issue #4010 

I can't find any `.item-content label` instances which are not also `.item-content .body label`, so unless any are created programmatically (apart from the enketo ones), then this change should be safe.

# TODO

- [ ] backport to 2.14.x