### PR TITLE
4144 Fix permission and role checking in changes handler and action bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,3 @@ tests/results
 *.sublime-project
 *.sublime-workspace
 /.env
-/.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ tests/results
 *.sublime-project
 *.sublime-workspace
 /.env
+/.vscode/

--- a/api/auth.js
+++ b/api/auth.js
@@ -66,6 +66,12 @@ module.exports = {
       callback(null, isDbAdmin(userCtx));
     });
   },
+
+  isAdmin: function(userCtx) {
+    return hasRole(userCtx, '_admin') ||
+           hasRole(userCtx, 'national_admin');
+  },
+
   hasAllPermissions: function(userCtx, permissions) {
     if (isDbAdmin(userCtx)) {
       return true;

--- a/api/config.default.json
+++ b/api/config.default.json
@@ -97,12 +97,6 @@
       ]
     },
     {
-      "name": "can_access_directly",
-      "roles": [
-        "national_admin"
-      ]
-    },
-    {
       "name": "can_view_data_records",
       "roles": [
         "national_admin",

--- a/api/handlers/changes.js
+++ b/api/handlers/changes.js
@@ -447,7 +447,7 @@ module.exports = {
         res.setHeader('X-Accel-Buffering', 'no');
       }
 
-      if (auth.hasAllPermissions(userCtx, 'can_access_directly')) {
+      if (auth.isAdmin(userCtx)) {
         proxy.web(req, res);
       } else {
         var feed = {

--- a/api/migrations/add-permissions-configuration.js
+++ b/api/migrations/add-permissions-configuration.js
@@ -44,12 +44,6 @@ var DEFAULT_PERMISSIONS = [
     ]
   },
   {
-    name: 'can_access_directly',
-    roles: [
-      'national_admin'
-    ]
-  },
-  {
     name: 'can_view_analytics',
     roles: [
       'national_admin',

--- a/api/tests/unit/auth.js
+++ b/api/tests/unit/auth.js
@@ -190,3 +190,11 @@ exports['checkUrl requests the given url and returns status'] = function(test) {
     test.done();
   });
 };
+
+exports['isAdmin checks for "admin" and "national_admin" roles'] = function(test) {
+  test.expect(3);
+  test.equal(auth.isAdmin({ roles: ['_admin'] }), true);
+  test.equal(auth.isAdmin({ roles: ['national_admin'] }), true);
+  test.equal(auth.isAdmin({ roles: ['district_admin'] }), false);
+  test.done();
+};

--- a/api/tests/unit/handlers/changes.js
+++ b/api/tests/unit/handlers/changes.js
@@ -17,7 +17,7 @@ exports.tearDown = function (callback) {
   callback();
 };
 
-exports['allows "can_access_directly" users direct access'] = function(test) {
+exports['allows "admin" and "national_admin" users direct access'] = function(test) {
   test.expect(2);
 
   var testReq = { query:{} };
@@ -25,7 +25,7 @@ exports['allows "can_access_directly" users direct access'] = function(test) {
 
   var userCtx = 'fake userCtx';
   sinon.stub(auth, 'getUserCtx').callsArgWith(1, null, userCtx);
-  sinon.stub(auth, 'hasAllPermissions').callsFake(function() { return true; });
+  sinon.stub(auth, 'isAdmin').returns(true);
 
   var proxy = {web: function(req, res) {
     test.equals(req, testReq);
@@ -58,6 +58,7 @@ exports['filters the changes to relevant ones'] = function(test) {
   };
 
   sinon.stub(auth, 'getUserCtx').callsArgWith(1, null, userCtx);
+  sinon.stub(auth, 'isAdmin').returns(false);
   sinon.stub(auth, 'hasAllPermissions').returns(false);
   sinon.stub(auth, 'getFacilityId').callsArgWith(2, null, 'facilityId');
   sinon.stub(auth, 'getContactId').callsArgWith(1, null, 'contactId');
@@ -152,9 +153,8 @@ exports['allows unallocated access when it is configured and the user has permis
   var subjectId = 'zyx';
 
   sinon.stub(auth, 'getUserCtx').callsArgWith(1, null, userCtx);
-  var hasAllPermissions = sinon.stub(auth, 'hasAllPermissions');
-  hasAllPermissions.withArgs(userCtx, 'can_access_directly').returns(false);
-  hasAllPermissions.withArgs(userCtx, 'can_view_unallocated_data_records').returns(true);
+  sinon.stub(auth, 'isAdmin').returns(false);
+  sinon.stub(auth, 'hasAllPermissions').returns(true);
   sinon.stub(auth, 'getFacilityId').callsArgWith(2, null, 'facilityId');
   sinon.stub(auth, 'getContactId').callsArgWith(1, null, 'contactId');
   sinon.stub(config, 'get').returns(true);
@@ -227,8 +227,7 @@ exports['respects replication depth when it is configured and the user has permi
   var subjectId = 'zyx';
 
   sinon.stub(auth, 'getUserCtx').callsArgWith(1, null, userCtx);
-  var hasAllPermissions = sinon.stub(auth, 'hasAllPermissions');
-  hasAllPermissions.withArgs(userCtx, 'can_access_directly').returns(false);
+  sinon.stub(auth, 'isAdmin').returns(false);
   sinon.stub(auth, 'getFacilityId').callsArgWith(2, null, 'facilityId');
   sinon.stub(auth, 'getContactId').callsArgWith(1, null, 'contactId');
   var get = sinon.stub(config, 'get');
@@ -298,8 +297,7 @@ exports['correctly handles depth of 0'] = function(test) {
   var subjectId = 'zyx';
 
   sinon.stub(auth, 'getUserCtx').callsArgWith(1, null, userCtx);
-  var hasAllPermissions = sinon.stub(auth, 'hasAllPermissions');
-  hasAllPermissions.withArgs(userCtx, 'can_access_directly').returns(false);
+  sinon.stub(auth, 'isAdmin').returns(false);
   sinon.stub(auth, 'getFacilityId').callsArgWith(2, null, 'facilityId');
   sinon.stub(auth, 'getContactId').callsArgWith(1, null, 'contactId');
   var get = sinon.stub(config, 'get');
@@ -365,8 +363,7 @@ exports['no configured depth defaults to Ininite depth'] = function(test) {
   var subjectId = 'zyx';
 
   sinon.stub(auth, 'getUserCtx').callsArgWith(1, null, userCtx);
-  var hasAllPermissions = sinon.stub(auth, 'hasAllPermissions');
-  hasAllPermissions.withArgs(userCtx, 'can_access_directly').returns(false);
+  sinon.stub(auth, 'isAdmin').returns(false);
   sinon.stub(auth, 'getFacilityId').callsArgWith(2, null, 'facilityId');
   sinon.stub(auth, 'getContactId').callsArgWith(1, null, 'contactId');
   var get = sinon.stub(config, 'get');
@@ -432,8 +429,7 @@ exports['no roles (eg: admin) defaults to Ininite depth'] = function(test) {
   var subjectId = 'zyx';
 
   sinon.stub(auth, 'getUserCtx').callsArgWith(1, null, userCtx);
-  var hasAllPermissions = sinon.stub(auth, 'hasAllPermissions');
-  hasAllPermissions.withArgs(userCtx, 'can_access_directly').returns(false);
+  sinon.stub(auth, 'isAdmin').returns(false);
   sinon.stub(auth, 'getFacilityId').callsArgWith(2, null, 'facilityId');
   sinon.stub(auth, 'getContactId').callsArgWith(1, null, 'contactId');
   var get = sinon.stub(config, 'get');
@@ -499,8 +495,7 @@ exports['does not return reports about you or your place by someone above you in
   var contactId = 'wsa';
 
   sinon.stub(auth, 'getUserCtx').callsArgWith(1, null, userCtx);
-  var hasAllPermissions = sinon.stub(auth, 'hasAllPermissions');
-  hasAllPermissions.withArgs(userCtx, 'can_access_directly').returns(false);
+  sinon.stub(auth, 'isAdmin').returns(false);
   sinon.stub(auth, 'getFacilityId').callsArgWith(2, null, facilityId);
   sinon.stub(auth, 'getContactId').callsArgWith(1, null, contactId);
   var get = sinon.stub(config, 'get');
@@ -577,6 +572,7 @@ exports['filters out undeleted docs they are not allowed to see'] = function(tes
   };
 
   sinon.stub(auth, 'getUserCtx').callsArgWith(1, null, userCtx);
+  sinon.stub(auth, 'isAdmin').returns(false);
   sinon.stub(auth, 'hasAllPermissions').returns(false);
   sinon.stub(auth, 'getFacilityId').callsArgWith(2, null, 'facilityId');
   sinon.stub(auth, 'getContactId').callsArgWith(1, null, 'contactId');
@@ -643,6 +639,7 @@ exports['updates the feed when the doc is updated'] = function(test) {
   };
 
   sinon.stub(auth, 'getUserCtx').callsArgWith(1, null, userCtx);
+  sinon.stub(auth, 'isAdmin').returns(false);
   sinon.stub(auth, 'hasAllPermissions').returns(false);
   sinon.stub(auth, 'getFacilityId').callsArgWith(2, null, 'facilityId');
   sinon.stub(auth, 'getContactId').callsArgWith(1, null, 'contactId');
@@ -742,6 +739,7 @@ exports['replicates new docs to relevant feeds'] = function(test) {
   sinon.stub(auth, 'getUserCtx')
     .onCall(0).callsArgWith(1, null, userCtx1)
     .onCall(1).callsArgWith(1, null, userCtx2);
+  sinon.stub(auth, 'isAdmin').returns(false);
   sinon.stub(auth, 'hasAllPermissions').returns(false);
   var getFacilityId = sinon.stub(auth, 'getFacilityId');
   getFacilityId.onCall(0).callsArgWith(2, null, 'a');
@@ -887,6 +885,7 @@ exports['cleans up when the client connection is closed - #2476'] = function(tes
   };
 
   sinon.stub(auth, 'getUserCtx').callsArgWith(1, null, userCtx);
+  sinon.stub(auth, 'isAdmin').returns(false);
   sinon.stub(auth, 'hasAllPermissions').returns(false);
   sinon.stub(auth, 'getFacilityId').callsArgWith(2, null, 'facilityId');
   sinon.stub(auth, 'getContactId').callsArgWith(1, null, 'contactId');
@@ -943,6 +942,7 @@ exports['makes multiple requests when you can see more than 100 docs - #3508'] =
   };
 
   sinon.stub(auth, 'getUserCtx').callsArgWith(1, null, userCtx);
+  sinon.stub(auth, 'isAdmin').returns(false);
   sinon.stub(auth, 'hasAllPermissions').returns(false);
   sinon.stub(auth, 'getFacilityId').callsArgWith(2, null, 'facilityId');
   sinon.stub(auth, 'getContactId').callsArgWith(1, null, 'contactId');
@@ -1033,6 +1033,7 @@ exports['test sorting by couchdb 2 sequence style'] = test => {
   };
 
   sinon.stub(auth, 'getUserCtx').callsArgWith(1, null, userCtx);
+  sinon.stub(auth, 'isAdmin').returns(false);
   sinon.stub(auth, 'hasAllPermissions').returns(false);
   sinon.stub(auth, 'getFacilityId').callsArgWith(2, null, 'facilityId');
   sinon.stub(auth, 'getContactId').callsArgWith(1, null, 'contactId');

--- a/static/js/controllers/inbox.js
+++ b/static/js/controllers/inbox.js
@@ -126,6 +126,7 @@ var feedback = require('../modules/feedback'),
       $scope.tours = [];
       $scope.baseUrl = Location.path;
       $scope.enketoStatus = { saving: false };
+      $scope.isAdmin = Session.isAdmin();
 
       if ($window.medicmobile_android && typeof $window.medicmobile_android.getAppVersion === 'function') {
         $scope.android_app_version = $window.medicmobile_android.getAppVersion();

--- a/static/js/controllers/messages.js
+++ b/static/js/controllers/messages.js
@@ -1,6 +1,6 @@
 var _ = require('underscore');
 
-angular.module('inboxControllers').controller('MessagesCtrl', 
+angular.module('inboxControllers').controller('MessagesCtrl',
   function (
     $log,
     $scope,

--- a/static/js/controllers/reports.js
+++ b/static/js/controllers/reports.js
@@ -18,7 +18,6 @@ angular.module('inboxControllers').controller('ReportsCtrl',
     ReportViewModelGenerator,
     Search,
     SearchFilters,
-    Session,
     Tour
   ) {
     'use strict';
@@ -340,8 +339,6 @@ angular.module('inboxControllers').controller('ReportsCtrl',
         $scope.search();
       });
     };
-
-    $scope.isAdmin = Session.isAdmin();
 
     $scope.resetFilterModel = function() {
       if ($scope.selectMode && $scope.selected && $scope.selected.length) {

--- a/templates/partials/actionbar.html
+++ b/templates/partials/actionbar.html
@@ -41,7 +41,7 @@
             <span class="fa fa-check-circle"></span>
             <p translate>select.mode.start</p>
           </a>
-          <a class="mm-icon mm-icon-inverse mm-icon-caption" mm-auth="can_access_directly" ng-click="actionBar.left.exportFn()">
+          <a class="mm-icon mm-icon-inverse mm-icon-caption" ng-show="isAdmin" ng-click="actionBar.left.exportFn()">
             <span class="fa fa-arrow-down"></span>
             <p translate>Export</p>
           </a>
@@ -57,7 +57,7 @@
             </span>
             <p translate>{{actionBar.left.addPlaceLabel}}</p>
           </a>
-          <a class="mm-icon mm-icon-inverse mm-icon-caption" mm-auth="can_access_directly" ng-click="actionBar.left.exportFn()">
+          <a class="mm-icon mm-icon-inverse mm-icon-caption" ng-show="isAdmin" ng-click="actionBar.left.exportFn()">
             <span class="fa fa-arrow-down"></span>
             <p translate>Export</p>
           </a>
@@ -70,7 +70,7 @@
             <span class="fa fa-plus"></span>
             <p translate>Send Message</p>
           </a>
-          <a class="mm-icon mm-icon-inverse mm-icon-caption" mm-auth="can_access_directly" ng-click="actionBar.left.exportFn()">
+          <a class="mm-icon mm-icon-inverse mm-icon-caption" ng-show="isAdmin" ng-click="actionBar.left.exportFn()">
             <span class="fa fa-arrow-down"></span>
             <p translate>Export</p>
           </a>

--- a/tests/karma/unit/controllers/inbox.js
+++ b/tests/karma/unit/controllers/inbox.js
@@ -48,7 +48,7 @@ describe('InboxCtrl controller', () => {
       });
       $provide.value('ReadMessages', sinon.stub());
       $provide.value('SendMessage', sinon.stub());
-      $provide.value('Session', { init: sinon.stub() });
+      $provide.value('Session', { init: sinon.stub(), isAdmin: sinon.stub() });
       $provide.value('SetLanguageCookie', sinon.stub());
       $provide.value('Settings', () => KarmaUtils.nullPromise());
       $provide.value('Snackbar', () => snackbar);

--- a/tests/karma/unit/controllers/reports.js
+++ b/tests/karma/unit/controllers/reports.js
@@ -82,7 +82,6 @@ describe('ReportsCtrl controller', () => {
         'Search': Search,
         'SearchFilters': () => {},
         'Settings': KarmaUtils.nullPromise(),
-        'Session': {isAdmin: () => {}},
         'Tour': () => {},
         'UpdateFacility': {},
         'UserDistrict': UserDistrict,


### PR DESCRIPTION
# Description

Following on from discussion in the issue, the changes handler has been changed to check for `admin` or `national_admin` roles instead of the `can_access_directly`. The only other use for `can_access_directly` was to show the export action icon which shouldn't be configurable, so this has been modified to check for the same roles.

medic/medic-webapp#4144

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.