### PR TITLE
Increase linkages between SMS reports and other docs to streamline analytics queries

### DIFF
--- a/sentinel/test/mocha/transitions/accept_patient_reports.js
+++ b/sentinel/test/mocha/transitions/accept_patient_reports.js
@@ -276,7 +276,7 @@ describe('accept_patient_reports', () => {
       sinon.stub(transition, '_silenceReminders').callsArgWith(4, null, true);
       const doc = { _id: 'z', fields: { patient_id: 'x' } };
       const config = { silence_type: 'x', messages: [] };
-      const registrations = [ { _id: 'a' } ];
+      const registrations = [ { _id: 'a', reported_date: '2017-02-05T09:23:07.853Z' } ];
       transition.silenceRegistrations(null, config, doc, registrations, (err, complete) => {
         complete.should.equal(true);
         doc.registration_id.should.equal(registrations[0]._id);
@@ -284,11 +284,15 @@ describe('accept_patient_reports', () => {
       });
     });
 
-    it('if there are multiple registrations uses the last one', done => {
+    it('if there are multiple registrations uses the latest one', done => {
       sinon.stub(transition, '_silenceReminders').callsArgWith(4, null, true);
       const doc = { _id: 'z', fields: { patient_id: 'x' } };
       const config = { silence_type: 'x', messages: [] };
-      const registrations = [ { _id: 'a' }, { _id: 'b' } ];
+      const registrations = [
+        { _id: 'a', reported_date: '2017-02-05T09:23:07.853Z' },
+        { _id: 'c', reported_date: '2018-02-05T09:23:07.853Z' },
+        { _id: 'b', reported_date: '2016-02-05T09:23:07.853Z' }
+      ];
       transition.silenceRegistrations(null, config, doc, registrations, (err, complete) => {
         complete.should.equal(true);
         doc.registration_id.should.equal(registrations[1]._id);

--- a/sentinel/test/mocha/transitions/accept_patient_reports.js
+++ b/sentinel/test/mocha/transitions/accept_patient_reports.js
@@ -122,7 +122,7 @@ describe('accept_patient_reports', () => {
 
     it('adding silence_type to handleReport calls _silenceReminders', done => {
       sinon.stub(transition, '_silenceReminders').callsArgWith(4);
-      const doc = { _id: 'a', fields: { patient_id: 'x'}};
+      const doc = { _id: 'a', fields: { patient_id: 'x' } };
       const config = { silence_type: 'x', messages: [] };
       const registrations = [
         { id: 'a' }, // should not be silenced as it's the doc being processed
@@ -134,7 +134,9 @@ describe('accept_patient_reports', () => {
         complete.should.equal(true);
         transition._silenceReminders.callCount.should.equal(2);
         transition._silenceReminders.args[0][1].id.should.equal('b');
+        transition._silenceReminders.args[0][2]._id.should.equal('a');
         transition._silenceReminders.args[1][1].id.should.equal('c');
+        transition._silenceReminders.args[1][2]._id.should.equal('a');
         done();
       });
     });
@@ -143,18 +145,17 @@ describe('accept_patient_reports', () => {
 
   describe('silenceReminders', () => {
     it('Sets tasks to cleared and saves them', done => {
+      const reportId = 'reportid';
+      const report = {
+        _id: reportId,
+        reported_date: 123
+      };
       const registration = {
         _id: 'test-registration',
         scheduled_tasks: [
-          {
-            state: 'scheduled'
-          },
-          {
-            state: 'scheduled'
-          },
-          {
-            state: 'pending'
-          },
+          { state: 'scheduled' },
+          { state: 'scheduled' },
+          { state: 'pending' }
         ]
       };
 
@@ -165,13 +166,16 @@ describe('accept_patient_reports', () => {
           registration._id.should.equal('test-registration');
           registration.scheduled_tasks.length.should.equal(3);
           registration.scheduled_tasks[0].state.should.equal('cleared');
+          registration.scheduled_tasks[0].cleared_by.should.equal(reportId);
           registration.scheduled_tasks[1].state.should.equal('cleared');
+          registration.scheduled_tasks[1].cleared_by.should.equal(reportId);
           registration.scheduled_tasks[2].state.should.equal('cleared');
+          registration.scheduled_tasks[2].cleared_by.should.equal(reportId);
           done();
         }
       };
 
-      transition._silenceReminders(audit, registration);
+      transition._silenceReminders(audit, registration, report);
     });
   });
 

--- a/sentinel/test/mocha/transitions/registration.js
+++ b/sentinel/test/mocha/transitions/registration.js
@@ -34,11 +34,14 @@ describe('registrations', () => {
 
     it('trigger creates a new patient', done => {
       const patientName = 'jack';
-      const submitterId = 'papa';
+      const submitterId = 'abc';
+      const parentId = 'papa';
       const patientId = '05649';
+      const reportId = 'def';
       const senderPhoneNumber = '+555123';
       const dob = '2017-03-31T01:15:09.000Z';
       const change = { doc: {
+        _id: reportId,
         type: 'data_record',
         form: 'R',
         reported_date: 53,
@@ -47,7 +50,10 @@ describe('registrations', () => {
         birth_date: dob
       } };
       // return expected view results when searching for contacts_by_phone
-      const view = sinon.stub().callsArgWith(3, null, { rows: [ { doc: { parent: { _id: submitterId } } } ] });
+      const view = sinon.stub().callsArgWith(3, null, { rows: [ { doc: {
+        _id: submitterId,
+        parent: { _id: parentId }
+      } } ] });
       const getPatientContactUuid = sinon.stub(utils, 'getPatientContactUuid').callsArgWith(2);
       const db = { medic: { view: view } };
       const saveDoc = sinon.stub().callsArgWith(1);
@@ -73,11 +79,13 @@ describe('registrations', () => {
         view.args[0][2].include_docs.should.equal(true);
         saveDoc.callCount.should.equal(1);
         saveDoc.args[0][0].name.should.equal(patientName);
-        saveDoc.args[0][0].parent._id.should.equal(submitterId);
+        saveDoc.args[0][0].parent._id.should.equal(parentId);
         saveDoc.args[0][0].reported_date.should.equal(53);
         saveDoc.args[0][0].type.should.equal('person');
         saveDoc.args[0][0].patient_id.should.equal(patientId);
         saveDoc.args[0][0].date_of_birth.should.equal(dob);
+        saveDoc.args[0][0].source_id.should.equal(reportId);
+        saveDoc.args[0][0].created_by.should.equal(submitterId);
         done();
       });
     });

--- a/sentinel/test/unit/patient_registration.js
+++ b/sentinel/test/unit/patient_registration.js
@@ -150,6 +150,7 @@ exports['valid form adds patient_id and patient document'] = function(test) {
     });
 
     var doc = {
+        _id: 'docid',
         form: 'PATR',
         fields: { patient_name: 'abc' },
         reported_date: 'now'
@@ -160,6 +161,7 @@ exports['valid form adds patient_id and patient document'] = function(test) {
             view: sinon.stub().callsArgWith(3, null, {rows: [
                 {
                     doc: {
+                        _id: 'the-contact',
                         parent: {
                             _id: 'the-parent'
                         }
@@ -189,7 +191,9 @@ exports['valid form adds patient_id and patient document'] = function(test) {
                 },
                 reported_date: 'now',
                 type: 'person',
-                patient_id: doc.patient_id
+                patient_id: doc.patient_id,
+                created_by: 'the-contact',
+                source_id: 'docid'
             });
         test.done();
     });

--- a/sentinel/transitions/accept_patient_reports.js
+++ b/sentinel/transitions/accept_patient_reports.js
@@ -96,7 +96,11 @@ const _silenceReminders = (audit, registration, report, config, callback) => {
 
 const addRegistrationToDoc = (doc, registrations) => {
     if (registrations.length) {
-        doc.registration_id = registrations[registrations.length - 1]._id;
+        const latest = _.max(
+            registrations,
+            registration => moment(registration.reported_date)
+        );
+        doc.registration_id = latest._id;
     }
 };
 

--- a/sentinel/transitions/accept_patient_reports.js
+++ b/sentinel/transitions/accept_patient_reports.js
@@ -94,6 +94,12 @@ const _silenceReminders = (audit, registration, report, config, callback) => {
     audit.saveDoc(registration, callback);
 };
 
+const addRegistrationToDoc = (doc, registrations) => {
+    if (registrations.length) {
+        doc.registration_id = registrations[registrations.length - 1]._id;
+    }
+};
+
 const silenceRegistrations = (
             audit,
             config,
@@ -103,10 +109,11 @@ const silenceRegistrations = (
     if (!config.silence_type) {
         return callback(null, true);
     }
+    addRegistrationToDoc(doc, registrations);
     async.forEach(
         registrations,
         function(registration, callback) {
-            if (doc._id === registration.id) {
+            if (doc._id === registration._id) {
                 // don't silence the registration you're processing
                 return callback();
             }

--- a/sentinel/transitions/accept_patient_reports.js
+++ b/sentinel/transitions/accept_patient_reports.js
@@ -81,13 +81,16 @@ const getConfig = function(form) {
     return _.findWhere(fullConfig, { form: form });
 };
 
-const _silenceReminders = (audit, registration, reported_date, config, callback) => {
-    var toClear = module.exports._findToClear(registration, reported_date, config);
+const _silenceReminders = (audit, registration, report, config, callback) => {
+    var toClear = module.exports._findToClear(registration, report.reported_date, config);
     if (!toClear.length) {
         return callback();
     }
 
-    toClear.forEach(task => utils.setTaskState(task, 'cleared'));
+    toClear.forEach(task => {
+        utils.setTaskState(task, 'cleared');
+        task.cleared_by = report._id;
+    });
     audit.saveDoc(registration, callback);
 };
 
@@ -108,7 +111,7 @@ const silenceRegistrations = (
                 return callback();
             }
             module.exports._silenceReminders(
-                audit, registration, doc.reported_date, config, callback);
+                audit, registration, doc, config, callback);
         },
         function(err) {
             callback(err, true);

--- a/sentinel/transitions/registration.js
+++ b/sentinel/transitions/registration.js
@@ -445,10 +445,12 @@ module.exports = {
         // create a new patient with this patient_id
         const patient = {
           name: doc.fields[patientNameField],
+          created_by: contact && contact._id,
           parent: contact && contact.parent,
           reported_date: doc.reported_date,
           type: 'person',
-          patient_id: patientShortcode
+          patient_id: patientShortcode,
+          source_id: doc._id
         };
         // include the DOB if it was generated on report
         if (doc.birth_date) {


### PR DESCRIPTION
# Description

During transitions update docs to have uuids of related docs. This makes it easier
to perform certain analytics queries.

medic/medic-webapp#3959

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.