### PR TITLE
Hydrate docs when editing

### DIFF
--- a/static/js/controllers/contacts-edit.js
+++ b/static/js/controllers/contacts-edit.js
@@ -9,8 +9,8 @@ angular.module('inboxControllers').controller('ContactsEditCtrl',
     ContactForm,
     ContactSave,
     ContactSchema,
-    DB,
     Enketo,
+    LineageModelGenerator,
     Snackbar
   ) {
 
@@ -53,10 +53,14 @@ angular.module('inboxControllers').controller('ContactsEditCtrl',
     };
 
     var getContact = function() {
-      if ($state.params.id) {
-        return DB().get($state.params.id);
+      var id = $state.params.id;
+      if (!id) {
+        return $q.resolve();
       }
-      return $q.resolve();
+      return LineageModelGenerator.contact(id, { merge: true })
+        .then(function(result) {
+          return result.doc;
+        });
     };
 
     var getCategory = function(type) {

--- a/static/js/controllers/reports-add.js
+++ b/static/js/controllers/reports-add.js
@@ -9,6 +9,7 @@ angular.module('inboxControllers').controller('ReportsAddCtrl',
     Enketo,
     FileReader,
     Geolocation,
+    LineageModelGenerator,
     Snackbar,
     XmlForm
   ) {
@@ -31,12 +32,11 @@ angular.module('inboxControllers').controller('ReportsAddCtrl',
         });
       }
       if ($state.params.reportId) { // editing
-        return DB()
-          .get($state.params.reportId)
-          .then(function(doc) {
+        return LineageModelGenerator.report($state.params.reportId, { merge: true })
+          .then(function(result) {
             return {
-              doc: doc,
-              formInternalId: doc.form
+              doc: result.doc,
+              formInternalId: result.doc && result.doc.form
             };
           });
       }


### PR DESCRIPTION
# Description

When editing a report or a contact we need to hydrate the parents
and contacts so information like the contact's name is bound to the
form model and can be shown.

medic/medic-webapp#4258

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.