### PR TITLE
Refactor transitions to use promises

### DIFF
--- a/sentinel/db.js
+++ b/sentinel/db.js
@@ -6,30 +6,34 @@ if (couchUrl) {
     // strip trailing slash from to prevent bugs in path matching
     couchUrl = couchUrl.replace(/\/$/, '');
     var parsedUrl = url.parse(couchUrl);
-    var baseUrl = couchUrl.substring(0, couchUrl.indexOf('/', 10));
-
-    module.exports = nano(baseUrl);
-    module.exports.medic = nano(couchUrl);
-
     var dbName = parsedUrl.path.replace('/','');
+    var auditName = dbName + '-audit';
+    var ddocName = 'medic';
+    module.exports = nano(couchUrl.substring(0, couchUrl.indexOf('/', 10)));
     module.exports.settings = {
         protocol: parsedUrl.protocol,
         port: parsedUrl.port,
         host: parsedUrl.hostname,
         db: dbName,
-        auditDb: dbName + '-audit',
-        ddoc: 'medic'
+        ddoc: ddocName
     };
-
     if (parsedUrl.auth) {
         var index = parsedUrl.auth.indexOf(':');
         module.exports.settings.username = parsedUrl.auth.substring(0, index);
         module.exports.settings.password = parsedUrl.auth.substring(index + 1);
     }
+    module.exports.medic = nano(couchUrl);
+    module.exports.audit = require('couchdb-audit')
+        .withNano(module.exports, dbName, auditName, ddocName, module.exports.settings.username);
 } else if (process.env.UNIT_TEST_ENV) {
     // Running tests only
     module.exports = {
         use: function() {},
+        audit: {
+            get: function() {},
+            saveDoc: function() {},
+            bulkSave: function() {}
+        },
         medic: {
             view: function() {},
             get: function() {},

--- a/sentinel/schedule/index.js
+++ b/sentinel/schedule/index.js
@@ -36,18 +36,16 @@ exports.sendable = function(_config, _now) {
 
 exports.checkSchedule = function() {
     var db = require('../db'),
-        audit = require('couchdb-audit')
-            .withNano(db, db.settings.db, db.settings.auditDb, db.settings.ddoc, db.settings.username),
         now = moment(date.getDate());
 
     async.forEachSeries(tasks, function(task, callback) {
         if (_.isFunction(task.execute)) {
             task.execute({
                 db: db,
-                audit: audit
+                audit: db.audit
             }, callback);
         } else if (exports.sendable(config, now)) {
-            task(db, audit, callback);
+            task(db, db.audit, callback);
         } else {
             callback();
         }

--- a/sentinel/test/functional/schedules.js
+++ b/sentinel/test/functional/schedules.js
@@ -49,7 +49,6 @@ exports.tearDown = function(callback) {
 
 exports['registration sets up schedule'] = function(test) {
 
-    test.expect(15);
     sinon.stub(transition, 'getConfig').returns([{
         form: 'PATR',
         events: [
@@ -98,10 +97,7 @@ exports['registration sets up schedule'] = function(test) {
         contact: contact
     };
 
-    transition.onMatch({
-        doc: doc
-    }, {}, {}, function(err, complete) {
-        test.equals(err, null);
+    transition.onMatch({ doc: doc }).then(complete => {
         test.equals(complete, true);
         test.ok(doc.tasks);
         test.equals(doc.tasks && doc.tasks.length, 1);
@@ -142,7 +138,6 @@ exports['registration sets up schedule'] = function(test) {
 
 exports['registration sets up schedule using translation_key'] = function(test) {
 
-    test.expect(13);
     sinon.stub(transition, 'getConfig').returns([{
         form: 'PATR',
         events: [{
@@ -183,10 +178,7 @@ exports['registration sets up schedule using translation_key'] = function(test) 
         contact: contact
     };
 
-    transition.onMatch({
-        doc: doc
-    }, {}, {}, function(err, complete) {
-        test.equals(err, null);
+    transition.onMatch({ doc: doc }).then(complete => {
         test.equals(complete, true);
         test.ok(doc.tasks);
         test.equals(doc.tasks && doc.tasks.length, 1);
@@ -215,7 +207,6 @@ exports['registration sets up schedule using translation_key'] = function(test) 
 
 exports['registration sets up schedule using bool_expr'] = function(test) {
 
-    test.expect(15);
     sinon.stub(transition, 'getConfig').returns([{
         form: 'PATR',
         events: [
@@ -266,10 +257,7 @@ exports['registration sets up schedule using bool_expr'] = function(test) {
         foo: 'baz'
     };
 
-    transition.onMatch({
-        doc: doc
-    }, {}, {}, function(err, complete) {
-        test.equals(err, null);
+    transition.onMatch({ doc: doc }).then(complete => {
         test.equals(complete, true);
         test.ok(doc.tasks);
         test.equals(doc.tasks && doc.tasks.length, 1);
@@ -310,7 +298,6 @@ exports['registration sets up schedule using bool_expr'] = function(test) {
 
 exports['two phase registration sets up schedule using bool_expr'] = function(test) {
 
-    test.expect(17);
     sinon.stub(transition, 'getConfig').returns([{
         form: 'PATR',
         events: [
@@ -365,10 +352,7 @@ exports['two phase registration sets up schedule using bool_expr'] = function(te
         }
     };
 
-    transition.onMatch({
-        doc: doc
-    }, {}, {}, function(err, complete) {
-        test.equals(err, null);
+    transition.onMatch({ doc: doc }).then(complete => {
         test.equals(complete, true);
         test.ok(doc.tasks);
         test.equals(doc.tasks && doc.tasks.length, 1);
@@ -412,7 +396,6 @@ exports['two phase registration sets up schedule using bool_expr'] = function(te
 
 exports['no schedule using false bool_expr'] = function(test) {
 
-    test.expect(10);
     sinon.stub(transition, 'getConfig').returns([{
         form: 'PATR',
         events: [
@@ -461,10 +444,7 @@ exports['no schedule using false bool_expr'] = function(test) {
         foo: 'baz'
     };
 
-    transition.onMatch({
-        doc: doc
-    }, {}, {}, function(err, complete) {
-        test.equals(err, null);
+    transition.onMatch({ doc: doc }).then(complete => {
         test.equals(complete, true);
         test.ok(doc.tasks);
         test.equals(doc.tasks && doc.tasks.length, 1);

--- a/sentinel/test/functional/validations.js
+++ b/sentinel/test/functional/validations.js
@@ -34,9 +34,7 @@ exports['patient id failing validation adds error'] = function(test) {
         form: 'x'
     }]);
 
-    transition.onMatch({
-        doc: doc
-    }, {}, {}, function(err, complete) {
+    transition.onMatch({ doc: doc }).then(complete => {
         test.equals(complete, true);
         test.ok(doc.errors);
         test.equals(doc.errors[0].message, 'bad id xxxx');
@@ -66,9 +64,7 @@ exports['validations use translation_key'] = function(test) {
         form: 'x'
     }]);
 
-    transition.onMatch({
-        doc: doc
-    }, {}, {}, function(err, complete) {
+    transition.onMatch({ doc: doc }).then(complete => {
         test.equals(complete, true);
         test.ok(doc.errors);
         test.equals(doc.errors[0].message, 'bad id xxxx');
@@ -111,9 +107,7 @@ exports['join responses concats validation response msgs'] = function(test) {
         form: 'x'
     }]);
 
-    transition.onMatch({
-        doc: doc
-    }, {}, {}, function(err, complete) {
+    transition.onMatch({ doc: doc }).then(complete => {
         test.equals(complete, true);
         test.ok(doc.errors);
         // check errors array
@@ -170,9 +164,7 @@ exports['false join_responses does not concat validation msgs'] = function(test)
         form: 'x'
     }]);
 
-    transition.onMatch({
-        doc: doc
-    }, {}, {}, function(err, complete) {
+    transition.onMatch({ doc: doc }).then(complete => {
         test.equals(complete, true);
         test.ok(doc.errors);
         // check errors array
@@ -227,9 +219,7 @@ exports['undefined join_responses does not concat validation msgs'] = function(t
         form: 'x'
     }]);
 
-    transition.onMatch({
-        doc: doc
-    }, {}, {}, function(err, complete) {
+    transition.onMatch({ doc: doc }).then(complete => {
         test.equals(complete, true);
         test.ok(doc.errors);
         // check errors array

--- a/sentinel/test/mocha/transitions/death_reporting.js
+++ b/sentinel/test/mocha/transitions/death_reporting.js
@@ -1,5 +1,6 @@
 require('chai').should();
 const sinon = require('sinon').sandbox.create(),
+      db = require('../../../db'),
       transition = require('../../../transitions/death_reporting'),
       utils = require('../../../lib/utils'),
       config = require('../../../config');
@@ -29,12 +30,10 @@ describe('death_reporting', () => {
         undo_deceased_forms: ['death-undo']
       });
       const getPatientContact = sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, patient);
-      const saveDoc = sinon.stub().callsArg(1);
-      const get = sinon.stub().callsArgWith(1, null, patient);
-      const db = { medic: { get: get } };
-      const audit = { saveDoc: saveDoc };
-      transition.onMatch(change, db, audit, (err, updated) => {
-        updated.should.equal(true);
+      const saveDoc = sinon.stub(db.audit, 'saveDoc').callsArg(1);
+      const get = sinon.stub(db.medic, 'get').callsArgWith(1, null, patient);
+      transition.onMatch(change).then(changed => {
+        changed.should.equal(true);
         get.callCount.should.equal(1);
         get.args[0][0].should.equal(patientId);
         getPatientContact.callCount.should.equal(0);
@@ -60,12 +59,10 @@ describe('death_reporting', () => {
         undo_deceased_forms: ['death-undo']
       });
       const getPatientContact = sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, patient);
-      const saveDoc = sinon.stub().callsArg(1);
-      const get = sinon.stub().callsArgWith(1, { statusCode: 404 });
-      const db = { medic: { get: get } };
-      const audit = { saveDoc: saveDoc };
-      transition.onMatch(change, db, audit, (err, updated) => {
-        updated.should.equal(true);
+      const saveDoc = sinon.stub(db.audit, 'saveDoc').callsArg(1);
+      sinon.stub(db.medic, 'get').callsArgWith(1, { statusCode: 404 });
+      transition.onMatch(change).then(changed => {
+        changed.should.equal(true);
         getPatientContact.callCount.should.equal(1);
         getPatientContact.args[0][0].should.equal(db);
         getPatientContact.args[0][1].should.equal(patientId);
@@ -89,12 +86,10 @@ describe('death_reporting', () => {
         undo_deceased_forms: ['death-undo']
       });
       const getPatientContact = sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, patient);
-      const saveDoc = sinon.stub().callsArg(1);
-      const get = sinon.stub().callsArgWith(1, { statusCode: 404 });
-      const db = { medic: { get: get } };
-      const audit = { saveDoc: saveDoc };
-      transition.onMatch(change, db, audit, (err, updated) => {
-        updated.should.equal(true);
+      const saveDoc = sinon.stub(db.audit, 'saveDoc').callsArg(1);
+      sinon.stub(db.medic, 'get').callsArgWith(1, { statusCode: 404 });
+      transition.onMatch(change).then(changed => {
+        changed.should.equal(true);
         getPatientContact.callCount.should.equal(1);
         getPatientContact.args[0][0].should.equal(db);
         getPatientContact.args[0][1].should.equal(patientId);
@@ -118,12 +113,10 @@ describe('death_reporting', () => {
         undo_deceased_forms: ['death-undo']
       });
       const getPatientContact = sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, patient);
-      const saveDoc = sinon.stub().callsArg(1);
-      const get = sinon.stub().callsArgWith(1, { statusCode: 404 });
-      const db = { medic: { get: get } };
-      const audit = { saveDoc: saveDoc };
-      transition.onMatch(change, db, audit, (err, updated) => {
-        updated.should.equal(false);
+      const saveDoc = sinon.stub(db.audit, 'saveDoc').callsArg(1);
+      sinon.stub(db.medic, 'get').callsArgWith(1, { statusCode: 404 });
+      transition.onMatch(change).then(changed => {
+        changed.should.equal(false);
         getPatientContact.callCount.should.equal(1);
         getPatientContact.args[0][0].should.equal(db);
         getPatientContact.args[0][1].should.equal(patientId);
@@ -145,12 +138,11 @@ describe('death_reporting', () => {
         undo_deceased_forms: ['death-undo']
       });
       const getPatientContact = sinon.stub(utils, 'getPatientContact').callsArgWith(2);
-      const saveDoc = sinon.stub().callsArg(1);
-      const get = sinon.stub().callsArgWith(1, { statusCode: 404 });
-      const db = { medic: { get: get } };
-      const audit = { saveDoc: saveDoc };
-      transition.onMatch(change, db, audit, (err, updated) => {
-        updated.should.equal(false);
+      const saveDoc = sinon.stub(db.audit, 'saveDoc').callsArg(1);
+      const get = sinon.stub(db.medic, 'get').callsArgWith(1, { statusCode: 404 });
+      transition.onMatch(change).then(changed => {
+        console.log('!!!!!!!!!!!!!');
+        (!!changed).should.equal(false);
         get.callCount.should.equal(1);
         getPatientContact.callCount.should.equal(1);
         saveDoc.callCount.should.equal(0);

--- a/sentinel/test/unit/birth_registration.js
+++ b/sentinel/test/unit/birth_registration.js
@@ -107,15 +107,11 @@ exports['valid form adds patient_id and expected_date'] = function(test) {
             weeks_since_birth: 1
         }
     };
-
-    transition.onMatch({
-        doc: doc
-    }, {}, {}, function(err, complete) {
-        test.equal(err, null);
-        test.equal(complete, true);
+    transition.onMatch({ doc: doc }).then(changed => {
+        test.equal(changed, true);
         test.ok(doc.patient_id);
         test.ok(doc.birth_date);
         test.equal(doc.tasks, undefined);
         test.done();
-    });
+    }).catch(test.done);
 };

--- a/sentinel/test/unit/conditional_alerts.js
+++ b/sentinel/test/unit/conditional_alerts.js
@@ -24,9 +24,7 @@ exports['when document type matches pass filter'] = function(test) {
 
 exports['when no alerts are registered do nothing'] = function(test) {
     sinon.stub(transition, '_getConfig').returns([]);
-    test.expect(2);
-    transition.onMatch({}, {}, {}, function(err, changed) {
-        test.equals(err, null);
+    transition.onMatch({}).then(changed => {
         test.equals(changed, false);
         test.done();
     });
@@ -37,12 +35,10 @@ exports['when no alerts match document do nothing'] = function(test) {
         form: 'STCK',
         condition: 'false'
     }]);
-    test.expect(2);
     var doc = {
         form: 'PINK'
     };
-    transition.onMatch({ doc: doc }, {}, {}, function(err, changed) {
-        test.equals(err, null);
+    transition.onMatch({ doc: doc }).then(changed => {
         test.equals(changed, false);
         test.done();
     });
@@ -67,12 +63,11 @@ exports['when alert matches document send message'] = function(test) {
     var doc = {
         form: 'STCK'
     };
-    transition.onMatch({ doc: doc }, {}, {}, function(err, changed) {
+    transition.onMatch({ doc: doc }).then(changed => {
         test.ok(messageFn.calledOnce);
         test.equals(messageFn.args[0][0], doc);
         test.equals(messageFn.args[0][1].message, 'hello world');
         test.equals(messageFn.args[0][2], '+5555555');
-        test.equals(err, null);
         test.equals(changed, true);
         test.done();
     });
@@ -97,7 +92,7 @@ exports['when alert matches multiple documents send message multiple times'] = f
     var doc = {
         form: 'STCK'
     };
-    transition.onMatch({ doc: doc }, {}, {}, function(err, changed) {
+    transition.onMatch({ doc: doc }).then(changed => {
         test.ok(messageFn.calledTwice);
         test.equals(messageFn.args[0][0], doc);
         test.equals(messageFn.args[0][1].message, 'hello world');
@@ -105,7 +100,6 @@ exports['when alert matches multiple documents send message multiple times'] = f
         test.equals(messageFn.args[1][0], doc);
         test.equals(messageFn.args[1][1].message, 'goodbye world');
         test.equals(messageFn.args[1][2], '+6666666');
-        test.equals(err, null);
         test.equals(changed, true);
         test.done();
     });
@@ -130,12 +124,11 @@ exports['when alert matches document and condition is true send message'] = func
     var doc = {
         form: 'STCK'
     };
-    transition.onMatch({ doc: doc }, {}, {}, function(err, changed) {
+    transition.onMatch({ doc: doc }).then(changed => {
         test.ok(messageFn.calledOnce);
         test.equals(messageFn.args[0][0], doc);
         test.equals(messageFn.args[0][1].message, 'hello world');
         test.equals(messageFn.args[0][2], '+5555555');
-        test.equals(err, null);
         test.equals(changed, true);
         test.done();
     });
@@ -171,12 +164,11 @@ exports['when recent form condition is true send message'] = function(test) {
     var doc = {
         form: 'STCK'
     };
-    transition.onMatch({ doc: doc }, {}, {}, function(err, changed) {
+    transition.onMatch({ doc: doc }).then(changed => {
         test.equals(messageFn.callCount, 1);
         test.equals(messageFn.args[0][0], doc);
         test.equals(messageFn.args[0][1].message, 'out of units');
         test.equals(messageFn.args[0][2], '+5555555');
-        test.equals(err, null);
         test.equals(changed, true);
         test.done();
     });
@@ -203,9 +195,9 @@ exports['handle missing condition reference gracefully'] = function(test) {
         form: 'STCK'
     };
     test.expect(2);
-    transition.onMatch({ doc: doc }, {}, {}, function(err, changed) {
+    transition.onMatch({ doc: doc }).catch(err => {
         test.ok(err.match(/Cannot read property 's1_avail' of undefined/));
-        test.equals(changed, false);
+        test.equals(!!err.changed, false);
         test.done();
     });
 };
@@ -247,12 +239,11 @@ exports['when complex condition is true send message'] = function(test) {
     var doc = {
         form: 'STCK'
     };
-    transition.onMatch({ doc: doc }, {}, {}, function(err, changed) {
+    transition.onMatch({ doc: doc }).then(changed => {
         test.equals(messageFn.callCount, 1);
         test.equals(messageFn.args[0][0], doc);
         test.equals(messageFn.args[0][1].message, 'low on units');
         test.equals(messageFn.args[0][2], '+5555555');
-        test.equals(err, null);
         test.equals(changed, true);
         test.done();
     });
@@ -294,12 +285,11 @@ exports['database records are sorted before condition evaluation'] = function(te
     var doc = {
         form: 'STCK'
     };
-    transition.onMatch({ doc: doc }, {}, {}, function(err, changed) {
+    transition.onMatch({ doc: doc }).then(changed => {
         test.equals(messageFn.callCount, 1);
         test.equals(messageFn.args[0][0], doc);
         test.equals(messageFn.args[0][1].message, 'low on units');
         test.equals(messageFn.args[0][2], '+5555555');
-        test.equals(err, null);
         test.equals(changed, true);
         test.done();
     });

--- a/sentinel/test/unit/default_responses.js
+++ b/sentinel/test/unit/default_responses.js
@@ -151,11 +151,10 @@ exports['add response if unstructured message and setting enabled'] = function(t
         type: 'data_record',
         errors: []
     };
-    transition.onMatch({ doc: doc }, {}, {}, function(err, changed) {
+    transition.onMatch({ doc: doc }).then(changed => {
         test.ok(messageFn.calledOnce);
         test.equals(messageFn.args[0][0], doc);
         test.equals(messageFn.args[0][1].translation_key, 'sms_received');
-        test.equals(err, null);
         test.equals(changed, true);
         test.done();
     });
@@ -168,11 +167,10 @@ exports['add response if unstructured message (form prop is undefined)'] = funct
         type: 'data_record',
         errors: []
     };
-    transition.onMatch({ doc: doc }, {}, {}, function(err, changed) {
+    transition.onMatch({ doc: doc }).then(changed => {
         test.ok(messageFn.calledOnce);
         test.equals(messageFn.args[0][0], doc);
         test.equals(messageFn.args[0][1].translation_key, 'sms_received');
-        test.equals(err, null);
         test.equals(changed, true);
         test.done();
     });
@@ -191,9 +189,8 @@ exports['do not add response if valid form'] = function(test) {
         type: 'data_record',
         errors: []
     };
-    transition.onMatch({ doc: doc }, {}, {}, function(err, changed) {
+    transition.onMatch({ doc: doc }).then(changed => {
         test.equals(messageFn.called, false);
-        test.equals(err, null);
         test.equals(changed, true);
         test.done();
     });
@@ -207,11 +204,10 @@ exports['add response if form not found'] = function(test) {
         type: 'data_record',
         errors: [ { code: 'sys.form_not_found' } ]
     };
-    transition.onMatch({ doc: doc }, {}, {}, function(err, changed) {
+    transition.onMatch({ doc: doc }).then(changed => {
         test.ok(messageFn.calledOnce);
         test.equals(messageFn.args[0][0], doc);
         test.equals(messageFn.args[0][1].translation_key, 'sms_received');
-        test.equals(err, null);
         test.equals(changed, true);
         test.done();
     });
@@ -225,11 +221,10 @@ exports['add response if form not found and forms_only_mode'] = function(test) {
         type: 'data_record',
         errors: [ { code: 'sys.form_not_found' } ]
     };
-    transition.onMatch({ doc: doc }, {}, {}, function(err, changed) {
+    transition.onMatch({ doc: doc }).then(changed => {
         test.ok(messageFn.calledOnce);
         test.equals(messageFn.args[0][0], doc);
         test.equals(messageFn.args[0][1].translation_key, 'form_not_found');
-        test.equals(err, null);
         test.equals(changed, true);
         test.done();
     });
@@ -243,11 +238,10 @@ exports['add response to empty message'] = function (test) {
         type: 'data_record',
         errors: [ { code: 'sys.empty' } ]
     };
-    transition.onMatch({ doc: doc }, {}, {}, function(err, changed) {
+    transition.onMatch({ doc: doc }).then(changed => {
         test.ok(messageFn.calledOnce);
         test.equals(messageFn.args[0][0], doc);
         test.equals(messageFn.args[0][1].translation_key, 'empty');
-        test.equals(err, null);
         test.equals(changed, true);
         test.done();
     });

--- a/sentinel/test/unit/finalize-transition.js
+++ b/sentinel/test/unit/finalize-transition.js
@@ -1,118 +1,87 @@
-var _ = require('underscore'),
-    transitions;
+const sinon = require('sinon').sandbox.create(),
+      db = require('../../db'),
+      transitions = require('../../transitions/index');
 
-exports.setUp = function(callback) {
-    process.env.TEST_ENV = true;
-    transitions = require('../../transitions/index');
+exports.tearDown = function(callback) {
+    sinon.restore();
     callback();
 };
 
-exports['finalize exposed'] = function(test) {
-    test.ok(_.isFunction(transitions.finalize));
+exports['save not called if transition results are null'] = test => {
+  const doc = { _rev: '1' };
+  const audit = sinon.stub(db.audit, 'saveDoc');
+  transitions.finalize({
+    change: { doc: doc },
+    results: null
+  }, () => {
+    test.equals(audit.callCount, 0);
     test.done();
+  });
 };
 
-exports['save not called if transition results are null'] = function(test) {
-    test.expect(0);
-    var doc = {
-        _rev: '1'
-    };
-    var audit = {
-        saveDoc: function() {
-            test.fail();
-        }
-    };
-    transitions.finalize({
-        change: { doc: doc },
-        audit: audit,
-        results: null
-    }, function() {
-        test.done();
-    });
-};
-
-exports['save is called if transition results have changes'] = function(test) {
-    test.expect(1);
-    var doc = {
-        _rev: '1'
-    };
-    var audit = {
-        saveDoc: function(doc) {
-            test.ok(doc._rev);
-        }
-    };
-    transitions.finalize({
-        change: { doc: doc },
-        audit: audit,
-        results: [null,null,true]
-    });
+exports['save is called if transition results have changes'] = test => {
+  const doc = { _rev: '1' };
+  const audit = sinon.stub(db.audit, 'saveDoc').callsArg(1);
+  transitions.finalize({
+    change: { doc: doc },
+    results: [null,null,true]
+  }, () => {
+    test.equals(audit.callCount, 1);
+    test.ok(audit.args[0][0]._rev);
     test.done();
+  });
 };
 
-exports['applyTransition creates transitions property'] = function(test) {
-    test.expect(7);
-    var doc = {
-        _rev: '1'
-    };
-    var audit = {
-        saveDoc: function(doc, callback) {
-            callback();
-        }
-    };
-    var transition = {
-        onMatch: function(change, db, audit, callback) {
-            change.doc.foo = 'bar';
-            callback(null, true);
-        }
-    };
-    transitions.applyTransition({
-        key: 'x',
-        change: {
-            doc: doc,
-            seq: 1
-        },
-        transition: transition,
-        audit: audit
-    }, function(err, changed) {
-        test.ok(!err);
-        test.ok(changed);
-        test.ok(doc.transitions.x.ok);
-        test.ok(doc.transitions.x.last_rev);
-        test.ok(doc.transitions.x.seq);
-        test.equals(doc.errors, undefined);
-        test.equals(doc.foo, 'bar');
-        test.done();
-    });
+exports['applyTransition creates transitions property'] = test => {
+  test.expect(7);
+  const doc = { _rev: '1' };
+  const audit = sinon.stub(db.audit, 'saveDoc').callsArg(1);
+  const transition = {
+    onMatch: change => {
+      change.doc.foo = 'bar';
+      return Promise.resolve(true);
+    }
+  };
+  transitions.applyTransition({
+    key: 'x',
+    change: {
+      doc: doc,
+      seq: 1
+    },
+    transition: transition,
+    audit: audit
+  }, (err, changed) => {
+    test.ok(!err);
+    test.ok(changed);
+    test.ok(doc.transitions.x.ok);
+    test.ok(doc.transitions.x.last_rev);
+    test.ok(doc.transitions.x.seq);
+    test.equals(doc.errors, undefined);
+    test.equals(doc.foo, 'bar');
+    test.done();
+  });
 };
 
-exports['applyTransition adds errors to doc but does not return errors'] = function(test) {
-    var doc = {
-        _rev: '1'
-    };
-    var audit = {
-        saveDoc: function(doc, callback) {
-            callback();
-        }
-    };
-    var transition = {
-        onMatch: function(change, db, audit, callback) {
-            callback(new Error('oops'));
-        }
-    };
-    transitions.applyTransition({
-        key: 'x',
-        change: {
-            doc: doc
-        },
-        transition: transition,
-        audit: audit
-    }, function(err, changed) {
-        test.ok(!err);
-        test.ok(!changed);
-        test.ok(_.isUndefined(doc.transitions)); // don't save the transition or it won't run next time
-        test.ok(doc.errors.length === 1);
-        // error message contains error
-        test.ok(doc.errors[0].message.match(/oops/));
-        test.done();
-    });
+exports['applyTransition adds errors to doc but does not return errors'] = test => {
+  const doc = { _rev: '1' };
+  const audit = sinon.stub(db.audit, 'saveDoc').callsArg(1);
+  var transition = {
+    onMatch: () => Promise.reject({ changed: false, message: 'oops' })
+  };
+  transitions.applyTransition({
+    key: 'x',
+    change: {
+      doc: doc
+    },
+    transition: transition,
+    audit: audit
+  }, (err, changed) => {
+    test.ok(!err);
+    test.ok(!changed);
+    test.equals(doc.transitions, undefined); // don't save the transition or it won't run next time
+    test.ok(doc.errors.length === 1);
+    // error message contains error
+    test.equals(doc.errors[0].message, 'Transition error on x: oops');
+    test.done();
+  });
 };

--- a/sentinel/test/unit/patient_registration.js
+++ b/sentinel/test/unit/patient_registration.js
@@ -1,331 +1,313 @@
-var _ = require('underscore'),
-    moment = require('moment'),
-    transition = require('../../transitions/registration'),
-    sinon = require('sinon').sandbox.create(),
-    utils = require('../../lib/utils'),
-    transitionUtils = require('../../transitions/utils'),
-    date = require('../../date');
+const _ = require('underscore'),
+      moment = require('moment'),
+      sinon = require('sinon').sandbox.create(),
+      transition = require('../../transitions/registration'),
+      db = require('../../db'),
+      utils = require('../../lib/utils'),
+      transitionUtils = require('../../transitions/utils'),
+      date = require('../../date');
 
-function getMessage(doc, idx) {
-    if (!doc || !doc.tasks) {
-        return;
-    }
-    if (idx) {
-        if (!doc.tasks[idx]) {
-            return;
-        }
-        return _.first(doc.tasks[idx].messages);
-    }
+const getMessage = (doc, idx) => {
+  if (!doc || !doc.tasks) {
+    return;
+  }
+  if (!idx) {
     return _.first(_.first(doc.tasks).messages);
-}
+  }
+  if (doc.tasks[idx]) {
+    return _.first(doc.tasks[idx].messages);
+  }
+};
 
-exports.setUp = function(callback) {
-    sinon.stub(transition, 'getConfig').returns([{
-        form: 'PATR',
-        events: [
-           {
-               name: 'on_create',
-               trigger: 'add_patient_id',
-               params: '',
-               bool_expr: ''
-           }
+exports.setUp = callback => {
+  sinon.stub(transition, 'getConfig').returns([{
+    form: 'PATR',
+    events: [
+      {
+        name: 'on_create',
+        trigger: 'add_patient_id',
+        params: '',
+        bool_expr: ''
+      }
+    ],
+    validations: [
+      {
+        property: 'patient_name',
+        rule: 'lenMin(1) && lenMax(100)',
+        message: 'Invalid patient name.'
+      }
+    ],
+    messages: [
+      {
+        message: [
+          {
+            content: 'thanks {{contact.name}}',
+            locale: 'en'
+          },
+          {
+            content: 'gracias {{contact.name}}',
+            locale: 'es'
+          }
         ],
-        validations: [
-            {
-                property: 'patient_name',
-                rule: 'lenMin(1) && lenMax(100)',
-                message: 'Invalid patient name.'
-            }
+        recipient: 'reporting_unit',
+      },
+      {
+        message: [
+          {
+            content: 'thanks {{fields.caregiver_name}}',
+            locale: 'en'
+          },
+          {
+            content: 'gracias {{fields.caregiver_name}}',
+            locale: 'es'
+          }
         ],
-        messages: [
-            {
-                message: [
-                    {
-                        content: 'thanks {{contact.name}}',
-                        locale: 'en'
-                    },
-                    {
-                        content: 'gracias {{contact.name}}',
-                        locale: 'es'
-                    }
-                ],
-                recipient: 'reporting_unit',
-            },
-            {
-                message: [
-                    {
-                        content: 'thanks {{fields.caregiver_name}}',
-                        locale: 'en'
-                    },
-                    {
-                        content: 'gracias {{fields.caregiver_name}}',
-                        locale: 'es'
-                    }
-                ],
-                recipient: 'caregiver_phone',
-            }
-        ]
-    }]);
-    callback();
+        recipient: 'caregiver_phone',
+      }
+    ]
+  }]);
+  callback();
 };
 
-exports.tearDown = function(callback) {
-    sinon.restore();
-    callback();
+exports.tearDown = callback => {
+  sinon.restore();
+  callback();
 };
 
-exports['getWeeksSinceLMP returns 0 not NaN or null'] = function(test) {
-    test.equal(transition.getWeeksSinceLMP({ fields: { lmp: 0 } }), 0);
-    test.equal(typeof transition.getWeeksSinceLMP({ fields: { lmp: 0 } }), 'number');
-    test.equal(transition.getWeeksSinceLMP({ fields: { weeks_since_lmp: 0 } }), 0);
-    test.equal(typeof transition.getWeeksSinceLMP({ fields: { weeks_since_lmp: 0 } }), 'number');
-    test.equal(transition.getWeeksSinceLMP({ fields: { last_menstrual_period: 0 } }), 0);
-    test.equal(typeof transition.getWeeksSinceLMP({ fields: { last_menstrual_period: 0 } }), 'number');
-    test.done();
+exports['getWeeksSinceLMP returns 0 not NaN or null'] = test => {
+  test.equal(transition.getWeeksSinceLMP({ fields: { lmp: 0 } }), 0);
+  test.equal(typeof transition.getWeeksSinceLMP({ fields: { lmp: 0 } }), 'number');
+  test.equal(transition.getWeeksSinceLMP({ fields: { weeks_since_lmp: 0 } }), 0);
+  test.equal(typeof transition.getWeeksSinceLMP({ fields: { weeks_since_lmp: 0 } }), 'number');
+  test.equal(transition.getWeeksSinceLMP({ fields: { last_menstrual_period: 0 } }), 0);
+  test.equal(typeof transition.getWeeksSinceLMP({ fields: { last_menstrual_period: 0 } }), 'number');
+  test.done();
 };
 
-exports['getWeeksSinceLMP always returns number'] = function(test) {
-    test.equal(transition.getWeeksSinceLMP({ fields: { lmp: '12' } }), 12);
-    test.done();
+exports['getWeeksSinceLMP always returns number'] = test => {
+  test.equal(transition.getWeeksSinceLMP({ fields: { lmp: '12' } }), 12);
+  test.done();
 };
 
-exports['getWeeksSinceLMP supports three property names'] = function(test) {
-    test.equal(transition.getWeeksSinceLMP({ fields: { lmp: '12' } }), 12);
-    test.equal(transition.getWeeksSinceLMP({ fields: { weeks_since_lmp: '12' } }), 12);
-    test.equal(transition.getWeeksSinceLMP({ fields: { last_menstrual_period: '12' } }), 12);
-    test.done();
+exports['getWeeksSinceLMP supports three property names'] = test => {
+  test.equal(transition.getWeeksSinceLMP({ fields: { lmp: '12' } }), 12);
+  test.equal(transition.getWeeksSinceLMP({ fields: { weeks_since_lmp: '12' } }), 12);
+  test.equal(transition.getWeeksSinceLMP({ fields: { last_menstrual_period: '12' } }), 12);
+  test.done();
 };
 
-exports['getWeeksSinceDOB supports four property names'] = function(test) {
-    test.equal(transition.getWeeksSinceDOB({ fields: { dob: '12' } }), 12);
-    test.equal(transition.getWeeksSinceDOB({ fields: { weeks_since_dob: '12' } }), 12);
-    test.equal(transition.getWeeksSinceDOB({ fields: { weeks_since_birth: '12' } }), 12);
-    test.equal(transition.getWeeksSinceDOB({ fields: { age_in_weeks: '12' } }), 12);
-    test.done();
+exports['getWeeksSinceDOB supports four property names'] = test => {
+  test.equal(transition.getWeeksSinceDOB({ fields: { dob: '12' } }), 12);
+  test.equal(transition.getWeeksSinceDOB({ fields: { weeks_since_dob: '12' } }), 12);
+  test.equal(transition.getWeeksSinceDOB({ fields: { weeks_since_birth: '12' } }), 12);
+  test.equal(transition.getWeeksSinceDOB({ fields: { age_in_weeks: '12' } }), 12);
+  test.done();
 };
 
-exports['getDaysSinceDOB supports three property names'] = function(test) {
-    test.equal(transition.getDaysSinceDOB({ fields: { days_since_dob: '12' } }), 12);
-    test.equal(transition.getDaysSinceDOB({ fields: { days_since_birth: '12' } }), 12);
-    test.equal(transition.getDaysSinceDOB({ fields: { age_in_days: '12' } }), 12);
-    test.done();
+exports['getDaysSinceDOB supports three property names'] = test => {
+  test.equal(transition.getDaysSinceDOB({ fields: { days_since_dob: '12' } }), 12);
+  test.equal(transition.getDaysSinceDOB({ fields: { days_since_birth: '12' } }), 12);
+  test.equal(transition.getDaysSinceDOB({ fields: { age_in_days: '12' } }), 12);
+  test.done();
 };
 
-exports['getDOB uses weeks since dob if available'] = function(test) {
-    var today = 1474942416907,
+exports['getDOB uses weeks since dob if available'] = test => {
+  const today = 1474942416907,
         expected = moment(today).startOf('day').subtract(5, 'weeks').valueOf();
-    sinon.stub(date, 'getDate').returns(today);
-    sinon.stub(transition, 'getWeeksSinceDOB').returns('5');
-    test.equal(transition.getDOB({ fields: {} }).valueOf(), expected);
-    test.done();
+  sinon.stub(date, 'getDate').returns(today);
+  sinon.stub(transition, 'getWeeksSinceDOB').returns('5');
+  test.equal(transition.getDOB({ fields: {} }).valueOf(), expected);
+  test.done();
 };
 
-exports['getDOB uses days since dob if available'] = function(test) {
-    var today = 1474942416907,
+exports['getDOB uses days since dob if available'] = test => {
+  const today = 1474942416907,
         expected = moment(today).startOf('day').subtract(5, 'days').valueOf();
-    sinon.stub(date, 'getDate').returns(today);
-    sinon.stub(transition, 'getWeeksSinceDOB').returns(undefined);
-    sinon.stub(transition, 'getDaysSinceDOB').returns('5');
-    test.equal(transition.getDOB({ fields: {} }).valueOf(), expected);
-    test.done();
+  sinon.stub(date, 'getDate').returns(today);
+  sinon.stub(transition, 'getWeeksSinceDOB').returns(undefined);
+  sinon.stub(transition, 'getDaysSinceDOB').returns('5');
+  test.equal(transition.getDOB({ fields: {} }).valueOf(), expected);
+  test.done();
 };
 
-exports['getDOB falls back to today if necessary'] = function(test) {
-    var today = 1474942416907,
+exports['getDOB falls back to today if necessary'] = test => {
+  const today = 1474942416907,
         expected = moment(today).startOf('day').valueOf();
-    sinon.stub(date, 'getDate').returns(today);
-    sinon.stub(transition, 'getWeeksSinceDOB').returns(undefined);
-    sinon.stub(transition, 'getDaysSinceDOB').returns(undefined);
-    test.equal(transition.getDOB({ fields: {} }).valueOf(), expected);
+  sinon.stub(date, 'getDate').returns(today);
+  sinon.stub(transition, 'getWeeksSinceDOB').returns(undefined);
+  sinon.stub(transition, 'getDaysSinceDOB').returns(undefined);
+  test.equal(transition.getDOB({ fields: {} }).valueOf(), expected);
+  test.done();
+};
+
+exports['valid form adds patient_id and patient document'] = test => {
+
+  sinon.stub(utils, 'getPatientContactUuid').callsArgWith(2);
+
+  sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc, callback) => {
+    doc.patient_id = 12345;
+    callback();
+  });
+
+  const doc = {
+    _id: 'docid',
+    form: 'PATR',
+    fields: { patient_name: 'abc' },
+    reported_date: 'now'
+  };
+  sinon.stub(db.medic, 'view').callsArgWith(3, null, {rows: [
+    {
+      doc: {
+        _id: 'the-contact',
+        parent: {
+          _id: 'the-parent'
+        }
+      }
+    }
+  ]});
+  const saveDoc = sinon.stub(db.audit, 'saveDoc').callsArg(1);
+
+  transition.onMatch({ doc: doc }).then(changed => {
+    test.equal(changed, true);
+    test.ok(doc.patient_id);
+    test.ok(saveDoc.called);
+
+    test.deepEqual(saveDoc.args[0][0], {
+      name: 'abc',
+      parent: {
+        _id: 'the-parent'
+      },
+      reported_date: 'now',
+      type: 'person',
+      patient_id: doc.patient_id,
+      created_by: 'the-contact',
+      source_id: 'docid'
+    });
     test.done();
+  });
 };
 
-exports['valid form adds patient_id and patient document'] = function(test) {
+exports['registration sets up responses'] = test => {
 
-    sinon.stub(utils, 'getPatientContactUuid').callsArgWith(2);
+  sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, []);
+  sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, {_id: 'uuid'});
+  sinon.stub(utils, 'getPatientContactUuid').callsArgWith(2, null, {_id: 'uuid'});
+  sinon.stub(transitionUtils, 'addUniqueId').callsArgWith(1);
 
-    sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc, callback) => {
-        doc.patient_id = 12345;
-        callback();
-    });
+  const doc = {
+    form: 'PATR',
+    from: '+1234',
+    fields: {
+      patient_name: 'foo',
+      caregiver_name: 'Sam',
+      caregiver_phone: '+987',
+    },
+    contact: {
+      phone: '+1234',
+      name: 'Julie'
+    },
+    locale: 'en'
+  };
 
-    var doc = {
-        _id: 'docid',
-        form: 'PATR',
-        fields: { patient_name: 'abc' },
-        reported_date: 'now'
-    };
+  transition.onMatch({ doc: doc }).then(changed => {
+    test.equal(changed, true);
+    test.ok(doc.tasks);
+    test.equal(doc.tasks && doc.tasks.length, 2);
 
-    var db = {
-        medic: {
-            view: sinon.stub().callsArgWith(3, null, {rows: [
-                {
-                    doc: {
-                        _id: 'the-contact',
-                        parent: {
-                            _id: 'the-parent'
-                        }
-                    }
-                }
-            ]})
-        }
-    };
+    const msg0 = getMessage(doc, 0);
+    test.ok(msg0);
+    test.ok(msg0.uuid);
+    test.ok(msg0.to);
+    test.ok(msg0.message);
+    if (msg0) {
+      delete msg0.uuid;
+      test.deepEqual(msg0, {
+        to: '+1234',
+        message: 'thanks Julie'
+      });
+    }
 
-    var auditDb = {
-        saveDoc: sinon.stub().callsArgWith(1)
-    };
-
-    transition.onMatch({
-        doc: doc
-    }, db, auditDb, function(err, complete) {
-        test.equal(err, null);
-        test.equal(complete, true);
-        test.ok(doc.patient_id);
-        test.ok(auditDb.saveDoc.called);
-
-        test.deepEqual(auditDb.saveDoc.args[0][0],
-            {
-                name: 'abc',
-                parent: {
-                    _id: 'the-parent'
-                },
-                reported_date: 'now',
-                type: 'person',
-                patient_id: doc.patient_id,
-                created_by: 'the-contact',
-                source_id: 'docid'
-            });
-        test.done();
-    });
+    /*
+     * Also checks that recipient using doc property value is handled
+     * resolved correctly
+     * */
+    const msg1 = getMessage(doc, 1);
+    test.ok(msg1);
+    test.ok(msg1.uuid);
+    test.ok(msg1.to);
+    test.ok(msg1.message);
+    if (msg1) {
+      delete msg1.uuid;
+      test.deepEqual(msg1, {
+        to: '+987',
+        message: 'thanks Sam'
+      });
+    }
+    test.done();
+  });
 };
 
-exports['registration sets up responses'] = function(test) {
+exports['registration responses support locale'] = test => {
 
-    sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, []);
-    sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, {_id: 'uuid'});
-    sinon.stub(utils, 'getPatientContactUuid').callsArgWith(2, null, {_id: 'uuid'});
-    sinon.stub(transitionUtils, 'addUniqueId').callsArgWith(1);
+  sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, []);
+  sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, {_id: 'uuid'});
+  sinon.stub(utils, 'getPatientContactUuid').callsArgWith(2, null, {_id: 'uuid'});
+  sinon.stub(transitionUtils, 'addUniqueId').callsArgWith(1);
 
-    var doc = {
-        form: 'PATR',
-        from: '+1234',
-        fields: {
-            patient_name: 'foo',
-            caregiver_name: 'Sam',
-            caregiver_phone: '+987',
-        },
+  const doc = {
+    form: 'PATR',
+    fields: {
+      patient_name: 'foo',
+      caregiver_name: 'Sam',
+      caregiver_phone: '+987',
+    },
+    contact: {
+      phone: '+1234',
+      name: 'Julie',
+      parent: {
         contact: {
-            phone: '+1234',
-            name: 'Julie'
-        },
-        locale: 'en'
-    };
-
-    transition.onMatch({
-        doc: doc
-    }, {}, {}, function(err, complete) {
-        test.equal(err, null);
-        test.equal(complete, true);
-        test.ok(doc.tasks);
-        test.equal(doc.tasks && doc.tasks.length, 2);
-
-        var msg0 = getMessage(doc, 0);
-        test.ok(msg0);
-        test.ok(msg0.uuid);
-        test.ok(msg0.to);
-        test.ok(msg0.message);
-        if (msg0) {
-            delete msg0.uuid;
-            test.deepEqual(msg0, {
-                to: '+1234',
-                message: 'thanks Julie'
-            });
+          phone: '+1234',
+          name: 'Julie'
         }
+      }
+    },
+    locale: 'es' //spanish
+  };
 
-        /*
-         * Also checks that recipient using doc property value is handled
-         * resolved correctly
-         * */
-        var msg1 = getMessage(doc, 1);
-        test.ok(msg1);
-        test.ok(msg1.uuid);
-        test.ok(msg1.to);
-        test.ok(msg1.message);
-        if (msg1) {
-            delete msg1.uuid;
-            test.deepEqual(msg1, {
-                to: '+987',
-                message: 'thanks Sam'
-            });
-        }
-        test.done();
-    });
-};
+  transition.onMatch({ doc: doc }).then(changed => {
+    test.equal(changed, true);
+    test.ok(doc.tasks);
+    test.equal(doc.tasks && doc.tasks.length, 2);
 
-exports['registration responses support locale'] = function(test) {
+    const msg0 = getMessage(doc, 0);
+    test.ok(msg0);
+    test.ok(msg0.uuid);
+    test.ok(msg0.to);
+    test.ok(msg0.message);
+    if (msg0) {
+      delete msg0.uuid;
+      test.deepEqual(msg0, {
+        to: '+1234',
+        message: 'gracias Julie'
+      });
+    }
 
-    sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, []);
-    sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, {_id: 'uuid'});
-    sinon.stub(utils, 'getPatientContactUuid').callsArgWith(2, null, {_id: 'uuid'});
-    sinon.stub(transitionUtils, 'addUniqueId').callsArgWith(1);
-
-    var doc = {
-        form: 'PATR',
-        fields: {
-            patient_name: 'foo',
-            caregiver_name: 'Sam',
-            caregiver_phone: '+987',
-        },
-        contact: {
-            phone: '+1234',
-            name: 'Julie',
-            parent: {
-                contact: {
-                    phone: '+1234',
-                    name: 'Julie'
-                }
-            }
-        },
-        locale: 'es' //spanish
-    };
-
-    transition.onMatch({
-        doc: doc
-    }, {}, {}, function(err, complete) {
-        test.equal(err, null);
-        test.equal(complete, true);
-        test.ok(doc.tasks);
-        test.equal(doc.tasks && doc.tasks.length, 2);
-
-        var msg0 = getMessage(doc, 0);
-        test.ok(msg0);
-        test.ok(msg0.uuid);
-        test.ok(msg0.to);
-        test.ok(msg0.message);
-        if (msg0) {
-            delete msg0.uuid;
-            test.deepEqual(msg0, {
-                to: '+1234',
-                message: 'gracias Julie'
-            });
-        }
-
-        /*
-         * Also checks that recipient using doc property value is resolved
-         * correctly.
-         * */
-        var msg1 = getMessage(doc, 1);
-        test.ok(msg1);
-        test.ok(msg1.uuid);
-        test.ok(msg1.to);
-        test.ok(msg1.message);
-        if (msg1) {
-            delete msg1.uuid;
-            test.deepEqual(msg1, {
-                to: '+987',
-                message: 'gracias Sam'
-            });
-        }
-        test.done();
-    });
+    /*
+     * Also checks that recipient using doc property value is resolved
+     * correctly.
+     * */
+    const msg1 = getMessage(doc, 1);
+    test.ok(msg1);
+    test.ok(msg1.uuid);
+    test.ok(msg1.to);
+    test.ok(msg1.message);
+    if (msg1) {
+      delete msg1.uuid;
+      test.deepEqual(msg1, {
+        to: '+987',
+        message: 'gracias Sam'
+      });
+    }
+    test.done();
+  });
 };

--- a/sentinel/test/unit/pregnancy_registration.js
+++ b/sentinel/test/unit/pregnancy_registration.js
@@ -5,12 +5,12 @@ var _ = require('underscore'),
     transitionUtils = require('../../transitions/utils'),
     utils = require('../../lib/utils');
 
-function getMessage(doc) {
+const getMessage = doc => {
     if (!doc || !doc.tasks) {
         return;
     }
     return _.first(_.first(doc.tasks).messages).message;
-}
+};
 
 exports.setUp = function(callback) {
     sinon.stub(transition, 'getConfig').returns([{
@@ -180,9 +180,7 @@ exports['setExpectedBirthDate sets lmp_date and expected_date correctly for lmp:
 };
 
 exports['valid adds lmp_date and patient_id'] = function(test) {
-    test.expect(5);
-    var doc,
-        start = moment().startOf('day').subtract(5, 'weeks');
+    var start = moment().startOf('day').subtract(5, 'weeks');
 
     sinon.stub(utils, 'getPatientContactUuid').callsArgWith(2, null, {_id: 'uuid'});
 
@@ -191,7 +189,7 @@ exports['valid adds lmp_date and patient_id'] = function(test) {
         callback();
     });
 
-    doc = {
+    const doc = {
         form: 'p',
         type: 'data_record',
         fields: {
@@ -200,10 +198,7 @@ exports['valid adds lmp_date and patient_id'] = function(test) {
         }
     };
 
-    transition.onMatch({
-        doc: doc
-    }, {}, {}, function(err, changed) {
-        test.equals(err, null);
+    transition.onMatch({ doc: doc }).then(function(changed) {
         test.equals(changed, true);
         test.equals(doc.lmp_date, start.toISOString());
         test.ok(doc.patient_id);
@@ -216,7 +211,7 @@ exports['pregnancies on existing patients fail without valid patient id'] = func
     sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, []);
     sinon.stub(utils, 'getPatientContactUuid').callsArgWith(2);
 
-    var doc = {
+    const doc = {
         form: 'ep',
         type: 'data_record',
         fields: {
@@ -225,10 +220,7 @@ exports['pregnancies on existing patients fail without valid patient id'] = func
         }
     };
 
-    transition.onMatch({
-        doc: doc
-    }, {}, {}, function(err, changed) {
-        test.equals(err, null);
+    transition.onMatch({ doc: doc }).then(function(changed) {
         test.equals(changed, true);
         test.equals(doc.errors.length, 1);
         test.equals(doc.errors[0].message, 'messages.generic.registration_not_found');
@@ -240,7 +232,7 @@ exports['pregnancies on existing patients succeeds with a valid patient id'] = f
     sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, []);
     sinon.stub(utils, 'getPatientContactUuid').callsArgWith(2, null, {_id: 'uuid'});
 
-    var doc = {
+    const doc = {
         form: 'ep',
         type: 'data_record',
         fields: {
@@ -249,10 +241,7 @@ exports['pregnancies on existing patients succeeds with a valid patient id'] = f
         }
     };
 
-    transition.onMatch({
-        doc: doc
-    }, {}, {}, function(err, changed) {
-        test.equals(err, null);
+    transition.onMatch({ doc: doc }).then(function(changed) {
         test.equals(changed, true);
         test.ok(!doc.errors);
         test.done();
@@ -268,7 +257,7 @@ exports['zero lmp value only registers patient'] = function(test) {
         callback();
     });
 
-    var doc = {
+    const doc = {
         form: 'p',
         type: 'data_record',
         fields: {
@@ -277,10 +266,7 @@ exports['zero lmp value only registers patient'] = function(test) {
         }
     };
 
-    transition.onMatch({
-        doc: doc
-    }, {}, {}, function(err, changed) {
-        test.equals(err, null);
+    transition.onMatch({ doc: doc }).then(function(changed) {
         test.equals(changed, true);
         test.equals(doc.lmp_date, null);
         test.ok(doc.patient_id);
@@ -290,8 +276,6 @@ exports['zero lmp value only registers patient'] = function(test) {
 };
 
 exports['id only logic with valid name'] = function(test) {
-    var doc;
-
     sinon.stub(utils, 'getPatientContactUuid').callsArgWith(2, null, {_id: 'uuid'});
 
     sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc, callback) => {
@@ -299,7 +283,7 @@ exports['id only logic with valid name'] = function(test) {
         callback();
     });
 
-    doc = {
+    const doc = {
         form: 'p',
         type: 'data_record',
         fields: {
@@ -309,10 +293,7 @@ exports['id only logic with valid name'] = function(test) {
         getid: 'x'
     };
 
-    transition.onMatch({
-        doc: doc
-    }, {}, {}, function(err, changed) {
-        test.equals(err, null);
+    transition.onMatch({ doc: doc }).then(function(changed) {
         test.equals(changed, true);
         test.equals(doc.lmp_date, undefined);
         test.ok(doc.patient_id);
@@ -322,13 +303,10 @@ exports['id only logic with valid name'] = function(test) {
 };
 
 exports['id only logic with invalid name'] = function(test) {
-    test.expect(5);
-    var doc;
-
     sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, []);
     sinon.stub(utils, 'getPatientContactUuid').callsArgWith(2, null, {_id: 'uuid'});
 
-    doc = {
+    const doc = {
         form: 'p',
         from: '+12345',
         type: 'data_record',
@@ -339,10 +317,7 @@ exports['id only logic with invalid name'] = function(test) {
         getid: 'x'
     };
 
-    transition.onMatch({
-        doc: doc
-    }, {}, {}, function(err, changed) {
-        test.equals(err, null);
+    transition.onMatch({ doc: doc }).then(function(changed) {
         test.equals(changed, true);
         test.equals(doc.patient_id, undefined);
         test.ok(doc.tasks);
@@ -352,11 +327,7 @@ exports['id only logic with invalid name'] = function(test) {
 };
 
 exports['invalid name valid LMP logic'] = function(test) {
-    test.expect(4);
-
-    var doc;
-
-    doc = {
+    const doc = {
         form: 'p',
         from: '+1234',
         type: 'data_record',
@@ -366,10 +337,7 @@ exports['invalid name valid LMP logic'] = function(test) {
         }
     };
 
-    transition.onMatch({
-        doc: doc
-    }, {}, {}, function(err, changed) {
-        test.equals(err, null);
+    transition.onMatch({ doc: doc }).then(function(changed) {
         test.equals(changed, true);
         test.equals(doc.patient_id, undefined);
         test.equals(getMessage(doc), 'Invalid patient name.');
@@ -379,9 +347,7 @@ exports['invalid name valid LMP logic'] = function(test) {
 };
 
 exports['valid name invalid LMP logic'] = function(test) {
-    var doc;
-
-    doc = {
+    const doc = {
         form: 'p',
         from: '+1234',
         type: 'data_record',
@@ -391,10 +357,7 @@ exports['valid name invalid LMP logic'] = function(test) {
         }
     };
 
-    transition.onMatch({
-        doc: doc
-    }, {}, {}, function(err, changed) {
-        test.equals(err, null);
+    transition.onMatch({ doc: doc }).then(function(changed) {
         test.equals(changed, true);
         test.equals(doc.patient_id, undefined);
         test.equals(getMessage(doc), 'Invalid LMP; must be between 0-40 weeks.');
@@ -404,9 +367,7 @@ exports['valid name invalid LMP logic'] = function(test) {
 };
 
 exports['invalid name invalid LMP logic'] = function(test) {
-    var doc;
-
-    doc = {
+    const doc = {
         form: 'p',
         from: '+123',
         type: 'data_record',
@@ -416,10 +377,7 @@ exports['invalid name invalid LMP logic'] = function(test) {
         }
     };
 
-    transition.onMatch({
-        doc: doc
-    }, {}, {}, function(err, changed) {
-        test.equals(err, null);
+    transition.onMatch({ doc: doc }).then(function(changed) {
         test.equals(changed, true);
         test.equals(doc.patient_id, undefined);
         test.equals(getMessage(doc), 'Invalid patient name.  Invalid LMP; must be between 0-40 weeks.');
@@ -429,27 +387,23 @@ exports['invalid name invalid LMP logic'] = function(test) {
 };
 
 exports['mismatched form returns false'] = function(test) {
-    transition.onMatch({
-        doc: {
-            form: 'x',
-            type: 'data_record'
-        }
-    }, {}, {}, function(err, changed) {
-        test.equals(changed, undefined);
+    const doc = {
+        form: 'x',
+        type: 'data_record'
+    };
+    transition.onMatch({ doc: doc }).catch(function() {
         test.done();
     });
 };
 
 exports['missing all fields returns validation errors'] = function(test) {
     test.expect(2);
-    var doc = {
+    const doc = {
         form: 'p',
         from: '+123',
         type: 'data_record'
     };
-    transition.onMatch({
-        doc: doc
-    }, {}, {}, function(err, changed) {
+    transition.onMatch({ doc: doc }).then(function(changed) {
         test.equals(changed, true);
         test.equals(
             getMessage(doc),

--- a/sentinel/test/unit/resolve_pending.js
+++ b/sentinel/test/unit/resolve_pending.js
@@ -1,10 +1,5 @@
 var transition = require('../../transitions/resolve_pending');
 
-exports.tearDown = function(callback) {
-    callback();
-};
-
-
 exports['filter fails on undefined tasks or scheduled_tasks'] = function(test) {
     test.equals(transition.filter({}), false);
     test.done();
@@ -76,7 +71,7 @@ exports['onMatch does not cause update if message is already sent'] = function(t
             state: 'sent'
         }]
     };
-    transition.onMatch({ doc: doc }, {}, {}, function(err, changed) {
+    transition.onMatch({ doc: doc }).then(changed => {
         test.equals(changed, false);
         test.done();
     });

--- a/sentinel/test/unit/transitions.js
+++ b/sentinel/test/unit/transitions.js
@@ -1,6 +1,5 @@
 const sinon = require('sinon').sandbox.create(),
       follow = require('follow'),
-      audit = require('couchdb-audit'),
       _ = require('underscore'),
       config = require('../../config'),
       db = require('../../db'),
@@ -203,15 +202,14 @@ exports['attach handles missing meta data doc'] = test => {
   const start = sinon.stub();
   const feed = sinon.stub(follow, 'Feed').returns({ on: on, follow: start, stop: () => {} });
   const applyTransitions = sinon.stub(transitions, 'applyTransitions').callsArg(1);
-  sinon.stub(audit, 'withNano');
   // wait for the queue processor
   transitions._changeQueue.drain = () => {
     test.equal(get.callCount, 4);
     test.equal(fetchHydratedDoc.callCount, 1);
     test.equal(fetchHydratedDoc.args[0][0], 'abc');
     test.equal(applyTransitions.callCount, 1);
-    test.equal(applyTransitions.args[0][0].change.id, 'abc');
-    test.equal(applyTransitions.args[0][0].change.seq, 55);
+    test.equal(applyTransitions.args[0][0].id, 'abc');
+    test.equal(applyTransitions.args[0][0].seq, 55);
     test.equal(insert.callCount, 1);
     test.equal(insert.args[0][0]._id, '_local/sentinel-meta-data');
     test.equal(insert.args[0][0].processed_seq, 55);
@@ -238,15 +236,14 @@ exports['attach handles old meta data doc'] = test => {
   const start = sinon.stub();
   const feed = sinon.stub(follow, 'Feed').returns({ on: on, follow: start, stop: () => {} });
   const applyTransitions = sinon.stub(transitions, 'applyTransitions').callsArg(1);
-  sinon.stub(audit, 'withNano');
   // wait for the queue processor
   transitions._changeQueue.drain = () => {
     test.equal(get.callCount, 4);
     test.equal(fetchHydratedDoc.callCount, 1);
     test.equal(fetchHydratedDoc.args[0][0], 'abc');
     test.equal(applyTransitions.callCount, 1);
-    test.equal(applyTransitions.args[0][0].change.id, 'abc');
-    test.equal(applyTransitions.args[0][0].change.seq, 55);
+    test.equal(applyTransitions.args[0][0].id, 'abc');
+    test.equal(applyTransitions.args[0][0].seq, 55);
     test.equal(insert.callCount, 3);
     test.equal(insert.args[0][0]._id, 'sentinel-meta-data');
     test.equal(insert.args[0][0]._rev, '1-123');
@@ -276,15 +273,14 @@ exports['attach handles existing meta data doc'] = test => {
   const start = sinon.stub();
   const feed = sinon.stub(follow, 'Feed').returns({ on: on, follow: start, stop: () => {} });
   const applyTransitions = sinon.stub(transitions, 'applyTransitions').callsArg(1);
-  sinon.stub(audit, 'withNano');
   // wait for the queue processor
   transitions._changeQueue.drain = () => {
     test.equal(get.callCount, 2);
     test.equal(fetchHydratedDoc.callCount, 1);
     test.equal(fetchHydratedDoc.args[0][0], 'abc');
     test.equal(applyTransitions.callCount, 1);
-    test.equal(applyTransitions.args[0][0].change.id, 'abc');
-    test.equal(applyTransitions.args[0][0].change.seq, 55);
+    test.equal(applyTransitions.args[0][0].id, 'abc');
+    test.equal(applyTransitions.args[0][0].seq, 55);
     test.equal(insert.callCount, 1);
     test.equal(insert.args[0][0]._id, '_local/sentinel-meta-data');
     test.equal(insert.args[0][0].processed_seq, 55);
@@ -302,7 +298,7 @@ exports['attach handles existing meta data doc'] = test => {
 };
 
 const requiredFunctions = {
-  onMatch: 4,
+  onMatch: 1,
   filter: 1
 };
 

--- a/sentinel/test/unit/transitions/multi_report_alerts.js
+++ b/sentinel/test/unit/transitions/multi_report_alerts.js
@@ -126,7 +126,7 @@ exports['fetches reports within time window'] = test => {
   sinon.stub(config, 'get').returns([alertConfig]);
   sinon.stub(utils, 'getReportsWithinTimeWindow').returns(Promise.resolve(reports));
   stubFetchHydratedDocs();
-  transition.onMatch({ doc: doc }, undefined, undefined, () => {
+  transition.onMatch({ doc: doc }).then(() => {
     test.equals(utils.getReportsWithinTimeWindow.callCount, 1);
     test.equals(utils.getReportsWithinTimeWindow.args[0][0], 12344);
     test.equals(utils.getReportsWithinTimeWindow.args[0][1], alertConfig.time_window_in_days);
@@ -138,7 +138,7 @@ exports['filters reports by form if forms is present in config'] = test => {
   sinon.stub(config, 'get').returns([_.extend({forms: ['A']} , alertConfig)]);
   sinon.stub(utils, 'getReportsWithinTimeWindow').returns(Promise.resolve(reports));
   sinon.stub(lineage, 'hydrateDocs').returns(Promise.resolve([hydratedReports[0]]));
-  transition.onMatch({ doc: doc }, undefined, undefined, () => {
+  transition.onMatch({ doc: doc }).then(() => {
     test.equals(lineage.hydrateDocs.callCount, 1);
     test.equals(lineage.hydrateDocs.args[0][0].length, 1);
     test.equals(lineage.hydrateDocs.args[0][0][0]._id, reports[0]._id);
@@ -154,7 +154,7 @@ exports['if not enough reports pass the is_report_counted func, does nothing'] =
   sinon.stub(messages, 'addError');
   sinon.stub(messages, 'addMessage');
 
-  transition.onMatch({ doc: doc }, undefined, undefined, () => {
+  transition.onMatch({ doc: doc }).then(() => {
     test.equals(messages.addError.getCalls().length, 0);
     test.equals(messages.addMessage.getCalls().length, 0);
     test.done();
@@ -169,7 +169,7 @@ exports['if no reports in time window, does nothing'] = test => {
   sinon.stub(messages, 'addError');
   sinon.stub(messages, 'addMessage');
 
-  transition.onMatch({ doc: doc }, undefined, undefined, (err, docNeedsSaving) => {
+  transition.onMatch({ doc: doc }).then(docNeedsSaving => {
     test.equals(messages.addError.getCalls().length, 0);
     test.equals(messages.addMessage.getCalls().length, 0);
     test.ok(!docNeedsSaving);
@@ -204,7 +204,7 @@ exports['if enough reports pass the is_report_counted func, adds message'] = tes
   sinon.stub(messages, 'addError');
   sinon.stub(messages, 'addMessage');
 
-  transition.onMatch({ doc: doc }, undefined, undefined, (err, docNeedsSaving) => {
+  transition.onMatch({ doc: doc }).then(docNeedsSaving => {
     test.equals(messages.addError.getCalls().length, 0);
 
     test.equals(messages.addMessage.getCalls().length, alertConfig.recipients.length);
@@ -213,7 +213,6 @@ exports['if enough reports pass the is_report_counted func, adds message'] = tes
     test.equals(doc.tasks[0].alert_name, alertConfig.name);
     test.deepEqual(doc.tasks[0].counted_reports, [ doc._id, ...reports.map(report => report._id) ]);
 
-    test.ok(!err);
     test.ok(docNeedsSaving);
     test.done();
   });
@@ -230,7 +229,7 @@ exports['adds message when recipient is evaled'] = test => {
   sinon.stub(messages, 'addError');
   sinon.stub(messages, 'addMessage');
 
-  transition.onMatch({ doc: doc }, undefined, undefined, (err, docNeedsSaving) => {
+  transition.onMatch({ doc: doc }).then(docNeedsSaving => {
     test.equals(messages.addMessage.getCalls().length, 1);
     test.equals(messages.addError.getCalls().length, 0);
 
@@ -248,7 +247,7 @@ exports['adds multiple messages when multiple recipients are evaled'] = test => 
   sinon.stub(messages, 'addError');
   sinon.stub(messages, 'addMessage');
 
-  transition.onMatch({ doc: doc }, undefined, undefined, (err, docNeedsSaving) => {
+  transition.onMatch({ doc: doc }).then(docNeedsSaving => {
     test.equals(messages.addMessage.getCalls().length, 3); // 3 counted reports, one phone number each.
     const actualPhones = messages.addMessage.getCalls().map(call => call.args[2]);
     const expectedPhones = [doc.contact.phone, hydratedReports[0].contact.phone, hydratedReports[1].contact.phone];
@@ -271,7 +270,7 @@ exports['does not add message when recipient cannot be evaled'] = test => {
   sinon.stub(messages, 'addError');
   sinon.stub(messages, 'addMessage');
 
-  transition.onMatch({ doc: doc }, undefined, undefined, (err, docNeedsSaving) => {
+  transition.onMatch({ doc: doc }).then(docNeedsSaving => {
     test.equals(messages.addError.getCalls().length, 3); // 3 countedReports, one failed recipient each
     test.equals(messages.addMessage.getCalls().length, 0);
 
@@ -290,7 +289,7 @@ exports['does not add message when recipient is bad'] = test => {
   sinon.stub(messages, 'addError');
   sinon.stub(messages, 'addMessage');
 
-  transition.onMatch({ doc: doc }, undefined, undefined, (err, docNeedsSaving) => {
+  transition.onMatch({ doc: doc }).then(docNeedsSaving => {
     test.equals(messages.addMessage.getCalls().length, 0);
     test.equals(messages.addError.getCalls().length, 3); // 3 countedReports, one failed recipient each
 
@@ -309,7 +308,7 @@ exports['does not add message when recipient is not international phone number']
   sinon.stub(messages, 'addError');
   sinon.stub(messages, 'addMessage');
 
-  transition.onMatch({ doc: doc }, undefined, undefined, (err, docNeedsSaving) => {
+  transition.onMatch({ doc: doc }).then(docNeedsSaving => {
     test.equals(messages.addMessage.getCalls().length, 0);
     test.equals(messages.addError.getCalls().length, 3); // 3 countedReports, one failed recipient each
 
@@ -353,7 +352,7 @@ exports['message only contains newReports'] = test => {
   sinon.stub(messages, 'addError');
   sinon.stub(messages, 'addMessage');
 
-  transition.onMatch({ doc: doc }, undefined, undefined, (err, docNeedsSaving) => {
+  transition.onMatch({ doc: doc }).then(docNeedsSaving => {
     test.equals(messages.addMessage.getCalls().length, 1);
     test.equals(messages.addError.getCalls().length, 0);
     test.deepEqual(messages.addMessage.getCall(0).args[3].templateContext.new_reports, [doc, hydratedReportsWithOneAlreadyMessaged[0] ]);
@@ -371,7 +370,7 @@ exports['adds multiple messages when mutiple recipients'] = test => {
   sinon.stub(messages, 'addError');
   sinon.stub(messages, 'addMessage');
 
-  transition.onMatch({ doc: doc }, undefined, undefined, () => {
+  transition.onMatch({ doc: doc }).then(() => {
     test.equals(messages.addError.getCalls().length, 0);
 
     // first recipient
@@ -397,7 +396,7 @@ exports['dedups message recipients'] = test => {
   sinon.stub(messages, 'addError');
   sinon.stub(messages, 'addMessage');
 
-  transition.onMatch({ doc: doc }, undefined, undefined, () => {
+  transition.onMatch({ doc: doc }).then(() => {
     test.equals(messages.addError.getCalls().length, 0);
 
     test.equals(messages.addMessage.getCalls().length, 3); // 3 countedReports, 2 recipients specified for each, deduped to 1 for each.
@@ -413,9 +412,8 @@ exports['when unexpected error, callback returns (error, false)'] = test => {
   sinon.stub(config, 'get').returns([alertConfig]);
   sinon.stub(utils, 'getReportsWithinTimeWindow').throws(new Error('much error'));
 
-  transition.onMatch({ doc: doc }, undefined, undefined, (err, docNeedsSaving) => {
-    test.ok(err);
-    test.ok(!docNeedsSaving);
+  transition.onMatch({ doc: doc }).catch(err => {
+    test.ok(!err.changed);
     test.done();
   });
 };
@@ -444,7 +442,7 @@ exports['runs multiple alerts'] = test => {
   sinon.stub(messages, 'addError');
   sinon.stub(messages, 'addMessage');
 
-  transition.onMatch({ doc: doc }, undefined, undefined, (err, docNeedsSaving) => {
+  transition.onMatch({ doc: doc }).then(docNeedsSaving => {
     test.equals(messages.addError.getCalls().length, 0);
 
     test.equals(messages.addMessage.getCalls().length, 3); // alert[0].recipients + alert[1].recipients
@@ -452,7 +450,6 @@ exports['runs multiple alerts'] = test => {
     assertMessage(test, messages.addMessage.getCall(1).args, twoAlerts[1].recipients[0], twoAlerts[1].message, twoAlerts[1].name, twoAlerts[1].num_reports_threshold, twoAlerts[1].time_window_in_days);
     assertMessage(test, messages.addMessage.getCall(2).args, twoAlerts[1].recipients[1], twoAlerts[1].message, twoAlerts[1].name, twoAlerts[1].num_reports_threshold, twoAlerts[1].time_window_in_days);
 
-    test.ok(!err);
     test.ok(docNeedsSaving);
     test.done();
   });
@@ -467,10 +464,9 @@ exports['skips doc with wrong form if forms is present in config'] = test => {
   sinon.stub(messages, 'addError');
   sinon.stub(messages, 'addMessage');
 
-  transition.onMatch({ doc: doc }, undefined, undefined, (err, docNeedsSaving) => {
+  transition.onMatch({ doc: doc }).then(docNeedsSaving => {
     test.equals(messages.addError.getCalls().length, 0);
     test.equals(messages.addMessage.getCalls().length, 0);
-    test.ok(!err);
     test.ok(!docNeedsSaving);
     test.done();
   });
@@ -491,10 +487,9 @@ exports['latest report has to go through is_report_counted function'] = test => 
   sinon.stub(messages, 'addError');
   sinon.stub(messages, 'addMessage');
 
-  transition.onMatch({ doc: doc }, undefined, undefined, (err, docNeedsSaving) => {
+  transition.onMatch({ doc: doc }).then(docNeedsSaving => {
     test.equals(messages.addError.getCalls().length, 0);
     test.equals(messages.addMessage.getCalls().length, 0);
-    test.ok(!err);
     test.ok(!docNeedsSaving);
     test.done();
   });

--- a/sentinel/test/unit/update_scheduled_reports.js
+++ b/sentinel/test/unit/update_scheduled_reports.js
@@ -1,17 +1,10 @@
-var _ = require('underscore'),
-    sinon = require('sinon').sandbox.create(),
+var sinon = require('sinon').sandbox.create(),
+    db = require('../../db'),
     transition = require('../../transitions/update_scheduled_reports');
 
-exports['onMatch signature'] = function(test) {
-    test.ok(_.isFunction(transition.onMatch));
-    test.equals(transition.onMatch.length, 4);
-    test.done();
-};
-
-exports['filter signature'] = function(test) {
-    test.ok(_.isFunction(transition.filter));
-    test.equals(transition.filter.length, 1);
-    test.done();
+exports.tearDown = function(callback) {
+    sinon.restore();
+    callback();
 };
 
 exports['filter fails when scheduled form not present'] = function(test) {
@@ -21,6 +14,7 @@ exports['filter fails when scheduled form not present'] = function(test) {
     }), false);
     test.done();
 };
+
 exports['filter fails when errors are on doc'] = function(test) {
     var contact = {
         phone: 'x'
@@ -36,6 +30,7 @@ exports['filter fails when errors are on doc'] = function(test) {
     }), false);
     test.done();
 };
+
 exports['filter fails when no year value on form submission'] = function(test) {
     var contact = {
         phone: 'x'
@@ -109,74 +104,45 @@ exports['filter passes when'] = function(test) {
 };
 
 exports['use week view when doc has week property'] = function(test) {
-  var db = {
-    medic: {
-      view: function(ddoc, view) {
-        test.same(
-            view,
-            'reports_by_form_year_week_clinic_id_reported_date'
-        );
-        test.done();
-      }
-    }
-  };
-  transition._getDuplicates(db, {fields:{week: 9}});
+  sinon.stub(db.medic, 'view').callsArg(3);
+  transition._getDuplicates({fields:{week: 9}}, () => {
+    test.equals(db.medic.view.args[0][1], 'reports_by_form_year_week_clinic_id_reported_date');
+    test.done();
+  });
 };
 
 exports['use month view when doc has month property'] = function(test) {
-  var db = {
-    medic: {
-      view: function(ddoc, view) {
-          test.same(
-              view,
-              'reports_by_form_year_month_clinic_id_reported_date'
-          );
-          test.done();
-      }
-    }
-  };
-  transition._getDuplicates(db, {fields:{month: 9}});
+  sinon.stub(db.medic, 'view').callsArg(3);
+  transition._getDuplicates({fields:{month: 9}}, () => {
+    test.equals(db.medic.view.args[0][1], 'reports_by_form_year_month_clinic_id_reported_date');
+    test.done();
+  });
 };
 
 exports['calls audit.bulkSave with correct arguments'] = function(test) {
-  test.expect(7);
-
-  var db = {
-    medic: {
-      view: function() {}
+  const view = sinon.stub(db.medic, 'view').callsArgWith(3, null, {rows: []});
+  const bulkSave = sinon.stub(db.audit, 'bulkSave').callsArg(2);
+  const change = {
+    doc: {
+      _id: 'abc',
+      form: 'z',
+      fields: {
+        year: 2013,
+        month: 4
+      }
     }
   };
 
-  var view = sinon.stub(db.medic, 'view').callsArgWith(3, null, {rows: []});
-
-  var audit = {
-      bulkSave: function(docs, options, callback) {
-          test.ok(docs);
-          test.ok(docs.length === 0);
-          test.ok(options);
-          test.ok(typeof(callback) === 'function');
-          callback();
-      }
-  };
-
-  var bulkSave = sinon.spy(audit, 'bulkSave');
-
-  transition.onMatch({
-      doc: {
-          _id: 'abc',
-          form: 'z',
-          fields: {
-            year: 2013,
-            month: 4
-          }
-      }
-  }, db, audit, function(err, complete) {
-      test.equals(complete, true);
+  transition.onMatch(change).then(changed => {
+    test.equals(changed, true);
+    test.equals(view.callCount, 1);
+    test.equals(bulkSave.callCount, 1);
+    test.ok(bulkSave.args[0][0]);
+    test.equals(bulkSave.args[0][0].length, 0);
+    test.ok(bulkSave.args[0][1]);
+    test.done();
   });
 
-  test.equals(view.callCount, 1);
-  test.equals(bulkSave.callCount, 1);
-  test.done();
 };
 
 exports['only one record in duplicates, mark transition complete'] = function(test) {
@@ -185,29 +151,6 @@ exports['only one record in duplicates, mark transition complete'] = function(te
 };
 
 exports['remove duplicates and replace with latest doc'] = function(test) {
-  test.expect(7);
-  var db = {
-    medic: {
-      view: function() {}
-    }
-  };
-  var audit = {
-      bulkSave: function(docs, options, cb) {
-          test.same(docs.length, 2);
-          test.ok(options.all_or_nothing);
-          // new doc inherits id/rev from previous record and is deleted
-          docs.forEach(function(doc) {
-            if (doc._id === 'abc') {
-              test.same(doc._rev, '1-dddd');
-              test.same(doc.fields.pills, 22);
-            }
-            if (doc._id === 'xyz') {
-              test.same(doc._deleted, true);
-            }
-          });
-          cb();
-      }
-  };
   sinon.stub(db.medic, 'view').callsArgWith(3, null, {
     // ascending records
     rows: [
@@ -241,23 +184,35 @@ exports['remove duplicates and replace with latest doc'] = function(test) {
       }
     ]
   });
-  var bulkSave = sinon.spy(audit, 'bulkSave');
+  var bulkSave = sinon.stub(db.audit, 'bulkSave').callsArg(2);
   var change = {
     doc: {
-        _id: 'xyz',
-        _rev: '1-kkkk',
-        form: 'z',
-        fields: {
-          month: 4,
-          year: 2013,
-          pills: 22
-        },
-        reported_date: 200
+      _id: 'xyz',
+      _rev: '1-kkkk',
+      form: 'z',
+      fields: {
+        month: 4,
+        year: 2013,
+        pills: 22
+      },
+      reported_date: 200
     }
   };
-  transition.onMatch(change, db, audit, function(err, complete) {
-    test.equals(complete, true);
+  transition.onMatch(change).then(changed => {
+    test.equals(changed, true);
     test.equals(bulkSave.callCount, 1);
+    test.same(bulkSave.args[0][0].length, 2);
+    // new doc inherits id/rev from previous record and is deleted
+    bulkSave.args[0][0].forEach(function(doc) {
+      if (doc._id === 'abc') {
+        test.same(doc._rev, '1-dddd');
+        test.same(doc.fields.pills, 22);
+      }
+      if (doc._id === 'xyz') {
+        test.same(doc._deleted, true);
+      }
+    });
+    test.ok(bulkSave.args[0][1].all_or_nothing);
     test.done();
   });
 };

--- a/sentinel/test/unit/update_sent_by.js
+++ b/sentinel/test/unit/update_sent_by.js
@@ -1,7 +1,6 @@
-var sinon = require('sinon').sandbox.create(),
-    fakedb = require('../fake-db'),
-    fakeaudit = require('../fake-audit'),
-    transition = require('../../transitions/update_sent_by');
+const sinon = require('sinon').sandbox.create(),
+      db = require('../../db'),
+      transition = require('../../transitions/update_sent_by');
 
 exports.setUp = function(callback) {
   process.env.TEST_ENV = true;
@@ -15,10 +14,8 @@ exports.tearDown = function(callback) {
 
 exports['updates sent_by to clinic name if contact name'] = function(test) {
   var doc = { from: '+34567890123' };
-  var dbView = sinon.stub(fakedb.medic, 'view').callsArgWith(3, null, { rows: [ { doc: { name: 'Clinic' } } ] } );
-  transition.onMatch({
-    doc: doc
-  }, fakedb, fakeaudit, function(err, changed) {
+  var dbView = sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [ { doc: { name: 'Clinic' } } ] } );
+  transition.onMatch({ doc: doc }).then(changed => {
     test.ok(changed);
     test.equal(doc.sent_by, 'Clinic');
     test.ok(dbView.calledOnce);
@@ -28,10 +25,8 @@ exports['updates sent_by to clinic name if contact name'] = function(test) {
 
 exports['sent_by untouched if nothing available'] = function(test) {
   var doc = { from: 'unknown number' };
-  sinon.stub(fakedb.medic, 'view').callsArgWith(3, null, {});
-  transition.onMatch({
-    doc: doc
-  }, fakedb, fakeaudit, function(err, changed) {
+  sinon.stub(db.medic, 'view').callsArgWith(3, null, {});
+  transition.onMatch({ doc: doc }).then(changed => {
     test.ok(!changed);
     test.strictEqual(doc.sent_by, undefined);
     test.done();

--- a/sentinel/transitions/conditional_alerts.js
+++ b/sentinel/transitions/conditional_alerts.js
@@ -50,33 +50,37 @@ module.exports = {
             !transitionUtils.hasRun(doc, NAME)
         );
     },
-    onMatch: function(change, db, audit, cb) {
-        var doc = change.doc,
-            config = module.exports._getConfig(),
-            updated = false;
+    onMatch: change => {
+        return new Promise((resolve, reject) => {
+            var doc = change.doc,
+                config = module.exports._getConfig(),
+                updated = false;
 
-        async.each(
-            _.values(config),
-            function(alert, callback) {
-                if (alert.form === doc.form) {
-                    evaluateCondition(doc, alert, function(err, result) {
-                        if (err) {
-                            return callback(err);
-                        }
-                        if (result) {
-                            messages.addMessage(doc, alert, alert.recipient);
-                            updated = true;
-                        }
+            async.each(
+                _.values(config),
+                function(alert, callback) {
+                    if (alert.form === doc.form) {
+                        evaluateCondition(doc, alert, function(err, result) {
+                            if (err) {
+                                return callback(err);
+                            }
+                            if (result) {
+                                messages.addMessage(doc, alert, alert.recipient);
+                                updated = true;
+                            }
+                            callback();
+                        });
+                    } else {
                         callback();
-                    });
-                } else {
-                    callback();
+                    }
+                },
+                function(err) {
+                    if (err) {
+                        return reject(err);
+                    }
+                    resolve(updated);
                 }
-            },
-            function(err) {
-                cb(err, updated);
-            }
-        );
-
+            );
+        });
     }
 };

--- a/sentinel/transitions/default_responses.js
+++ b/sentinel/transitions/default_responses.js
@@ -72,7 +72,7 @@ module.exports = {
     _getConfig: function(key) {
         return config.get(key);
     },
-    onMatch: function(change, db, audit, callback) {
+    onMatch: change => {
 
         var self = module.exports,
             doc = change.doc,
@@ -90,6 +90,6 @@ module.exports = {
             messages.addMessage(doc, { translation_key: key });
         }
 
-        callback(null, true);
+        return Promise.resolve(true);
     }
 };

--- a/sentinel/transitions/generate_patient_id_on_people.js
+++ b/sentinel/transitions/generate_patient_id_on_people.js
@@ -1,11 +1,15 @@
 var transitionUtils = require('./utils');
 
 module.exports = {
-  filter: function(doc) {
-    return doc.type === 'person' &&
-           !doc.patient_id;
-  },
-  onMatch: function(change, db, audit, callback) {
-    transitionUtils.addUniqueId(change.doc, err => callback(err, !err));
+  filter: doc => doc.type === 'person' && !doc.patient_id,
+  onMatch: change => {
+    return new Promise((resolve, reject) => {
+      transitionUtils.addUniqueId(change.doc, err => {
+        if (err) {
+          return reject(err);
+        }
+        resolve(true);
+      });
+    });
   }
 };

--- a/sentinel/transitions/multi_report_alerts.js
+++ b/sentinel/transitions/multi_report_alerts.js
@@ -258,7 +258,7 @@ const runOneAlert = (alert, latestReport) => {
   });
 };
 
-const onMatch = (change, db, audit, callback) => {
+const onMatch = change => {
   const latestReport = change.doc;
   const alertConfig = getAlertConfig();
   const errors = [];
@@ -273,14 +273,14 @@ const onMatch = (change, db, audit, callback) => {
         .catch(errors.push);
     });
   });
-  promiseSeries.then(() => {
+  return promiseSeries.then(() => {
     if (errors.length) {
-      return callback(errors, true);
+      const err = new Error(`${TRANSITION_NAME} threw errors`);
+      err.errors = errors;
+      err.changed = true;
+      throw err;
     }
-    callback(null, docNeedsSaving);
-  })
-  .catch((err) => {
-    callback(err, false);
+    return docNeedsSaving;
   });
 };
 


### PR DESCRIPTION
# Description

This refactor changes the onMatch function of each transition to be
promise rather than callback based. It also changes transitions to
import the medic and audit databases via require rather than passing
them to each function call.

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.