### PR TITLE
Always set return_docs:false in PouchDB.changes() calls

### DIFF
--- a/api/handlers/changes.js
+++ b/api/handlers/changes.js
@@ -449,7 +449,8 @@ var init = function(since) {
     since: since,
     heartbeat: true,
     feed: 'longpoll',
-    include_docs: true
+    include_docs: true,
+    return_docs: false,
   };
   db.medic.changes(options, function(err, changes) {
     if (!err) {

--- a/api/handlers/changes.js
+++ b/api/handlers/changes.js
@@ -449,8 +449,7 @@ var init = function(since) {
     since: since,
     heartbeat: true,
     feed: 'longpoll',
-    include_docs: true,
-    return_docs: false,
+    include_docs: true
   };
   db.medic.changes(options, function(err, changes) {
     if (!err) {

--- a/static/js/services/changes.js
+++ b/static/js/services/changes.js
@@ -63,7 +63,8 @@ angular.module('inboxServices').factory('Changes',
           live: true,
           since: meta ? dbs.meta.lastSeq : dbs.medic.lastSeq,
           timeout: false,
-          include_docs: true
+          include_docs: true,
+          return_docs: false,
         })
         .on('change', function(change) {
           notifyAll(meta, change);


### PR DESCRIPTION
Issue: #4236

Looks like it works locally.  Should be backported to `2.14.x`.