### PR TITLE
Shorter export urls and reduce export latency

### DIFF
--- a/api/controllers/export-data.js
+++ b/api/controllers/export-data.js
@@ -32,6 +32,8 @@ const writeExportHeaders = (res, type, format) => {
   res
     .set('Content-Type', format.contentType)
     .set('Content-Disposition', 'attachment; filename=' + filename);
+  // To respond as quickly to the request as possible
+  res.flushHeaders();
 };
 
 const getExportPermission = function(type) {

--- a/shared-libs/search/src/generate-search-requests.js
+++ b/shared-libs/search/src/generate-search-requests.js
@@ -259,6 +259,8 @@ var requestBuilders = {
 //     options: [ 'person', 'clinic', 'district_hospital' ]
 //   }
 //  };
+//
+// NB: options is not required: it is an optimisation shortcut
 module.exports = {
   generate: function(type, filters) {
     var builder = requestBuilders[type];

--- a/static/js/controllers/reports.js
+++ b/static/js/controllers/reports.js
@@ -424,7 +424,13 @@ angular.module('inboxControllers').controller('ReportsCtrl',
 
     $scope.setLeftActionBar({
       exportFn: function() {
-        Export($scope.filters, 'reports');
+        var exportFilters = _.extendOwn({}, $scope.filters);
+        ['forms', 'facilities'].forEach(function(type) {
+          if (exportFilters[type]) {
+            delete exportFilters[type].options;
+          }
+        });
+        Export(exportFilters, 'reports');
       }
     });
 


### PR DESCRIPTION
Remove cruft from the URL that we don't need to perform the search.

Flush headers ASAP to reduce the time it takes for the download to initiate on the client side.

medic/medic-webapp#3594

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.