### PR TITLE
Adds a switch that modifies skip/limit in Contacts Search queries if needed

### DIFF
--- a/static/js/controllers/contacts.js
+++ b/static/js/controllers/contacts.js
@@ -290,9 +290,9 @@ var _ = require('underscore'),
         return $scope.search();
       });
 
-      this.getSetupPromiseForTesting = function(scrollLoaderStub) {
-        if (scrollLoaderStub) {
-          scrollLoader = scrollLoaderStub;
+      this.getSetupPromiseForTesting = function(options) {
+        if (options && options.scrollLoaderStub) {
+          scrollLoader = options.scrollLoaderStub;
         }
         return setupPromise;
       };

--- a/static/js/controllers/contacts.js
+++ b/static/js/controllers/contacts.js
@@ -104,7 +104,7 @@ var _ = require('underscore'),
               return contact._id === usersHomePlace._id;
             });
 
-            additionalListItem = !$scope.filters.search &&
+            additionalListItem = (!$scope.filters.search && !$scope.filters.simprintsIdentities) &&
                                  (additionalListItem || !$scope.appending) &&
                                  homeIndex === -1;
 

--- a/static/js/controllers/contacts.js
+++ b/static/js/controllers/contacts.js
@@ -302,9 +302,10 @@ var _ = require('underscore'),
         key: 'contacts-list',
         callback: function(change) {
           if (change.deleted) {
+            var initialCount = liveList.count();
             liveList.remove(change.doc);
-            if ($scope.moreItems) {
-              _query({limit: liveList.count() + 1, silent: true});
+            if ($scope.moreItems && initialCount > liveList.count()) {
+              _query({limit: initialCount, silent: true});
             }
           } else {
             _query({limit: liveList.count(), silent: true});

--- a/static/js/controllers/contacts.js
+++ b/static/js/controllers/contacts.js
@@ -290,7 +290,12 @@ var _ = require('underscore'),
         return $scope.search();
       });
 
-      this.getSetupPromiseForTesting = function() { return setupPromise; };
+      this.getSetupPromiseForTesting = function(scrollLoaderStub) {
+        if (scrollLoaderStub) {
+          scrollLoader = scrollLoaderStub;
+        }
+        return setupPromise;
+      };
 
       $scope.$on('$stateChangeStart', function(event, toState) {
         if (toState.name.indexOf('contacts') === -1) {

--- a/static/js/controllers/contacts.js
+++ b/static/js/controllers/contacts.js
@@ -300,16 +300,8 @@ var _ = require('underscore'),
 
       var changeListener = Changes({
         key: 'contacts-list',
-        callback: function(change) {
-          if (change.deleted) {
-            var initialCount = liveList.count();
-            liveList.remove(change.doc);
-            if ($scope.moreItems && initialCount > liveList.count()) {
-              _query({limit: initialCount, silent: true});
-            }
-          } else {
-            _query({limit: liveList.count(), silent: true});
-          }
+        callback: function() {
+          _query({ limit: liveList.count(), silent: true });
         },
         filter: function(change) {
           return ContactSchema.getTypes().indexOf(change.doc.type) !== -1;

--- a/static/js/controllers/contacts.js
+++ b/static/js/controllers/contacts.js
@@ -99,25 +99,31 @@ var _ = require('underscore'),
 
         Search('contacts', actualFilter, options).then(function(contacts) {
           // If you have a home place make sure its at the top
-          if (usersHomePlace && !$scope.appending) {
+          if (usersHomePlace) {
             var homeIndex = _.findIndex(contacts, function(contact) {
               return contact._id === usersHomePlace._id;
             });
-            if (homeIndex !== -1) {
-              // move it to the top
-              contacts.splice(homeIndex, 1);
-              contacts.unshift(usersHomePlace);
-            } else if (!$scope.filters.search && !$scope.filters.simprintsIdentities) {
-              additionalListItem = true;
-              contacts.unshift(usersHomePlace);
-            }
-            if ($scope.filters.simprintsIdentities) {
-              contacts.forEach(function(contact) {
-                var identity = $scope.filters.simprintsIdentities.find(function(identity) {
-                  return identity.id === contact.simprints_id;
+
+            additionalListItem = !$scope.filters.search &&
+                                 (additionalListItem || !$scope.appending) &&
+                                 homeIndex === -1;
+
+            if (!$scope.appending) {
+              if (homeIndex !== -1) {
+                // move it to the top
+                contacts.splice(homeIndex, 1);
+                contacts.unshift(usersHomePlace);
+              } else if (!$scope.filters.search && !$scope.filters.simprintsIdentities) {
+                contacts.unshift(usersHomePlace);
+              }
+              if ($scope.filters.simprintsIdentities) {
+                contacts.forEach(function(contact) {
+                  var identity = $scope.filters.simprintsIdentities.find(function(identity) {
+                    return identity.id === contact.simprints_id;
+                  });
+                  contact.simprints = identity || { confidence: 0, tierNumber: 5 };
                 });
-                contact.simprints = identity || { confidence: 0, tierNumber: 5 };
-              });
+              }
             }
           }
 

--- a/tests/karma/unit/controllers/contacts.js
+++ b/tests/karma/unit/controllers/contacts.js
@@ -339,8 +339,11 @@ describe('Contacts controller', () => {
       searchResults = Array(50).fill(searchResult);
 
       return createController().getSetupPromiseForTesting(scrollLoaderStub).then(() => {
+        const lhs = contactsLiveList.getList();
+        assert.equal(lhs.length, 50);
         scrollLoaderCallback();
         assert.equal(searchService.args[1][2].skip, 50);
+        assert.equal(searchService.args[1][2].limit, 50);
       });
     });
 
@@ -350,9 +353,10 @@ describe('Contacts controller', () => {
 
       return createController().getSetupPromiseForTesting(scrollLoaderStub).then(() => {
         const lhs = contactsLiveList.getList();
-        scrollLoaderCallback();
         assert.equal(lhs.length, 51);
+        scrollLoaderCallback();
         assert.equal(searchService.args[1][2].skip, 50);
+        assert.equal(searchService.args[1][2].limit, 50);
       });
     });
 
@@ -367,6 +371,7 @@ describe('Contacts controller', () => {
         changesCallback();
         assert.equal(lhs.length, 10);
         assert.equal(searchService.args[1][2].limit, 10);
+        assert.equal(searchService.args[1][2].skip, undefined);
       });
     });
 
@@ -376,9 +381,10 @@ describe('Contacts controller', () => {
 
       return createController().getSetupPromiseForTesting(scrollLoaderStub).then(() => {
         const lhs = contactsLiveList.getList();
-        changesCallback();
         assert.equal(lhs.length, 11);
+        changesCallback();
         assert.equal(searchService.args[1][2].limit, 10);
+        assert.equal(searchService.args[1][2].skip, undefined);
       });
     });
 
@@ -395,12 +401,14 @@ describe('Contacts controller', () => {
         searchService.returns(Promise.resolve(searchResults));
         scope.search();
         assert.equal(searchService.args[1][2].limit, 50);
+        assert.equal(searchService.args[1][2].skip, undefined);
         setTimeout(() => {
           lhs = contactSearchLiveList.getList();
           assert.equal(lhs.length, 50);
           //aand paginate the search results, also not skipping the extra place
           scrollLoaderCallback();
           assert.equal(searchService.args[2][2].skip, 50);
+          assert.equal(searchService.args[2][2].limit, 50);
           done();
         });
       }).catch(e => {

--- a/tests/karma/unit/controllers/contacts.js
+++ b/tests/karma/unit/controllers/contacts.js
@@ -332,7 +332,7 @@ describe('Contacts controller', () => {
       });
     });
 
-    it('when paginating, does not skip the extra place for admins', () => {
+    it('when paginating, does not skip the extra place for admins #4085', () => {
       isAdmin = true;
       userSettings = KarmaUtils.promiseService(null, { facility_id: undefined });
       const searchResult = { _id: 'search-result' };
@@ -344,7 +344,7 @@ describe('Contacts controller', () => {
       });
     });
 
-    it('when paginating, does skip the extra place for non-admins', () => {
+    it('when paginating, does modify skip for non-admins #4085', () => {
       const searchResult = { _id: 'search-result' };
       searchResults = Array(50).fill(searchResult);
 
@@ -356,7 +356,7 @@ describe('Contacts controller', () => {
       });
     });
 
-    it('when refreshing list as admin, does not reduce limit because of extra place', () => {
+    it('when refreshing list as admin, does not modify limit #4085', () => {
       isAdmin = true;
       userSettings = KarmaUtils.promiseService(null, { facility_id: undefined });
       const searchResult = { _id: 'search-result' };
@@ -370,7 +370,7 @@ describe('Contacts controller', () => {
       });
     });
 
-    it('when refreshing list as non-admin, does reduce limit because of extra place', () => {
+    it('when refreshing list as non-admin, does modify limit #4085', () => {
       const searchResult = { _id: 'search-result' };
       searchResults = Array(10).fill(searchResult);
 
@@ -382,7 +382,7 @@ describe('Contacts controller', () => {
       });
     });
 
-    it('resets the extra top limit reducer when filtering', (done) => {
+    it('resets limit/skip modifier when filtering #4085', (done) => {
       let lhs;
       const searchResult = { _id: 'search-result' };
       searchResults = Array(10).fill(searchResult);
@@ -398,7 +398,7 @@ describe('Contacts controller', () => {
         setTimeout(() => {
           lhs = contactSearchLiveList.getList();
           assert.equal(lhs.length, 50);
-          //aand paginate the search results, also not skipping
+          //aand paginate the search results, also not skipping the extra place
           scrollLoaderCallback();
           assert.equal(searchService.args[2][2].skip, 50);
           done();

--- a/tests/karma/unit/controllers/contacts.js
+++ b/tests/karma/unit/controllers/contacts.js
@@ -338,7 +338,7 @@ describe('Contacts controller', () => {
       const searchResult = { _id: 'search-result' };
       searchResults = Array(50).fill(searchResult);
 
-      return createController().getSetupPromiseForTesting(scrollLoaderStub).then(() => {
+      return createController().getSetupPromiseForTesting({ scrollLoaderStub }).then(() => {
         const lhs = contactsLiveList.getList();
         assert.equal(lhs.length, 50);
         scrollLoaderCallback();
@@ -351,7 +351,7 @@ describe('Contacts controller', () => {
       const searchResult = { _id: 'search-result' };
       searchResults = Array(50).fill(searchResult);
 
-      return createController().getSetupPromiseForTesting(scrollLoaderStub).then(() => {
+      return createController().getSetupPromiseForTesting({ scrollLoaderStub }).then(() => {
         const lhs = contactsLiveList.getList();
         assert.equal(lhs.length, 51);
         scrollLoaderCallback();
@@ -366,7 +366,7 @@ describe('Contacts controller', () => {
       const searchResult = { _id: 'search-result' };
       searchResults = Array(10).fill(searchResult);
 
-      return createController().getSetupPromiseForTesting(scrollLoaderStub).then(() => {
+      return createController().getSetupPromiseForTesting({ scrollLoaderStub }).then(() => {
         const lhs = contactsLiveList.getList();
         changesCallback();
         assert.equal(lhs.length, 10);
@@ -379,7 +379,7 @@ describe('Contacts controller', () => {
       const searchResult = { _id: 'search-result' };
       searchResults = Array(10).fill(searchResult);
 
-      return createController().getSetupPromiseForTesting(scrollLoaderStub).then(() => {
+      return createController().getSetupPromiseForTesting({ scrollLoaderStub }).then(() => {
         const lhs = contactsLiveList.getList();
         assert.equal(lhs.length, 11);
         changesCallback();
@@ -393,7 +393,7 @@ describe('Contacts controller', () => {
       const searchResult = { _id: 'search-result' };
       searchResults = Array(10).fill(searchResult);
 
-      createController().getSetupPromiseForTesting(scrollLoaderStub).then(() => {
+      createController().getSetupPromiseForTesting({ scrollLoaderStub }).then(() => {
         lhs = contactsLiveList.getList();
         assert.equal(lhs.length, 11);
         scope.filters = { search: true };

--- a/tests/karma/unit/controllers/contacts.js
+++ b/tests/karma/unit/controllers/contacts.js
@@ -3,29 +3,29 @@ describe('Contacts controller', () => {
   'use strict';
 
   let assert = chai.assert,
-    buttonLabel,
-    contactsLiveList,
-    childType,
-    contactSchema,
-    createController,
-    district,
-    forms,
-    icon,
-    isAdmin = false,
-    person,
-    scope,
-    userSettings,
-    searchResults,
-    searchService,
-    getDataRecords,
-    typeLabel,
-    xmlForms,
-    $rootScope,
-    scrollLoaderStub,
-    scrollLoaderCallback,
-    changes,
-    changesCallback,
-    contactSearchLiveList;
+      buttonLabel,
+      contactsLiveList,
+      childType,
+      contactSchema,
+      createController,
+      district,
+      forms,
+      icon,
+      isAdmin = false,
+      person,
+      scope,
+      userSettings,
+      searchResults,
+      searchService,
+      getDataRecords,
+      typeLabel,
+      xmlForms,
+      $rootScope,
+      scrollLoaderStub,
+      scrollLoaderCallback,
+      changes,
+      changesCallback,
+      contactSearchLiveList;
 
   beforeEach(module('inboxApp'));
 
@@ -468,4 +468,3 @@ describe('Contacts controller', () => {
     });
   });
 });
-


### PR DESCRIPTION
# Description
Adds a switch that modifies skip/limit in Contacts Search queries, depending
on whether or not current user's HomePlace is pushed at the start of the LiveList.

medic/medic-webapp#4085

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.