### PR TITLE
Be explicit when querying a view with reduce

### DIFF
--- a/static/js/services/message-contacts.js
+++ b/static/js/services/message-contacts.js
@@ -11,7 +11,8 @@ angular.module('inboxServices').factory('MessageContacts',
 
     var listParams = function() {
       return {
-        group_level: 1
+        group_level: 1,
+        reduce: true,
       };
     };
 


### PR DESCRIPTION
The PouchDB docs and implementation disagree whether options.reduce defaults to
true or false when querying a view which has both map and reduce functions
defined: https://github.com/pouchdb/pouchdb/issues/7127

We should be explicit when calling a reduce because:

1. the current default (reduce: true) is non-obvious
2. if PouchDB fix 7127 by changing the implementation, then this commit will
   prevent our code from breaking.


# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.