### PR TITLE
Don't allow unqualified medicmobile_android references

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -77,7 +77,6 @@
     // Custom Globals
     "globals"       : {         // additional predefined global variables
         "angular"   : true,
-        "medicmobile_android": true,
         "Tour"      : true,
         "unescape"  : true
     }

--- a/static/js/enketo/widgets/android-datepicker.js
+++ b/static/js/enketo/widgets/android-datepicker.js
@@ -90,9 +90,9 @@ define( function( require, exports, module ) {
                     $el.attr( 'data-mm-android-dp', randomId );
 
                     if ( val ) {
-                        medicmobile_android.datePicker( selector, val );
+                        window.medicmobile_android.datePicker( selector, val );
                     } else {
-                        medicmobile_android.datePicker( selector );
+                        window.medicmobile_android.datePicker( selector );
                     }
                 });
             });

--- a/static/js/enketo/widgets/countdown-widget.js
+++ b/static/js/enketo/widgets/countdown-widget.js
@@ -115,7 +115,7 @@ function TimerAnimation(canvas, canvasW, canvasH, duration) {
         return {
             play: function() {
                 if(androidSoundSupport) {
-                    medicmobile_android.playAlert();
+                    window.medicmobile_android.playAlert();
                 } else {
                     cached.play();
                 }


### PR DESCRIPTION
# Description

Seems weird to have a lint exception for this, especially when we're often referencing it via `window` (or `$window`).