### PR TITLE
Block restricted users from access couchdb

### DIFF
--- a/api/auth.js
+++ b/api/auth.js
@@ -28,6 +28,10 @@ var isDbAdmin = function(userCtx) {
   return hasRole(userCtx, '_admin');
 };
 
+var isNationalAdmin = function(userCtx) {
+  return hasRole(userCtx, 'national_admin');
+};
+
 var hasPermission = function(userCtx, permission) {
   var perm = _.findWhere(config.get('permissions'), { name: permission });
   if (!perm) {
@@ -63,6 +67,14 @@ module.exports = {
       }
 
       callback(null, isDbAdmin(userCtx));
+    });
+  },
+  canAccessAllData: function(req, callback) {
+    module.exports.getUserCtx(req, (err, userCtx) => {
+      if (err) {
+        return callback(err);
+      }
+      callback(null, isDbAdmin(userCtx) || isNationalAdmin(userCtx));
     });
   },
   hasAllPermissions: function(userCtx, permissions) {


### PR DESCRIPTION
Previously any request to an that wasn't explicitely handled was
proxied on to couchdb to let it handle permissions. This change
means only db admins and national admins who already have full
data access get proxied through to couchdb. This greatly reduces
the access available to restricted users meaning we can provide
fine grained document level permissions.

Issue: #2734

# Description

[description]

medic/medic-webapp#[number]

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.