### PR TITLE
Log when sentinel catches up to the changes feed on start up

### DIFF
--- a/sentinel/test/unit/transitions.js
+++ b/sentinel/test/unit/transitions.js
@@ -206,7 +206,7 @@ exports['attach handles missing meta data doc'] = test => {
   sinon.stub(audit, 'withNano');
   // wait for the queue processor
   transitions._changeQueue.drain = () => {
-    test.equal(get.callCount, 6);
+    test.equal(get.callCount, 4);
     test.equal(fetchHydratedDoc.callCount, 1);
     test.equal(fetchHydratedDoc.args[0][0], 'abc');
     test.equal(applyTransitions.callCount, 1);

--- a/sentinel/test/unit/transitions.js
+++ b/sentinel/test/unit/transitions.js
@@ -201,12 +201,12 @@ exports['attach handles missing meta data doc'] = test => {
   const insert = sinon.stub(db.medic, 'insert').callsArg(1);
   const on = sinon.stub();
   const start = sinon.stub();
-  sinon.stub(follow, 'Feed').returns({ on: on, follow: start, stop: () => {} });
+  const feed = sinon.stub(follow, 'Feed').returns({ on: on, follow: start, stop: () => {} });
   const applyTransitions = sinon.stub(transitions, 'applyTransitions').callsArg(1);
   sinon.stub(audit, 'withNano');
   // wait for the queue processor
   transitions._changeQueue.drain = () => {
-    test.equal(get.callCount, 4);
+    test.equal(get.callCount, 6);
     test.equal(fetchHydratedDoc.callCount, 1);
     test.equal(fetchHydratedDoc.args[0][0], 'abc');
     test.equal(applyTransitions.callCount, 1);
@@ -218,6 +218,12 @@ exports['attach handles missing meta data doc'] = test => {
     test.done();
   };
   transitions._attach();
+  test.equal(feed.callCount, 1);
+  test.equal(feed.args[0][0].since, 0);
+  test.equal(on.callCount, 3);
+  test.equal(on.args[0][0], 'change');
+  test.equal(on.args[1][0], 'error');
+  test.equal(start.callCount, 1);
   // invoke the change handler
   on.args[0][1]({ id: 'abc', seq: 55 });
 };
@@ -230,7 +236,7 @@ exports['attach handles old meta data doc'] = test => {
   const insert = sinon.stub(db.medic, 'insert').callsArg(1);
   const on = sinon.stub();
   const start = sinon.stub();
-  sinon.stub(follow, 'Feed').returns({ on: on, follow: start, stop: () => {} });
+  const feed = sinon.stub(follow, 'Feed').returns({ on: on, follow: start, stop: () => {} });
   const applyTransitions = sinon.stub(transitions, 'applyTransitions').callsArg(1);
   sinon.stub(audit, 'withNano');
   // wait for the queue processor
@@ -251,6 +257,12 @@ exports['attach handles old meta data doc'] = test => {
     test.done();
   };
   transitions._attach();
+  test.equal(feed.callCount, 1);
+  test.equal(feed.args[0][0].since, 22);
+  test.equal(on.callCount, 3);
+  test.equal(on.args[0][0], 'change');
+  test.equal(on.args[1][0], 'error');
+  test.equal(start.callCount, 1);
   // invoke the change handler
   on.args[0][1]({ id: 'abc', seq: 55 });
 };
@@ -262,7 +274,7 @@ exports['attach handles existing meta data doc'] = test => {
   const insert = sinon.stub(db.medic, 'insert').callsArg(1);
   const on = sinon.stub();
   const start = sinon.stub();
-  sinon.stub(follow, 'Feed').returns({ on: on, follow: start, stop: () => {} });
+  const feed = sinon.stub(follow, 'Feed').returns({ on: on, follow: start, stop: () => {} });
   const applyTransitions = sinon.stub(transitions, 'applyTransitions').callsArg(1);
   sinon.stub(audit, 'withNano');
   // wait for the queue processor
@@ -279,6 +291,12 @@ exports['attach handles existing meta data doc'] = test => {
     test.done();
   };
   transitions._attach();
+  test.equal(feed.callCount, 1);
+  test.equal(feed.args[0][0].since, 22);
+  test.equal(on.callCount, 3);
+  test.equal(on.args[0][0], 'change');
+  test.equal(on.args[1][0], 'error');
+  test.equal(start.callCount, 1);
   // invoke the change handler
   on.args[0][1]({ id: 'abc', seq: 55 });
 };

--- a/sentinel/test/unit/transitions.js
+++ b/sentinel/test/unit/transitions.js
@@ -201,7 +201,7 @@ exports['attach handles missing meta data doc'] = test => {
   const insert = sinon.stub(db.medic, 'insert').callsArg(1);
   const on = sinon.stub();
   const start = sinon.stub();
-  const feed = sinon.stub(follow, 'Feed').returns({ on: on, follow: start, stop: () => {} });
+  sinon.stub(follow, 'Feed').returns({ on: on, follow: start, stop: () => {} });
   const applyTransitions = sinon.stub(transitions, 'applyTransitions').callsArg(1);
   sinon.stub(audit, 'withNano');
   // wait for the queue processor
@@ -218,12 +218,6 @@ exports['attach handles missing meta data doc'] = test => {
     test.done();
   };
   transitions._attach();
-  test.equal(feed.callCount, 1);
-  test.equal(feed.args[0][0].since, 0);
-  test.equal(on.callCount, 2);
-  test.equal(on.args[0][0], 'change');
-  test.equal(on.args[1][0], 'error');
-  test.equal(start.callCount, 1);
   // invoke the change handler
   on.args[0][1]({ id: 'abc', seq: 55 });
 };
@@ -236,7 +230,7 @@ exports['attach handles old meta data doc'] = test => {
   const insert = sinon.stub(db.medic, 'insert').callsArg(1);
   const on = sinon.stub();
   const start = sinon.stub();
-  const feed = sinon.stub(follow, 'Feed').returns({ on: on, follow: start, stop: () => {} });
+  sinon.stub(follow, 'Feed').returns({ on: on, follow: start, stop: () => {} });
   const applyTransitions = sinon.stub(transitions, 'applyTransitions').callsArg(1);
   sinon.stub(audit, 'withNano');
   // wait for the queue processor
@@ -257,12 +251,6 @@ exports['attach handles old meta data doc'] = test => {
     test.done();
   };
   transitions._attach();
-  test.equal(feed.callCount, 1);
-  test.equal(feed.args[0][0].since, 22);
-  test.equal(on.callCount, 2);
-  test.equal(on.args[0][0], 'change');
-  test.equal(on.args[1][0], 'error');
-  test.equal(start.callCount, 1);
   // invoke the change handler
   on.args[0][1]({ id: 'abc', seq: 55 });
 };
@@ -274,7 +262,7 @@ exports['attach handles existing meta data doc'] = test => {
   const insert = sinon.stub(db.medic, 'insert').callsArg(1);
   const on = sinon.stub();
   const start = sinon.stub();
-  const feed = sinon.stub(follow, 'Feed').returns({ on: on, follow: start, stop: () => {} });
+  sinon.stub(follow, 'Feed').returns({ on: on, follow: start, stop: () => {} });
   const applyTransitions = sinon.stub(transitions, 'applyTransitions').callsArg(1);
   sinon.stub(audit, 'withNano');
   // wait for the queue processor
@@ -291,12 +279,6 @@ exports['attach handles existing meta data doc'] = test => {
     test.done();
   };
   transitions._attach();
-  test.equal(feed.callCount, 1);
-  test.equal(feed.args[0][0].since, 22);
-  test.equal(on.callCount, 2);
-  test.equal(on.args[0][0], 'change');
-  test.equal(on.args[1][0], 'error');
-  test.equal(start.callCount, 1);
   // invoke the change handler
   on.args[0][1]({ id: 'abc', seq: 55 });
 };

--- a/sentinel/transitions/index.js
+++ b/sentinel/transitions/index.js
@@ -17,6 +17,9 @@ const _ = require('underscore'),
 
 let changesFeed;
 
+// We log the first time we catch up to the changes feed
+let caughtUpOnce;
+
 /*
  * Add new transitions here to make them available for configuration and execution.
  *
@@ -519,6 +522,12 @@ const attach = () => {
     });
     changesFeed.on('error', err => {
       logger.error('transitions: error from changes feed', err);
+    });
+    changesFeed.on('catchup', seq => {
+      if (!caughtUpOnce) {
+        caughtUpOnce = true;
+        logger.info(`Sentinel caught up to ${seq}`);
+      }
     });
     changesFeed.follow();
   });


### PR DESCRIPTION
It's annoying that we can't tell when sentinel has finished processing.

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.