### PR TITLE
3657 Hide message and call actions based on configurable permissions

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@
 ### Features
 
 - [#3627](https://github.com/medic/medic-webapp/issues/3627): Generate scheduled messages just-in-time so changes to contacts are reflected in yet to be sent messages. NB: This feature only works with the `translation_key` configuration and not with the deprecated `messages` array so now is a good time to update your configuration.
+- [#3657](https://github.com/medic/medic-webapp/issues/3657): Add permissions to control whether or not users see the call and message buttons on mobile.
 
 ### UI/UX Improvements
 

--- a/api/config.default.json
+++ b/api/config.default.json
@@ -304,20 +304,14 @@
       "name": "can_view_message_action",
       "roles": [
         "national_admin",
-        "district_admin",
-        "data_entry",
-        "analytics",
-        "gateway"
+        "district_admin"
       ]
     },
     {
       "name": "can_view_call_action",
       "roles": [
         "national_admin",
-        "district_admin",
-        "data_entry",
-        "analytics",
-        "gateway"
+        "district_admin"
       ]
     }
   ]

--- a/api/config.default.json
+++ b/api/config.default.json
@@ -299,6 +299,26 @@
         "national_admin",
         "district_admin"
       ]
+    },
+    {
+      "name": "can_view_message_action",
+      "roles": [
+        "national_admin",
+        "district_admin",
+        "data_entry",
+        "analytics",
+        "gateway"
+      ]
+    },
+    {
+      "name": "can_view_call_action",
+      "roles": [
+        "national_admin",
+        "district_admin",
+        "data_entry",
+        "analytics",
+        "gateway"
+      ]
     }
   ]
 }

--- a/api/migrations/add-permissions-configuration.js
+++ b/api/migrations/add-permissions-configuration.js
@@ -138,6 +138,26 @@ var DEFAULT_PERMISSIONS = [
       'national_admin',
       'district_admin'
     ]
+  },
+  {
+    name: 'can_view_message_action',
+    roles: [
+      'national_admin',
+      'district_admin',
+      'data_entry',
+      'analytics',
+      'gateway'
+    ]
+  },
+  {
+    name: 'can_view_call_action',
+    roles: [
+      'national_admin',
+      'district_admin',
+      'data_entry',
+      'analytics',
+      'gateway'
+    ]
   }
 ];
 

--- a/api/migrations/add-permissions-configuration.js
+++ b/api/migrations/add-permissions-configuration.js
@@ -143,20 +143,14 @@ var DEFAULT_PERMISSIONS = [
     name: 'can_view_message_action',
     roles: [
       'national_admin',
-      'district_admin',
-      'data_entry',
-      'analytics',
-      'gateway'
+      'district_admin'
     ]
   },
   {
     name: 'can_view_call_action',
     roles: [
       'national_admin',
-      'district_admin',
-      'data_entry',
-      'analytics',
-      'gateway'
+      'district_admin'
     ]
   }
 ];

--- a/api/migrations/add-permissions-configuration.js
+++ b/api/migrations/add-permissions-configuration.js
@@ -95,7 +95,7 @@ var DEFAULT_PERMISSIONS = [
     roles: [
       'national_admin',
       'district_admin',
-      'date_entry',
+      'data_entry',
       'gateway'
     ]
   },

--- a/templates/partials/actionbar.html
+++ b/templates/partials/actionbar.html
@@ -153,15 +153,15 @@
             <p translate>action.person.add</p>
           </a>
 
-          <a class="mm-icon mm-icon-inverse mm-icon-caption mobile-only" href="tel:{{actionBar.right.sendTo.phone}}" ng-class="{'mm-icon-disabled': !actionBar.right.sendTo.phone}" ng-show="actionBar.right.sendTo">
+          <a class="mm-icon mm-icon-inverse mm-icon-caption mobile-only" href="tel:{{actionBar.right.sendTo.phone}}" ng-class="{'mm-icon-disabled': !actionBar.right.sendTo.phone}" ng-show="actionBar.right.sendTo" mm-auth="can_view_call_action">
             <span class="fa fa-phone"></span>
             <p translate>call</p>
           </a>
-          <a class="mm-icon mm-icon-inverse mm-icon-caption mobile-only" href="sms:{{actionBar.right.sendTo.phone}}" ng-class="{'mm-icon-disabled': !actionBar.right.sendTo.phone}" ng-show="actionBar.right.sendTo">
+          <a class="mm-icon mm-icon-inverse mm-icon-caption mobile-only" href="sms:{{actionBar.right.sendTo.phone}}" ng-class="{'mm-icon-disabled': !actionBar.right.sendTo.phone}" ng-show="actionBar.right.sendTo" mm-auth="can_view_message_action">
             <span class="fa fa-envelope"></span>
             <p translate>Send Message</p>
           </a>
-          <a class="mm-icon mm-icon-inverse mm-icon-caption send-message desktop-only" data-send-to="{{actionBar.right.sendTo._id}}" ng-class="{'mm-icon-disabled': !actionBar.right.sendTo.phone}" ng-show="actionBar.right.sendTo">
+          <a class="mm-icon mm-icon-inverse mm-icon-caption send-message desktop-only" data-send-to="{{actionBar.right.sendTo._id}}" ng-class="{'mm-icon-disabled': !actionBar.right.sendTo.phone}" ng-show="actionBar.right.sendTo" mm-auth="can_view_message_action">
             <span class="fa fa-envelope"></span>
             <p translate>Send Message</p>
           </a>


### PR DESCRIPTION
# Description

Added two new permissions to the configuration in medic-webapp: `can_view_message_action` and 
`can_view_call_action` to determine whether these actions are available to particular users.

Also wasn't 100% clear on when the `config.default.json` is used along with the add permissions migration, but figured it probably needed to be added to both.

medic/medic-webapp#3657

# Review checklist

- [x] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [x] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.