### PR TITLE
Gracefully handle partial doc replication

### DIFF
--- a/sentinel/lib/lineage.js
+++ b/sentinel/lib/lineage.js
@@ -73,22 +73,22 @@ const buildHydratedDoc = (doc, lineage) => {
   if (!doc) {
     return doc;
   }
-  let current = doc;
+  let currentParent = doc;
   if (doc.type === 'data_record') {
     doc.contact = lineage.shift();
-    current = doc.contact;
+    currentParent = doc.contact;
   }
-  let stub = doc.parent;
+  let currentStub = currentParent.parent;
   while (true) {
-    const parent = lineage.shift() || stub;
+    // if the parent doc isn't found the element in lineage is null,
+    // so retain the stub.
+    const parent = lineage.shift() || currentStub;
     if (!parent) {
       break;
     }
-    current.parent = parent;
-    current = current.parent;
-    if (stub) {
-      stub = stub.parent;
-    }
+    currentParent.parent = parent;
+    currentParent = currentParent.parent;
+    currentStub = currentStub.parent;
   }
 };
 

--- a/sentinel/lib/lineage.js
+++ b/sentinel/lib/lineage.js
@@ -78,9 +78,17 @@ const buildHydratedDoc = (doc, lineage) => {
     doc.contact = lineage.shift();
     current = doc.contact;
   }
-  while (current) {
-    current.parent = lineage.shift();
+  let stub = doc.parent;
+  while (true) {
+    const parent = lineage.shift() || stub;
+    if (!parent) {
+      break;
+    }
+    current.parent = parent;
     current = current.parent;
+    if (stub) {
+      stub = stub.parent;
+    }
   }
 };
 

--- a/static/js/services/contact-save.js
+++ b/static/js/services/contact-save.js
@@ -45,7 +45,7 @@ angular.module('inboxServices').service('ContactSave',
 
           return {
             docId: doc._id,
-            preparedDocs: [].concat(repeated, siblings, doc)
+            preparedDocs: [ doc ].concat(repeated, siblings) // NB: order matters: #4200
           };
         });
     }

--- a/static/js/services/enketo.js
+++ b/static/js/services/enketo.js
@@ -432,14 +432,21 @@ angular.module('inboxServices').service('Enketo',
     };
 
     var saveDocs = function(docs) {
-      return $q.all(docs.map(function(doc) {
-        return DB()
-          .put(doc)
-          .then(function(res) {
-            doc._rev = res.rev;
-            return doc;
+      return DB().bulkDocs(docs)
+        .then(function(results) {
+          results.forEach(function(result) {
+            if (result.error) {
+              $log.error('Error saving report', result);
+              throw new Error('Error saving report');
+            }
+            docs.forEach(function(doc) {
+              if (doc._id === result.id) {
+                doc._rev = result.rev;
+              }
+            });
           });
-      }));
+          return docs;
+        });
     };
 
     var update = function(docId) {

--- a/tests/karma/unit/services/contact-save.js
+++ b/tests/karma/unit/services/contact-save.js
@@ -140,15 +140,15 @@ describe('ContactSave service', () => {
 
         const savedDocs = bulkDocs.args[0][0];
 
-        assert.equal(savedDocs[0]._id, 'kid1');
-        assert.equal(savedDocs[0].parent._id, 'main1');
-        assert.equal(savedDocs[0].parent.extracted, true);
+        assert.equal(savedDocs[0]._id, 'main1');
 
-        assert.equal(savedDocs[1]._id, 'sis1');
+        assert.equal(savedDocs[1]._id, 'kid1');
         assert.equal(savedDocs[1].parent._id, 'main1');
         assert.equal(savedDocs[1].parent.extracted, true);
 
-        assert.equal(savedDocs[2]._id, 'main1');
+        assert.equal(savedDocs[2]._id, 'sis1');
+        assert.equal(savedDocs[2].parent._id, 'main1');
+        assert.equal(savedDocs[2].parent.extracted, true);
 
         assert.equal(ExtractLineage.callCount, 3);
       });


### PR DESCRIPTION
When saving with bulkDocs it's possible that the docs will be
replicated to the server one at a time. This causes sentinel
hydration to not find the parent doc which then is set to null
and the doc is later persisted.

This change handles this situation gracefully by

- changing sentinel hydration to leave the stub if no doc found
  so data is not lost, and
- changing the contact save service to save the parent doc before
  any children docs so they are replicated first.

This also modifies the enketo service to use bulkDocs instead of
multiple individual puts.

medic/medic-webapp#4200

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.