### PR TITLE
Fixes bug where PNC schedule was not being added for valid SMS forms

### DIFF
--- a/sentinel/test/unit/update_clinics.js
+++ b/sentinel/test/unit/update_clinics.js
@@ -81,7 +81,7 @@ exports['should update clinic by phone'] = function(test) {
     }
   };
 
-  sinon.stub(fakedb.medic, 'view').callsArgWith(3, null, {rows: [{ doc: contact }]});
+  sinon.stub(fakedb.medic, 'view').callsArgWith(3, null, {rows: [{ id: contact._id }]});
   lineageStub.returns(Promise.resolve(contact));
 
   transition.onMatch({
@@ -277,4 +277,23 @@ exports['from field is cast to string in view query'] = function(test) {
     }
   };
   transition.onMatch(change, db, {}, function(){});
+};
+
+exports['handles lineage rejection properly'] = function(test) {
+  test.expect(2);
+  var doc = {
+    from: '123',
+    type: 'data_record'
+  };
+
+  sinon.stub(fakedb.medic, 'view').callsArgWith(3, null, { rows: [{id: 'someID'}] });
+  lineageStub.withArgs('someID').returns(Promise.reject('some error'));
+
+  transition.onMatch({
+    doc: doc
+  }, fakedb, fakeaudit, function(err, complete) {
+    test.equal(err, 'some error');
+    test.equal(complete, undefined);
+    test.done();
+  });
 };

--- a/sentinel/test/unit/update_clinics.js
+++ b/sentinel/test/unit/update_clinics.js
@@ -2,10 +2,13 @@ var sinon = require('sinon').sandbox.create(),
     fakedb = require('../fake-db'),
     fakeaudit = require('../fake-audit'),
     transition = require('../../transitions/update_clinics'),
-    phone = '+34567890123';
+    lineage = require('../../lib/lineage'),
+    phone = '+34567890123',
+    lineageStub;
 
 exports.setUp = function(callback) {
   process.env.TEST_ENV = true;
+  lineageStub = sinon.stub(lineage, 'fetchHydratedDoc');
   callback();
 };
 
@@ -43,7 +46,8 @@ exports['should update clinic by phone'] = function(test) {
       parent: null
     }
   };
-  sinon.stub(fakedb.medic, 'view').callsArgWith(3, null, {rows: [{ doc: {
+
+  var contact = {
     _id: '9ed7d9c6095cc0e37e4d3e94d3387ed9',
     _rev: '6-e447d8801d7bed36614af92449586851',
     type: 'clinic',
@@ -75,7 +79,11 @@ exports['should update clinic by phone'] = function(test) {
         }
       }
     }
-  }}]});
+  };
+
+  sinon.stub(fakedb.medic, 'view').callsArgWith(3, null, {rows: [{ doc: contact }]});
+  lineageStub.returns(Promise.resolve(contact));
+
   transition.onMatch({
     doc: doc
   }, fakedb, fakeaudit, function(err, complete) {
@@ -123,7 +131,8 @@ exports['should update clinic by refid and fix number'] = function(test) {
     from: '+12345',
     refid: '1000'
   };
-  sinon.stub(fakedb.medic, 'view').callsArgWith(3, null, {rows: [{ doc: {
+
+  var contact = {
     _id: '9ed7d9c6095cc0e37e4d3e94d3387ed9',
     _rev: '6-e447d8801d7bed36614af92449586851',
     type: 'clinic',
@@ -155,7 +164,10 @@ exports['should update clinic by refid and fix number'] = function(test) {
         }
       }
     }
-  }}]});
+  };
+
+  lineageStub.returns(Promise.resolve(contact));
+  sinon.stub(fakedb.medic, 'view').callsArgWith(3, null, {rows: [{ doc: contact}]});
   transition.onMatch({
     doc: doc
   }, fakedb, fakeaudit, function(err, complete) {
@@ -211,6 +223,7 @@ exports['should update clinic by refid and get latest contact'] = function(test)
   };
   sinon.stub(fakedb.medic, 'view').callsArgWith(3, null, { rows: [{ doc: clinic }] });
   sinon.stub(fakedb.medic, 'get').callsArgWith(1, null, contact);
+  lineageStub.returns(Promise.resolve(contact));
   transition.onMatch({
     doc: doc
   }, fakedb, fakeaudit, function(err, complete) {

--- a/sentinel/transitions/index.js
+++ b/sentinel/transitions/index.js
@@ -32,20 +32,20 @@ let caughtUpOnce;
  *    medic-docs
  */
 const AVAILABLE_TRANSITIONS = [
-  'accept_patient_reports',
-  'conditional_alerts',
-  'default_responses',
   'maintain_info_document',
-  'multi_report_alerts',
-  'update_sent_by',
-  'resolve_pending',
-  'registration',
   'update_clinics',
+  'registration',
+  'accept_patient_reports',
+  'generate_patient_id_on_people',
+  'default_responses',
+  'update_sent_by',
+  'update_sent_forms',
+  'death_reporting',
+  'conditional_alerts',
+  'multi_report_alerts',
   'update_notifications',
   'update_scheduled_reports',
-  'update_sent_forms',
-  'generate_patient_id_on_people',
-  'death_reporting'
+  'resolve_pending'
 ];
 
 /*

--- a/sentinel/transitions/registration.js
+++ b/sentinel/transitions/registration.js
@@ -67,7 +67,7 @@ const booleanExpressionFails = (doc, expr) => {
     } catch (err) {
       // TODO should this count as a fail or as a real error
       logger.warn('Failed to eval boolean expression:');
-      logger.warn(err);
+      logger.warn(err.message);
       result = true;
     }
   }

--- a/sentinel/transitions/registration.js
+++ b/sentinel/transitions/registration.js
@@ -67,7 +67,7 @@ const booleanExpressionFails = (doc, expr) => {
     } catch (err) {
       // TODO should this count as a fail or as a real error
       logger.warn('Failed to eval boolean expression:');
-      console.log(err);
+      console.error(err);
       result = true;
     }
   }

--- a/sentinel/transitions/registration.js
+++ b/sentinel/transitions/registration.js
@@ -67,7 +67,7 @@ const booleanExpressionFails = (doc, expr) => {
     } catch (err) {
       // TODO should this count as a fail or as a real error
       logger.warn('Failed to eval boolean expression:');
-      logger.warn(err.message);
+      console.log(err);
       result = true;
     }
   }

--- a/sentinel/transitions/registration.js
+++ b/sentinel/transitions/registration.js
@@ -67,7 +67,7 @@ const booleanExpressionFails = (doc, expr) => {
     } catch (err) {
       // TODO should this count as a fail or as a real error
       logger.warn('Failed to eval boolean expression:');
-      console.error(err);
+      console.log(err);
       result = true;
     }
   }

--- a/sentinel/transitions/update_clinics.js
+++ b/sentinel/transitions/update_clinics.js
@@ -28,6 +28,17 @@ var associateContact = function(audit, doc, contact, callback) {
     }
 };
 
+var getHydratedContact = function(id, callback) {
+  return lineage
+    .fetchHydratedDoc(id)
+    .then(function(contact) {
+      callback(null, contact);
+    })
+    .catch(function(err) {
+      callback(err);
+    });
+};
+
 var getContact = function(db, doc, callback) {
     if (doc.refid) { // use reference id to find clinic if defined
         let params = {
@@ -44,50 +55,38 @@ var getContact = function(db, doc, callback) {
             }
             var result = data.rows[0].doc;
             if (result.type === 'person') {
-                return callback(null, result);
+              return getHydratedContact(result._id, callback);
             }
             if (result.type === 'clinic') {
                 var id = result.contact && result.contact._id;
                 if (!id) {
                     return callback(null, result.contact || { parent: result });
                 }
-              return db.medic.get(id, callback);
+
+                return getHydratedContact(id, callback);
             }
             callback();
         });
     } else if (doc.from) {
         let params = {
             key: String(doc.from),
-            include_docs: true,
+            include_docs: false,
             limit: 1
         };
         db.medic.view('medic-client', 'contacts_by_phone', params, function(err, data) {
             if (err) {
                 return callback(err);
             }
-            callback(null, data.rows.length && data.rows[0].doc);
+
+            if (data.rows.length && data.rows[0].id) {
+              return getHydratedContact(data.rows[0].id, callback);
+            }
+
+            return callback();
         });
     } else {
         callback();
     }
-};
-
-var getHydratedContact = function(db, doc, callback) {
-    getContact(db, doc, function(err, contact) {
-      if (err) {
-        return callback(err);
-      }
-
-      if (contact && contact._id) {
-        return lineage
-          .fetchHydratedDoc(contact._id)
-          .then(function (contact) {
-            callback(null, contact);
-          });
-      }
-
-      return callback(null, contact);
-    });
 };
 
 /**
@@ -108,7 +107,7 @@ module.exports = {
         );
     },
     onMatch: function(change, db, audit, callback) {
-        getHydratedContact(db, change.doc, function(err, contact) {
+        getContact(db, change.doc, function(err, contact) {
             if (err) {
                 return callback(err);
             }

--- a/sentinel/transitions/update_clinics.js
+++ b/sentinel/transitions/update_clinics.js
@@ -28,7 +28,7 @@ var associateContact = function(audit, doc, contact, callback) {
     }
 };
 
-var getContactID = function(db, doc, callback) {
+var getContact = function(db, doc, callback) {
     if (doc.refid) { // use reference id to find clinic if defined
         let params = {
             key: [ 'external', doc.refid ],
@@ -72,8 +72,8 @@ var getContactID = function(db, doc, callback) {
     }
 };
 
-var getContact = function(db, doc, callback) {
-    getContactID(db, doc, function(err, contact) {
+var getHydratedContact = function(db, doc, callback) {
+    getContact(db, doc, function(err, contact) {
       if (err) {
         return callback(err);
       }
@@ -108,7 +108,7 @@ module.exports = {
         );
     },
     onMatch: function(change, db, audit, callback) {
-        getContact(db, change.doc, function(err, contact) {
+        getHydratedContact(db, change.doc, function(err, contact) {
             if (err) {
                 return callback(err);
             }


### PR DESCRIPTION
# Description

Valid SMS forms would not generate a PNC schedule because of missing
doc properties at transition time.
To fix, Sentinel transitions are now in a specific order, so
`update_clinics` is executed before `registration`.
Also, `update_clinics` hydrates the contact property.

medic/medic-webapp#4201

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.