### PR TITLE
Add permission to allow mobile users to log out

### DIFF
--- a/api/config.default.json
+++ b/api/config.default.json
@@ -313,6 +313,11 @@
         "national_admin",
         "district_admin"
       ]
+    },
+    {
+      "name": "can_log_out_on_android",
+      "roles": [
+      ]
     }
   ]
 }

--- a/static/js/controllers/inbox.js
+++ b/static/js/controllers/inbox.js
@@ -20,6 +20,7 @@ var feedback = require('../modules/feedback'),
       $translate,
       $window,
       APP_CONFIG,
+      Auth,
       Changes,
       CheckDate,
       ContactSchema,
@@ -131,8 +132,22 @@ var feedback = require('../modules/feedback'),
         $scope.android_app_version = $window.medicmobile_android.getAppVersion();
       }
 
+      $scope.canLogOut = false;
+      if ($scope.android_app_version) {
+        Auth('can_log_out_on_android')
+          .then(function() {
+            $scope.canLogOut = true;
+          })
+          .catch(function() {}); // not permitted to log out
+      } else {
+        $scope.canLogOut = true;
+      }
       $scope.logout = function() {
-        Session.logout();
+        Modal({
+          templateUrl: 'templates/modals/logout_confirm.html',
+          controller: 'LogoutConfirmCtrl',
+          singleton: true
+        });
       };
 
       $scope.isMobile = function() {

--- a/static/js/controllers/index.js
+++ b/static/js/controllers/index.js
@@ -51,6 +51,7 @@
   require('./guided-setup-modal');
   require('./home');
   require('./import-translation');
+  require('./logout-confirm');
   require('./medic-reporter-modal');
   require('./messages');
   require('./messages-content');

--- a/static/js/controllers/logout-confirm.js
+++ b/static/js/controllers/logout-confirm.js
@@ -1,0 +1,20 @@
+angular.module('inboxControllers').controller('LogoutConfirmCtrl',
+  function(
+    $scope,
+    $uibModalInstance,
+    Session
+  ) {
+    'use strict';
+    'ngInject';
+
+    $scope.submit = function() {
+      $scope.setProcessing();
+      Session.logout();
+      $uibModalInstance.close();
+    };
+
+    $scope.cancel = function() {
+      $uibModalInstance.dismiss();
+    };
+  }
+);

--- a/templates/modals/logout_confirm.html
+++ b/templates/modals/logout_confirm.html
@@ -1,0 +1,11 @@
+<mm-modal
+  status="status"
+  danger="true"
+  title-key="'Confirm'"
+  submit-key="'yes'"
+  cancel-key="'no'"
+  on-cancel="cancel()"
+  on-submit="submit()"
+>
+  <p translate>confirm.logout</p>
+</mm-modal>

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -78,12 +78,7 @@
               <span translate>Report Bug</span>
             </a>
           </li>
-          <!--
-            ng-show="!android_app_version" is a hack for hiding logout from LG
-            deployment.  Should be replaced with a new issue for adding a
-            `hide_logout_on_mobile_devices` setting or similar.
-          //-->
-          <li role="presentation" ng-show="!android_app_version">
+          <li role="presentation" ng-show="canLogOut">
             <a role="menuitem" tabindex="-1" rel="external" ng-click="logout()">
               <i class="fa fa-fw fa-power-off"></i>
               <span translate>Log Out</span>

--- a/translations/messages-en.properties
+++ b/translations/messages-en.properties
@@ -980,3 +980,4 @@ password.incorrect = Password is not correct.
 online.action.title = Please make sure that you are online.
 online.action.message = This action requires you to be online, please try again when you have network access.
 instance.upgrade.install = Install
+confirm.logout = Are you sure you want to log out?


### PR DESCRIPTION
Users can now log out if in a browser or if the can_log_out_on_android
permission is set. By default no roles have that permission so
existing instances will continue to behave as they always have.

medic/medic-webapp#3450

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.