### PR TITLE
Enforce transition order

### DIFF
--- a/sentinel/test/functional/transitions.js
+++ b/sentinel/test/functional/transitions.js
@@ -45,7 +45,7 @@ exports['transitions are only executed once if successful'] = function(test) {
     var change2 = {
       id: 'abc',
       seq: '45',
-      doc: saveDoc.args[0][0]
+      doc: saved
     };
     transitions.applyTransitions({ audit: audit, change: change2 }, function() {
       // not updated


### PR DESCRIPTION
# Description

Transitions are now guaranteed to run in the order listed in the
available transitions array.

medic/medic-webapp#3565

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.