### PR TITLE
Adds Change feed filtering in ContactsContent to keep info up to date

### DIFF
--- a/static/js/controllers/contacts-content.js
+++ b/static/js/controllers/contacts-content.js
@@ -24,9 +24,7 @@ angular.module('inboxControllers').controller('ContactsContentCtrl',
     'ngInject';
 
     var taskEndDate,
-        reportStartDate,
-        debounceWait = 1000,
-        debouncedReloadContact;
+        reportStartDate;
 
     $scope.filterTasks = function(task) {
       return !taskEndDate || taskEndDate.isAfter(task.date);
@@ -135,7 +133,7 @@ angular.module('inboxControllers').controller('ContactsContentCtrl',
       });
     });
 
-    debouncedReloadContact = Debounce(selectContact, debounceWait);
+    var debouncedReloadContact = Debounce(selectContact, 1000, 10 * 1000);
 
     var changeListener = Changes({
       key: 'contacts-content',

--- a/static/js/controllers/contacts-content.js
+++ b/static/js/controllers/contacts-content.js
@@ -99,8 +99,8 @@ angular.module('inboxControllers').controller('ContactsContentCtrl',
         });
     };
 
-    var selectContact = function(id, silent, noLoadingThrobber) {
-      if (!noLoadingThrobber) {
+    var selectContact = function(id, silent) {
+      if (!silent) {
         $scope.setLoadingContent(id);
       }
       return ContactViewModelGenerator(id)
@@ -147,7 +147,7 @@ angular.module('inboxControllers').controller('ContactsContentCtrl',
       }
 
       hasChanges = false;
-      return selectContact($scope.selected.doc._id, true, true);
+      return selectContact($scope.selected.doc._id, true);
     };
     debouncedReloadContact = _.debounce(reloadContact, debounceWait);
 
@@ -155,23 +155,21 @@ angular.module('inboxControllers').controller('ContactsContentCtrl',
       key: 'contacts-content',
       filter: function(change) {
         return ContactChangeFilter.matchContact(change, $scope.selected) ||
-          ContactChangeFilter.isRelevantContact(change, $scope.selected) ||
-          ContactChangeFilter.isRelevantReport(change, $scope.selected);
+               ContactChangeFilter.isRelevantContact(change, $scope.selected) ||
+               ContactChangeFilter.isRelevantReport(change, $scope.selected);
       },
       callback: function(change) {
-        if (ContactChangeFilter.matchContact(change, $scope.selected)) {
-          if (ContactChangeFilter.isDeleted(change)) {
-            var parentId = $scope.selected.doc.parent && $scope.selected.doc.parent._id;
-            hasChanges = false;
-            if (parentId) {
-              // redirect to the parent
-              $state.go($state.current.name, {id: parentId});
-            } else {
-              // top level contact deleted - clear selection
-              $scope.clearSelected();
-            }
-            return;
+        if (ContactChangeFilter.matchContact(change, $scope.selected) && ContactChangeFilter.isDeleted(change)) {
+          var parentId = $scope.selected.doc.parent && $scope.selected.doc.parent._id;
+          hasChanges = false;
+          if (parentId) {
+            // redirect to the parent
+            $state.go($state.current.name, {id: parentId});
+          } else {
+            // top level contact deleted - clear selection
+            $scope.clearSelected();
           }
+          return;
         }
 
         hasChanges = true;

--- a/static/js/controllers/contacts-content.js
+++ b/static/js/controllers/contacts-content.js
@@ -135,10 +135,7 @@ angular.module('inboxControllers').controller('ContactsContentCtrl',
       });
     });
 
-    var reloadContact = function() {
-      return selectContact($scope.selected.doc._id, true);
-    };
-    debouncedReloadContact = Debounce(reloadContact, debounceWait);
+    debouncedReloadContact = Debounce(selectContact, debounceWait);
 
     var changeListener = Changes({
       key: 'contacts-content',
@@ -149,19 +146,17 @@ angular.module('inboxControllers').controller('ContactsContentCtrl',
       },
       callback: function(change) {
         if (ContactChangeFilter.matchContact(change, $scope.selected) && ContactChangeFilter.isDeleted(change)) {
-          var parentId = $scope.selected.doc.parent && $scope.selected.doc.parent._id;
           debouncedReloadContact.cancel();
+          var parentId = $scope.selected.doc.parent && $scope.selected.doc.parent._id;
           if (parentId) {
             // redirect to the parent
-            $state.go($state.current.name, {id: parentId});
+            return $state.go($state.current.name, {id: parentId});
           } else {
             // top level contact deleted - clear selection
-            $scope.clearSelected();
+            return $scope.clearSelected();
           }
-          return;
         }
-
-        return debouncedReloadContact();
+        return debouncedReloadContact($scope.selected.doc._id, true);
       }
     });
 

--- a/static/js/services/contact-change-filter.js
+++ b/static/js/services/contact-change-filter.js
@@ -4,7 +4,7 @@
 var _ = require('underscore');
 
 angular.module('inboxServices').factory('ContactChangeFilter',
-  function() {
+  function(ContactSchema) {
     'ngInject';
     'use strict';
 
@@ -14,7 +14,7 @@ angular.module('inboxServices').factory('ContactChangeFilter',
 
     var isContact = function(change) {
       var isValidDocType = function() {
-        return ['person', 'clinic', 'health_center', 'district_hospital'].indexOf(change.doc.type) !== -1;
+        return ContactSchema.getTypes().indexOf(change.doc.type) !== -1;
       };
       return !!change.doc.type && isValidDocType();
     };

--- a/static/js/services/contact-change-filter.js
+++ b/static/js/services/contact-change-filter.js
@@ -1,5 +1,5 @@
 /**
- * Service to identify relevant changes from Changes feed for contacts
+ * Service to identify relevant changes in relation to a Contact document.
  */
 var _ = require('underscore');
 

--- a/static/js/services/contact-change-filter.js
+++ b/static/js/services/contact-change-filter.js
@@ -43,22 +43,15 @@ angular.module('inboxServices').factory('ContactChangeFilter',
     };
 
     var wasChild = function(change, contact) {
-      if (!contact.children) {
-        return false;
-      }
-      return !!_.find(contact.children, function(children) {
-        return children instanceof Array && _.find(children, function(child) {
+      return _.some(contact.children, function(children) {
+        return children instanceof Array && _.some(children, function(child) {
           return child.doc._id === change.doc._id;
         });
       });
     };
 
     var isAncestor = function(change, contact) {
-      if (!contact.lineage || !contact.lineage.length) {
-        return false;
-      }
-
-      return !!_.find(contact.lineage, function(lineage) {
+     return _.some(contact.lineage, function(lineage) {
         return lineage._id === change.doc._id;
       });
     };
@@ -80,23 +73,16 @@ angular.module('inboxServices').factory('ContactChangeFilter',
           return true;
         }
 
-        if (!contact.children) {
-          return false;
-        }
-
-        return !!_.find(contact.children, function(children) {
-          return children instanceof Array && _.find(children, function(child) {
+        return _.some(contact.children, function(children) {
+          return children instanceof Array && _.some(children, function(child) {
             return matchReportSubject(change, child);
           });
         });
       },
       isRelevantContact: function(change, contact) {
-        if (!isValidInput(change, contact)) {
-          return false;
-        }
-
-        return isContact(change) &&
-          (isAncestor(change, contact) || isChild(change, contact) || wasChild(change, contact));
+        return isValidInput(change, contact) &&
+               isContact(change) &&
+               (isAncestor(change, contact) || isChild(change, contact) || wasChild(change, contact));
       },
       isDeleted: function(change) {
         return !!change && !!change.deleted;

--- a/static/js/services/contact-change-filter.js
+++ b/static/js/services/contact-change-filter.js
@@ -9,7 +9,7 @@ angular.module('inboxServices').factory('ContactChangeFilter',
     'use strict';
 
     var isValidInput = function(change, contact) {
-      return !!change && !!change.doc && !!contact && !!contact.doc;
+      return !!(change && change.doc && contact && contact.doc);
     };
 
     var isContact = function(change) {
@@ -56,28 +56,22 @@ angular.module('inboxServices').factory('ContactChangeFilter',
       });
     };
 
+    var matchChildReportSubject = function(change, contact) {
+      return _.some(contact.children, function(children) {
+        return children instanceof Array && _.some(children, function(child) {
+          return matchReportSubject(change, child);
+        });
+      });
+    };
+
     return {
       matchContact: function(change, contact) {
-        if (!isValidInput(change, contact)) {
-          return false;
-        }
-
-        return contact.doc._id === change.doc._id;
+        return isValidInput(change, contact) && contact.doc._id === change.doc._id;
       },
       isRelevantReport: function(change, contact) {
-        if (!isValidInput(change, contact) || !isReport(change)) {
-          return false;
-        }
-
-        if (matchReportSubject(change, contact)) {
-          return true;
-        }
-
-        return _.some(contact.children, function(children) {
-          return children instanceof Array && _.some(children, function(child) {
-            return matchReportSubject(change, child);
-          });
-        });
+        return isValidInput(change, contact) &&
+               isReport(change) &&
+               (matchReportSubject(change, contact) || matchChildReportSubject(change, contact));
       },
       isRelevantContact: function(change, contact) {
         return isValidInput(change, contact) &&

--- a/static/js/services/contact-change-filter.js
+++ b/static/js/services/contact-change-filter.js
@@ -13,14 +13,11 @@ angular.module('inboxServices').factory('ContactChangeFilter',
     };
 
     var isContact = function(change) {
-      var isValidDocType = function() {
-        return ContactSchema.getTypes().indexOf(change.doc.type) !== -1;
-      };
-      return !!change.doc.type && isValidDocType();
+      return !!change.doc.type && ContactSchema.getTypes().indexOf(change.doc.type) !== -1;
     };
 
     var isReport = function(change) {
-      return change.doc.form && change.doc.type === 'data_record';
+      return !!change.doc.form && change.doc.type === 'data_record';
     };
 
     var matchReportSubject = function(report, contact) {
@@ -65,7 +62,6 @@ angular.module('inboxServices').factory('ContactChangeFilter',
         return lineage._id === change.doc._id;
       });
     };
-
 
     return {
       matchContact: function(change, contact) {

--- a/static/js/services/contact-change-filter.js
+++ b/static/js/services/contact-change-filter.js
@@ -1,0 +1,106 @@
+/**
+ * Service to identify relevant changes from Changes feed for contacts
+ */
+var _ = require('underscore');
+
+angular.module('inboxServices').factory('ContactChangeFilter',
+  function() {
+    'ngInject';
+    'use strict';
+
+    var isValidInput = function(change, contact) {
+      return !!change && !!change.doc && !!contact && !!contact.doc;
+    };
+
+    var isReportSubject = function(report, contact) {
+      if (report.doc.fields && (
+          (report.doc.fields.patient_uuid && report.doc.fields.patient_uuid === contact.doc._id) ||
+          (report.doc.fields.patient_id && report.doc.fields.patient_id === contact.doc.patient_id) ||
+          (report.doc.fields.place_id && report.doc.fields.place_id === contact.doc._id) ||
+          (report.doc.fields.place_id && report.doc.fields.place_id === contact.doc.place_id)
+        )) {
+        return true;
+      }
+
+      if ((report.doc.patient_id && report.doc.patient_id === contact.doc.patient_id) ||
+        (report.doc.place_id && report.doc.place_id === contact.doc.place_id)) {
+        return true;
+      }
+
+      return false;
+    };
+
+    var isContact = function(change) {
+      var isValidDocType = function() {
+        return ['person', 'clinic', 'health_center', 'district_hospital'].indexOf(change.doc.type) !== -1;
+      };
+      return !!change.doc.type && isValidDocType();
+    };
+
+    var isChild = function(change, contact) {
+      return !!change.doc.parent && change.doc.parent._id === contact.doc._id;
+    };
+
+    var wasChild = function(change, contact) {
+      if (!contact.children) {
+        return false;
+      }
+      return !!_.find(contact.children, function(children) {
+        return children instanceof Array && _.find(children, function(child) {
+          return child.doc._id === change.doc._id;
+        });
+      });
+    };
+
+    var isParent = function(change, contact) {
+      if (!contact.lineage || !contact.lineage.length) {
+        return false;
+      }
+
+      return !!_.find(contact.lineage, function(lineage) {
+        return lineage._id === change.doc._id;
+      });
+    };
+
+
+    return {
+      matchSelected: function(change, contact) {
+        if (!isValidInput(change, contact)) {
+          return false;
+        }
+
+        return contact.doc._id === change.doc._id;
+      },
+      isRelevantReport: function(change, contact) {
+        if (!isValidInput(change, contact) || change.doc.type !== 'data_record' || !change.doc.form) {
+          return false;
+        }
+
+        if (isReportSubject(change, contact)) {
+          return true;
+        }
+
+        if (!contact.children) {
+          return false;
+        }
+
+        return !!_.find(contact.children, function(children) {
+          return children instanceof Array && _.find(children, function(child) {
+            return isReportSubject(change, child);
+          });
+        });
+      },
+      isRelevantContact: function(change, contact) {
+        if (!isValidInput(change, contact)) {
+          return false;
+        }
+
+        return isContact(change) &&
+          (isParent(change, contact) || isChild(change, contact) || wasChild(change, contact));
+      },
+      isDeleted: function(change) {
+        return !!change.deleted;
+      }
+    };
+  }
+);

--- a/static/js/services/debounce.js
+++ b/static/js/services/debounce.js
@@ -2,7 +2,7 @@ angular.module('inboxServices').factory('Debounce',
   function($timeout) {
     'use strict';
 
-    return function(func, wait, invokeApply, immediate) {
+    return function(func, wait, immediate, invokeApply) {
       var timeout,
           result,
           args,

--- a/static/js/services/debounce.js
+++ b/static/js/services/debounce.js
@@ -1,0 +1,43 @@
+angular.module('inboxServices').factory('Debounce',
+  function($timeout) {
+    'use strict';
+
+    return function(func, wait, invokeApply, immediate) {
+      var timeout,
+          result,
+          args,
+          context;
+
+      var later = function() {
+        timeout = null;
+        if (!immediate) {
+          result = func.apply(context, args);
+        }
+      };
+
+      var debounced = function() {
+        context = this;
+        args = arguments;
+
+        if (timeout) {
+          $timeout.cancel(timeout);
+        }
+
+        var callImmediately = immediate && !timeout;
+        timeout = $timeout(later, wait, invokeApply);
+        if (callImmediately) {
+          result = func.apply(context, args);
+        }
+
+        return result;
+      };
+
+      debounced.cancel = function() {
+        $timeout.cancel(timeout);
+        timeout = null;
+      };
+
+      return debounced;
+    };
+  }
+);

--- a/static/js/services/index.js
+++ b/static/js/services/index.js
@@ -24,6 +24,7 @@
   require('./count-messages');
   require('./db');
   require('./db-sync');
+  require('./debounce');
   require('./debug');
   require('./delete-docs');
   require('./download-url');

--- a/static/js/services/index.js
+++ b/static/js/services/index.js
@@ -14,6 +14,7 @@
   require('./check-date');
   require('./child-facility');
   require('./clean-etag');
+  require('./contact-change-filter');
   require('./contact-form');
   require('./contact-save');
   require('./contact-schema');

--- a/tests/karma/unit/controllers/contacts-content.js
+++ b/tests/karma/unit/controllers/contacts-content.js
@@ -8,7 +8,6 @@ describe('ContactsContentCtrl', () => {
       state,
       contactViewModelGenerator,
       tasksForContact,
-      reportsForContact,
       changes,
       changesCallback,
       changesFilter,
@@ -59,7 +58,6 @@ describe('ContactsContentCtrl', () => {
       },
       'ContactViewModelGenerator': contactViewModelGenerator,
       'TasksForContact': tasksForContact,
-      'ReportsForContact': reportsForContact,
       'UserSettings': KarmaUtils.promiseService(null, ''),
       'ContactChangeFilter': contactChangeFilter,
       'Debounce': debounce
@@ -85,7 +83,6 @@ describe('ContactsContentCtrl', () => {
 
     contactViewModelGenerator = sinon.stub();
     tasksForContact = sinon.stub();
-    reportsForContact = sinon.stub();
     changes = (options) => {
       changesFilter = options.filter;
       changesCallback = options.callback;
@@ -93,7 +90,7 @@ describe('ContactsContentCtrl', () => {
     };
 
     debounce = (func) => {
-      var fn = func;
+      const fn = func;
       fn.cancel = () => {};
       return fn;
     };

--- a/tests/karma/unit/controllers/contacts-content.js
+++ b/tests/karma/unit/controllers/contacts-content.js
@@ -2,17 +2,17 @@ describe('ContactsContentCtrl', () => {
   'use strict';
 
   let assert = chai.assert,
-    controller,
-    stateParams,
-    scope,
-    state,
-    contactViewModelGenerator,
-    tasksForContact,
-    reportsForContact,
-    changes,
-    changesCallback,
-    changesFilter,
-    contactChangeFilter = sinon.stub();
+      controller,
+      stateParams,
+      scope,
+      state,
+      contactViewModelGenerator,
+      tasksForContact,
+      reportsForContact,
+      changes,
+      changesCallback,
+      changesFilter,
+      contactChangeFilter = sinon.stub();
 
   const childPerson = {
     _id: 'peach',

--- a/tests/karma/unit/controllers/contacts-content.js
+++ b/tests/karma/unit/controllers/contacts-content.js
@@ -28,7 +28,7 @@ describe('ContactsContentCtrl', () => {
     children: { persons: [ ] }
   };
 
-  const stubContactViewModelGenerator = (doc, childArray = []) => {
+  const stubContactViewModelGenerator = (doc, childArray) => {
     const childRows = childArray.map(child => {
       return { id: child._id, doc: child };
     });
@@ -159,9 +159,9 @@ describe('ContactsContentCtrl', () => {
       change = { doc: {} };
     });
 
-    const runChangeFeedProcessTest = ({ childrenArray = [], doc }) => {
+    const runChangeFeedProcessTest = () => {
       stateParams = { id: doc._id};
-      stubContactViewModelGenerator(doc, childrenArray);
+      stubContactViewModelGenerator(doc,  []);
       return createController().setupPromise.then(() => {
         assert(scope.selected, 'selected should be set on the scope');
         return scope.selected;
@@ -182,7 +182,7 @@ describe('ContactsContentCtrl', () => {
     };
 
     it('updates information when selected contact is updated', () => {
-      return runChangeFeedProcessTest({ doc }).then(() => {
+      return runChangeFeedProcessTest().then(() => {
         stubContactChangeFilter({ matchContact: true, isDeleted: false });
         chai.assert.equal(changesFilter(change), true);
         return changesCallback(change).then(() => {
@@ -197,7 +197,7 @@ describe('ContactsContentCtrl', () => {
     it('redirects to parent when selected contact is deleted', () => {
       doc.parent = { _id: 'parent_id' };
 
-      return runChangeFeedProcessTest({ doc }).then(() => {
+      return runChangeFeedProcessTest().then(() => {
         stubContactChangeFilter({ matchContact: true, isDeleted: true });
         chai.assert.equal(changesFilter(change), true);
         changesCallback(change);
@@ -209,7 +209,7 @@ describe('ContactsContentCtrl', () => {
     });
 
     it('clears when selected contact is deleted and has no parent', () => {
-      return runChangeFeedProcessTest({ doc }).then(() => {
+      return runChangeFeedProcessTest().then(() => {
         stubContactChangeFilter({ matchContact: true, isDeleted: true });
         chai.assert.equal(changesFilter(change), true);
         changesCallback(changes);
@@ -220,7 +220,7 @@ describe('ContactsContentCtrl', () => {
     });
 
     it('updates information when relevant contact change is received', () => {
-      return runChangeFeedProcessTest({ doc }).then(() => {
+      return runChangeFeedProcessTest().then(() => {
         stubContactChangeFilter({ matchContact: false, isRelevantContact: true });
         chai.assert.equal(changesFilter(change), true);
         return changesCallback(change).then(() => {
@@ -234,7 +234,7 @@ describe('ContactsContentCtrl', () => {
     });
 
     it('updates information when relevant report change is received', () => {
-      return runChangeFeedProcessTest({ doc }).then(() => {
+      return runChangeFeedProcessTest().then(() => {
         stubContactChangeFilter({ matchContact: false, isRelevantReport: true, isRelevantContact: false });
         chai.assert.equal(changesFilter(change), true);
         return changesCallback(change).then(() => {
@@ -249,7 +249,7 @@ describe('ContactsContentCtrl', () => {
     });
 
     it('does not update information when irrelevant change is received', () => {
-      return runChangeFeedProcessTest({ doc }).then(() => {
+      return runChangeFeedProcessTest().then(() => {
         stubContactChangeFilter({ matchContact: false, isRelevantReport: false, isRelevantContact: false });
         chai.assert.equal(changesFilter(change), false);
         chai.assert.equal(contactChangeFilter.matchContact.callCount, 1);

--- a/tests/karma/unit/controllers/contacts-content.js
+++ b/tests/karma/unit/controllers/contacts-content.js
@@ -69,36 +69,35 @@ describe('ContactsContentCtrl', () => {
   beforeEach(module('inboxApp'));
 
   beforeEach(inject((_$rootScope_, $controller) => {
-      scope = _$rootScope_.$new();
-      scope.setLoadingContent = sinon.stub();
-      scope.setSelected = selected => scope.selected = selected;
-      scope.clearSelected = sinon.stub();
-      scope.settingSelected = sinon.stub();
-      state = {
-        current: {
-          name: 'something'
-        },
-        go: sinon.stub()
-      };
+    scope = _$rootScope_.$new();
+    scope.setLoadingContent = sinon.stub();
+    scope.setSelected = selected => scope.selected = selected;
+    scope.clearSelected = sinon.stub();
+    scope.settingSelected = sinon.stub();
+    state = {
+      current: {
+        name: 'something'
+      },
+      go: sinon.stub()
+    };
 
-      controller = $controller;
+    controller = $controller;
 
-      contactViewModelGenerator = sinon.stub();
-      tasksForContact = sinon.stub();
-      reportsForContact = sinon.stub();
-      changes = (options) => {
-        changesFilter = options.filter;
-        changesCallback = options.callback;
-        return {unsubscribe: () => {}};
-      };
+    contactViewModelGenerator = sinon.stub();
+    tasksForContact = sinon.stub();
+    reportsForContact = sinon.stub();
+    changes = (options) => {
+      changesFilter = options.filter;
+      changesCallback = options.callback;
+      return {unsubscribe: () => {}};
+    };
 
-      debounce = (func) => {
-        var fn = func;
-        fn.cancel = () => {};
-        return fn;
-      };
-    }
-  ));
+    debounce = (func) => {
+      var fn = func;
+      fn.cancel = () => {};
+      return fn;
+    };
+  }));
 
   describe('Tasks', () => {
     const runTasksTest = childrenArray => {

--- a/tests/karma/unit/controllers/contacts-content.js
+++ b/tests/karma/unit/controllers/contacts-content.js
@@ -175,7 +175,7 @@ describe('ContactsContentCtrl', () => {
 
     it('updates information when selected contact is updated', () => {
       return runChangeFeedProcessTest({ doc }).then(() => {
-        stubContactChangeFilter({ matchSelected: true, isDeleted: false });
+        stubContactChangeFilter({ matchContact: true, isDeleted: false });
         return changesCallback({ doc: {} }).then(() => {
           chai.assert.equal(contactViewModelGenerator.callCount, 2);
           chai.assert.equal(contactViewModelGenerator.getCall(1).args[0], doc._id);
@@ -188,9 +188,9 @@ describe('ContactsContentCtrl', () => {
       doc.parent = { _id: 'parent_id' };
 
       return runChangeFeedProcessTest({ doc }).then(() => {
-        stubContactChangeFilter({ matchSelected: true, isDeleted: true });
+        stubContactChangeFilter({ matchContact: true, isDeleted: true });
         changesCallback({ doc: {} });
-        chai.assert.equal(contactChangeFilter.matchSelected.callCount, 1);
+        chai.assert.equal(contactChangeFilter.matchContact.callCount, 1);
         chai.assert.equal(contactViewModelGenerator.callCount, 1);
         chai.assert.equal(state.go.callCount, 1);
         chai.assert.equal(state.go.getCall(0).args[1].id, doc.parent._id);
@@ -199,7 +199,7 @@ describe('ContactsContentCtrl', () => {
 
     it('clears when selected contact is deleted and has no parent', () => {
       return runChangeFeedProcessTest({ doc }).then(() => {
-        stubContactChangeFilter({ matchSelected: true, isDeleted: true });
+        stubContactChangeFilter({ matchContact: true, isDeleted: true });
         changesCallback({ doc: {} });
         chai.assert.equal(contactViewModelGenerator.callCount, 1);
         chai.assert.equal(scope.clearSelected.callCount, 1);
@@ -208,9 +208,9 @@ describe('ContactsContentCtrl', () => {
 
     it('updates information when relevant contact change is received', () => {
       return runChangeFeedProcessTest({ doc }).then(() => {
-        stubContactChangeFilter({ matchSelected: false, isRelevantContact: true });
+        stubContactChangeFilter({ matchContact: false, isRelevantContact: true });
         return changesCallback({ doc: {} }).then(() => {
-          chai.assert.equal(contactChangeFilter.matchSelected.callCount, 1);
+          chai.assert.equal(contactChangeFilter.matchContact.callCount, 1);
           chai.assert.equal(contactViewModelGenerator.callCount, 2);
           chai.assert.equal(contactViewModelGenerator.getCall(1).args, doc._id);
           chai.assert.equal(scope.clearSelected.callCount, 0);
@@ -220,9 +220,9 @@ describe('ContactsContentCtrl', () => {
 
     it('updates information when relevant report change is received', () => {
       return runChangeFeedProcessTest({ doc }).then(() => {
-        stubContactChangeFilter({ matchSelected: false, isRelevantReport: true, isRelevantContact: false });
+        stubContactChangeFilter({ matchContact: false, isRelevantReport: true, isRelevantContact: false });
         return changesCallback({ doc: {} }).then(() => {
-          chai.assert.equal(contactChangeFilter.matchSelected.callCount, 1);
+          chai.assert.equal(contactChangeFilter.matchContact.callCount, 1);
           chai.assert.equal(contactViewModelGenerator.callCount, 2);
           chai.assert.equal(contactViewModelGenerator.getCall(1).args, doc._id);
           chai.assert.equal(scope.clearSelected.callCount, 0);
@@ -232,7 +232,7 @@ describe('ContactsContentCtrl', () => {
 
     it('does not update information when irrelevant change is received', () => {
       return runChangeFeedProcessTest({ doc }).then(() => {
-        stubContactChangeFilter({ matchSelected: false, isRelevantReport: false, isRelevantContact: false });
+        stubContactChangeFilter({ matchContact: false, isRelevantReport: false, isRelevantContact: false });
         changesCallback({ doc: {} });
         chai.assert.equal(contactViewModelGenerator.callCount, 1);
         chai.assert.equal(scope.clearSelected.callCount, 0);
@@ -242,7 +242,7 @@ describe('ContactsContentCtrl', () => {
     it('debounces the update call', (done) => {
       runChangeFeedProcessTest({ doc, noDebounce: false }).then(() => {
         stubContactChangeFilter({
-          matchSelected: [ true, false, false, false ],
+          matchContact: [ true, false, false, false ],
           isDeleted: false,
           isRelevantReport: true,
           isRelevantContact: [true, true]

--- a/tests/karma/unit/services/contact-change-filter.js
+++ b/tests/karma/unit/services/contact-change-filter.js
@@ -10,22 +10,24 @@ describe('ContactChangeFilter service', () => {
   });
 
   it('checks for invalid input', () => {
-    chai.assert.equal(service.matchSelected(), false);
-    chai.assert.equal(service.matchSelected({}, { something: true }), false);
+    chai.assert.equal(service.matchContact(), false);
+    chai.assert.equal(service.matchContact({}, { something: true }), false);
+    chai.assert.equal(service.matchContact('notAnObject', undefined), false);
+    chai.assert.equal(service.isDeleted(undefined), false);
   });
 
-  describe('matchSelected', () => {
+  describe('matchContact', () => {
     it('returns true for same ID', () => {
       const change = { doc: { _id: '123' } };
       const contact = { doc: { _id: '123' } };
-      chai.expect(service.matchSelected(change, contact)).to.equal(true);
+      chai.expect(service.matchContact(change, contact)).to.equal(true);
     });
 
     it('returns false for different ID', () => {
       const change = { doc: { _id: '456' } };
       const contact = { doc: { _id: '123' } };
 
-      chai.expect(service.matchSelected(change, contact)).to.equal(false);
+      chai.expect(service.matchContact(change, contact)).to.equal(false);
     });
   });
 
@@ -54,7 +56,7 @@ describe('ContactChangeFilter service', () => {
       chai.expect(service.isRelevantContact(change4, contact)).to.equal(true);
     });
 
-    it('returns true for old children', () => {
+    it('returns true for previous children', () => {
       const change1 = { doc: { _id: 'p1', type: 'person' } };
       const change2 = { doc: { _id: 'o1', type: 'district_hospital' } };
       const change3 = { doc: { _id: 'p2', type: 'clinic' } };
@@ -78,7 +80,7 @@ describe('ContactChangeFilter service', () => {
       chai.expect(service.isRelevantContact(change3, contact)).to.equal(true);
     });
 
-    it('returns true for parent', () => {
+    it('returns true for ancestor', () => {
       const change1 = { doc: { _id: '123', type: 'clinic'} };
       const change2 = { doc: { _id: '456', type: 'district_hospital'} };
       const change3 = { doc: { _id: '789', type: 'health_center'} };

--- a/tests/karma/unit/services/contact-change-filter.js
+++ b/tests/karma/unit/services/contact-change-filter.js
@@ -13,6 +13,7 @@ describe('ContactChangeFilter service', () => {
     chai.assert.equal(service.matchContact(), false);
     chai.assert.equal(service.matchContact({}, { something: true }), false);
     chai.assert.equal(service.matchContact('notAnObject', undefined), false);
+    chai.assert.equal(service.matchContact([undefined], 11), false);
     chai.assert.equal(service.isDeleted(undefined), false);
   });
 
@@ -25,6 +26,13 @@ describe('ContactChangeFilter service', () => {
 
     it('returns false for different ID', () => {
       const change = { doc: { _id: '456' } };
+      const contact = { doc: { _id: '123' } };
+
+      chai.expect(service.matchContact(change, contact)).to.equal(false);
+    });
+
+    it('returns false for missing ID', () => {
+      const change = { doc: { } };
       const contact = { doc: { _id: '123' } };
 
       chai.expect(service.matchContact(change, contact)).to.equal(false);

--- a/tests/karma/unit/services/contact-change-filter.js
+++ b/tests/karma/unit/services/contact-change-filter.js
@@ -1,0 +1,280 @@
+describe('ContactChangeFilter service', () => {
+
+  let service;
+
+  beforeEach(() => {
+    module('inboxApp');
+    inject(_ContactChangeFilter_ => {
+      service = _ContactChangeFilter_;
+    });
+  });
+
+  it('checks for invalid input', () => {
+    chai.assert.equal(service.matchSelected(), false);
+    chai.assert.equal(service.matchSelected({}, { something: true }), false);
+  });
+
+  describe('matchSelected', () => {
+    it('returns true for same ID', () => {
+      const change = { doc: { _id: '123' } };
+      const contact = { doc: { _id: '123' } };
+      chai.expect(service.matchSelected(change, contact)).to.equal(true);
+    });
+
+    it('returns false for different ID', () => {
+      const change = { doc: { _id: '456' } };
+      const contact = { doc: { _id: '123' } };
+
+      chai.expect(service.matchSelected(change, contact)).to.equal(false);
+    });
+  });
+
+  describe('isRelevantContact', () => {
+    it('returns false when not a contact', () => {
+      const change1 = { doc: { parent: { _id: '123'} } };
+      const change2 = { doc: { parent: { _id: '123'}, type: 'data_record' } };
+      const change3 = { doc: {} };
+      const contact = { doc: { _id: '123' } };
+
+      chai.expect(service.isRelevantContact(change1, contact)).to.equal(false);
+      chai.expect(service.isRelevantContact(change2, contact)).to.equal(false);
+      chai.expect(service.isRelevantContact(change3, contact)).to.equal(false);
+    });
+
+    it('returns true for new children', () => {
+      const change1 = { doc: { type: 'person', parent: { _id: '123'} } };
+      const change2 = { doc: { type: 'health_center', parent: { _id: '123'} } };
+      const change3 = { doc: { type: 'clinic', parent: { _id: '123'} } };
+      const change4 = { doc: { type: 'district_hospital', parent: { _id: '123'} } };
+      const contact = { doc: { _id: '123' } };
+
+      chai.expect(service.isRelevantContact(change1, contact)).to.equal(true);
+      chai.expect(service.isRelevantContact(change2, contact)).to.equal(true);
+      chai.expect(service.isRelevantContact(change3, contact)).to.equal(true);
+      chai.expect(service.isRelevantContact(change4, contact)).to.equal(true);
+    });
+
+    it('returns true for old children', () => {
+      const change1 = { doc: { _id: 'p1', type: 'person' } };
+      const change2 = { doc: { _id: 'o1', type: 'district_hospital' } };
+      const change3 = { doc: { _id: 'p2', type: 'clinic' } };
+      const contact = {
+        doc: { },
+        children: {
+          persons: [
+            { doc: { _id: 'p1' } },
+            { doc: { _id: 'p2' } }
+          ],
+          other: [
+            { doc: { _id: 'o1' } },
+            { doc: { _id: 'o2' } }
+          ],
+          someProperty: 'someValue'
+        }
+      };
+
+      chai.expect(service.isRelevantContact(change1, contact)).to.equal(true);
+      chai.expect(service.isRelevantContact(change2, contact)).to.equal(true);
+      chai.expect(service.isRelevantContact(change3, contact)).to.equal(true);
+    });
+
+    it('returns true for parent', () => {
+      const change1 = { doc: { _id: '123', type: 'clinic'} };
+      const change2 = { doc: { _id: '456', type: 'district_hospital'} };
+      const change3 = { doc: { _id: '789', type: 'health_center'} };
+      const contact = {
+        doc: { _id: 'id' },
+        lineage: [
+          {_id: '123'},
+          {_id: '456'},
+          {_id: '789'}
+        ]
+      };
+
+      chai.expect(service.isRelevantContact(change1, contact)).to.equal(true);
+      chai.expect(service.isRelevantContact(change2, contact)).to.equal(true);
+      chai.expect(service.isRelevantContact(change3, contact)).to.equal(true);
+    });
+
+    it('returns false for anything else', () => {
+      const change = { doc: { _id: 'oid', parent: { _id: 'opid' } } };
+
+      const contact = {
+        doc: {_id: 'id', parent: {_id: 'pid'}},
+        children: {
+          persons: [
+            {doc: {_id: 'p1'}},
+            {doc: {_id: 'p2'}}
+          ],
+          other: [
+            {doc: {_id: 'o1'}},
+            {doc: {_id: 'o2'}}
+          ],
+          someProperty: 'someValue'
+        },
+        lineage: [
+          {_id: '123'},
+          {_id: '456'},
+          {_id: '789'}
+        ]
+      };
+
+      chai.expect(service.isRelevantContact(change, contact)).to.equal(false);
+    });
+  });
+
+  describe('isRelevantReport', () => {
+    let change1,
+        change2,
+        contact;
+    beforeEach(() => {
+      change1 = {
+        doc: {
+          form: 'a',
+          type: 'data_record',
+          fields: {}
+        }
+      };
+
+      change2 = {
+        doc: {
+          form: 'a',
+          type: 'data_record'
+        }
+      };
+
+      contact = {
+        doc: { _id: 'id', patient_id: 'patient', place_id: 'place' },
+        children: {
+          persons: [
+            { doc: { _id: 'child_id1', patient_id: 'child_patient1', place_id: 'child_place1' }},
+            { doc: { _id: 'child_id2', patient_id: 'child_patient2', place_id: 'child_place2' }}
+          ],
+          clinics: [
+            { doc: { _id: 'child_id3', patient_id: 'child_patient3', place_id: 'child_place3' }}
+          ]
+        },
+      };
+    });
+
+    it('returns true for direct contact with matching uuid', () => {
+      change1.doc.fields.patient_uuid = 'id';
+      chai.expect(service.isRelevantReport(change1, contact)).to.equal(true);
+    });
+
+    it('returns true for direct contact with matching patient_id', () => {
+      change1.doc.fields.patient_id = 'patient';
+      change2.doc.patient_id = 'patient';
+
+      chai.expect(service.isRelevantReport(change1, contact)).to.equal(true);
+      chai.expect(service.isRelevantReport(change2, contact)).to.equal(true);
+    });
+
+    it('returns true for direct contact with matching place_id', () => {
+      change1.doc.fields.place_id = 'place';
+      change2.doc.place_id = 'place';
+
+      chai.expect(service.isRelevantReport(change1, contact)).to.equal(true);
+      chai.expect(service.isRelevantReport(change2, contact)).to.equal(true);
+    });
+
+    it('returns true for child contact with matching uuid', () => {
+      change1.doc.fields.patient_uuid = 'child_id2';
+      chai.expect(service.isRelevantReport(change1, contact)).to.equal(true);
+      change1.doc.fields.patient_uuid = 'child_id3';
+      chai.expect(service.isRelevantReport(change1, contact)).to.equal(true);
+    });
+
+    it('returns true for child contact with matching patient_id', () => {
+      change1.doc.fields.patient_id = 'child_patient1';
+      chai.expect(service.isRelevantReport(change1, contact)).to.equal(true);
+      change1.doc.fields.patient_id = 'child_patient3';
+      chai.expect(service.isRelevantReport(change1, contact)).to.equal(true);
+
+      change2.doc.patient_id = 'child_patient1';
+      chai.expect(service.isRelevantReport(change2, contact)).to.equal(true);
+      change2.doc.patient_id = 'child_patient3';
+      chai.expect(service.isRelevantReport(change2, contact)).to.equal(true);
+    });
+
+    it('returns true for child contact with matching place_id', () => {
+      change1.doc.fields.place_id = 'child_place2';
+      chai.expect(service.isRelevantReport(change1, contact)).to.equal(true);
+      change1.doc.fields.place_id = 'child_place3';
+      chai.expect(service.isRelevantReport(change1, contact)).to.equal(true);
+
+      change2.doc.place_id = 'child_place2';
+      chai.expect(service.isRelevantReport(change2, contact)).to.equal(true);
+      change2.doc.place_id = 'child_place3';
+      chai.expect(service.isRelevantReport(change2, contact)).to.equal(true);
+    });
+
+    it('returns false for direct contact with different uuid', () => {
+      change1.doc.fields.patient_uuid = 'nid';
+      chai.expect(service.isRelevantReport(change1, contact)).to.equal(false);
+    });
+
+    it('returns false for direct contact with different patient_id', () => {
+      change1.doc.fields.patient_id = 'npatient';
+      chai.expect(service.isRelevantReport(change1, contact)).to.equal(false);
+
+      change2.doc.patient_id = 'npatient';
+      chai.expect(service.isRelevantReport(change2, contact)).to.equal(false);
+    });
+
+    it('returns false for direct contact with different place_id', () => {
+      change1.doc.fields.place_id = 'nplace';
+      chai.expect(service.isRelevantReport(change1, contact)).to.equal(false);
+
+      change2.doc.place_id = 'nplace';
+      chai.expect(service.isRelevantReport(change2, contact)).to.equal(false);
+    });
+
+    it('returns false for child contact with different uuid', () => {
+      change1.doc.fields.patient_uuid = 'nchild_id2';
+      chai.expect(service.isRelevantReport(change1,  contact)).to.equal(false);
+      change1.doc.fields.patient_uuid = 'nchild_id3';
+      chai.expect(service.isRelevantReport(change1, contact)).to.equal(false);
+    });
+
+    it('returns false for child contact with different patient_id', () => {
+      change1.doc.fields.patient_id = 'nchild_patient1';
+      chai.expect(service.isRelevantReport(change1, contact)).to.equal(false);
+      change1.doc.fields.patient_id = 'nchild_patient3';
+      chai.expect(service.isRelevantReport(change1, contact)).to.equal(false);
+
+      change2.doc.patient_id = 'nchild_patient1';
+      chai.expect(service.isRelevantReport(change2, contact)).to.equal(false);
+      change2.doc.patient_id = 'nchild_patient3';
+      chai.expect(service.isRelevantReport(change2, contact)).to.equal(false);
+    });
+
+    it('returns false for child contact with different place_id', () => {
+      change1.doc.fields.place_id = 'nchild_place2';
+      chai.expect(service.isRelevantReport(change1, contact)).to.equal(false);
+      change1.doc.fields.place_id = 'nchild_place3';
+      chai.expect(service.isRelevantReport(change1, contact)).to.equal(false);
+
+      change2.doc.place_id = 'nchild_place2';
+      chai.expect(service.isRelevantReport(change2, contact)).to.equal(false);
+      change2.doc.place_id = 'nchild_place3';
+      chai.expect(service.isRelevantReport(change2, contact)).to.equal(false);
+    });
+
+  });
+
+  describe('isDeleted', () => {
+    it('returns true when deleted', () => {
+      const change = { doc: { _id: '123' }, deleted: true };
+      chai.expect(service.isDeleted(change)).to.equal(true);
+    });
+
+    it('returns false when property is not set or validates to false', () => {
+      const change1 = { doc: { _id: '123' }};
+      const change2 = { doc: { _id: '123' }, deleted: false };
+      chai.expect(service.isDeleted(change1)).to.equal(false);
+      chai.expect(service.isDeleted(change2)).to.equal(false);
+    });
+  });
+
+});

--- a/tests/karma/unit/services/debounce.js
+++ b/tests/karma/unit/services/debounce.js
@@ -1,0 +1,191 @@
+describe('Debounce Service', () => {
+  'use strict';
+
+  let $timeout,
+      service,
+      callback,
+      counter;
+
+  describe('Actual debouncing', () => {
+    beforeEach(function() {
+      module('inboxApp');
+      inject(function(_Debounce_, _$timeout_) {
+        service = _Debounce_;
+        $timeout = _$timeout_;
+      });
+
+      callback = sinon.stub();
+      callback.callsFake(() => {
+        counter++;
+        return counter;
+      });
+      counter = 0;
+    });
+
+    it('should callback after wait interval', () => {
+      service(callback, 50)();
+      chai.expect(callback.callCount).to.equal(0);
+      $timeout.flush(50);
+      chai.expect(callback.callCount).to.equal(1);
+    });
+
+    it('should only callback once for multiple within-wait-interval calls', () => {
+      const debounced = service(callback, 50);
+      debounced();
+      $timeout.flush(25);
+      debounced();
+      $timeout.flush(44);
+      debounced();
+      $timeout.flush(45);
+      chai.expect(callback.callCount).to.equal(0);
+      $timeout.flush(5);
+      chai.expect(callback.callCount).to.equal(1);
+      chai.expect(counter).to.equal(1);
+      debounced();
+      $timeout.flush(51);
+      debounced();
+      $timeout.flush(51);
+      chai.expect(callback.callCount).to.equal(3);
+      chai.expect(counter).to.equal(3);
+    });
+
+    it('should call immediately when using immediate', () => {
+      service(callback, 50, false, true)();
+      chai.expect(callback.callCount).to.equal(1);
+      $timeout.flush(50);
+      chai.expect(callback.callCount).to.equal(1);
+      chai.expect(counter).to.equal(1);
+    });
+
+    it('should only callback once for multiple within-wait-interval calls when using immediate', () => {
+      const debounced = service(callback, 50, false, true);
+      debounced();
+      chai.expect(callback.callCount).to.equal(1);
+      $timeout.flush(25);
+      debounced();
+      $timeout.flush(44);
+      debounced();
+      $timeout.flush(50);
+      chai.expect(callback.callCount).to.equal(1);
+      chai.expect(counter).to.equal(1);
+    });
+
+    it('should not callback if canceled', () => {
+      const debounced = service(callback, 50);
+      debounced();
+      $timeout.flush(25);
+      debounced.cancel();
+      $timeout.flush(25);
+      chai.expect(callback.callCount).to.equal(0);
+    });
+
+    it('should not callback if canceled with multiple within-wait-interval calls', () => {
+      const debounced = service(callback, 50);
+      debounced();
+      $timeout.flush(25);
+      debounced();
+      $timeout.flush(43);
+      debounced();
+      $timeout.flush(15);
+      debounced.cancel();
+      $timeout.flush(35);
+      chai.expect(callback.callCount).to.equal(0);
+    });
+
+    it('should not callback if canceled, when using immediate', () => {
+      const debounced = service(callback, 50, false, true);
+      debounced(1);
+      debounced.cancel();
+      chai.expect(callback.callCount).to.equal(1);
+      chai.expect(callback.args[0][0]).to.equal(1);
+      debounced(2);
+      debounced.cancel();
+      chai.expect(callback.callCount).to.equal(2);
+      chai.expect(callback.args[1][0]).to.equal(2);
+
+    });
+
+    it('should pass the arguments from the last call to the callback', () => {
+      const debounced = service(callback, 50);
+      debounced(10);
+      $timeout.flush(25);
+      debounced(11);
+      $timeout.flush(43);
+      debounced(12);
+      $timeout.flush(50);
+      chai.expect(callback.callCount).to.equal(1);
+      chai.expect(callback.args[0][0]).to.equal(12);
+    });
+
+    it('should pass the arguments from the first call to the callback, when using immediate', () => {
+      const debounced = service(callback, 50, false, true);
+      debounced(10);
+      $timeout.flush(25);
+      debounced(11);
+      $timeout.flush(43);
+      debounced(12);
+      $timeout.flush(50);
+      chai.expect(callback.callCount).to.equal(1);
+      chai.expect(callback.args[0][0]).to.equal(10);
+    });
+
+    it('should return the result from the first call, when using immediate', () => {
+      const debounced = service(callback, 50, false, true);
+      callback.returnsArg(0);
+      chai.expect(debounced(10)).to.equal(10);
+      $timeout.flush(25);
+      chai.expect(debounced(11)).to.equal(10);
+      $timeout.flush(43);
+      chai.expect(debounced(12)).to.equal(10);
+      $timeout.flush(50);
+      chai.expect(callback.callCount).to.equal(1);
+    });
+
+    it('should create independent debounced functions', () => {
+      const debounced1 = service(callback, 50);
+      const debounced2 = service(callback, 50);
+      debounced1(10);
+      debounced2(10);
+      debounced1(20);
+      debounced2(20);
+      $timeout.flush(50);
+      chai.expect(callback.callCount).to.equal(2);
+    });
+  });
+
+
+  describe('Interaction with $timeout service', () => {
+    beforeEach(function() {
+      $timeout = sinon.stub();
+      $timeout.cancel = sinon.stub();
+
+      module('inboxApp');
+      module(function ($provide) {
+        $provide.value('$timeout', $timeout);
+      });
+      inject(function(_Debounce_) {
+        service = _Debounce_;
+      });
+
+      callback = sinon.stub();
+      callback.callsFake(() => {
+        counter++;
+        return counter;
+      });
+      counter = 0;
+    });
+
+    it('$timeout should receive correct arguments', () => {
+      let debounced = service(callback, 50, true);
+      debounced();
+      chai.expect($timeout.callCount).to.equal(1);
+      chai.expect($timeout.args[0][1]).to.equal(50);
+      chai.expect($timeout.args[0][2]).to.equal(true);
+      debounced = service(callback, 10, false);
+      debounced();
+      chai.expect($timeout.callCount).to.equal(2);
+      chai.expect($timeout.args[1][1]).to.equal(10);
+      chai.expect($timeout.args[1][2]).to.equal(false);
+    });
+  });
+});

--- a/tests/karma/unit/services/debounce.js
+++ b/tests/karma/unit/services/debounce.js
@@ -62,7 +62,7 @@ describe('Debounce Service', () => {
       debounced();
       $timeout.flush(40);
       debounced();
-      $timeout.flush(50);
+      $timeout.flush(150);
       chai.expect(callback.callCount).to.equal(2);
     });
 
@@ -75,7 +75,7 @@ describe('Debounce Service', () => {
       debounced();
       $timeout.flush(40);
       debounced();
-      $timeout.flush(50);
+      $timeout.flush(100);
       chai.expect(callback.callCount).to.equal(1);
     });
 
@@ -85,7 +85,7 @@ describe('Debounce Service', () => {
         debounced();
         $timeout.flush(9);
       }
-      $timeout.flush(10);
+      $timeout.flush(50);
       chai.expect(callback.callCount).to.equal(4);
     });
 
@@ -122,7 +122,7 @@ describe('Debounce Service', () => {
       debounced();
       $timeout.flush(25);
       debounced.cancel();
-      $timeout.flush(50);
+      $timeout.flush(100);
       chai.expect(callback.callCount).to.equal(0);
 
     });
@@ -136,7 +136,7 @@ describe('Debounce Service', () => {
       debounced();
       $timeout.flush(15);
       debounced.cancel();
-      $timeout.flush(50);
+      $timeout.flush(100);
       chai.expect(callback.callCount).to.equal(0);
     });
 
@@ -149,7 +149,7 @@ describe('Debounce Service', () => {
       debounced();
       $timeout.flush(15);
       debounced.cancel();
-      $timeout.flush(50);
+      $timeout.flush(150);
       chai.expect(callback.callCount).to.equal(0);
     });
 
@@ -163,7 +163,7 @@ describe('Debounce Service', () => {
       debounced();
       $timeout.flush(49);
       debounced();
-      $timeout.flush(50);
+      $timeout.flush(150);
       chai.expect(callback.callCount).to.equal(1);
     });
 
@@ -186,7 +186,7 @@ describe('Debounce Service', () => {
       debounced(2);
       $timeout.flush(43);
       debounced(3);
-      $timeout.flush(50);
+      $timeout.flush(100);
       chai.expect(callback.callCount).to.equal(1);
       chai.expect(callback.args[0][0]).to.equal(3);
     });
@@ -200,7 +200,7 @@ describe('Debounce Service', () => {
       debounced(3);
       $timeout.flush(40);
       debounced(4);
-      $timeout.flush(50);
+      $timeout.flush(150);
       chai.expect(callback.callCount).to.equal(2);
       chai.expect(callback.args[0][0]).to.equal(3);
       chai.expect(callback.args[1][0]).to.equal(4);
@@ -213,7 +213,7 @@ describe('Debounce Service', () => {
       debounced(11);
       $timeout.flush(43);
       debounced(12);
-      $timeout.flush(50);
+      $timeout.flush(100);
       chai.expect(callback.callCount).to.equal(1);
       chai.expect(callback.args[0][0]).to.equal(10);
     });
@@ -226,7 +226,7 @@ describe('Debounce Service', () => {
       chai.expect(debounced(11)).to.equal(10);
       $timeout.flush(43);
       chai.expect(debounced(12)).to.equal(10);
-      $timeout.flush(50);
+      $timeout.flush(100);
       chai.expect(callback.callCount).to.equal(1);
     });
 
@@ -237,7 +237,7 @@ describe('Debounce Service', () => {
       debounced2(2);
       debounced1(1);
       debounced2(2);
-      $timeout.flush(50);
+      $timeout.flush(100);
       chai.expect(callback.callCount).to.equal(2);
       chai.expect(callback.args[0][0]).to.equal(1);
       chai.expect(callback.args[1][0]).to.equal(2);

--- a/tests/karma/unit/services/debounce.js
+++ b/tests/karma/unit/services/debounce.js
@@ -277,7 +277,7 @@ describe('Debounce Service', () => {
       chai.expect($timeout.args[1][2]).to.equal(undefined);
     });
 
-    it('$timeout should receive correct invokeApply argument', () => {
+    it('$timeout should receive correct invokeApply value - true', () => {
       service(callback, 50, 100, false, true)();
       chai.expect($timeout.callCount).to.equal(2);
       chai.expect($timeout.args[0][1]).to.equal(50);
@@ -286,7 +286,7 @@ describe('Debounce Service', () => {
       chai.expect($timeout.args[1][2]).to.equal(true);
     });
 
-    it('$timeout should receive correct invokeApply argument', () => {
+    it('$timeout should receive correct invokeApply value - false', () => {
       service(callback, 50, 100, false, false)();
       chai.expect($timeout.callCount).to.equal(2);
       chai.expect($timeout.args[0][1]).to.equal(50);

--- a/tests/karma/unit/services/debounce.js
+++ b/tests/karma/unit/services/debounce.js
@@ -50,7 +50,7 @@ describe('Debounce Service', () => {
     });
 
     it('should call immediately when using immediate', () => {
-      service(callback, 50, false, true)();
+      service(callback, 50, true)();
       chai.expect(callback.callCount).to.equal(1);
       $timeout.flush(50);
       chai.expect(callback.callCount).to.equal(1);
@@ -58,7 +58,7 @@ describe('Debounce Service', () => {
     });
 
     it('should only callback once for multiple within-wait-interval calls when using immediate', () => {
-      const debounced = service(callback, 50, false, true);
+      const debounced = service(callback, 50, true);
       debounced();
       chai.expect(callback.callCount).to.equal(1);
       $timeout.flush(25);
@@ -93,7 +93,7 @@ describe('Debounce Service', () => {
     });
 
     it('should not callback if canceled, when using immediate', () => {
-      const debounced = service(callback, 50, false, true);
+      const debounced = service(callback, 50, true);
       debounced(1);
       debounced.cancel();
       chai.expect(callback.callCount).to.equal(1);
@@ -118,7 +118,7 @@ describe('Debounce Service', () => {
     });
 
     it('should pass the arguments from the first call to the callback, when using immediate', () => {
-      const debounced = service(callback, 50, false, true);
+      const debounced = service(callback, 50, true);
       debounced(10);
       $timeout.flush(25);
       debounced(11);
@@ -130,7 +130,7 @@ describe('Debounce Service', () => {
     });
 
     it('should return the result from the first call, when using immediate', () => {
-      const debounced = service(callback, 50, false, true);
+      const debounced = service(callback, 50, true);
       callback.returnsArg(0);
       chai.expect(debounced(10)).to.equal(10);
       $timeout.flush(25);
@@ -176,16 +176,21 @@ describe('Debounce Service', () => {
     });
 
     it('$timeout should receive correct arguments', () => {
-      let debounced = service(callback, 50, true);
+      let debounced = service(callback, 50, false, true);
       debounced();
       chai.expect($timeout.callCount).to.equal(1);
       chai.expect($timeout.args[0][1]).to.equal(50);
       chai.expect($timeout.args[0][2]).to.equal(true);
-      debounced = service(callback, 10, false);
+      debounced = service(callback, 10, false, false);
       debounced();
       chai.expect($timeout.callCount).to.equal(2);
       chai.expect($timeout.args[1][1]).to.equal(10);
       chai.expect($timeout.args[1][2]).to.equal(false);
+      debounced = service(callback, 12, false);
+      debounced();
+      chai.expect($timeout.callCount).to.equal(3);
+      chai.expect($timeout.args[2][1]).to.equal(12);
+      chai.expect($timeout.args[2][2]).to.equal(undefined);
     });
   });
 });


### PR DESCRIPTION
# Description

ContactsContent page is now updated when a relevant change is received
through the Change listener.
The following are considered relevant changes: selected contact,
any ancestor, any direct child (new, current or removed), any
report with a subject matching either selected contact or a child.

medic/medic-webapp#3530

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.