### PR TITLE
Force icons to our dimensions

### DIFF
--- a/static/css/content-list.less
+++ b/static/css/content-list.less
@@ -51,9 +51,10 @@
       align-self: start;
       margin: 5px;
       margin-left: -10px;
-      img {
-        max-height: 30px;
-        max-width: 30px;
+      img,
+      svg {
+        height: @icon-small;
+        width: @icon-small;
       }
     }
 

--- a/static/css/dropdown.less
+++ b/static/css/dropdown.less
@@ -44,6 +44,11 @@
       overflow: hidden;
       text-overflow: ellipsis;
     }
+    img,
+    svg {
+      width: @icon-small;
+      height: @icon-small;
+    }
     &:after {
       color: @grey;
       content: '\f054'; // http://fontawesome.io/icon/chevron-right/

--- a/static/css/material.less
+++ b/static/css/material.less
@@ -44,8 +44,8 @@
     align-items: center;
     img,
     svg {
-      width: 60px;
-      height: 60px;
+      width: @icon-large;
+      height: @icon-large;
       margin-left: -10px;
       margin-right: 5px;
     }

--- a/static/css/targets.less
+++ b/static/css/targets.less
@@ -51,8 +51,10 @@
       }
       .icon {
         float: left;
-        img {
-          width: 60px;
+        img,
+        svg {
+          width: @icon-large;
+          height: @icon-large;
         }
       }
     }

--- a/static/css/theme.less
+++ b/static/css/theme.less
@@ -174,6 +174,11 @@ ul {
   padding: 10px;
   .icon {
     float: left;
+    img,
+    svg {
+      width: @icon-small;
+      height: @icon-small;
+    }
   }
   .detail {
     overflow: auto;

--- a/static/css/variables.less
+++ b/static/css/variables.less
@@ -66,6 +66,9 @@
 @font-medium: 1rem;
 @font-small: 0.875rem;
 
+@icon-small: 30px;
+@icon-large: 60px;
+
 .button-text() {
   color: @button-text-color;
   text-shadow: rgba(255, 255, 255, 0.5) 1px 1px 2px;


### PR DESCRIPTION
# Description

We have two sizes of icons: 30px by 30px and 60px by 60px. All
icons are to be scaled to these sizes. This may cause scaling
issues for small or non-square icons but these should be replaced
with square svgs.

medic/medic-webapp#4063

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.