### PR TITLE
Report exporting 2.0

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -382,6 +382,7 @@ module.exports = function(grunt) {
       unit: {
         src: [
           'tests/mocha/unit/**/*.spec.js',
+          'api/tests/mocha/**/*.js',
           'sentinel/test/mocha/**/*.js'
         ],
       },

--- a/api/controllers/export-data-2.js
+++ b/api/controllers/export-data-2.js
@@ -38,18 +38,11 @@ const CSV_MAPPER = {
     let p = Promise.resolve();
     // If they have not selected any forms we need to get all available ones
     if (!forms) {
-      p = p.then(() => {
-        // TODO: look at the XmlForms and JsonForms code and use those to work
-        //   this out. You may need to pull these out into a shared library,
-        //   or just copy what they do.
-        console.warn('****************************');
-        console.warn('****************************');
-        console.warn('Exporting ALL forms is not yet supported');
-        console.warn('****************************');
-        console.warn('****************************');
-        return DB.query('medic-client/forms')
-          .then(results => _.pluck(results.rows, 'key'));
-        });
+      p = p.then(() =>
+        DB.query('medic-client/reports_by_form', {
+          group: true
+        }).then(results => results.rows.map(r => r.key[0]))
+      );
     } else {
       p = p.then(() => forms);
     }
@@ -60,7 +53,8 @@ const CSV_MAPPER = {
         DB.query('medic-client/reports_by_form', {
           key: [form],
           limit: 1,
-          include_docs: true
+          include_docs: true,
+          reduce: false
         })
         .then(results =>
           results.rows[0] &&

--- a/api/controllers/export-data-2.js
+++ b/api/controllers/export-data-2.js
@@ -227,6 +227,10 @@ class SearchResultReader extends Readable {
           this.push(
             _.pluck(results.rows, 'doc')
              .map(this.csvFn)
+             // TODO: pass this through a better CSV generator:
+             //  - quote things
+             //  - escape quotes
+             //  - ???
              .map(csvLine => csvLine.join(JOIN_COL))
              .join(JOIN_ROW) + JOIN_ROW // new line at the end
           )

--- a/api/controllers/export-data-2.js
+++ b/api/controllers/export-data-2.js
@@ -90,7 +90,7 @@ const hydrateDataRecords = result => {
  * }
  */
 const flatten = (fields, prepend=[]) => {
-  Object.keys(fields).reduce((acc, k) => {
+  return Object.keys(fields).reduce((acc, k) => {
     const path = [...prepend, k];
 
     if (typeof fields[k] === 'object' && fields[k] && !Array.isArray(fields[k])) {

--- a/api/controllers/export-data-2.js
+++ b/api/controllers/export-data-2.js
@@ -1,0 +1,50 @@
+const PouchDB = require('pouchdb-core');
+PouchDB.plugin(require('pouchdb-adapter-http'));
+PouchDB.plugin(require('pouchdb-mapreduce'));
+
+const db = new PouchDB(process.env.COUCH_URL);
+
+const { Readable } = require('stream'),
+      search = require('search')(Promise, db);
+
+const BATCH = 1000;
+
+class SearchResultReader extends Readable {
+
+  constructor(type, filters, searchOptions, readableOptions) {
+    super(readableOptions);
+
+    this.type = type;
+    this.filters = filters;
+    this.options = searchOptions;
+
+    this.more = true;
+  }
+
+  _read() {
+    if (!this.more) {
+      return this.push(null);
+    }
+
+    this.more = false;
+    search(this.type, this.filters, this.options)
+      .then(ids => {
+        console.log('IDS', JSON.stringify(ids, null, 2));
+
+        // TODO: write this so we stream the ids back in BATCH amounts
+        // TODO: resolve into documents
+        // TODO: convert into a CSV
+        // TODO: stream the above process, including searching in pages
+        // TODO: pipe through a zip creation?
+        this.push(JSON.stringify(ids, null, 2));
+      })
+      .catch(err => {
+        process.nextTick(() => this.emit('error', err));
+      });
+  }
+}
+
+module.exports = {
+  export: (type, filters, options) =>
+    new SearchResultReader(type, filters, options)
+};

--- a/api/controllers/export-data-2.js
+++ b/api/controllers/export-data-2.js
@@ -27,7 +27,7 @@ const SUPPORTED_EXPORTS = ['reports'];
 // right now, though it would need to be ES5-a-fied if we wanted to use it on
 // the front end.
 //
-// https://github.com/medic/medic-webapp/issues/XXXX
+// https://github.com/medic/medic-webapp/issues/3826
 //
 const findContact = (contactRows, id) => {
   return id && contactRows.find(contactRow => contactRow.id === id);

--- a/api/controllers/export-data-2.js
+++ b/api/controllers/export-data-2.js
@@ -89,20 +89,23 @@ const hydrateDataRecords = result => {
  *   "foo.bar": "smang"
  * }
  */
-const flatten = (fields, prepend=[]) =>
+const flatten = (fields, prepend=[]) => {
   Object.keys(fields).reduce((acc, k) => {
     const path = [...prepend, k];
+
     if (typeof fields[k] === 'object' && fields[k] && !Array.isArray(fields[k])) {
       // Recurse into valid objects. We ignore arrays as they are variable
       // length, so you can't generate a stable header out of them. Instead,
       // when we convert them into CSV we JSON.stringify them and treat them as
       // one cell.
-      return _.extend(acc, flatten(fields[k], path));
+      _.extend(acc, flatten(fields[k], path));
     } else {
       acc[path.join('.')] = fields[k];
-      return acc;
     }
+
+    return acc;
   }, {});
+};
 
 const CSV_MAPPER = {
   reports: (filters) => {
@@ -207,8 +210,8 @@ class SearchResultReader extends Readable {
     const escapedCsvLine = csvLine.map(cell => {
       let escaped;
 
-      // Strings and arrays (because they might contain strings etc) need to
-      // be quoted and escaped
+      // Strings and arrays (because they contain commas, might contain strings
+      // etc) need to be quoted and escaped
       if (typeof cell === 'string') {
         escaped = cell.replace(/"/g, '\\"');
       } else if (Array.isArray(cell)) {

--- a/api/controllers/export-data-2.js
+++ b/api/controllers/export-data-2.js
@@ -47,7 +47,7 @@ const hydrateDataRecords = result => {
   });
 
   if (!contactIds.length) {
-    return Promise.resolve();
+    return Promise.resolve(result);
   }
 
   return DB.allDocs({

--- a/api/controllers/export-data-2.js
+++ b/api/controllers/export-data-2.js
@@ -211,18 +211,16 @@ class SearchResultReader extends Readable {
   }
 
   _read() {
-    let printHeader;
-
-    let p = Promise.resolve();
     if (!this.csvFn) {
-      p = p
+      return Promise.resolve()
         .then(() => CSV_MAPPER[this.type](this.filters, this.options))
         .then(({ header, fn }) => {
           this.csvFn = fn;
-          printHeader = header;
+          this.push(header.join(JOIN_COL) + JOIN_ROW);
         });
     }
-    p = p
+
+    return Promise.resolve()
       .then(() => search(this.type, this.filters, this.options))
       .then(ids => {
 
@@ -239,7 +237,6 @@ class SearchResultReader extends Readable {
         .then(hydrateDataRecords)
         .then(results =>
           this.push(
-            printHeader ? printHeader.join(JOIN_COL) + JOIN_ROW : '' +
             _.pluck(results.rows, 'doc')
              .map(this.csvFn)
              .map(csvLine => csvLine.join(JOIN_COL))

--- a/api/controllers/export-data-2.js
+++ b/api/controllers/export-data-2.js
@@ -16,7 +16,7 @@ const SUPPORTED_EXPORTS = ['reports'];
 
 
 //
-// TODO: these functions is copied from `export-data.js`, and modified to use
+// TODO: these functions are copied from `export-data.js`, and modified to use
 // PouchDB / promises. We should remove both copies of these functions and create
 // a shared lineage library that we can use here, as well as in the rest of api,
 // sentinel and webapp.

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1459,6 +1459,20 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
       "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
     },
+    "pouchdb-abstract-mapreduce": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-abstract-mapreduce/-/pouchdb-abstract-mapreduce-6.4.3.tgz",
+      "integrity": "sha512-omSNRtSf5S/O6SdIy3RV5ODdftL7x0txoBKo2BBr72Ji1r3460ftRfKzurRnHwTYTPzxAZYqm2IkRExSqQRfNQ==",
+      "requires": {
+        "pouchdb-binary-utils": "6.4.3",
+        "pouchdb-collate": "6.4.3",
+        "pouchdb-collections": "6.4.3",
+        "pouchdb-mapreduce-utils": "6.4.3",
+        "pouchdb-md5": "6.4.3",
+        "pouchdb-promise": "6.4.3",
+        "pouchdb-utils": "6.4.3"
+      }
+    },
     "pouchdb-adapter-http": {
       "version": "6.4.3",
       "resolved": "https://registry.npmjs.org/pouchdb-adapter-http/-/pouchdb-adapter-http-6.4.3.tgz",
@@ -1553,6 +1567,36 @@
       "integrity": "sha512-EU83ZZJjorwGL9DQZ9HAILY8D+ulX2RYVMtsCfIuzaIJEUrHh/dhSIy5854n42NBOUWug3gFDyO58w5k+64HTQ==",
       "requires": {
         "inherits": "2.0.3"
+      }
+    },
+    "pouchdb-mapreduce": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-mapreduce/-/pouchdb-mapreduce-6.4.3.tgz",
+      "integrity": "sha512-hffB4/ecq5HwLPztRZrTDf/BgzwjvRDJQjTcVJ4h/Jd8g7jGkkPUUcXP4ky7lOf2DBG9hEDFo1/dE1IlMJmqSg==",
+      "requires": {
+        "pouchdb-abstract-mapreduce": "6.4.3",
+        "pouchdb-mapreduce-utils": "6.4.3",
+        "pouchdb-utils": "6.4.3"
+      }
+    },
+    "pouchdb-mapreduce-utils": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-mapreduce-utils/-/pouchdb-mapreduce-utils-6.4.3.tgz",
+      "integrity": "sha512-gbxX6h+nOKPDv2eYZznUthHiZ1Ml1xViE8DalEy6+fPzCba6CZ6dTKGZoFrBg4oLF3Wc+cUNX9Uk8cezVMGOhA==",
+      "requires": {
+        "argsarray": "0.0.1",
+        "inherits": "2.0.3",
+        "pouchdb-collections": "6.4.3",
+        "pouchdb-utils": "6.4.3"
+      }
+    },
+    "pouchdb-md5": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-md5/-/pouchdb-md5-6.4.3.tgz",
+      "integrity": "sha512-EnToEO+JLJA5bHDYWs42B8hU9Q1TckVozQjTSXL/pDXKXLATuVEKHNq8F/4lrpxblpngx4Zt8z2Luwu0etLSqw==",
+      "requires": {
+        "pouchdb-binary-utils": "6.4.3",
+        "spark-md5": "3.0.0"
       }
     },
     "pouchdb-merge": {
@@ -1925,7 +1969,6 @@
     },
     "search": {
       "version": "file:../shared-libs/search",
-      "integrity": null,
       "requires": {
         "moment": "2.19.1",
         "underscore": "1.8.3"
@@ -1999,6 +2042,11 @@
       "requires": {
         "hoek": "2.16.3"
       }
+    },
+    "spark-md5": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.0.tgz",
+      "integrity": "sha1-NyIifFTi+vJLHcbZM8wUTm9xv+8="
     },
     "sshpk": {
       "version": "1.13.0",

--- a/api/package.json
+++ b/api/package.json
@@ -26,6 +26,7 @@
     "pass-stream": "^1.0.0",
     "pouchdb-adapter-http": "^6.4.3",
     "pouchdb-core": "^6.4.3",
+    "pouchdb-mapreduce": "^6.4.3",
     "properties": "^1.2.1",
     "request": "^2.83.0",
     "search": "file:../shared-libs/search",

--- a/api/server.js
+++ b/api/server.js
@@ -1,6 +1,7 @@
 var _ = require('underscore'),
     async = require('async'),
     bodyParser = require('body-parser'),
+    domain = require('domain');
     express = require('express'),
     morgan = require('morgan'),
     moment = require('moment'),
@@ -383,16 +384,13 @@ app.postJson('/api/v2/export/:type', (req, res) => {
     //  - If they are online then it's normal
     //  - If they are offline it's scoped to their facility
 
-    // TODO: support streaming, presumably by passing the response down? Or
-    // changing the api to return some kind of streaming thing?
-
-    exportData2.export(type, filters, options).pipe(res);
-      // .then(results => {
-      //   res.json(results);
-      // })
-      // .catch(err => {
-      //   return serverUtils.error(err, req, res);
-      // });
+    // TODO: pipe through a zip creation?
+    const d = domain.create();
+    d.on('error', err => serverUtils.error(err, req, res));
+    d.run(() =>
+      exportData2
+        .export(type, filters, options)
+        .pipe(res));
   });
 });
 

--- a/api/server.js
+++ b/api/server.js
@@ -373,10 +373,11 @@ app.all([
 });
 
 const exportDataV2 = (req, res) => {
-  req.body = req.body || (req.query.body && JSON.parse(req.query.body)) || {};
   const type = req.params.type,
-        filters = req.body.filters || {},
-        options = req.body.options || {};
+        filters = (req.body && req.body.filters) ||
+                  (req.query && req.query.filters) || {},
+        options = (req.body && req.body.options) ||
+                  (req.query && req.query.options) || {};
 
   if (!exportData2.supportedExports.includes(type)) {
     return serverUtils.error({

--- a/api/server.js
+++ b/api/server.js
@@ -387,12 +387,12 @@ const exportDataV2 = (req, res) => {
     }, req, res);
   }
 
-  // We currently only support online users (CouchDB admins and National Admisn)
+  // We currently only support online users (CouchDB admins and National Admins)
   // If we want to support offline users we should either:
   //  - Forcibly scope their search object to their facility, which is returned
   //    by the following auth check in ctx.district (maybe?)
-  //  - Still don't let offilne users use this API, and instead refactor the
-  //    export logic so it can be used in webapp, and have exports workn offline
+  //  - Still don't let offline users use this API, and instead refactor the
+  //    export logic so it can be used in webapp, and have exports works offline
   auth.check(req, ['national_admin', getExportPermission(req.params.type)], null, function(err) {
     if (err) {
       return serverUtils.error(err, req, res);

--- a/api/server.js
+++ b/api/server.js
@@ -379,7 +379,7 @@ app.postJson('/api/v2/export/:type', (req, res) => {
 
   if (!exportData2.supportedExports.includes(type)) {
     return serverUtils.error({
-      message: 'v2 export only supports forms and contacts',
+      message: `v2 export only supports ${exportData2.supportedExports}`,
       code: 404
     }, req, res);
   }

--- a/api/server.js
+++ b/api/server.js
@@ -373,9 +373,10 @@ app.all([
 });
 
 const exportDataV2 = (req, res) => {
+  req.body = req.body || (req.query.body && JSON.parse(req.query.body)) || {};
   const type = req.params.type,
-        filters = req.body && req.body.filters || {},
-        options = req.body && req.body.options || {};
+        filters = req.body.filters || {},
+        options = req.body.options || {};
 
   if (!exportData2.supportedExports.includes(type)) {
     return serverUtils.error({

--- a/api/server.js
+++ b/api/server.js
@@ -32,6 +32,7 @@ var _ = require('underscore'),
     monthlyRegistrations = require('./controllers/monthly-registrations'),
     monthlyDeliveries = require('./controllers/monthly-deliveries'),
     exportData = require('./controllers/export-data'),
+    exportData2 = require('./controllers/export-data-2'),
     messages = require('./controllers/messages'),
     records = require('./controllers/records'),
     forms = require('./controllers/forms'),
@@ -367,6 +368,31 @@ app.all([
         res.send(exportDataResult);
       }
     });
+  });
+});
+
+// TODO: consider security of this new api
+//       How do we check to make sure people aren't passing search requests
+app.postJson('/api/v2/export/:type', (req, res) => {
+  const type = req.params.type,
+        filters = req.body.filters,
+        options = req.body.options;
+
+  auth.check(req, getExportPermission(req.params.type), null, function(err, ctx) {
+    // TODO: determine root of search:
+    //  - If they are online then it's normal
+    //  - If they are offline it's scoped to their facility
+
+    // TODO: support streaming, presumably by passing the response down? Or
+    // changing the api to return some kind of streaming thing?
+
+    exportData2.export(type, filters, options).pipe(res);
+      // .then(results => {
+      //   res.json(results);
+      // })
+      // .catch(err => {
+      //   return serverUtils.error(err, req, res);
+      // });
   });
 });
 

--- a/api/tests/mocha/.jshintrc
+++ b/api/tests/mocha/.jshintrc
@@ -1,0 +1,4 @@
+{
+    "extends"       : "../../.jshintrc",
+    "mocha"         : "true"
+}

--- a/api/tests/mocha/controllers/export-data-2.js
+++ b/api/tests/mocha/controllers/export-data-2.js
@@ -1,6 +1,5 @@
 require('chai').should();
 
-const sinon = require('sinon').sandbox.create();
 const controller = require('../../../controllers/export-data-2');
 
 describe('Export Data 2.0', () => {

--- a/api/tests/mocha/controllers/export-data-2.js
+++ b/api/tests/mocha/controllers/export-data-2.js
@@ -1,0 +1,50 @@
+require('chai').should();
+
+const controller = require('../../../controllers/export-data-2');
+
+describe('Export Data 2.0', () => {
+  describe('Extract fields', () => {
+    it('flattens fields', () => {
+      controller._flatten({
+        foo: 'fooVal',
+        bars: {
+          bar1: 'bar1Val',
+          smang: {
+            smong: 'smongVal'
+          }
+        }
+      }).should.deep.equal({
+        foo: 'fooVal',
+        'bars.bar1': 'bar1Val',
+        'bars.smang.smong': 'smongVal'
+      });
+    });
+    it('Converts null / undefined into empty string', () => {
+      controller._flatten({
+        foo: '',
+        bar: null,
+        smang: undefined
+      }).should.deep.equal({
+        foo: '',
+        bar: '',
+        smang: ''
+      });
+    });
+    it('Handles arrays', () => {
+      // TODO: do we want it to work this way? Does it matter?
+      controller._flatten({
+        foo: [1,2,3],
+        bar: {
+          smang:['a','b','c']
+        }
+      }).should.deep.equal({
+        'foo.0': 1,
+        'foo.1': 2,
+        'foo.2': 3,
+        'bar.smang.0': 'a',
+        'bar.smang.1': 'b',
+        'bar.smang.2': 'c'
+      });
+    });
+  });
+});

--- a/api/tests/mocha/controllers/export-data-2.js
+++ b/api/tests/mocha/controllers/export-data-2.js
@@ -19,17 +19,6 @@ describe('Export Data 2.0', () => {
         'bars.smang.smong': 'smongVal'
       });
     });
-    it('Converts null / undefined into empty string', () => {
-      controller._flatten({
-        foo: '',
-        bar: null,
-        smang: undefined
-      }).should.deep.equal({
-        foo: '',
-        bar: '',
-        smang: ''
-      });
-    });
     it('Handles arrays', () => {
       // TODO: do we want it to work this way? Does it matter?
       controller._flatten({

--- a/api/tests/mocha/controllers/export-data-2.js
+++ b/api/tests/mocha/controllers/export-data-2.js
@@ -19,20 +19,15 @@ describe('Export Data 2.0', () => {
         'bars.smang.smong': 'smongVal'
       });
     });
-    it('Handles arrays', () => {
-      // TODO: do we want it to work this way? Does it matter?
+    it('assigns arrays to a single cell', () => {
       controller._flatten({
         foo: [1,2,3],
         bar: {
           smang:['a','b','c']
         }
       }).should.deep.equal({
-        'foo.0': 1,
-        'foo.1': 2,
-        'foo.2': 3,
-        'bar.smang.0': 'a',
-        'bar.smang.1': 'b',
-        'bar.smang.2': 'c'
+        foo: [1,2,3],
+        'bar.smang': ['a', 'b', 'c']
       });
     });
   });

--- a/api/tests/mocha/controllers/export-data-2.js
+++ b/api/tests/mocha/controllers/export-data-2.js
@@ -1,5 +1,6 @@
 require('chai').should();
 
+const sinon = require('sinon').sandbox.create();
 const controller = require('../../../controllers/export-data-2');
 
 describe('Export Data 2.0', () => {

--- a/ddocs/medic-client/views/reports_by_form/reduce.js
+++ b/ddocs/medic-client/views/reports_by_form/reduce.js
@@ -1,0 +1,3 @@
+function(keys, values) {
+  return true;
+}

--- a/ddocs/medic-client/views/reports_by_form/reduce.js
+++ b/ddocs/medic-client/views/reports_by_form/reduce.js
@@ -1,3 +1,3 @@
-function(keys, values) {
+function() {
   return true;
 }

--- a/scripts/mp-2584-unclearing-schedules/find_registrations.js
+++ b/scripts/mp-2584-unclearing-schedules/find_registrations.js
@@ -18,6 +18,7 @@ const findRegistrations = () => {
       startkey: [ pCode ],
       endkey: [ pCode + '\ufff0'],
       include_docs: true,
+      reduce: false,
       limit: 5000
     }).then(data => {
       return data.rows.map(row => row.id);

--- a/shared-libs/search/src/generate-search-requests.js
+++ b/shared-libs/search/src/generate-search-requests.js
@@ -63,7 +63,7 @@ var reportedDateRequest = function(filters) {
 };
 
 var formRequest = function(filters) {
-  return getRequestForMultidropdown(
+  var req = getRequestForMultidropdown(
     'medic-client/reports_by_form',
     filters.forms,
     function(forms) {
@@ -71,6 +71,12 @@ var formRequest = function(filters) {
         return [ form.code ];
       });
     });
+
+  if (req) {
+    req.params.reduce = false;
+  }
+
+  return req;
 };
 
 var validityRequest = function(filters) {

--- a/shared-libs/search/src/generate-search-requests.js
+++ b/shared-libs/search/src/generate-search-requests.js
@@ -10,13 +10,12 @@ var getKeysArray = function(keys) {
 
 // filter = { selected: [...], options: [...]}
 var getRequestForMultidropdown = function(view, filter, mapKeysFunc) {
-  if (!filter || !filter.selected || !filter.options) {
+  if (!filter || !filter.selected) {
     return;
   }
 
-  // If everything is selected, no filter to apply.
-  var everythingSelected = filter.selected.length === filter.options.length;
-  if (everythingSelected) {
+  // If we know everything is selected, no filter to apply.
+  if (filter.options && filter.selected.length === filter.options.length) {
     return;
   }
 

--- a/shared-libs/search/src/search.js
+++ b/shared-libs/search/src/search.js
@@ -70,18 +70,20 @@ module.exports = function(Promise, DB) {
   };
 
   return function(type, filters, options) {
-    options = options || {};
-    _.defaults(options, {
-      limit: 50,
-      skip: 0
-    });
-
-    var requests = GenerateSearchRequests.generate(type, filters);
-
-    return getRows(type, requests, options)
-      .then(function(results) {
-        return _.pluck(results, 'id');
+    return Promise.resolve().then(function() {
+      options = options || {};
+      _.defaults(options, {
+        limit: 50,
+        skip: 0
       });
+
+      var requests = GenerateSearchRequests.generate(type, filters);
+
+      return getRows(type, requests, options)
+        .then(function(results) {
+          return _.pluck(results, 'id');
+        });
+    });
   };
 };
 

--- a/shared-libs/search/src/search.js
+++ b/shared-libs/search/src/search.js
@@ -1,6 +1,7 @@
 // TODO: consider rewriting to not support skip and limit.
 // Skip and Limit are not considered fast:
 //    http://docs.couchdb.org/en/latest/ddocs/views/pagination.html
+//    https://github.com/medic/medic-webapp/issues/4206
 var _ = require('underscore'),
     GenerateSearchRequests = require('./generate-search-requests');
 

--- a/shared-libs/search/src/search.js
+++ b/shared-libs/search/src/search.js
@@ -1,3 +1,6 @@
+// TODO: consider rewriting to not support skip and limit.
+// Skip and Limit are not considered fast:
+//    http://docs.couchdb.org/en/latest/ddocs/views/pagination.html
 var _ = require('underscore'),
     GenerateSearchRequests = require('./generate-search-requests');
 

--- a/shared-libs/search/src/search.js
+++ b/shared-libs/search/src/search.js
@@ -73,20 +73,23 @@ module.exports = function(Promise, DB) {
   };
 
   return function(type, filters, options) {
-    return Promise.resolve().then(function() {
-      options = options || {};
-      _.defaults(options, {
-        limit: 50,
-        skip: 0
-      });
-
-      var requests = GenerateSearchRequests.generate(type, filters);
-
-      return getRows(type, requests, options)
-        .then(function(results) {
-          return _.pluck(results, 'id');
-        });
+    options = options || {};
+    _.defaults(options, {
+      limit: 50,
+      skip: 0
     });
+
+    var requests;
+    try {
+      requests = GenerateSearchRequests.generate(type, filters);
+    } catch (err) {
+      return Promise.reject(err);
+    }
+
+    return getRows(type, requests, options)
+      .then(function(results) {
+        return _.pluck(results, 'id');
+      });
   };
 };
 

--- a/shared-libs/search/test/generate-search-requests.js
+++ b/shared-libs/search/test/generate-search-requests.js
@@ -51,7 +51,8 @@ describe('GenerateSearchRequests service', function() {
       chai.expect(result.length).to.equal(1);
       chai.expect(result[0].view).to.equal('medic-client/reports_by_form');
       chai.expect(result[0].params).to.deep.equal({
-        keys: [ [ 'P' ], [ 'R' ] ]
+        keys: [ [ 'P' ], [ 'R' ] ],
+        reduce: false
       });
     });
 

--- a/static/js/services/download-url.js
+++ b/static/js/services/download-url.js
@@ -5,7 +5,7 @@
   var inboxServices = angular.module('inboxServices');
 
   var TYPES = {
-    reports:  { name: 'reports', apiName: 'forms', format: 'xml', lucene: true },
+    reports:  { name: 'reports', v2: true },
     contacts: { name: 'contacts', format: 'json', lucene: true },
     messages: { name: 'messages', format: 'xml' },
     audit:    { name: 'audit', format: 'xml' },
@@ -21,10 +21,14 @@
     ) {
       'ngInject';
 
-      var buildUrl = function(type, language, filters) {
+      var buildV1Url = function(type, language, filters) {
         var name = type.apiName || type.name;
         var params = getParams(type, language, filters);
         return '/api/v1/export/' + name + '?' + $.param(params);
+      };
+
+      var buildV2Url = function(type, body) {
+        return '/api/v2/export/' + type + '?' + $.param(body);
       };
 
       var getParams = function(type, language, filters) {
@@ -45,9 +49,15 @@
         if (!type) {
           return $q.reject(new Error('Unknown download type'));
         }
-        return Language().then(function(language) {
-          return buildUrl(type, language, filters);
-        });
+
+        if (type.v2) {
+          return $q.resolve(buildV2Url(type.name, {filters: filters}));
+        } else {
+          return Language().then(function(language) {
+            return buildV1Url(type, language, filters);
+          });
+        }
+
       };
     }
   );

--- a/static/js/services/download-url.js
+++ b/static/js/services/download-url.js
@@ -28,7 +28,8 @@
       };
 
       var buildV2Url = function(type, body) {
-        return '/api/v2/export/' + type + '?' + $.param(body);
+        var params = body ? '?' + $.param(body) : '';
+        return '/api/v2/export/' + type + params;
       };
 
       var getParams = function(type, language, filters) {
@@ -51,7 +52,7 @@
         }
 
         if (type.v2) {
-          return $q.resolve(buildV2Url(type.name, {filters: filters}));
+          return $q.resolve(buildV2Url(type.name, filters ? {filters: filters} : null));
         } else {
           return Language().then(function(language) {
             return buildV1Url(type, language, filters);

--- a/static/js/services/search.js
+++ b/static/js/services/search.js
@@ -24,6 +24,7 @@ var _ = require('underscore'),
 
   inboxServices.factory('Search',
     function(
+      $log,
       $q,
       GetDataRecords,
       SearchFactory
@@ -49,6 +50,8 @@ var _ = require('underscore'),
       var _search = SearchFactory();
 
       return function(type, filters, options) {
+        $log.debug('Doing Search', type, filters, options);
+
         options = options || {};
         _.defaults(options, {
           limit: 50,

--- a/tests/karma/unit/services/download-url.js
+++ b/tests/karma/unit/services/download-url.js
@@ -50,12 +50,25 @@ describe('DownloadUrl service', function() {
     });
   });
 
-  it('builds url for reports', function() {
-    Language.returns(Promise.resolve('en'));
-    GenerateLuceneQuery.returns({ query: 'form:P' });
-    return service(null, 'reports').then(function(actual) {
-      chai.expect(decodeURIComponent(actual))
-          .to.equal('/api/v2/export/reports');
+  describe('urls for reports', function() {
+    it('builds base url', function() {
+      Language.returns(Promise.resolve('en'));
+      GenerateLuceneQuery.returns({ query: 'form:P' });
+      return service(null, 'reports').then(function(actual) {
+        chai.expect(decodeURIComponent(actual))
+            .to.equal('/api/v2/export/reports');
+
+        // We no longer use translate or use lucence
+        chai.expect(Language.callCount).to.equal(0);
+        chai.expect(GenerateLuceneQuery.callCount).to.equal(0);
+      });
+    });
+    it('attaches filter object as params', function() {
+      return service({forms: {selected: [{code: 'foo-form'}]}}, 'reports').then(function(actual) {
+        chai.expect(decodeURIComponent(actual)).to.equal(
+          '/api/v2/export/reports?filters[forms][selected][0][code]=foo-form'
+        );
+      });
     });
   });
 

--- a/tests/karma/unit/services/download-url.js
+++ b/tests/karma/unit/services/download-url.js
@@ -50,12 +50,12 @@ describe('DownloadUrl service', function() {
     });
   });
 
-  it('builds url for forms', function() {
+  it('builds url for reports', function() {
     Language.returns(Promise.resolve('en'));
     GenerateLuceneQuery.returns({ query: 'form:P' });
     return service(null, 'reports').then(function(actual) {
       chai.expect(decodeURIComponent(actual))
-          .to.equal('/api/v1/export/forms?format=xml&locale=en&query="form:P"&schema=');
+          .to.equal('/api/v2/export/reports');
     });
   });
 

--- a/tests/protractor/e2e/api/controllers/export-data-2.js
+++ b/tests/protractor/e2e/api/controllers/export-data-2.js
@@ -34,23 +34,34 @@ describe('Export Data V2.0', () => {
     fields: {
       baz: 'bazVal',
     }
+  }, {
+    _id: 'export-data-2-test-doc-4',
+    form: 'weird-data-types',
+    type: 'data_record',
+    fields: {
+      wd_array: [0,1,2],
+      wd_emptyString: '',
+      wd_false: false,
+      wd_null: null,
+      wd_zero: 0,
+    }
   }];
-
   beforeAll(() => utils.saveDocs(docs));
   afterAll(utils.deleteAllDocs);
 
-  describe('GET|POST /api/v2/export/reports', () => {
+  fdescribe('GET|POST /api/v2/export/reports', () => {
     it('Returns all reports that exist in the system', () =>
       utils.request('/api/v2/export/reports', {notJson: true}).then(result => {
         const rows = result.split('\n');
         rows.pop(); // Last row is empty string, discard
         const expected = [
-          '_id,patient_id,reported_date,from,contact.name,contact.parent.name,contact.parent.parent.name,contact.parent.parent.parent.name,bar,baz,foo,smang.smong',
-          'export-data-2-test-doc-3,abc125,,,,,,,,bazVal,,',
-          'export-data-2-test-doc-2,abc124,,,,,,,barVal2,,fooVal2,smangsmongVal2',
-          'export-data-2-test-doc-1,abc123,,,,,,,barVal,,fooVal,smangsmongVal'
+          '_id,form,patient_id,reported_date,from,contact.name,contact.parent.name,contact.parent.parent.name,contact.parent.parent.parent.name,bar,baz,foo,smang.smong,wd_array.0,wd_array.1,wd_array.2,wd_emptyString,wd_false,wd_null,wd_zero',
+          'export-data-2-test-doc-4,weird-data-types,,,,,,,,,,,,0,1,2,,false,,0',
+          'export-data-2-test-doc-3,b,abc125,,,,,,,,bazVal,,,,,,,,,',
+          'export-data-2-test-doc-2,a,abc124,,,,,,,barVal2,,fooVal2,smangsmongVal2,,,,,,,',
+          'export-data-2-test-doc-1,a,abc123,,,,,,,barVal,,fooVal,smangsmongVal,,,,,,,'
         ];
-        expect(rows.length).toBe(4);
+        expect(rows.length).toBe(5);
         expect(rows[0]).toBe(expected[0]);
         rows.splice(1).forEach(row => {
           expect(expected).toContain(row);
@@ -75,8 +86,8 @@ describe('Export Data V2.0', () => {
           const rows = result.split('\n');
           rows.pop(); // Last row is empty string, discard
           const expected = [
-            '_id,patient_id,reported_date,from,contact.name,contact.parent.name,contact.parent.parent.name,contact.parent.parent.parent.name,baz',
-            'export-data-2-test-doc-3,abc125,,,,,,,bazVal'
+            '_id,form,patient_id,reported_date,from,contact.name,contact.parent.name,contact.parent.parent.name,contact.parent.parent.parent.name,baz',
+            'export-data-2-test-doc-3,b,abc125,,,,,,,bazVal'
           ];
           expect(rows.length).toBe(2);
           expect(rows).toEqual(expected);

--- a/tests/protractor/e2e/api/controllers/export-data-2.js
+++ b/tests/protractor/e2e/api/controllers/export-data-2.js
@@ -1,0 +1,85 @@
+const utils = require('../../../utils');
+
+describe('Export Data V2.0', () => {
+
+  const docs = [{
+    _id: 'export-data-2-test-doc-1',
+    form: 'a',
+    type: 'data_record',
+    patient_id: 'abc123',
+    fields: {
+      foo: 'fooVal',
+      bar: 'barVal',
+      smang: {
+        smong: 'smangsmongVal'
+      }
+    }
+  }, {
+    _id: 'export-data-2-test-doc-2',
+    form: 'a',
+    type: 'data_record',
+    patient_id: 'abc124',
+    fields: {
+      foo: 'fooVal2',
+      bar: 'barVal2',
+      smang: {
+        smong: 'smangsmongVal2'
+      }
+    }
+  }, {
+    _id: 'export-data-2-test-doc-3',
+    form: 'b',
+    type: 'data_record',
+    patient_id: 'abc125',
+    fields: {
+      baz: 'bazVal',
+    }
+  }];
+
+  beforeAll(() => utils.saveDocs(docs));
+  afterAll(utils.deleteAllDocs);
+
+  describe('GET|POST /api/v2/export/reports', () => {
+    it('Returns all reports that exist in the system', () =>
+      utils.request('/api/v2/export/reports', {notJson: true}).then(result => {
+        const rows = result.split('\n');
+        rows.pop(); // Last row is empty string, discard
+        const expected = [
+          '_id,patient_id,reported_date,from,contact.name,contact.parent.name,contact.parent.parent.name,contact.parent.parent.parent.name,bar,baz,foo,smang.smong',
+          'export-data-2-test-doc-3,abc125,,,,,,,,bazVal,,',
+          'export-data-2-test-doc-2,abc124,,,,,,,barVal2,,fooVal2,smangsmongVal2',
+          'export-data-2-test-doc-1,abc123,,,,,,,barVal,,fooVal,smangsmongVal'
+        ];
+        expect(rows.length).toBe(4);
+        expect(rows[0]).toBe(expected[0]);
+        rows.splice(1).forEach(row => {
+          expect(expected).toContain(row);
+        });
+      }));
+    it('Filters by form', () =>
+      utils.request({
+        method: 'POST',
+        path: '/api/v2/export/reports',
+        headers: {
+          'content-type': 'application/json'
+        },
+        body: {
+          filters: {
+            forms: {
+              selected: [{code: 'b'}]
+            }
+          }
+        }}, {
+          notJson: true
+        }).then(result => {
+          const rows = result.split('\n');
+          rows.pop(); // Last row is empty string, discard
+          const expected = [
+            '_id,patient_id,reported_date,from,contact.name,contact.parent.name,contact.parent.parent.name,contact.parent.parent.parent.name,baz',
+            'export-data-2-test-doc-3,abc125,,,,,,,bazVal'
+          ];
+          expect(rows.length).toBe(2);
+          expect(rows).toEqual(expected);
+        }));
+  });
+});

--- a/tests/protractor/e2e/api/controllers/export-data-2.js
+++ b/tests/protractor/e2e/api/controllers/export-data-2.js
@@ -1,67 +1,56 @@
 const utils = require('../../../utils');
 
-describe('Export Data V2.0', () => {
+fdescribe('Export Data V2.0', () => {
 
-  const docs = [{
-    _id: 'export-data-2-test-doc-1',
-    form: 'a',
-    type: 'data_record',
-    patient_id: 'abc123',
-    fields: {
-      foo: 'fooVal',
-      bar: 'barVal',
-      smang: {
-        smong: 'smangsmongVal'
-      }
-    }
-  }, {
-    _id: 'export-data-2-test-doc-2',
-    form: 'a',
-    type: 'data_record',
-    patient_id: 'abc124',
-    fields: {
-      foo: 'fooVal2',
-      bar: 'barVal2',
-      smang: {
-        smong: 'smangsmongVal2'
-      }
-    }
-  }, {
-    _id: 'export-data-2-test-doc-3',
-    form: 'b',
-    type: 'data_record',
-    patient_id: 'abc125',
-    fields: {
-      baz: 'bazVal',
-    }
-  }, {
-    _id: 'export-data-2-test-doc-4',
-    form: 'weird-data-types',
-    type: 'data_record',
-    fields: {
-      wd_array: [0,1,2],
-      wd_emptyString: '',
-      wd_false: false,
-      wd_null: null,
-      wd_zero: 0,
-    }
-  }];
-  beforeAll(() => utils.saveDocs(docs));
   afterAll(utils.deleteAllDocs);
 
-  fdescribe('GET|POST /api/v2/export/reports', () => {
+  describe('GET|POST /api/v2/export/reports', () => {
+    const docs = [{
+      _id: 'export-data-2-test-doc-1',
+      form: 'a',
+      type: 'data_record',
+      patient_id: 'abc123',
+      fields: {
+        foo: 'fooVal',
+        bar: 'barVal',
+        smang: {
+          smong: 'smangsmongVal'
+        }
+      }
+    }, {
+      _id: 'export-data-2-test-doc-2',
+      form: 'a',
+      type: 'data_record',
+      patient_id: 'abc124',
+      fields: {
+        foo: 'fooVal2',
+        bar: 'barVal2',
+        smang: {
+          smong: 'smangsmongVal2'
+        }
+      }
+    }, {
+      _id: 'export-data-2-test-doc-3',
+      form: 'b',
+      type: 'data_record',
+      patient_id: 'abc125',
+      fields: {
+        baz: 'bazVal',
+      }
+    }];
+    beforeAll(() => utils.saveDocs(docs));
+
     it('Returns all reports that exist in the system', () =>
       utils.request('/api/v2/export/reports', {notJson: true}).then(result => {
         const rows = result.split('\n');
         rows.pop(); // Last row is empty string, discard
         const expected = [
-          '_id,form,patient_id,reported_date,from,contact.name,contact.parent.name,contact.parent.parent.name,contact.parent.parent.parent.name,bar,baz,foo,smang.smong,wd_array.0,wd_array.1,wd_array.2,wd_emptyString,wd_false,wd_null,wd_zero',
-          'export-data-2-test-doc-4,weird-data-types,,,,,,,,,,,,0,1,2,,false,,0',
-          'export-data-2-test-doc-3,b,abc125,,,,,,,,bazVal,,,,,,,,,',
-          'export-data-2-test-doc-2,a,abc124,,,,,,,barVal2,,fooVal2,smangsmongVal2,,,,,,,',
-          'export-data-2-test-doc-1,a,abc123,,,,,,,barVal,,fooVal,smangsmongVal,,,,,,,'
+          '_id,form,patient_id,reported_date,from,contact.name,contact.parent.name,contact.parent.parent.name,contact.parent.parent.parent.name,bar,baz,foo,smang.smong',
+          '"export-data-2-test-doc-3","b","abc125",,,,,,,,"bazVal",,',
+          '"export-data-2-test-doc-2","a","abc124",,,,,,,"barVal2",,"fooVal2","smangsmongVal2"',
+          '"export-data-2-test-doc-1","a","abc123",,,,,,,"barVal",,"fooVal","smangsmongVal"',
         ];
-        expect(rows.length).toBe(5);
+        expect(rows.length).toBe(expected.length);
         expect(rows[0]).toBe(expected[0]);
         rows.splice(1).forEach(row => {
           expect(expected).toContain(row);
@@ -87,7 +76,54 @@ describe('Export Data V2.0', () => {
           rows.pop(); // Last row is empty string, discard
           const expected = [
             '_id,form,patient_id,reported_date,from,contact.name,contact.parent.name,contact.parent.parent.name,contact.parent.parent.parent.name,baz',
-            'export-data-2-test-doc-3,b,abc125,,,,,,,bazVal'
+            '"export-data-2-test-doc-3","b","abc125",,,,,,,"bazVal"'
+          ];
+          expect(rows.length).toBe(2);
+          expect(rows).toEqual(expected);
+        }));
+  });
+  describe('Weird data', () => {
+    beforeAll(() => utils.saveDoc({
+      _id: 'export-data-2-test-doc-4',
+      form: 'weird-data-types',
+      type: 'data_record',
+      fields: {
+        wd_array: [0,1,2],
+        wd_emptyString: '',
+        wd_false: false,
+        wd_naughtyArray: [0, {foo: false, bar: null}, 'Hello, "world"'],
+        wd_naughtyString: 'Woah there, "Jimmy O\'Tool"',
+        wd_null: null,
+        wd_zero: 0,
+      }
+    }));
+
+    it('Outputs weird data types correctly', () =>
+      utils.request({
+        method: 'POST',
+        path: '/api/v2/export/reports',
+        headers: {
+          'content-type': 'application/json'
+        },
+        body: {
+          filters: {
+            forms: {
+              selected: [{code: 'weird-data-types'}]
+            }
+          }
+        }}, {
+          notJson: true
+        }).then(result => {
+          const rows = result.split('\n');
+          rows.pop(); // Last row is empty string, discard
+          //
+          // NB: if you have to debug this test failing, note that the test
+          // runner will not output the escaped string values correctly to the
+          // console. You can rely on its output to debug the problem.
+          //
+          const expected = [
+            '_id,form,patient_id,reported_date,from,contact.name,contact.parent.name,contact.parent.parent.name,contact.parent.parent.parent.name,wd_array,wd_emptyString,wd_false,wd_naughtyArray,wd_naughtyString,wd_null,wd_zero',
+            '"export-data-2-test-doc-4","weird-data-types",,,,,,,,"[0,1,2]","",false,"[0,{\\"foo\\":false,\\"bar\\":null},\\"Hello, \\\\"world\\\\"\\"]","Woah there, \\"Jimmy O\'Tool\\"",,0',
           ];
           expect(rows.length).toBe(2);
           expect(rows).toEqual(expected);

--- a/tests/protractor/e2e/api/controllers/messages.js
+++ b/tests/protractor/e2e/api/controllers/messages.js
@@ -82,7 +82,7 @@ describe('messages controller', () => {
   afterEach(utils.afterEach);
 
   it('should fetch all messages', () =>
-    utils.request('/api/v1/messages', true)
+    utils.request('/api/v1/messages')
       .then((result) => {
         // TODO stop emitting everything twice : https://github.com/medic/medic-webapp/issues/3400
         // assert.equal(result.length, 3);

--- a/tests/protractor/e2e/api/controllers/users.js
+++ b/tests/protractor/e2e/api/controllers/users.js
@@ -137,7 +137,7 @@ describe('Users API', () => {
           place: 'NewPlaceId'
         },
         auth: `${username}:${password}`
-      }, true)
+      })
       .then(() => fail('You should get a 401 in this situation'))
       .catch(err => {
         expect(err).toBe('You do not have permissions to modify this person');
@@ -189,7 +189,7 @@ describe('Users API', () => {
           body: {
             password: 'swizzlesticks'
           },
-        }, false, true)
+        }, {noAuth: true})
         .then(() => fail('You should get an error in this situation'))
         .catch(err => {
           expect(err).toBe('You must authenticate with Basic Auth to modify your password');

--- a/tests/protractor/e2e/api/handlers/changes.js
+++ b/tests/protractor/e2e/api/handlers/changes.js
@@ -131,7 +131,7 @@ describe('changes handler', () => {
           'Content-Type': 'application/json'
         },
         body: user
-      }, true));
+      }));
     });
 
     return promises.then(done);

--- a/tests/protractor/utils.js
+++ b/tests/protractor/utils.js
@@ -10,7 +10,9 @@ const _ = require('underscore'),
 
 let originalSettings;
 
-const request = (options, debug, noAuth) => {
+// First Object is passed to http.request, second is for specific options / flags
+// for this wrapper
+const request = (options, {debug, noAuth, notJson} = {}) => {
   if (typeof options === 'string') {
     options = {
       path: options
@@ -41,6 +43,10 @@ const request = (options, debug, noAuth) => {
     });
     res.on('end', () => {
       try {
+        if (notJson) {
+          return deferred.fulfill(body);
+        }
+
         body = JSON.parse(body);
         if (body.error) {
           deferred.reject(new Error(`Request failed: ${options.path},\n  body: ${JSON.stringify(options.body)}\n  response: ${JSON.stringify(body)}`));
@@ -225,7 +231,7 @@ module.exports = {
       };
     }
     options.path = '/' + constants.DB_NAME + (options.path || '');
-    return request(options, debug);
+    return request(options, {debug: debug});
   },
 
   saveDoc: doc => {


### PR DESCRIPTION
# Description

Adds a new version of exporting, currently just for reports.

Features include only supporting a single CSV, streaming the output for server performance, and using the same query logic as the front end.

medic/medic-webapp#3594

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.