### PR TITLE
Remove the relevant attribute from UI fields

### DIFF
--- a/static/js/enketo/widgets/phone-widget.js
+++ b/static/js/enketo/widgets/phone-widget.js
@@ -82,6 +82,7 @@ define( function( require, exports, module ) {
         // TODO(estellecomment): format the visible field onBlur to user-friendly format.
         var $proxyInput = $input.clone();
         $proxyInput.addClass('ignore');
+        $proxyInput.removeAttr('data-relevant');
         $proxyInput.removeAttr('name');
         $input.before( $proxyInput );
         $proxyInput.val( $input.val() );


### PR DESCRIPTION
The phone widget adds an input for interacting with in the UI but
keeps the form input for the formatted phone value. The UI input
has to have the `data-relevant` attribute removed otherwise
Enketo tries to process it.

medic/medic-webapp#4230

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.