### PR TITLE
Adds loading throbber to "Configuration > Upgrade" before DDOC load

### DIFF
--- a/templates/partials/configuration_upgrade.html
+++ b/templates/partials/configuration_upgrade.html
@@ -1,11 +1,15 @@
-<div class="upgrade-config col-sm-12" ng-hide="deployInfo">
+<div class="col-sm-12" ng-show="loading || upgrading">
+  <div class="loader"></div>
+</div>
+
+<div class="upgrade-config col-sm-12" ng-hide="deployInfo || loading">
   <legend translate>instance.upgrade.no_horti</legend>
   <p translate>instance.upgrade.no_horti.detail</p>
 </div>
+
 <div class="upgrade-config col-sm-12" ng-show="deployInfo">
-  <div ng-show="loading || upgrading">
-    <div class="loader"></div>
-    <p class="status" ng-show="upgrading"
+  <div ng-show="upgrading">
+    <p class="status"
       translate="instance.upgrade.upgrading"
       translate-values="{ before: deployInfo.version, after: upgrading }"></p>
   </div>
@@ -14,7 +18,7 @@
     <p class="error">{{error}}</p>
   </div>
 
-  <div ng-hide="loading || upgrading">
+  <div ng-hide="upgrading">
 
     <div>
       <legend translate>instance.upgrade.current_version</legend>


### PR DESCRIPTION
# Description

Instead of displaying the default message saying "instance
must be deployed via Horticulturalist" before the DDOC is fetched,
show a loading throbber. Once the DDOC is downloaded, relevant content
is displayed (either the "no-horti" message or the actual UI).

medic/medic-webapp#3966

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.