### PR TITLE
Guard against an empty patient

### DIFF
--- a/sentinel/test/unit/update_notifications.js
+++ b/sentinel/test/unit/update_notifications.js
@@ -209,6 +209,48 @@ exports['registration not found adds error and response'] = function(test) {
     });
 };
 
+exports['patient not found adds error and response'] = function(test) {
+    var doc = {
+        form: 'on',
+        type: 'data_record',
+        fields: { patient_id: 'x' },
+        contact: { phone: 'x' }
+    };
+
+    sinon.stub(transition, 'getConfig').returns({
+        messages: [{
+            event_type: 'on_unmute',
+            message: [{
+                content: 'Thank you {{contact.name}}',
+                locale: 'en'
+            }]
+        }, {
+            event_type: 'patient_not_found',
+            message: [{
+                content: 'not found {{patient_id}}',
+                locale: 'en'
+            }]
+        }],
+        on_form: 'on'
+    });
+    sinon.stub(utils, 'getRegistrations').callsArgWithAsync(1, null, ['a registration']);
+    sinon.stub(utils, 'getPatientContact').callsArgWithAsync(2, null, null);
+
+    transition.onMatch({
+        doc: doc,
+        form: 'on'
+    }, {}, {}, function(err, complete) {
+        test.equals(err, null);
+        test.equals(complete, true);
+        test.equals(doc.errors.length, 1);
+        test.equals(doc.errors[0].message, 'not found x');
+        test.equals(doc.tasks.length, 1);
+        test.equals(doc.tasks[0].messages[0].message, 'not found x');
+        test.equals(doc.tasks[0].messages[0].to, 'x');
+        test.done();
+    });
+};
+
 exports['validation failure adds error and response'] = function(test) {
 
     var doc = {

--- a/sentinel/transitions/update_notifications.js
+++ b/sentinel/transitions/update_notifications.js
@@ -119,7 +119,7 @@ module.exports = {
                     return callback(err);
                 }
 
-                if (registrations.length) {
+                if (registrations.length && patient) {
                     if (eventType.mute) {
                         if (config.confirm_deactivation) {
                             self._addErr('confirm_deactivation', config, doc);


### PR DESCRIPTION
Just as we error if there is no registration, we should also error
if there is no patient. There should no longer be cases where there
are not patients attached.

medic/medic-webapp#4121

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.