### PR TITLE
Make Simprints registration input field visible

### DIFF
--- a/static/js/enketo/widgets/simprints.js
+++ b/static/js/enketo/widgets/simprints.js
@@ -33,7 +33,7 @@ define( function( require, exports, module ) {
     Simprintswidget.prototype._init = function() {
         var $el = $( this.element );
         var $input = $el.find( 'input' );
-        $input.hide();
+        $input.attr( 'disabled', true );
         var angularServices = angular.element( document.body ).injector();
         var $translate = angularServices.get( '$translate' );
         var service = angularServices.get( 'Simprints' );


### PR DESCRIPTION
This means that user can see when they have succesfully set a value for this
field.

Issue: #3511

