### PR TITLE
Makes Horticulturalist UI upgrade throbber visible until deployment

### DIFF
--- a/static/js/controllers/configuration-upgrade.js
+++ b/static/js/controllers/configuration-upgrade.js
@@ -120,11 +120,9 @@ angular.module('inboxControllers').controller('ConfigurationUpgradeCtrl',
             .then(function(msg) {
               $log.error(msg, err);
               $scope.error = msg;
+              $scope.upgrading = false;
+              $scope.versionCandidate = false;
             });
-        })
-        .then(function() {
-          $scope.upgrading = false;
-          $scope.versionCandidate = false;
         });
     };
 

--- a/templates/partials/configuration_upgrade.html
+++ b/templates/partials/configuration_upgrade.html
@@ -15,7 +15,7 @@
   </div>
 
   <div ng-show="error">
-    <p class="error">{{error}}</p>
+    <p class="alert alert-danger error">{{error}}</p>
   </div>
 
   <div ng-hide="upgrading">


### PR DESCRIPTION
# Description

After clicking the upgrade button, the loading throbber and the upgrade
message stay visible until the upgrade is complete and the app is
redeployed by Horticulturalist.
Adds a little markup in the template so the upgrade error is more
obvious.

medic/medic-webapp#3967

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.