### PR TITLE
Fixes bug where circular reference prevents report deletion

### DIFF
--- a/static/js/services/delete-docs.js
+++ b/static/js/services/delete-docs.js
@@ -10,7 +10,8 @@ var _ = require('underscore');
     function(
       $log,
       $q,
-      DB
+      DB,
+      ExtractLineage
     ) {
 
       'ngInject';
@@ -51,6 +52,14 @@ var _ = require('underscore');
         }
       };
 
+      var minifyLineage = function (docs) {
+        docs.forEach(function (doc) {
+          if (doc.type === 'data_record' && doc.contact) {
+            doc.contact = ExtractLineage(doc.contact);
+          }
+        });
+      };
+
       /**
        * Delete the given docs. If 'person' type then also fix the
        * contact hierarchy.
@@ -76,6 +85,9 @@ var _ = require('underscore');
           }))
           .then(function() {
             return checkForDuplicates(docs);
+          })
+          .then(function() {
+            return minifyLineage(docs);
           })
           .then(function() {
             return DB().bulkDocs(docs);

--- a/tests/karma/unit/services/delete-docs.js
+++ b/tests/karma/unit/services/delete-docs.js
@@ -305,7 +305,6 @@ describe('DeleteDocs service', function() {
     };
 
     var docs = [ report ];
-    get.returns(Promise.resolve(person));
     bulkDocs.returns(Promise.resolve());
     var isCircularBefore = false;
     var isCircularAfter = false;

--- a/tests/karma/unit/services/delete-docs.js
+++ b/tests/karma/unit/services/delete-docs.js
@@ -280,4 +280,55 @@ describe('DeleteDocs service', function() {
       chai.expect(bulkDocs.args[0][0].length).to.equal(2);
     });
   });
+
+
+  it('minifies lineage for circular referenced report #4076', function() {
+    var clinic = {
+      _id: 'b',
+      type: 'clinic',
+      contact: {
+        _id: 'a',
+      }
+    };
+    var person = {
+      _id: 'a',
+      type: 'person',
+      name: 'sally',
+      parent: clinic
+    };
+    clinic.contact = person;
+
+    var report = {
+      _id: 'c',
+      type: 'data_record',
+      contact: person
+    };
+
+    var docs = [ report ];
+    get.returns(Promise.resolve(person));
+    bulkDocs.returns(Promise.resolve());
+    var isCircularBefore = false;
+    var isCircularAfter = false;
+    try {
+      JSON.stringify(report);
+    } catch (e) {
+      if (e.message === 'Converting circular structure to JSON') {
+        isCircularBefore = true;
+      }
+    }
+
+    return service(docs).then(function() {
+      chai.expect(docs.length).to.equal(1);
+      chai.expect(isCircularBefore).to.equal(true);
+      try {
+        JSON.stringify(bulkDocs.args[0][0][0]);
+      } catch (e) {
+        if (e.message === 'Converting circular structure to JSON') {
+          isCircularAfter = true;
+        }
+      }
+      chai.expect(isCircularAfter).to.equal(false);
+      chai.expect(bulkDocs.args[0][0].length).to.equal(1);
+    });
+  });
 });


### PR DESCRIPTION
# Description

When a report is submitted by the district's primary contact,
applying LineageModelGenerator on that report results in a circular
referenced object, which throws an error when attempting to delete.
Fix is to minify the report's contact lineage prior to deletion.

medic/medic-webapp#4076

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.