### PR TITLE
Death reporting by UUID

### DIFF
--- a/sentinel/transitions/death_reporting.js
+++ b/sentinel/transitions/death_reporting.js
@@ -31,7 +31,7 @@ const updatePatient = (audit, patient, doc, callback) => {
 const getPatient = (db, patientId, callback) => {
   db.medic.get(patientId, (err, patient) => {
     if (err && err.statusCode !== 404) {
-      callback(err);
+      return callback(err);
     }
     if (patient) {
       return callback(null, patient);


### PR DESCRIPTION
# Description

Enhances death reporting by allowing reporting death confirmations
using the UUID of the patient in cases where they don't have a
shortcode, for example, smartphone deployments.

medic/medic-webapp#3956

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.