### PR TITLE
Add pouchdb-mapreduce plugin for e2e tests.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10197,6 +10197,21 @@
       "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
       "dev": true
     },
+    "pouchdb-abstract-mapreduce": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-abstract-mapreduce/-/pouchdb-abstract-mapreduce-6.4.3.tgz",
+      "integrity": "sha512-omSNRtSf5S/O6SdIy3RV5ODdftL7x0txoBKo2BBr72Ji1r3460ftRfKzurRnHwTYTPzxAZYqm2IkRExSqQRfNQ==",
+      "dev": true,
+      "requires": {
+        "pouchdb-binary-utils": "6.4.3",
+        "pouchdb-collate": "6.4.3",
+        "pouchdb-collections": "6.4.3",
+        "pouchdb-mapreduce-utils": "6.4.3",
+        "pouchdb-md5": "6.4.3",
+        "pouchdb-promise": "6.4.3",
+        "pouchdb-utils": "6.4.3"
+      }
+    },
     "pouchdb-adapter-http": {
       "version": "6.4.3",
       "resolved": "https://registry.npmjs.org/pouchdb-adapter-http/-/pouchdb-adapter-http-6.4.3.tgz",
@@ -10519,6 +10534,15 @@
         }
       }
     },
+    "pouchdb-binary-utils": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-binary-utils/-/pouchdb-binary-utils-6.4.3.tgz",
+      "integrity": "sha512-eRKH/1eiZwrqNdAR3CL1XIIkq04I9hHIABHwIRboz1LjBSchKmaf4ZDngiWGDvRYT9Gl/MogGDGOk1WRMoV4wg==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "0.1.1"
+      }
+    },
     "pouchdb-browser": {
       "version": "6.4.3",
       "resolved": "https://registry.npmjs.org/pouchdb-browser/-/pouchdb-browser-6.4.3.tgz",
@@ -10623,6 +10647,18 @@
         }
       }
     },
+    "pouchdb-collate": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-collate/-/pouchdb-collate-6.4.3.tgz",
+      "integrity": "sha512-iwKAdc8vjLx8AzxBFnfV24Hp4FkbADTUcuQl/2IUOaF8JzZ/wVYa0DgBd+uErk2rj5yf1HxFp+5/9EgHV4PxAw==",
+      "dev": true
+    },
+    "pouchdb-collections": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-collections/-/pouchdb-collections-6.4.3.tgz",
+      "integrity": "sha512-uWb9+hvjiijeyrCeEz/FUND1oj0AQK/f166egBOTofNlAwQLNrJUTn+uJ34b3NODAmKhg7+ZeDVvnl9D2pijuQ==",
+      "dev": true
+    },
     "pouchdb-core": {
       "version": "6.4.3",
       "resolved": "https://registry.npmjs.org/pouchdb-core/-/pouchdb-core-6.4.3.tgz",
@@ -10719,6 +10755,68 @@
         }
       }
     },
+    "pouchdb-errors": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-errors/-/pouchdb-errors-6.4.3.tgz",
+      "integrity": "sha512-EU83ZZJjorwGL9DQZ9HAILY8D+ulX2RYVMtsCfIuzaIJEUrHh/dhSIy5854n42NBOUWug3gFDyO58w5k+64HTQ==",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
+    "pouchdb-mapreduce": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-mapreduce/-/pouchdb-mapreduce-6.4.3.tgz",
+      "integrity": "sha512-hffB4/ecq5HwLPztRZrTDf/BgzwjvRDJQjTcVJ4h/Jd8g7jGkkPUUcXP4ky7lOf2DBG9hEDFo1/dE1IlMJmqSg==",
+      "dev": true,
+      "requires": {
+        "pouchdb-abstract-mapreduce": "6.4.3",
+        "pouchdb-mapreduce-utils": "6.4.3",
+        "pouchdb-utils": "6.4.3"
+      }
+    },
+    "pouchdb-mapreduce-utils": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-mapreduce-utils/-/pouchdb-mapreduce-utils-6.4.3.tgz",
+      "integrity": "sha512-gbxX6h+nOKPDv2eYZznUthHiZ1Ml1xViE8DalEy6+fPzCba6CZ6dTKGZoFrBg4oLF3Wc+cUNX9Uk8cezVMGOhA==",
+      "dev": true,
+      "requires": {
+        "argsarray": "0.0.1",
+        "inherits": "2.0.3",
+        "pouchdb-collections": "6.4.3",
+        "pouchdb-utils": "6.4.3"
+      }
+    },
+    "pouchdb-md5": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-md5/-/pouchdb-md5-6.4.3.tgz",
+      "integrity": "sha512-EnToEO+JLJA5bHDYWs42B8hU9Q1TckVozQjTSXL/pDXKXLATuVEKHNq8F/4lrpxblpngx4Zt8z2Luwu0etLSqw==",
+      "dev": true,
+      "requires": {
+        "pouchdb-binary-utils": "6.4.3",
+        "spark-md5": "3.0.0"
+      }
+    },
+    "pouchdb-promise": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-promise/-/pouchdb-promise-6.4.3.tgz",
+      "integrity": "sha512-ruJaSFXwzsxRHQfwNHjQfsj58LBOY1RzGzde4PM5CWINZwFjCQAhZwfMrch2o/0oZT6d+Xtt0HTWhq35p3b0qw==",
+      "dev": true,
+      "requires": {
+        "lie": "3.1.1"
+      },
+      "dependencies": {
+        "lie": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+          "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+          "dev": true,
+          "requires": {
+            "immediate": "3.0.6"
+          }
+        }
+      }
+    },
     "pouchdb-selector-core": {
       "version": "6.4.3",
       "resolved": "https://registry.npmjs.org/pouchdb-selector-core/-/pouchdb-selector-core-6.4.3.tgz",
@@ -10781,6 +10879,30 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
           "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+        }
+      }
+    },
+    "pouchdb-utils": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-utils/-/pouchdb-utils-6.4.3.tgz",
+      "integrity": "sha512-22QXh743YXl/afheeumrUKsO/0Q4Q8bvoboFp/1quXq//BDJa9nv55WUZX0l05t3VPW+nD/pse2FzU9cs3nEag==",
+      "dev": true,
+      "requires": {
+        "argsarray": "0.0.1",
+        "clone-buffer": "1.0.0",
+        "immediate": "3.0.6",
+        "inherits": "2.0.3",
+        "pouchdb-collections": "6.4.3",
+        "pouchdb-errors": "6.4.3",
+        "pouchdb-promise": "6.4.3",
+        "uuid": "3.2.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "nodemon": "^1.14.12",
     "pouchdb-adapter-http": "^6.4.3",
     "pouchdb-core": "^6.4.3",
+    "pouchdb-mapreduce": "^6.4.3",
     "protractor-jasmine2-screenshot-reporter": "^0.5.0",
     "proxyquire": "^1.7.4",
     "sinon": "^4.0.1",

--- a/tests/protractor/utils.js
+++ b/tests/protractor/utils.js
@@ -10,6 +10,7 @@ const _ = require('underscore'),
 
 const PouchDB = require('pouchdb-core');
 PouchDB.plugin(require('pouchdb-adapter-http'));
+PouchDB.plugin(require('pouchdb-mapreduce'));
 const db = new PouchDB(`http://${auth.user}:${auth.pass}@${constants.COUCH_HOST}:${constants.COUCH_PORT}/${constants.DB_NAME}`);
 
 let originalSettings;


### PR DESCRIPTION
Add `pouchdb-mapreduce` for testing db contents in e2e tests.