### PR TITLE
Make android feature detection safer

### DIFF
--- a/static/js/bootstrapper.js
+++ b/static/js/bootstrapper.js
@@ -71,7 +71,7 @@ var utils = require('kujua-utils');
   };
 
   var getDataUsage = function() {
-    if (window.medicmobile_android && window.medicmobile_android.getDataUsage) {
+    if (window.medicmobile_android && typeof window.medicmobile_android.getDataUsage === 'function') {
       return JSON.parse(window.medicmobile_android.getDataUsage());
     }
   };

--- a/static/js/controllers/about.js
+++ b/static/js/controllers/about.js
@@ -38,7 +38,7 @@ angular.module('inboxControllers').controller('AboutCtrl',
     };
     $scope.$watch('enableDebugModel.val', Debug.set);
 
-    if (window.medicmobile_android && window.medicmobile_android.getDataUsage) {
+    if (window.medicmobile_android && typeof window.medicmobile_android.getDataUsage === 'function') {
       $scope.androidDataUsage = JSON.parse(window.medicmobile_android.getDataUsage());
 
       var dataUsageUpdate = $interval(function() {

--- a/static/js/controllers/inbox.js
+++ b/static/js/controllers/inbox.js
@@ -126,7 +126,7 @@ var feedback = require('../modules/feedback'),
       $scope.baseUrl = Location.path;
       $scope.enketoStatus = { saving: false };
 
-      if ($window.medicmobile_android) {
+      if ($window.medicmobile_android && typeof $window.medicmobile_android.getAppVersion === 'function') {
         $scope.android_app_version = $window.medicmobile_android.getAppVersion();
       }
 

--- a/static/js/enketo/widgets/android-datepicker.js
+++ b/static/js/enketo/widgets/android-datepicker.js
@@ -60,7 +60,7 @@ define( function( require, exports, module ) {
     Androiddatepicker.prototype.constructor = Androiddatepicker;
 
     Androiddatepicker.prototype._init = function() {
-        if ( !window.medicmobile_android || !window.medicmobile_android.datePicker ) {
+        if ( !window.medicmobile_android || typeof window.medicmobile_android.datePicker !== 'function' ) {
             return;
         }
 

--- a/static/js/enketo/widgets/countdown-widget.js
+++ b/static/js/enketo/widgets/countdown-widget.js
@@ -101,12 +101,11 @@ function TimerAnimation(canvas, canvasW, canvasH, duration) {
     var audio = (function() {
         var cached;
 
-        if(!isAndroid()) {
-            cached = loadSound();
-        }
+        var androidSoundSupport = window.medicmobile_android &&
+                typeof window.medicmobile_android.playAlert === 'function';
 
-        function isAndroid() {
-            return typeof medicmobile_android !== 'undefined';
+        if(!androidSoundSupport) {
+            cached = loadSound();
         }
 
         function loadSound() {
@@ -115,7 +114,7 @@ function TimerAnimation(canvas, canvasW, canvasH, duration) {
 
         return {
             play: function() {
-                if(isAndroid()) {
+                if(androidSoundSupport) {
                     medicmobile_android.playAlert();
                 } else {
                     cached.play();

--- a/static/js/services/simprints.js
+++ b/static/js/services/simprints.js
@@ -39,7 +39,7 @@ angular.module('inboxServices').service('Simprints',
       enabled: function() {
         return !!(
           $window.medicmobile_android &&
-          $window.medicmobile_android.simprints_available &&
+          typeof $window.medicmobile_android.simprints_available === 'function' &&
           $window.medicmobile_android.simprints_available()
         );
       },


### PR DESCRIPTION
# Description

Previously some checks assume:
1. if `medicmobile_android` is present, then a particular function may also be present
2. if `medicmobile_android` has a particular property, that property must refer to a function

The 2nd assumption seems safer than the first, but currently working on a bug which is visible because of `1`: https://github.com/medic/medic-projects/issues/3092

_Perhaps_ it's better that this bug has surfaced - if this PR is accepted, then future problems like this will just make webapp think that its not running on a phone...