### PR TITLE
Update relative dates throughout the app.

### DIFF
--- a/static/js/controllers/inbox.js
+++ b/static/js/controllers/inbox.js
@@ -47,7 +47,8 @@ var feedback = require('../modules/feedback'),
       UpdateSettings,
       UpdateUser,
       UserSettings,
-      XmlForms
+      XmlForms,
+      RecurringProcessManager
     ) {
       'ngInject';
 
@@ -646,6 +647,11 @@ var feedback = require('../modules/feedback'),
           }
         });
       }
+
+      RecurringProcessManager.startUpdateRelativeDate();
+      $scope.$on('$destroy', function() {
+        RecurringProcessManager.stopUpdateRelativeDate();
+      });
 
     }
   );

--- a/static/js/filters/date.js
+++ b/static/js/filters/date.js
@@ -17,8 +17,8 @@ var _ = require('underscore'),
   var getRelativeDateString = function(date, options) {
     if (options.age) {
       return options.FormatDate.age(date, options);
-    //} else if (!options.withoutTime && moment(date).isSame(moment(), 'day')) {
-    //  return options.FormatDate.time(date);
+    } else if (!options.withoutTime && moment(date).isSame(moment(), 'day')) {
+      return options.FormatDate.time(date);
     } else {
       return options.FormatDate.relative(date, options);
     }
@@ -52,7 +52,7 @@ var _ = require('underscore'),
            '<span class="' + classes.join(' ') + '" title="' + absolute + '">' +
              '<span ' +
                'class="relative-date-content '+ options.RelativeDate.getCssSelector() +'" ' +
-                options.RelativeDate.generateDataset(date, options) +
+                options.RelativeDate.generateDataset(date, options, true) +
              '>' +
                 relative +
              '</span>' +

--- a/static/js/filters/date.js
+++ b/static/js/filters/date.js
@@ -17,8 +17,8 @@ var _ = require('underscore'),
   var getRelativeDateString = function(date, options) {
     if (options.age) {
       return options.FormatDate.age(date, options);
-    } else if (!options.withoutTime && moment(date).isSame(moment(), 'day')) {
-      return options.FormatDate.time(date);
+    //} else if (!options.withoutTime && moment(date).isSame(moment(), 'day')) {
+    //  return options.FormatDate.time(date);
     } else {
       return options.FormatDate.relative(date, options);
     }
@@ -50,7 +50,12 @@ var _ = require('underscore'),
 
     return options.prefix +
            '<span class="' + classes.join(' ') + '" title="' + absolute + '">' +
-             '<span class="relative-date-content">' + relative + '</span>' +
+             '<span ' +
+               'class="relative-date-content '+ options.RelativeDate.getCssSelector() +'" ' +
+                options.RelativeDate.generateDataset(date, options) +
+             '>' +
+                relative +
+             '</span>' +
            '</span>' +
            options.suffix;
   };
@@ -73,7 +78,7 @@ var _ = require('underscore'),
     return '<span class="state ' + state + '">' + label + '</span>';
   };
 
-  module.filter('autoreply', function(FormatDate, $translate) {
+  module.filter('autoreply', function(FormatDate, RelativeDate, $translate, $sce) {
     'ngInject';
     return function (task) {
       if (!task || !task.state) {
@@ -83,10 +88,11 @@ var _ = require('underscore'),
         '<span class="autoreply" title="' + task.messages[0].message + '">' +
           '<span class="autoreply-content">' + $translate.instant('autoreply') + '</span>' +
         '</span>&nbsp';
-      return getRelativeDate(getTaskDate(task), {
+      return $sce.trustAsHtml(getRelativeDate(getTaskDate(task), {
         FormatDate: FormatDate,
-        prefix: content
-      });
+        RelativeDate: RelativeDate,
+        prefix: content,
+      }));
     };
   });
 
@@ -99,42 +105,45 @@ var _ = require('underscore'),
     return '';
   };
 
-  module.filter('state', function(FormatDate, $translate) {
+  module.filter('state', function(FormatDate, RelativeDate, $translate, $sce) {
     'ngInject';
     return function (task) {
       if (!task) {
         return '';
       }
-      return getRelativeDate(getTaskDate(task), {
+      return $sce.trustAsHtml(getRelativeDate(getTaskDate(task), {
         FormatDate: FormatDate,
+        RelativeDate: RelativeDate,
         prefix: getState(task.state || 'received', $translate) + '&nbsp;',
-        suffix: getRecipient(task, $translate)
-      });
+        suffix: getRecipient(task, $translate),
+      }));
     };
   });
 
-  module.filter('dateOfDeath', function(FormatDate, $translate) {
+  module.filter('dateOfDeath', function(FormatDate, RelativeDate, $translate, $sce) {
     'ngInject';
     return function (dod) {
       if (!dod) {
         return '';
       }
-      return getRelativeDate(dod, {
+      return $sce.trustAsHtml(getRelativeDate(dod, {
         FormatDate: FormatDate,
+        RelativeDate: RelativeDate,
         prefix: $translate.instant('contact.deceased.date.prefix') + '&nbsp;'
-      });
+      }));
     };
   });
 
-  module.filter('age', function(FormatDate) {
+  module.filter('age', function(FormatDate, RelativeDate, $sce) {
     'ngInject';
     return function (dob, dod) {
-      return getRelativeDate(dob, {
+      return $sce.trustAsHtml(getRelativeDate(dob, {
         FormatDate: FormatDate,
+        RelativeDate: RelativeDate,
         withoutTime: true,
         age: true,
         end: dod
-      });
+      }));
     };
   });
 
@@ -145,20 +154,24 @@ var _ = require('underscore'),
     };
   });
 
-  module.filter('relativeDate', function(FormatDate) {
+  module.filter('relativeDate', function(FormatDate, RelativeDate, $sce) {
     'ngInject';
     return function (date) {
-      return getRelativeDate(date, { FormatDate: FormatDate });
+      return $sce.trustAsHtml(getRelativeDate(date, {
+        FormatDate: FormatDate,
+        RelativeDate: RelativeDate
+      }));
     };
   });
 
-  module.filter('relativeDay', function(FormatDate) {
+  module.filter('relativeDay', function(FormatDate, RelativeDate, $sce) {
     'ngInject';
     return function (date) {
-      return getRelativeDate(date, {
+      return $sce.trustAsHtml(getRelativeDate(date, {
         FormatDate: FormatDate,
+        RelativeDate: RelativeDate,
         withoutTime: true
-      });
+      }));
     };
   });
 
@@ -174,13 +187,20 @@ var _ = require('underscore'),
     };
   });
 
-  module.filter('fullDate', function(FormatDate) {
+  module.filter('fullDate', function(FormatDate, RelativeDate, $sce) {
     return function (date) {
       if (!date) {
         return '';
       }
-      return '<div class="relative-date-content">' + FormatDate.relative(date) + '</div>' +
-             '<div class="full-date">' + FormatDate.datetime(date) + '</div>';
+      var result = '<div ' +
+                      'class="relative-date-content '+ RelativeDate.getCssSelector() +'" ' +
+                      RelativeDate.generateDataset(date) +
+                   '>' +
+                      FormatDate.relative(date) +
+                   '</div>' +
+                   '<div class="full-date">' + FormatDate.datetime(date) + '</div>';
+
+      return $sce.trustAsHtml(result);
     };
   });
 

--- a/static/js/services/index.js
+++ b/static/js/services/index.js
@@ -57,6 +57,8 @@
   require('./moment-locale-data');
   require('./place-hierarchy');
   require('./properties');
+  require('./recurring-process-manager');
+  require('./relative-date');
   require('./report-view-model-generator');
   require('./resource-icons');
   require('./rules-engine');

--- a/static/js/services/recurring-process-manager.js
+++ b/static/js/services/recurring-process-manager.js
@@ -1,0 +1,36 @@
+angular.module('inboxServices').factory('RecurringProcessManager',
+  function(
+    $interval,
+    RelativeDate
+  ) {
+    'use strict';
+    'ngInject';
+
+    var recurringProcesses = {
+      updateRelativeDates: {
+        interval: false,
+        timeDelta: 10 * 60 * 1000,
+        callback: RelativeDate.updateRelativeDates
+      }
+    };
+
+    return {
+      startUpdateRelativeDate: function() {
+        if (recurringProcesses.updateRelativeDates.interval) {
+          $interval.cancel(recurringProcesses.updateRelativeDates.interval);
+        }
+
+        recurringProcesses.updateRelativeDates.interval = $interval(
+          recurringProcesses.updateRelativeDates.callback,
+          recurringProcesses.updateRelativeDates.timeDelta,
+          false //don't digest
+        );
+      },
+      stopUpdateRelativeDate: function() {
+        if (recurringProcesses.updateRelativeDates.interval) {
+          $interval.cancel(recurringProcesses.updateRelativeDates.interval);
+        }
+      }
+    };
+  }
+);

--- a/static/js/services/recurring-process-manager.js
+++ b/static/js/services/recurring-process-manager.js
@@ -7,28 +7,25 @@ angular.module('inboxServices').factory('RecurringProcessManager',
     'ngInject';
 
     var recurringProcesses = {
-      updateRelativeDates: {
-        interval: false,
-        timeDelta: 10 * 60 * 1000,
-        callback: RelativeDate.updateRelativeDates
-      }
+      updateRelativeDates: false
     };
 
     return {
       startUpdateRelativeDate: function() {
-        if (recurringProcesses.updateRelativeDates.interval) {
-          $interval.cancel(recurringProcesses.updateRelativeDates.interval);
+        if (recurringProcesses.updateRelativeDates) {
+          $interval.cancel(recurringProcesses.updateRelativeDates);
         }
 
-        recurringProcesses.updateRelativeDates.interval = $interval(
-          recurringProcesses.updateRelativeDates.callback,
-          recurringProcesses.updateRelativeDates.timeDelta,
+        recurringProcesses.updateRelativeDates = $interval(
+          RelativeDate.updateRelativeDates,
+          10 * 60 * 1000,
           false //don't digest
         );
       },
       stopUpdateRelativeDate: function() {
-        if (recurringProcesses.updateRelativeDates.interval) {
-          $interval.cancel(recurringProcesses.updateRelativeDates.interval);
+        if (recurringProcesses.updateRelativeDates) {
+          $interval.cancel(recurringProcesses.updateRelativeDates);
+          recurringProcesses.updateRelativeDates = false;
         }
       }
     };

--- a/static/js/services/recurring-process-manager.js
+++ b/static/js/services/recurring-process-manager.js
@@ -18,7 +18,8 @@ angular.module('inboxServices').factory('RecurringProcessManager',
 
         recurringProcesses.updateRelativeDates = $interval(
           RelativeDate.updateRelativeDates,
-          10 * 60 * 1000,
+          RelativeDate.getUpdateTimeDelta || 10 * 60 * 1000,
+          0,
           false //don't digest
         );
       },

--- a/static/js/services/relative-date.js
+++ b/static/js/services/relative-date.js
@@ -1,0 +1,65 @@
+var moment = require('moment');
+
+angular.module('inboxServices').factory('RelativeDate',
+  function(
+    FormatDate
+  ) {
+    'use strict';
+    'ngInject';
+
+    var config = {
+      cssSelector: 'update-relative-date'
+    };
+
+    var getDataAttribute = function(key, value) {
+      return 'data-' + camelCaseToDash(key) + '="' + value + '"';
+    };
+
+    var camelCaseToDash = function(string) {
+      return string.replace(/[A-Z]/g, function(match) {
+        return '-' + match[0].toLowerCase();
+      });
+    };
+
+    var skipOptions = ['FormatDate', 'RelativeDate', 'suffix', 'prefix'];
+
+    return {
+      getCssSelector: function() {
+        return config.cssSelector;
+      },
+      generateDataset: function(date, options) {
+        var dataAttributes = [];
+        var momentDate = moment(date);
+        dataAttributes.push(getDataAttribute('date', momentDate.valueOf()));
+
+        for (var key in options) {
+          if (typeof options[key] !== 'object' && skipOptions.indexOf(key) === -1 && options[key]) {
+            dataAttributes.push(getDataAttribute(key, options[key]));
+          }
+        }
+
+        return dataAttributes.join(' ');
+      },
+      updateRelativeDates: function () {
+        var elements = document.querySelectorAll('.' + config.cssSelector);
+        elements.forEach(function(element) {
+          var options = Object.assign({}, element.dataset);
+          var timestamp = parseInt(options.date);
+
+          var isTimestamp = (new Date(timestamp)).getTime() > 0;
+          if (!isTimestamp) {
+            return;
+          }
+
+          if (options.age) {
+            element.textContent = FormatDate.age(timestamp, options);
+          } else {
+            element.textContent = FormatDate.relative(timestamp, options);
+          }
+        });
+
+        return elements;
+      }
+    };
+  }
+);

--- a/static/js/services/relative-date.js
+++ b/static/js/services/relative-date.js
@@ -57,8 +57,6 @@ angular.module('inboxServices').factory('RelativeDate',
             element.textContent = FormatDate.relative(timestamp, options);
           }
         });
-
-        return elements;
       }
     };
   }

--- a/static/js/services/relative-date.js
+++ b/static/js/services/relative-date.js
@@ -11,39 +11,44 @@ angular.module('inboxServices').factory('RelativeDate',
       cssSelector: 'update-relative-date'
     };
 
-    var getDataAttribute = function(key, value) {
-      return 'data-' + camelCaseToDash(key) + '="' + value + '"';
-    };
-
-    var camelCaseToDash = function(string) {
-      return string.replace(/[A-Z]/g, function(match) {
-        return '-' + match[0].toLowerCase();
-      });
-    };
-
     var skipOptions = ['FormatDate', 'RelativeDate', 'suffix', 'prefix'];
 
     return {
       getCssSelector: function() {
         return config.cssSelector;
       },
-      generateDataset: function(date, options) {
-        var dataAttributes = [];
+      generateDataset: function(date, options, absoluteToday) {
+        var dataAttributes = {};
         var momentDate = moment(date);
-        dataAttributes.push(getDataAttribute('date', momentDate.valueOf()));
+
+        dataAttributes.date = momentDate.valueOf();
+        if (absoluteToday) {
+          dataAttributes.absoluteToday = true;
+        }
 
         for (var key in options) {
           if (typeof options[key] !== 'object' && skipOptions.indexOf(key) === -1 && options[key]) {
-            dataAttributes.push(getDataAttribute(key, options[key]));
+            dataAttributes[key] = options[key];
           }
         }
 
-        return dataAttributes.join(' ');
+        return 'data-date-options=\''+ JSON.stringify(dataAttributes) +'\'';
       },
       updateRelativeDates: function () {
         var elements = document.querySelectorAll('.' + config.cssSelector);
         elements.forEach(function(element) {
-          var options = Object.assign({}, element.dataset);
+          var dataset = element.dataset.dateOptions;
+          var options;
+          if (!dataset) {
+            return;
+          }
+
+          try {
+            options = JSON.parse(dataset);
+          } catch (e) {
+            return;
+          }
+
           var timestamp = parseInt(options.date);
 
           var isTimestamp = (new Date(timestamp)).getTime() > 0;
@@ -53,6 +58,8 @@ angular.module('inboxServices').factory('RelativeDate',
 
           if (options.age) {
             element.textContent = FormatDate.age(timestamp, options);
+          } else if (!options.withoutTime && moment(timestamp).isSame(moment(), 'day') && options.absoluteToday) {
+            element.textContent = FormatDate.time(timestamp);
           } else {
             element.textContent = FormatDate.relative(timestamp, options);
           }

--- a/tests/karma/unit/controllers/inbox.js
+++ b/tests/karma/unit/controllers/inbox.js
@@ -7,11 +7,18 @@ describe('InboxCtrl controller', () => {
       snackbar,
       spyState,
       stubModal,
-      dummyId = 'dummydummy';
+      dummyId = 'dummydummy',
+      RecurringProcessManager
+  ;
 
   beforeEach(() => {
     snackbar = sinon.stub();
     module('inboxApp');
+
+    RecurringProcessManager = {
+      startUpdateRelativeDate: sinon.stub(),
+      stopUpdateRelativeDate: sinon.stub()
+    };
 
     module($provide => {
       $provide.value('ActiveRequests', sinon.stub());
@@ -66,10 +73,7 @@ describe('InboxCtrl controller', () => {
       $provide.value('UserSettings', sinon.stub());
       $provide.value('Tour', { getTours: () => Promise.resolve([]) });
       $provide.value('RulesEngine', { init: KarmaUtils.nullPromise()() });
-      $provide.value('RecurringProcessManager', {
-          startUpdateRelativeDate: sinon.stub(),
-          stopUpdateRelativeDate: sinon.stub()
-      });
+      $provide.value('RecurringProcessManager', RecurringProcessManager);
       $provide.constant('APP_CONFIG', {
         name: 'name',
         version: 'version'
@@ -132,4 +136,16 @@ describe('InboxCtrl controller', () => {
     });
   });
 
+  it('should start the relative date update recurring process', () => {
+    setTimeout(() => {
+      scope.$apply();
+
+      chai.expect(RecurringProcessManager.startUpdateRelativeDate.callCount).to.equal(1);
+    });
+  });
+
+  it('should cancel the relative date update recurring process when destroyed', () => {
+    scope.$destroy();
+    chai.expect(RecurringProcessManager.stopUpdateRelativeDate.callCount).to.equal(1);
+  });
 });

--- a/tests/karma/unit/controllers/inbox.js
+++ b/tests/karma/unit/controllers/inbox.js
@@ -66,6 +66,10 @@ describe('InboxCtrl controller', () => {
       $provide.value('UserSettings', sinon.stub());
       $provide.value('Tour', { getTours: () => Promise.resolve([]) });
       $provide.value('RulesEngine', { init: KarmaUtils.nullPromise()() });
+      $provide.value('RecurringProcessManager', {
+          startUpdateRelativeDate: sinon.stub(),
+          stopUpdateRelativeDate: sinon.stub()
+      });
       $provide.constant('APP_CONFIG', {
         name: 'name',
         version: 'version'

--- a/tests/karma/unit/filters/relative-date.js
+++ b/tests/karma/unit/filters/relative-date.js
@@ -42,12 +42,12 @@ describe('relativeDate filter', function() {
     chai.expect(element.text()).to.equal('somerelativetime');
   });
 
-  it('should render a time when the date is today', () => {
+  it('should render a relative date when the date is today', () => {
     //           today
     scope.date = moment().valueOf();
     var element = compile('<div ng-bind-html="date | relativeDate"></div>')(scope);
     scope.$digest();
     chai.expect(element.find('span').attr('title')).to.equal('day 0');
-    chai.expect(element.text()).to.equal('sometime');
+    chai.expect(element.text()).to.equal('somerelativetime');
   });
 });

--- a/tests/karma/unit/filters/relative-date.js
+++ b/tests/karma/unit/filters/relative-date.js
@@ -42,12 +42,12 @@ describe('relativeDate filter', function() {
     chai.expect(element.text()).to.equal('somerelativetime');
   });
 
-  it('should render a relative date when the date is today', () => {
+  it('should render a time when the date is today', () => {
     //           today
     scope.date = moment().valueOf();
     var element = compile('<div ng-bind-html="date | relativeDate"></div>')(scope);
     scope.$digest();
     chai.expect(element.find('span').attr('title')).to.equal('day 0');
-    chai.expect(element.text()).to.equal('somerelativetime');
+    chai.expect(element.text()).to.equal('sometime');
   });
 });

--- a/tests/karma/unit/services/recurring-process-manager.js
+++ b/tests/karma/unit/services/recurring-process-manager.js
@@ -1,0 +1,75 @@
+describe('RecurringProcessManager Service', () => {
+  let service,
+    $interval,
+    RelativeDate;
+
+  beforeEach(() => {
+    module('inboxApp');
+    $interval = sinon.stub();
+    $interval.cancel = sinon.stub();
+    RelativeDate = {
+      updateRelativeDates: sinon.stub(),
+      getUpdateTimeDelta: 10
+    };
+
+    module($provide => {
+      $provide.value('RelativeDate', RelativeDate);
+      $provide.value('$interval', $interval);
+    });
+    inject((_RecurringProcessManager_) => {
+      service = _RecurringProcessManager_;
+    });
+  });
+
+  it('should register the interval', done => {
+    service.startUpdateRelativeDate();
+
+    chai.expect($interval.callCount).to.equal(1);
+    chai.expect($interval.args[0][0]).to.equal(RelativeDate.updateRelativeDates);
+    chai.expect($interval.args[0][1]).to.equal(10);
+    chai.expect($interval.args[0][2]).to.equal(0);
+    chai.expect($interval.args[0][3]).to.equal(false);
+    done();
+  });
+
+  it('should cancel the interval', done => {
+    $interval.returns('theInterval');
+    service.startUpdateRelativeDate();
+    service.stopUpdateRelativeDate();
+
+    chai.expect($interval.cancel.callCount).to.equal(1);
+    chai.expect($interval.cancel.args[0].length).to.equal(1);
+    chai.expect($interval.cancel.args[0][0]).to.equal('theInterval');
+    done();
+  });
+
+  it('should cancel the previous interval before adding a new one', done => {
+    $interval.returns('theInterval');
+    service.startUpdateRelativeDate();
+    service.startUpdateRelativeDate();
+
+    chai.expect($interval.cancel.callCount).to.equal(1);
+    chai.expect($interval.cancel.args[0].length).to.equal(1);
+    chai.expect($interval.cancel.args[0][0]).to.equal('theInterval');
+    done();
+  });
+
+  it('should register and stop the interval', done => {
+    $interval.returns(setInterval(RelativeDate.updateRelativeDates, RelativeDate.getUpdateTimeDelta));
+    $interval.cancel = function(interval) {
+      clearInterval(interval);
+    };
+
+    service.startUpdateRelativeDate();
+    setTimeout(() => {
+      chai.expect(RelativeDate.updateRelativeDates.callCount).to.equal(5);
+      service.stopUpdateRelativeDate();
+    }, 50);
+
+    setTimeout(() => {
+      chai.expect(RelativeDate.updateRelativeDates.callCount).to.equal(5);
+      done();
+    }, 100);
+  });
+
+});

--- a/tests/karma/unit/services/relative-date.js
+++ b/tests/karma/unit/services/relative-date.js
@@ -1,0 +1,148 @@
+describe('RelativeDate Service', () => {
+  'use strict';
+
+  let service;
+  const TEST_DATE = 2398472085558;
+
+  beforeEach(() => {
+    module('inboxApp');
+    module($provide => {
+      $provide.value('FormatDate', {
+        datetime: function() {
+          return 'day 0';
+        },
+        relative: function(timestamp, options) {
+          if (options.withoutTime) {
+            return 'somerelativeday';
+          }
+          return 'somerelativetime';
+        },
+        time: function() {
+          return 'sometime';
+        },
+        age: function() {
+          return 'someage';
+        }
+      });
+    });
+    inject((_RelativeDate_) => {
+      service = _RelativeDate_;
+    });
+  });
+
+  afterEach(() => {
+    let elements = document.querySelectorAll('.update-relative-date');
+    elements.forEach(element => {
+      element.remove();
+    });
+  });
+
+  it('returns correct CSS selector', done => {
+    let actual = service.getCssSelector();
+    chai.expect(actual).to.equal('update-relative-date');
+    done();
+  });
+
+  it('generates correct dataset', done => {
+    let options = {
+      RelativeDate: service,
+      FormatDate: { someObject: 'somevalue' },
+      prefix: 'prefix',
+      suffix: 'suffix',
+      camelCase: 123456,
+      text: 'string',
+      undef: undefined,
+      isFalse: false,
+      isNull: null,
+      obj: { someProperty: 'somevalue' }
+    };
+
+    let actual = service.generateDataset(TEST_DATE, options);
+    chai.expect(actual).to.equal('data-date="2398472085558" data-camel-case="123456" data-text="string"');
+    done();
+  });
+
+  it('does nothing with no elements are present', done => {
+    let elements = service.updateRelativeDates();
+    chai.expect(elements.length).to.equal(0);
+    done();
+  });
+
+  it('does not update relative date when no date is present, date is undefined or incorrect', done => {
+    let spanNoDate = document.createElement('span');
+    spanNoDate.appendChild(document.createTextNode('sometext'));
+    spanNoDate.setAttribute('id', 'spanNoDate');
+    spanNoDate.className += 'update-relative-date';
+    document.body.appendChild(spanNoDate);
+
+    let spanUndefDate = document.createElement('span');
+    spanUndefDate.appendChild(document.createTextNode('sometext'));
+    spanUndefDate.setAttribute('id', 'spanUndefDate');
+    spanUndefDate.setAttribute('data-date', '');
+    spanUndefDate.className += 'update-relative-date';
+    document.body.appendChild(spanUndefDate);
+
+    let spanBadDate = document.createElement('span');
+    spanBadDate.appendChild(document.createTextNode('sometext'));
+    spanBadDate.setAttribute('id', 'spanBadDate');
+    spanBadDate.setAttribute('data-date', 'alpha');
+    spanBadDate.className += 'update-relative-date';
+    document.body.appendChild(spanBadDate);
+
+    let elements = service.updateRelativeDates();
+
+    chai.expect(elements.length).to.equal(3);
+    chai.expect(document.getElementById('spanNoDate').innerHTML).to.equal('sometext');
+    chai.expect(document.getElementById('spanUndefDate').innerHTML).to.equal('sometext');
+    chai.expect(document.getElementById('spanBadDate').innerHTML).to.equal('sometext');
+    done();
+  });
+
+  it('processes age option correctly', done => {
+    let spanAge = document.createElement('span');
+    spanAge.appendChild(document.createTextNode('sometext'));
+    spanAge.setAttribute('id', 'spanAge');
+    spanAge.setAttribute('data-date', '123456789');
+    spanAge.setAttribute('data-age', 'true');
+    spanAge.className += 'update-relative-date';
+    document.body.appendChild(spanAge);
+
+    let spanNoAge = document.createElement('span');
+    spanNoAge.appendChild(document.createTextNode('sometext'));
+    spanNoAge.setAttribute('id', 'spanNoAge');
+    spanNoAge.setAttribute('data-date', '123456789');
+    spanNoAge.className += 'update-relative-date';
+    document.body.appendChild(spanNoAge);
+
+    let elements = service.updateRelativeDates();
+
+    chai.expect(document.getElementById('spanAge').innerHTML).to.equal('someage');
+    chai.expect(document.getElementById('spanNoAge').innerHTML).to.equal('somerelativetime');
+    chai.expect(elements.length).to.equal(2);
+
+    done();
+  });
+
+  it('processes withoutTime option correctly', done => {
+    let spanWithoutTime = document.createElement('span');
+    spanWithoutTime.setAttribute('id', 'spanWithoutTime');
+    spanWithoutTime.setAttribute('data-date', '123456789');
+    spanWithoutTime.setAttribute('data-without-time', 'true');
+    spanWithoutTime.className += 'update-relative-date';
+    document.body.appendChild(spanWithoutTime);
+
+    let spanNoWithoutTime = document.createElement('span');
+    spanNoWithoutTime.setAttribute('id', 'spanNoWithoutTime');
+    spanNoWithoutTime.setAttribute('data-date', '123456789');
+    spanNoWithoutTime.className += 'update-relative-date';
+    document.body.appendChild(spanNoWithoutTime);
+
+    let elements = service.updateRelativeDates();
+
+    chai.expect(document.getElementById('spanWithoutTime').innerHTML).to.equal('somerelativeday');
+    chai.expect(document.getElementById('spanNoWithoutTime').innerHTML).to.equal('somerelativetime');
+    chai.expect(elements.length).to.equal(2);
+
+    done();
+  });
+});

--- a/tests/karma/unit/services/relative-date.js
+++ b/tests/karma/unit/services/relative-date.js
@@ -2,32 +2,40 @@ describe('RelativeDate Service', () => {
   'use strict';
 
   let service;
+  let formatDateRelativeDay = sinon.stub(),
+    formatDateRelativeTime = sinon.stub(),
+    formatDateAge = sinon.stub();
+
+  const resetStubs = () => {
+    formatDateAge.reset();
+    formatDateAge.returns('someage');
+
+    formatDateRelativeDay.reset();
+    formatDateRelativeDay.returns('somerelativeday');
+
+    formatDateRelativeTime.reset();
+    formatDateRelativeTime.returns('somerelativetime');
+  };
+
   const TEST_DATE = 2398472085558;
 
   beforeEach(() => {
     module('inboxApp');
     module($provide => {
       $provide.value('FormatDate', {
-        datetime: function() {
-          return 'day 0';
-        },
         relative: function(timestamp, options) {
           if (options.withoutTime) {
-            return 'somerelativeday';
+            return formatDateRelativeDay();
           }
-          return 'somerelativetime';
+          return formatDateRelativeTime();
         },
-        time: function() {
-          return 'sometime';
-        },
-        age: function() {
-          return 'someage';
-        }
+        age: formatDateAge
       });
     });
     inject((_RelativeDate_) => {
       service = _RelativeDate_;
     });
+    resetStubs();
   });
 
   afterEach(() => {
@@ -63,8 +71,9 @@ describe('RelativeDate Service', () => {
   });
 
   it('does nothing with no elements are present', done => {
-    let elements = service.updateRelativeDates();
-    chai.expect(elements.length).to.equal(0);
+    service.updateRelativeDates();
+    chai.expect(formatDateRelativeTime.callCount).to.equal(0);
+    chai.expect(formatDateAge.callCount).to.equal(0);
     done();
   });
 
@@ -89,12 +98,14 @@ describe('RelativeDate Service', () => {
     spanBadDate.className += 'update-relative-date';
     document.body.appendChild(spanBadDate);
 
-    let elements = service.updateRelativeDates();
+    service.updateRelativeDates();
 
-    chai.expect(elements.length).to.equal(3);
     chai.expect(document.getElementById('spanNoDate').innerHTML).to.equal('sometext');
     chai.expect(document.getElementById('spanUndefDate').innerHTML).to.equal('sometext');
     chai.expect(document.getElementById('spanBadDate').innerHTML).to.equal('sometext');
+
+    chai.expect(formatDateRelativeTime.callCount).to.equal(0);
+    chai.expect(formatDateAge.callCount).to.equal(0);
     done();
   });
 
@@ -114,11 +125,13 @@ describe('RelativeDate Service', () => {
     spanNoAge.className += 'update-relative-date';
     document.body.appendChild(spanNoAge);
 
-    let elements = service.updateRelativeDates();
+    service.updateRelativeDates();
 
     chai.expect(document.getElementById('spanAge').innerHTML).to.equal('someage');
     chai.expect(document.getElementById('spanNoAge').innerHTML).to.equal('somerelativetime');
-    chai.expect(elements.length).to.equal(2);
+
+    chai.expect(formatDateRelativeTime.callCount).to.equal(1);
+    chai.expect(formatDateAge.callCount).to.equal(1);
 
     done();
   });
@@ -137,11 +150,12 @@ describe('RelativeDate Service', () => {
     spanNoWithoutTime.className += 'update-relative-date';
     document.body.appendChild(spanNoWithoutTime);
 
-    let elements = service.updateRelativeDates();
-
+    service.updateRelativeDates();
     chai.expect(document.getElementById('spanWithoutTime').innerHTML).to.equal('somerelativeday');
     chai.expect(document.getElementById('spanNoWithoutTime').innerHTML).to.equal('somerelativetime');
-    chai.expect(elements.length).to.equal(2);
+
+    chai.expect(formatDateRelativeTime.callCount).to.equal(1);
+    chai.expect(formatDateRelativeDay.callCount).to.equal(1);
 
     done();
   });

--- a/tests/mocha/unit/filters/date.spec.js
+++ b/tests/mocha/unit/filters/date.spec.js
@@ -15,30 +15,67 @@ describe('date filter', function() {
     state: 'STATE',
   };
 
+  const camelCaseToDash = function(string) {
+    return string.replace(/[A-Z]/g, function(match) {
+      return '-' + match[0].toLowerCase();
+    });
+  };
+
   const FormatDate = {
     age: momentDate => `${momentDate.year() - 1970} years`,
     date: d => `${d.toISOString().split('T')[0]}`,
     datetime: d => `${d.toISOString()}`,
     relative: d => `${Math.floor((d - TEST_DATE) / 86400000)} days`,
   };
+  const RelativeDate = {
+    getCssSelector: () => {
+      return 'update-relative-date';
+    },
+    generateDataset: (date, options) => {
+      let dataset = [];
+      dataset.push(`data-date="${date.valueOf()}"`);
+
+      let allowedKeys = ['age', 'withoutTime', 'end'];
+      for (let key in options) {
+        if (allowedKeys.indexOf(key) !== -1 && options[key]) {
+          dataset.push(`data-${camelCaseToDash(key)}="${options[key]}"`);
+        }
+      }
+
+      return dataset.join(' ');
+    }
+  };
   const $translate = {
     instant: x => x,
   };
+  const $sce = {
+    trustAsHtml: x => x
+  };
+
 
   describe('age', function() {
 
-    const age = filter.age(FormatDate);
+    const age = filter.age(FormatDate, RelativeDate, $sce);
 
     it('should return nicely-formatted output', function() {
       // expect
-      assert.equal(age(TEST_DATE), '<span class="relative-date future" title="2046-01-02"><span class="relative-date-content">76 years</span></span>');
+      const expected = '<span class="relative-date future" title="2046-01-02">' +
+                         '<span class="relative-date-content update-relative-date" ' +
+                           'data-date="'+ TEST_DATE.valueOf() +'" ' +
+                           'data-without-time="true" ' +
+                           'data-age="true"' +
+                         '>' +
+                           '76 years' +
+                         '</span>' +
+                       '</span>';
+      assert.equal(age(TEST_DATE), expected);
     });
 
   });
 
   describe('autoreply', function() {
 
-    const autoreply = filter.autoreply(FormatDate, $translate);
+    const autoreply = filter.autoreply(FormatDate, RelativeDate, $translate, $sce);
 
     it('should return nicely-formatted output', function() {
       // expect
@@ -60,33 +97,48 @@ describe('date filter', function() {
 
   describe('fullDate', function() {
 
-    const fullDate = filter.fullDate(FormatDate);
+    const fullDate = filter.fullDate(FormatDate, RelativeDate, $sce);
 
     it('should return nicely-formatted output', function() {
       // expect
-      assert.equal(fullDate(TEST_DATE), '<div class="relative-date-content">0 days</div><div class="full-date">2046-01-02T02:14:45.558Z</div>');
+      const expected = '<div class="relative-date-content update-relative-date" data-date="' + TEST_DATE.valueOf() + '">' +
+                       '0 days' +
+                       '</div>' +
+                       '<div class="full-date">2046-01-02T02:14:45.558Z</div>';
+      assert.equal(fullDate(TEST_DATE), expected);
     });
 
   });
 
   describe('relativeDate', function() {
 
-    const relativeDate = filter.relativeDate(FormatDate);
+    const relativeDate = filter.relativeDate(FormatDate, RelativeDate, $sce);
 
     it('should return nicely-formatted output', function() {
       // expect
-      assert.equal(relativeDate(TEST_DATE), '<span class="relative-date future" title="2046-01-02T02:14:45.558Z"><span class="relative-date-content">0 days</span></span>');
+      const expected = '<span class="relative-date future" title="2046-01-02T02:14:45.558Z">' +
+                         '<span class="relative-date-content update-relative-date" data-date="' + TEST_DATE.valueOf() + '">0 days</span>' +
+                       '</span>';
+      assert.equal(relativeDate(TEST_DATE), expected);
     });
 
   });
 
   describe('relativeDay', function() {
 
-    const relativeDay = filter.relativeDay(FormatDate);
+    const relativeDay = filter.relativeDay(FormatDate, RelativeDate, $sce);
 
     it('should return nicely-formatted output', function() {
       // expect
-      assert.equal(relativeDay(TEST_DATE), '<span class="relative-date future" title="2046-01-02"><span class="relative-date-content">0 days</span></span>');
+      const expected = '<span class="relative-date future" title="2046-01-02">' +
+                         '<span class="relative-date-content update-relative-date" ' +
+                           'data-date="' + TEST_DATE.valueOf() + '" ' +
+                           'data-without-time="true"' +
+                         '>' +
+                           '0 days' +
+                         '</span>' +
+                       '</span>';
+      assert.equal(relativeDay(TEST_DATE), expected);
     });
 
   });
@@ -115,7 +167,7 @@ describe('date filter', function() {
 
   describe('state', function() {
 
-    const state = filter.state(FormatDate, $translate);
+    const state = filter.state(FormatDate, RelativeDate, $translate, $sce);
 
     it('should return nicely-formatted output', function() {
       // expect

--- a/tests/mocha/unit/filters/date.spec.js
+++ b/tests/mocha/unit/filters/date.spec.js
@@ -15,36 +15,22 @@ describe('date filter', function() {
     state: 'STATE',
   };
 
-  const camelCaseToDash = function(string) {
-    return string.replace(/[A-Z]/g, function(match) {
-      return '-' + match[0].toLowerCase();
-    });
-  };
-
   const FormatDate = {
     age: momentDate => `${momentDate.year() - 1970} years`,
     date: d => `${d.toISOString().split('T')[0]}`,
     datetime: d => `${d.toISOString()}`,
     relative: d => `${Math.floor((d - TEST_DATE) / 86400000)} days`,
   };
+
   const RelativeDate = {
     getCssSelector: () => {
       return 'update-relative-date';
     },
-    generateDataset: (date, options) => {
-      let dataset = [];
-      dataset.push(`data-date="${date.valueOf()}"`);
-
-      let allowedKeys = ['age', 'withoutTime', 'end'];
-      for (let key in options) {
-        if (allowedKeys.indexOf(key) !== -1 && options[key]) {
-          dataset.push(`data-${camelCaseToDash(key)}="${options[key]}"`);
-        }
-      }
-
-      return dataset.join(' ');
+    generateDataset: () => {
+      return 'data-date-options="someOptions"';
     }
   };
+
   const $translate = {
     instant: x => x,
   };
@@ -54,16 +40,13 @@ describe('date filter', function() {
 
 
   describe('age', function() {
-
     const age = filter.age(FormatDate, RelativeDate, $sce);
 
     it('should return nicely-formatted output', function() {
       // expect
       const expected = '<span class="relative-date future" title="2046-01-02">' +
                          '<span class="relative-date-content update-relative-date" ' +
-                           'data-date="'+ TEST_DATE.valueOf() +'" ' +
-                           'data-without-time="true" ' +
-                           'data-age="true"' +
+                           'data-date-options="someOptions"' +
                          '>' +
                            '76 years' +
                          '</span>' +
@@ -101,8 +84,10 @@ describe('date filter', function() {
 
     it('should return nicely-formatted output', function() {
       // expect
-      const expected = '<div class="relative-date-content update-relative-date" data-date="' + TEST_DATE.valueOf() + '">' +
-                       '0 days' +
+      const expected = '<div class="relative-date-content update-relative-date" ' +
+                         'data-date-options="someOptions"' +
+                       '>' +
+                         '0 days' +
                        '</div>' +
                        '<div class="full-date">2046-01-02T02:14:45.558Z</div>';
       assert.equal(fullDate(TEST_DATE), expected);
@@ -117,7 +102,7 @@ describe('date filter', function() {
     it('should return nicely-formatted output', function() {
       // expect
       const expected = '<span class="relative-date future" title="2046-01-02T02:14:45.558Z">' +
-                         '<span class="relative-date-content update-relative-date" data-date="' + TEST_DATE.valueOf() + '">0 days</span>' +
+                         '<span class="relative-date-content update-relative-date" data-date-options="someOptions">0 days</span>' +
                        '</span>';
       assert.equal(relativeDate(TEST_DATE), expected);
     });
@@ -132,8 +117,7 @@ describe('date filter', function() {
       // expect
       const expected = '<span class="relative-date future" title="2046-01-02">' +
                          '<span class="relative-date-content update-relative-date" ' +
-                           'data-date="' + TEST_DATE.valueOf() + '" ' +
-                           'data-without-time="true"' +
+                           'data-date-options="someOptions"' +
                          '>' +
                            '0 days' +
                          '</span>' +


### PR DESCRIPTION
# Description

Adds a service which handles recurring processes and adds some
additional markup to relative dates, so the displayed text can be
regenerated at desired intervals.

medic/medic-webapp#2753

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.