### PR TITLE
Close bootstrapper database when we've finished with it

### DIFF
--- a/static/js/bootstrapper.js
+++ b/static/js/bootstrapper.js
@@ -129,17 +129,17 @@
           .then(function() {
             // replication complete - bootstrap angular
             $('.bootstrap-layer .status').text('Starting app…');
-            callback();
           })
           .catch(function(err) {
-            if (err.status === 401) {
+            return err;
+          })
+          .then(function(err) {
+            localDb.close();
+            remoteDb.close();
+            if (err && err.status === 401) {
               return redirectToLogin(dbInfo, err, callback);
             }
             callback(err);
-          })
-          .then(function() {
-            localDb.close();
-            remoteDb.close();
           });
       });
 

--- a/static/js/bootstrapper.js
+++ b/static/js/bootstrapper.js
@@ -118,6 +118,7 @@
       .get('_design/medic-client')
       .then(function() {
         // ddoc found - bootstrap immediately
+        localDb.close();
         callback();
       })
       .catch(function() {
@@ -135,6 +136,10 @@
               return redirectToLogin(dbInfo, err, callback);
             }
             callback(err);
+          })
+          .then(function() {
+            localDb.close();
+            remoteDb.close();
           });
       });
 


### PR DESCRIPTION
We should do this as a first step.  Should be backported to `2.14.x`.

Issue: #4196 
