### PR TITLE
Remove bad assumption from uniqueWithin validation

### DIFF
--- a/sentinel/lib/validation.js
+++ b/sentinel/lib/validation.js
@@ -54,19 +54,12 @@ const _exists = (doc, fields, options, callback) => {
                 return callback(err);
             }
             // filter out docs with errors
-            const rows = result.rows.filter(row => {
-                return (!row.doc.errors || row.doc.errors.length === 0);
+            const found = result.rows.some(row => {
+                const doc = row.doc;
+                return (!doc.errors || doc.errors.length === 0) &&
+                       (!options.startDate || doc.reported_date >= options.startDate);
             });
-            if (!rows.length) {
-                return callback(null, false);
-            }
-            if (!options.startDate) {
-                return callback(null, true);
-            }
-            // the views all respond with the reported_date as the value
-            // and in ascending order so check the last value in the intersection
-            const latestReportedDate = rows[rows.length - 1].doc.reported_date;
-            callback(null, latestReportedDate >= options.startDate);
+            return callback(null, found);
         });
     });
 };

--- a/sentinel/test/unit/validations.js
+++ b/sentinel/test/unit/validations.js
@@ -241,17 +241,40 @@ exports['fail uniqueWithin validation on new doc'] = function(test) {
     test.expect(1);
     clock = sinon.useFakeTimers();
     sinon.stub(db.medic, 'view').callsArgWith(3, null, {
-        rows: [{ id: 'different' }]
+        rows: [
+            { id: 'different1' },
+            { id: 'different2' },
+            { id: 'different3' }
+        ]
     });
+    // rows are sorted based on uuid not on date, so we have to check all docs
     sinon.stub(db.medic, 'fetch').callsArgWith(1, null, {
-        rows: [{
-            id: 'different',
-            doc: {
-                _id: 'different',
-                errors: [],
-                reported_date: moment().subtract(1, 'weeks').valueOf()
+        rows: [
+            {
+                id: 'different1',
+                doc: {
+                    _id: 'different1',
+                    errors: [],
+                    reported_date: moment().subtract(3, 'weeks').valueOf()
+                }
+            },
+            {
+                id: 'different2',
+                doc: {
+                    _id: 'different2',
+                    errors: [],
+                    reported_date: moment().subtract(1, 'weeks').valueOf()
+                }
+            },
+            {
+                id: 'different3',
+                doc: {
+                    _id: 'different3',
+                    errors: [],
+                    reported_date: moment().subtract(10, 'weeks').valueOf()
+                }
             }
-        }]
+        ]
     });
     var validations = [{
         property: 'xyz',


### PR DESCRIPTION
# Description

The view sorting doesn't work as expected so resort to checking the
reported_date of each doc until one is found.

medic/medic-webapp#651

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.