### PR TITLE
Empties transitions array on load

### DIFF
--- a/sentinel/transitions/index.js
+++ b/sentinel/transitions/index.js
@@ -207,6 +207,8 @@ const loadTransitions = (autoEnableSystemTransitions = true) => {
   const transitionsConfig = config.get('transitions') || [];
   let loadError = false;
 
+  transitions.splice(0, transitions.length);
+
   // Load all system or configured transitions
   AVAILABLE_TRANSITIONS.forEach(transition => {
     const conf = transitionsConfig[transition];


### PR DESCRIPTION
# Description

As a consequence of changing `transitions` from Object
pairs to Array, every time sentinel config were reloaded,
all available transitions were pushed into the array.
Hence, after multiple reloads, the transitions array had
as many duplicates, all of which were applied to changes.

The fix is to empty the transitions array on load.

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.