### PR TITLE
1359 No associated contact error message

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,10 @@
 - [#3627](https://github.com/medic/medic-webapp/issues/3627): Generate scheduled messages just-in-time so changes to contacts are reflected in yet to be sent messages. NB: This feature only works with the `translation_key` configuration and not with the deprecated `messages` array so now is a good time to update your configuration.
 - [#3657](https://github.com/medic/medic-webapp/issues/3657): Add permissions to control whether or not users see the call and message buttons on mobile.
 
+### Bug fixes
+
+- [#1359](https://github.com/medic/medic-webapp/issues/1359): Helpful error message not shown if no contact associated with current user when trying to submit a report.
+
 ### UI/UX Improvements
 
 - [#3910](https://github.com/medic/medic-webapp/issues/3910): users are required to provide their current password if they wish to change it

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -92,6 +92,7 @@ _.templateSettings = {
     remote: { skip_setup: true, ajax: { timeout: 30000 }}
   };
   app.constant('POUCHDB_OPTIONS', POUCHDB_OPTIONS);
+  app.constant('NO_ASSOCIATED_CONTACT_ERROR', 'NO_ASSOCIATED_CONTACT');
 
   if (window.location.href === 'http://localhost:9876/context.html') {
     // karma unit testing - do not bootstrap

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -92,7 +92,6 @@ _.templateSettings = {
     remote: { skip_setup: true, ajax: { timeout: 30000 }}
   };
   app.constant('POUCHDB_OPTIONS', POUCHDB_OPTIONS);
-  app.constant('NO_ASSOCIATED_CONTACT_ERROR', 'NO_ASSOCIATED_CONTACT');
 
   if (window.location.href === 'http://localhost:9876/context.html') {
     // karma unit testing - do not bootstrap

--- a/static/js/controllers/contacts-edit.js
+++ b/static/js/controllers/contacts-edit.js
@@ -142,6 +142,7 @@ angular.module('inboxControllers').controller('ContactsEditCtrl',
         $scope.loadingContent = false;
       })
       .catch(function(err) {
+        $scope.errorTranslationKey = err.translationKey || 'error.loading.form';
         $scope.loadingContent = false;
         $scope.contentError = true;
         $log.error('Error loading contact form.', err);

--- a/static/js/controllers/contacts-report.js
+++ b/static/js/controllers/contacts-report.js
@@ -7,7 +7,6 @@ angular.module('inboxControllers').controller('ContactsReportCtrl',
     ContactViewModelGenerator,
     Enketo,
     Geolocation,
-    NO_ASSOCIATED_CONTACT_ERROR,
     Snackbar,
     TranslateFrom,
     XmlForm
@@ -53,13 +52,6 @@ angular.module('inboxControllers').controller('ContactsReportCtrl',
         });
     };
 
-    var getErrorTranslationKey = function(err) {
-      if (err.type === NO_ASSOCIATED_CONTACT_ERROR) {
-        return 'error.loading.form.no_contact';
-      }
-      return 'error.loading.form';
-    };
-
     $scope.save = function() {
       if ($scope.enketoStatus.saving) {
         $log.debug('Attempted to call contacts-report:$scope.save more than once');
@@ -93,7 +85,7 @@ angular.module('inboxControllers').controller('ContactsReportCtrl',
       .then(render)
       .catch(function(err) {
         $log.error('Error loading form', err);
-        $scope.errorTranslationKey = getErrorTranslationKey(err);
+        $scope.errorTranslationKey = err.translationKey || 'error.loading.form';
         $scope.contentError = true;
         $scope.loadingForm = false;
       });

--- a/static/js/controllers/contacts-report.js
+++ b/static/js/controllers/contacts-report.js
@@ -7,6 +7,7 @@ angular.module('inboxControllers').controller('ContactsReportCtrl',
     ContactViewModelGenerator,
     Enketo,
     Geolocation,
+    NO_ASSOCIATED_CONTACT_ERROR,
     Snackbar,
     TranslateFrom,
     XmlForm
@@ -52,6 +53,13 @@ angular.module('inboxControllers').controller('ContactsReportCtrl',
         });
     };
 
+    var getErrorTranslationKey = function(err) {
+      if (err.type === NO_ASSOCIATED_CONTACT_ERROR) {
+        return 'error.loading.form.no_contact';
+      }
+      return 'error.loading.form';
+    };
+
     $scope.save = function() {
       if ($scope.enketoStatus.saving) {
         $log.debug('Attempted to call contacts-report:$scope.save more than once');
@@ -85,6 +93,7 @@ angular.module('inboxControllers').controller('ContactsReportCtrl',
       .then(render)
       .catch(function(err) {
         $log.error('Error loading form', err);
+        $scope.errorTranslationKey = getErrorTranslationKey(err);
         $scope.contentError = true;
         $scope.loadingForm = false;
       });

--- a/static/js/controllers/reports-add.js
+++ b/static/js/controllers/reports-add.js
@@ -9,6 +9,7 @@ angular.module('inboxControllers').controller('ReportsAddCtrl',
     Enketo,
     FileReader,
     Geolocation,
+    NO_ASSOCIATED_CONTACT_ERROR,
     Snackbar,
     XmlForm
   ) {
@@ -75,6 +76,13 @@ angular.module('inboxControllers').controller('ReportsAddCtrl',
       $scope.enketoStatus.edited = true;
     };
 
+    var getErrorTranslationKey = function(err) {
+      if (err.type === NO_ASSOCIATED_CONTACT_ERROR) {
+        return 'error.loading.form.no_contact';
+      }
+      return 'error.loading.form';
+    };
+
     getSelected()
       .then(function(model) {
         $log.debug('setting selected', model);
@@ -113,6 +121,7 @@ angular.module('inboxControllers').controller('ReportsAddCtrl',
                 }));
             })
             .catch(function(err) {
+              $scope.errorTranslationKey = getErrorTranslationKey(err);
               $scope.loadingContent = false;
               $scope.contentError = true;
               $log.error('Error loading form.', err);

--- a/static/js/controllers/reports-add.js
+++ b/static/js/controllers/reports-add.js
@@ -9,7 +9,6 @@ angular.module('inboxControllers').controller('ReportsAddCtrl',
     Enketo,
     FileReader,
     Geolocation,
-    NO_ASSOCIATED_CONTACT_ERROR,
     Snackbar,
     XmlForm
   ) {
@@ -76,13 +75,6 @@ angular.module('inboxControllers').controller('ReportsAddCtrl',
       $scope.enketoStatus.edited = true;
     };
 
-    var getErrorTranslationKey = function(err) {
-      if (err.type === NO_ASSOCIATED_CONTACT_ERROR) {
-        return 'error.loading.form.no_contact';
-      }
-      return 'error.loading.form';
-    };
-
     getSelected()
       .then(function(model) {
         $log.debug('setting selected', model);
@@ -121,7 +113,7 @@ angular.module('inboxControllers').controller('ReportsAddCtrl',
                 }));
             })
             .catch(function(err) {
-              $scope.errorTranslationKey = getErrorTranslationKey(err);
+              $scope.errorTranslationKey = err.translationKey || 'error.loading.form';
               $scope.loadingContent = false;
               $scope.contentError = true;
               $log.error('Error loading form.', err);

--- a/static/js/controllers/tasks-content.js
+++ b/static/js/controllers/tasks-content.js
@@ -71,6 +71,7 @@ angular.module('inboxControllers').controller('TasksContentCtrl',
               });
           })
           .catch(function(err) {
+            $scope.errorTranslationKey = err.translationKey || 'error.loading.form';
             $scope.contentError = true;
             $scope.loadingForm = false;
             $log.error('Error loading form.', err);

--- a/static/js/services/enketo.js
+++ b/static/js/services/enketo.js
@@ -18,6 +18,7 @@ angular.module('inboxServices').service('Enketo',
     FileReader,
     Language,
     LineageModelGenerator,
+    NO_ASSOCIATED_CONTACT_ERROR,
     Search,
     TranslateFrom,
     UserContact,
@@ -452,7 +453,9 @@ angular.module('inboxServices').service('Enketo',
     var getUserContact = function() {
       return UserContact().then(function(contact) {
         if (!contact) {
-          throw new Error('Your user does not have an associated contact, or does not have access to the associated contact. Talk to your administrator to correct this.');
+          var err = new Error('Your user does not have an associated contact, or does not have access to the associated contact. Talk to your administrator to correct this.');
+          err.type = NO_ASSOCIATED_CONTACT_ERROR;
+          throw err;
         }
         return contact;
       });

--- a/static/js/services/enketo.js
+++ b/static/js/services/enketo.js
@@ -18,7 +18,6 @@ angular.module('inboxServices').service('Enketo',
     FileReader,
     Language,
     LineageModelGenerator,
-    NO_ASSOCIATED_CONTACT_ERROR,
     Search,
     TranslateFrom,
     UserContact,
@@ -454,7 +453,7 @@ angular.module('inboxServices').service('Enketo',
       return UserContact().then(function(contact) {
         if (!contact) {
           var err = new Error('Your user does not have an associated contact, or does not have access to the associated contact. Talk to your administrator to correct this.');
-          err.type = NO_ASSOCIATED_CONTACT_ERROR;
+          err.translationKey = 'error.loading.form.no_contact';
           throw err;
         }
         return contact;

--- a/templates/partials/contacts_edit.html
+++ b/templates/partials/contacts_edit.html
@@ -5,7 +5,7 @@
     </div>
   </div>
   <div class="col-sm-8 item-content empty-selection" ng-show="!loadingContent && contentError">
-    <div translate>error.loading.form</div>
+    <div translate>{{ errorTranslationKey }}</div>
   </div>
   <div class="col-sm-8 item-content material" ng-show="!loadingContent && !contentError">
     <div class="card">

--- a/templates/partials/contacts_report.html
+++ b/templates/partials/contacts_report.html
@@ -1,5 +1,4 @@
 <div class="content-pane right-pane">
-
   <div class="col-sm-8 item-content empty-selection" ng-show="loadingForm">
     <div>
       <div class="loader"></div>
@@ -7,7 +6,7 @@
   </div>
 
   <div class="col-sm-8 item-content empty-selection" ng-show="!loadingForm && contentError">
-    <div translate>error.loading.form</div>
+    <div translate>{{ errorTranslationKey }}</div>
   </div>
 
   <div class="col-sm-8 item-content material" ng-show="selected && form && !loadingForm">
@@ -15,5 +14,4 @@
       <mm-enketo id="'contact-report'" status="enketoStatus" on-submit="save()" on-cancel="navigationCancel()" />
     </div>
   </div>
-
 </div>

--- a/templates/partials/reports_add.html
+++ b/templates/partials/reports_add.html
@@ -4,9 +4,11 @@
       <div class="loader"></div>
     </div>
   </div>
+
   <div class="col-sm-8 item-content empty-selection" ng-show="!loadingContent && contentError">
-    <div translate>error.loading.form</div>
+    <div translate>{{ errorTranslationKey }}</div>
   </div>
+
   <div class="col-sm-8 item-content" ng-show="!loadingContent && !contentError">
     <div class="body">
       <mm-enketo id="'report-form'" status="enketoStatus" on-submit="save()"on-cancel="navigationCancel()" />

--- a/templates/partials/tasks_content.html
+++ b/templates/partials/tasks_content.html
@@ -11,7 +11,7 @@
   </div>
 
   <div class="col-sm-8 item-content empty-selection" ng-show="!loadingContent && !loadingForm && contentError">
-    <div translate>error.loading.form</div>
+    <div translate>{{ errorTranslationKey }}</div>
   </div>
 
   <div class="col-sm-8 item-content" ng-show="selected && !form && !loadingContent && !loadingForm && !contentError">

--- a/tests/karma/unit/services/enketo.js
+++ b/tests/karma/unit/services/enketo.js
@@ -63,6 +63,7 @@ describe('Enketo service', function() {
     </model>`;
 
   var service,
+      NO_ASSOCIATED_CONTACT_ERROR,
       enketoInit = sinon.stub(),
       transform = sinon.stub(),
       dbGetAttachment = sinon.stub(),
@@ -122,8 +123,9 @@ describe('Enketo service', function() {
       $provide.value('XmlForm', XmlForm);
       $provide.value('$q', Q); // bypass $q so we don't have to digest
     });
-    inject(function(_Enketo_) {
+    inject(function(_Enketo_, _NO_ASSOCIATED_CONTACT_ERROR_) {
       service = _Enketo_;
+      NO_ASSOCIATED_CONTACT_ERROR = _NO_ASSOCIATED_CONTACT_ERROR_;
     });
     Language.returns(Promise.resolve('en'));
     TranslateFrom.returns('translated');
@@ -144,6 +146,7 @@ describe('Enketo service', function() {
         })
         .catch(function(actual) {
           chai.expect(actual.message).to.equal('Your user does not have an associated contact, or does not have access to the associated contact. Talk to your administrator to correct this.');
+          chai.expect(actual.type).to.equal(NO_ASSOCIATED_CONTACT_ERROR);
           done();
         });
     });

--- a/tests/karma/unit/services/enketo.js
+++ b/tests/karma/unit/services/enketo.js
@@ -63,7 +63,6 @@ describe('Enketo service', function() {
     </model>`;
 
   var service,
-      NO_ASSOCIATED_CONTACT_ERROR,
       enketoInit = sinon.stub(),
       transform = sinon.stub(),
       dbGetAttachment = sinon.stub(),
@@ -123,9 +122,8 @@ describe('Enketo service', function() {
       $provide.value('XmlForm', XmlForm);
       $provide.value('$q', Q); // bypass $q so we don't have to digest
     });
-    inject(function(_Enketo_, _NO_ASSOCIATED_CONTACT_ERROR_) {
+    inject(function(_Enketo_) {
       service = _Enketo_;
-      NO_ASSOCIATED_CONTACT_ERROR = _NO_ASSOCIATED_CONTACT_ERROR_;
     });
     Language.returns(Promise.resolve('en'));
     TranslateFrom.returns('translated');
@@ -146,7 +144,7 @@ describe('Enketo service', function() {
         })
         .catch(function(actual) {
           chai.expect(actual.message).to.equal('Your user does not have an associated contact, or does not have access to the associated contact. Talk to your administrator to correct this.');
-          chai.expect(actual.type).to.equal(NO_ASSOCIATED_CONTACT_ERROR);
+          chai.expect(actual.translationKey).to.equal('error.loading.form.no_contact');
           done();
         });
     });

--- a/translations/messages-en.properties
+++ b/translations/messages-en.properties
@@ -474,6 +474,7 @@ selection.doc.content.raw = Raw report content
 associated.contact = Associated contact
 associated.contact.help = When this user creates reports they will be assigned to this contact
 error.loading.form = Error loading form. Please try again or check with an administrator.
+error.loading.form.no_contact = Error loading form. Your user does not have an associated contact, or does not have access to the associated contact. Talk to your administrator to correct this.
 people = People
 contact.type.person = Person
 contact.type.person.new = New person


### PR DESCRIPTION
# Description

Added in a `type` property to the `Error` being thrown to determine what type of error it was (generic or because of the lack of associated contact), and thus display a different error message depending on error type.

medic/medic-webapp#1359

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.