### PR TITLE
Don't merge changes responses if there's only one

### DIFF
--- a/api/handlers/changes.js
+++ b/api/handlers/changes.js
@@ -224,12 +224,21 @@ const getChanges = feed => {
           });
           return;
         }
-        const changes = mergeChangesResponses(responses);
-        if (!changes) {
+        const malformedResponse = responses.find(response => {
+          if (!response || !response.results) {
+            // See: https://github.com/medic/medic-webapp/issues/3099
+            // This should never happen, but apparently it does sometimes.
+            // Attempting to log out the response usefully to see what's occuring
+            console.error('No _changes error, but malformed response:', JSON.stringify(changes));
+            return true;
+          }
+        });
+        if (malformedResponse) {
           return errorResponse(feed, 'No _changes error, but malformed response.');
         }
-        cleanUp(feed);
+        const changes = responses.length === 1 ? responses[0] : mergeChangesResponses(responses);
         prepareResponse(feed, changes);
+        cleanUp(feed);
         feed.res.end();
         endTimer('getChanges().end', startTime);
       });
@@ -240,32 +249,16 @@ const getChanges = feed => {
 const mergeChangesResponses = responses => {
   let lastSeqNum = 0;
   let lastSeq;
-  let err = false;
   const results = [];
 
   responses.forEach(changes => {
-    if (err) {
-      return;
-    }
-    if (!changes || !changes.results) {
-      // See: https://github.com/medic/medic-webapp/issues/3099
-      // This should never happen, but apparently it does sometimes.
-      // Attempting to log out the response usefully to see what's occuring
-      console.error('No _changes error, but malformed response:', JSON.stringify(changes));
-      err = true;
-    } else {
-      results.push(changes.results);
-      const numericSeq = numericSeqFrom(changes.last_seq);
-      if (numericSeq > lastSeqNum) {
-        lastSeq = changes.last_seq;
-        lastSeqNum = numericSeq;
-      }
+    results.push(changes.results);
+    const numericSeq = numericSeqFrom(changes.last_seq);
+    if (numericSeq > lastSeqNum) {
+      lastSeq = changes.last_seq;
+      lastSeqNum = numericSeq;
     }
   });
-
-  if (err) {
-    return;
-  }
 
   const merged = Array.prototype.concat(...results); // flatten the result sets
   merged.sort((a, b) => numericSeqFrom(a.seq) - numericSeqFrom(b.seq));

--- a/api/handlers/changes.js
+++ b/api/handlers/changes.js
@@ -229,16 +229,16 @@ const getChanges = feed => {
             // See: https://github.com/medic/medic-webapp/issues/3099
             // This should never happen, but apparently it does sometimes.
             // Attempting to log out the response usefully to see what's occuring
-            console.error('No _changes error, but malformed response:', JSON.stringify(changes));
+            console.error('No _changes error, but malformed response:', JSON.stringify(responses));
             return true;
           }
         });
         if (malformedResponse) {
           return errorResponse(feed, 'No _changes error, but malformed response.');
         }
+        cleanUp(feed);
         const changes = responses.length === 1 ? responses[0] : mergeChangesResponses(responses);
         prepareResponse(feed, changes);
-        cleanUp(feed);
         feed.res.end();
         endTimer('getChanges().end', startTime);
       });


### PR DESCRIPTION
# Description

With longpoll replication we don't make multiple requests to couch
so there's only one response. In this case we can shortcircuit
response merging and sorting and just copy the response.

This gives us a small performance improvement for a common use case.

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.