### PR TITLE
Sentinel buildHydratedDoc SMS transition bugfix

### DIFF
--- a/sentinel/lib/lineage.js
+++ b/sentinel/lib/lineage.js
@@ -70,7 +70,7 @@ const fillContactsInDocs = (docs, contacts) => {
 };
 
 const buildHydratedDoc = (doc, lineage) => {
-  if (!doc) {
+  if (!doc || !lineage.length) {
     return doc;
   }
   let currentParent = doc;

--- a/sentinel/test/unit/lineage.js
+++ b/sentinel/test/unit/lineage.js
@@ -679,5 +679,36 @@ exports['hydrateDocs ignores db-fetch errors'] = test => {
 
     test.done();
   }).catch(test.done);
+};
+
+exports['fetchHydratedDoc works for SMS reports'] = test => {
+  const view = sinon.stub(db.medic, 'view');
+  let doc = {
+    _id: 'some_id',
+    type: 'data_record',
+    from: '123',
+    form: 'D',
+    fields: {},
+    sms_message: {
+      message_id: '76992',
+      message: 'somemessage',
+      from: '123',
+      type: 'sms_message',
+      form: 'D'
+    }
+  };
+
+  view.onCall(0).callsArgWith(3, null, { rows: [{ doc: doc }] });
+  lineage
+    .fetchHydratedDoc(doc._id)
+    .then(() => {
+      test.done();
+    })
+    .catch(err => {
+      test.equals(err instanceof TypeError, true);
+      test.equals(err.message, 'Cannot read property \'parent\' of undefined');
+      test.ok(false, 'fails with error: '+ err.message);
+      test.done();
+    });
 
 };

--- a/sentinel/test/unit/lineage.js
+++ b/sentinel/test/unit/lineage.js
@@ -702,11 +702,13 @@ exports['fetchHydratedDoc works for SMS reports'] = test => {
   lineage
     .fetchHydratedDoc(doc._id)
     .then(() => {
+      test.equals(view.callCount, 1);
       test.done();
     })
     .catch(err => {
       test.equals(err instanceof TypeError, true);
       test.equals(err.message, 'Cannot read property \'parent\' of undefined');
+      test.equals(view.callCount, 1);
       test.ok(false, 'fails with error: '+ err.message);
       test.done();
     });


### PR DESCRIPTION
# Description

When processing changes, fetchHydratedDoc is called before any
transition. In the case of SMS reports, for example, buildHydratedDoc will
receive an empty array as lineage parameter, which will cause it to
throw a TypeError. This stops all of the transitions from executing.

The fix is to return original document if lineage array is empty.

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.