### PR TITLE
Include reports from deceased children in place profile

### DIFF
--- a/static/js/services/contact-view-model-generator.js
+++ b/static/js/services/contact-view-model-generator.js
@@ -227,11 +227,13 @@ angular.module('inboxServices').factory('ContactViewModelGenerator',
 
     var setReports = function(model) {
       var contacts = [ model.doc ];
-      if (model.children.persons) {
-        model.children.persons.forEach(function(child) {
-          contacts.push(child.doc);
-        });
-      }
+      [ 'persons', 'deceased' ].forEach(function(type) {
+        if (model.children[type]) {
+          model.children[type].forEach(function(child) {
+            contacts.push(child.doc);
+          });
+        }
+      });
       return getReports(contacts)
         .then(function(reports) {
           addPatientName(reports, contacts);

--- a/tests/karma/unit/services/contact-view-model-generator.js
+++ b/tests/karma/unit/services/contact-view-model-generator.js
@@ -267,10 +267,10 @@ describe('ContactViewModelGenerator service', () => {
       });
     });
 
-    it('includes reports from child places', () => {
+    it('includes reports from children', () => {
       stubSearch(null, [ { _id: 'ab' },{ _id: 'cd' } ]);
-      return runReportsTest([childPerson, childPerson2]).then(model => {
-        chai.expect(search.args[0][1].subjectIds).to.deep.equal([ doc._id, childPerson2._id, childPerson._id ]);
+      return runReportsTest([childPerson, childPerson2, deceasedChildPerson]).then(model => {
+        chai.expect(search.args[0][1].subjectIds).to.deep.equal([ doc._id, childPerson2._id, childPerson._id, deceasedChildPerson._id ]);
         chai.expect(search.callCount).to.equal(1);
         chai.expect(model.reports.length).to.equal(2);
         chai.expect(model.reports[0]._id).to.equal('ab');


### PR DESCRIPTION
Places with deceased children will now show the reports for those
children on the contact detail page in the list of reports.

medic/medic-webapp#3956

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.