### PR TITLE
Adding Translation-Keys option to the list of languages

### DIFF
--- a/static/js/controllers/configuration-translation-application.js
+++ b/static/js/controllers/configuration-translation-application.js
@@ -34,8 +34,8 @@ angular.module('inboxControllers').controller('ConfigurationTranslationApplicati
     };
 
     var updateTranslationModels = function() {
-      var lhsOption = $scope.localeModel.lhs === TRANSLATION_KEYS_OPTION.doc.code ?
-                        DEFAULT_LANGUAGE : $scope.localeModel.lhs;
+      var showKeys = $scope.localeModel.lhs === TRANSLATION_KEYS_OPTION.doc.code;
+      var lhsOption =  showKeys ? DEFAULT_LANGUAGE : $scope.localeModel.lhs;
       var lhsTranslation = findTranslation(lhsOption);
       var rhsTranslation = findTranslation($scope.localeModel.rhs);
       var lhs = (lhsTranslation && lhsTranslation.values) || {};
@@ -43,7 +43,7 @@ angular.module('inboxControllers').controller('ConfigurationTranslationApplicati
       $scope.translationModels = Object.keys(lhs).map(function(key) {
         return {
           key: key,
-          lhs: lhs[key],
+          lhs: showKeys ? key : lhs[key],
           rhs: rhs[key]
         };
       });

--- a/static/js/controllers/configuration-translation-application.js
+++ b/static/js/controllers/configuration-translation-application.js
@@ -1,5 +1,8 @@
 var _ = require('underscore');
 
+var TRANSLATION_KEYS_OPTION = { doc: {code: 'keys', name: 'Translation Keys'} };
+var DEFAULT_LANGUAGE = 'en';
+
 angular.module('inboxControllers').controller('ConfigurationTranslationApplicationCtrl',
   function (
     $log,
@@ -18,8 +21,8 @@ angular.module('inboxControllers').controller('ConfigurationTranslationApplicati
         return translation.doc.code !== language;
       });
       $scope.localeModel = {
-        lhs: language || 'en',
-        rhs: rhs && rhs.doc.code || 'en'
+        lhs: language || DEFAULT_LANGUAGE,
+        rhs: rhs && rhs.doc.code || DEFAULT_LANGUAGE
       };
     };
 
@@ -31,7 +34,9 @@ angular.module('inboxControllers').controller('ConfigurationTranslationApplicati
     };
 
     var updateTranslationModels = function() {
-      var lhsTranslation = findTranslation($scope.localeModel.lhs);
+      var lhsOption = $scope.localeModel.lhs === TRANSLATION_KEYS_OPTION.doc.code ?
+                        DEFAULT_LANGUAGE : $scope.localeModel.lhs;
+      var lhsTranslation = findTranslation(lhsOption);
       var rhsTranslation = findTranslation($scope.localeModel.rhs);
       var lhs = (lhsTranslation && lhsTranslation.values) || {};
       var rhs = (rhsTranslation && rhsTranslation.values) || {};
@@ -53,6 +58,7 @@ angular.module('inboxControllers').controller('ConfigurationTranslationApplicati
         })
         .then(function(results) {
           $scope.translations = results.rows;
+          $scope.translationOptions = _.union([TRANSLATION_KEYS_OPTION], $scope.translations);
         })
         .catch(function(err) {
           $log.error('Error fetching translation documents', err);

--- a/templates/partials/configuration_translation_application.html
+++ b/templates/partials/configuration_translation_application.html
@@ -15,7 +15,7 @@
   </div>
   <div class="row translation selection" ng-repeat="translation in translationModels track by translation.key" ng-click="editTranslation(translation.key)">
     <div class="col-xs-6">
-      {{ localeModel.lhs === 'keys' ? translation.key : translation.lhs }}
+      {{translation.lhs}}
     </div>
     <div class="col-xs-6">
       {{translation.rhs}}

--- a/templates/partials/configuration_translation_application.html
+++ b/templates/partials/configuration_translation_application.html
@@ -7,7 +7,7 @@
 <div class="section">
   <div class="row selection-heading">
     <div class="col-xs-6">
-      <select class="form-control small" ng-model="localeModel.lhs" ng-options="translation.doc.code as translation.doc.name for translation in translations"></select>
+      <select class="form-control small" ng-model="localeModel.lhs" ng-options="translation.doc.code as translation.doc.name for translation in translationOptions"></select>
     </div>
     <div class="col-xs-6">
       <select class="form-control small" ng-model="localeModel.rhs" ng-options="translation.doc.code as translation.doc.name for translation in translations"></select>
@@ -15,7 +15,7 @@
   </div>
   <div class="row translation selection" ng-repeat="translation in translationModels track by translation.key" ng-click="editTranslation(translation.key)">
     <div class="col-xs-6">
-      {{translation.lhs}}
+      {{ localeModel.lhs === 'keys' ? translation.key : translation.lhs }}
     </div>
     <div class="col-xs-6">
       {{translation.rhs}}


### PR DESCRIPTION
# Description
Adding Translation-Keys option to the list of languages

medic/medic-webapp#3022

# Review checklist

- [x] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.