### PR TITLE
Adding support to delete a user with enter

### DIFF
--- a/static/js/directives/enter.js
+++ b/static/js/directives/enter.js
@@ -1,19 +1,22 @@
 /**
  * Directive to detect enter key
  * */
-angular.module('inboxDirectives').directive('ngEnter', function($document) {
+angular.module('inboxDirectives').directive('mmEnter', function($document) {
   'use strict';
   return {
     restrict: 'A',
     link: function(scope, elem, attrs) {
       var keydownEvent = function(event) {
         if (event.which === 13) {
-          scope.$eval(attrs.ngEnter);
+          scope.$eval(attrs.mmEnter);
           event.preventDefault();
           $document.unbind('keydown keypress', keydownEvent);
         }
       };
       $document.bind('keydown keypress', keydownEvent);
+      scope.$on('$destroy', function() {
+        $document.unbind('keydown keypress', keydownEvent);
+      });
     }
   };
 });

--- a/static/js/directives/enter.js
+++ b/static/js/directives/enter.js
@@ -1,0 +1,19 @@
+/**
+ * Directive to detect enter key
+ * */
+angular.module('inboxDirectives').directive('ngEnter', function($document) {
+  'use strict';
+  return {
+    restrict: 'A',
+    link: function(scope, elem, attrs) {
+      var keydownEvent = function(event) {
+        if (event.which === 13) {
+          scope.$eval(attrs.ngEnter);
+          event.preventDefault();
+          $document.unbind('keydown keypress', keydownEvent);
+        }
+      };
+      $document.bind('keydown keypress', keydownEvent);
+    }
+  };
+});

--- a/static/js/directives/index.js
+++ b/static/js/directives/index.js
@@ -10,5 +10,6 @@
   require('./modal');
   require('./report-image');
   require('./sender');
+  require('./enter');
 
 }());

--- a/templates/directives/modal.html
+++ b/templates/directives/modal.html
@@ -7,7 +7,7 @@
   <div class="modal-footer">
     <p class="note" ng-if="status.error" translate>{{status.error}}</p>
     <a class="btn cancel" ng-class="{ 'disabled': status.processing }" ng-click="onCancel()" translate>{{cancelKey || 'Cancel'}}</a>
-    <a class="btn submit" ng-class="{ 'btn-primary': !danger, 'btn-danger': danger, 'disabled': disableSubmit }" ng-enter="onSubmit()" ng-click="onSubmit()" ng-show="!status.processing" translate>{{submitKey}}</a>
+    <a class="btn submit" ng-class="{ 'btn-primary': !danger, 'btn-danger': danger, 'disabled': disableSubmit }" mm-enter="onSubmit()" ng-click="onSubmit()" ng-show="!status.processing" translate>{{submitKey}}</a>
     <a class="btn submit disabled" ng-class="{ 'btn-primary': !danger, 'btn-danger': danger }" ng-show="status.processing" translate>{{submittingKey || submitKey}}</a>
   </div>
 </div>

--- a/templates/directives/modal.html
+++ b/templates/directives/modal.html
@@ -7,7 +7,7 @@
   <div class="modal-footer">
     <p class="note" ng-if="status.error" translate>{{status.error}}</p>
     <a class="btn cancel" ng-class="{ 'disabled': status.processing }" ng-click="onCancel()" translate>{{cancelKey || 'Cancel'}}</a>
-    <a class="btn submit" ng-class="{ 'btn-primary': !danger, 'btn-danger': danger, 'disabled': disableSubmit }" ng-click="onSubmit()" ng-show="!status.processing" translate>{{submitKey}}</a>
+    <a class="btn submit" ng-class="{ 'btn-primary': !danger, 'btn-danger': danger, 'disabled': disableSubmit }" ng-enter="onSubmit()" ng-click="onSubmit()" ng-show="!status.processing" translate>{{submitKey}}</a>
     <a class="btn submit disabled" ng-class="{ 'btn-primary': !danger, 'btn-danger': danger }" ng-show="status.processing" translate>{{submittingKey || submitKey}}</a>
   </div>
 </div>

--- a/tests/karma/unit/directives/enter.js
+++ b/tests/karma/unit/directives/enter.js
@@ -18,25 +18,25 @@ describe('enter directive', function() {
   });
 
   it('it should call the mock function on pressing enter', done => {
-    compile('<div><a ng-enter="mockFunction()">Test</a></div>')(scope);
+    compile('<div><a mm-enter="mockFunction()">Test</a></div>')(scope);
     scope.$digest();
-    chai.expect(scope.mockFunction.called).to.be.false;
+    chai.expect(scope.mockFunction.called).to.equal(false);
     document.triggerHandler({ type: 'keydown', which: 13 });
 
     setTimeout(function() {
-      chai.expect(scope.mockFunction.called).to.be.true;
+      chai.expect(scope.mockFunction.called).to.equal(true);
       done();
     });
   });
 
   it('it should not call the mock function on pressing any key', done => {
-    compile('<div><a ng-enter="mockFunction()">Test</a></div>')(scope);
+    compile('<div><a mm-enter="mockFunction()">Test</a></div>')(scope);
     scope.$digest();
-    chai.expect(scope.mockFunction.called).to.be.false;
+    chai.expect(scope.mockFunction.called).to.equal(false);
     document.triggerHandler({ type: 'keydown', which: 27 });
 
     setTimeout(function() {
-      chai.expect(scope.mockFunction.called).to.be.false;
+      chai.expect(scope.mockFunction.called).to.equal(false);
       done();
     });
   });

--- a/tests/karma/unit/directives/enter.js
+++ b/tests/karma/unit/directives/enter.js
@@ -1,0 +1,44 @@
+describe('enter directive', function() {
+
+  'use strict';
+
+  var compile,
+      scope,
+      document;
+
+  beforeEach(function () {
+    module('inboxApp');
+    module('inboxDirectives');
+    inject(function(_$compile_, _$rootScope_, $document) {
+      compile = _$compile_;
+      scope = _$rootScope_;
+      document = $document;
+    });
+    scope.mockFunction = sinon.stub().returns(Promise.resolve());
+  });
+
+  it('it should call the mock function on pressing enter', done => {
+    compile('<div><a ng-enter="mockFunction()">Test</a></div>')(scope);
+    scope.$digest();
+    chai.expect(scope.mockFunction.called).to.be.false;
+    document.triggerHandler({ type: 'keydown', which: 13 });
+
+    setTimeout(function() {
+      chai.expect(scope.mockFunction.called).to.be.true;
+      done();
+    });
+  });
+
+  it('it should not call the mock function on pressing any key', done => {
+    compile('<div><a ng-enter="mockFunction()">Test</a></div>')(scope);
+    scope.$digest();
+    chai.expect(scope.mockFunction.called).to.be.false;
+    document.triggerHandler({ type: 'keydown', which: 27 });
+
+    setTimeout(function() {
+      chai.expect(scope.mockFunction.called).to.be.false;
+      done();
+    });
+  });
+
+});


### PR DESCRIPTION
# Description
Adding support to delete a single user by using enter in the delete modal dialog.

medic/medic-webapp#2309

# Review checklist

- [x] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.