### PR TITLE
Disable download button temporarily

### DIFF
--- a/static/js/controllers/reports.js
+++ b/static/js/controllers/reports.js
@@ -430,11 +430,13 @@ angular.module('inboxControllers').controller('ReportsCtrl',
             delete exportFilters[type].options;
           }
         });
-        var a = $(e.target).closest('a')[0];
-        a.classList.add('mm-icon-disabled');
+
+        var $link = $(e.target).closest('a');
+        $link.addClass('mm-icon-disabled');
         $timeout(function() {
-          a.classList.remove('mm-icon-disabled');
+          $link.removeClass('mm-icon-disabled');
         }, 2000);
+
         Export(exportFilters, 'reports');
       }
     });

--- a/static/js/controllers/reports.js
+++ b/static/js/controllers/reports.js
@@ -423,13 +423,18 @@ angular.module('inboxControllers').controller('ReportsCtrl',
     };
 
     $scope.setLeftActionBar({
-      exportFn: function() {
+      exportFn: function(e) {
         var exportFilters = _.extendOwn({}, $scope.filters);
         ['forms', 'facilities'].forEach(function(type) {
           if (exportFilters[type]) {
             delete exportFilters[type].options;
           }
         });
+        var a = $(e.target).closest('a')[0];
+        a.classList.add('mm-icon-disabled');
+        $timeout(function() {
+          a.classList.remove('mm-icon-disabled');
+        }, 2000);
         Export(exportFilters, 'reports');
       }
     });

--- a/templates/partials/actionbar.html
+++ b/templates/partials/actionbar.html
@@ -41,7 +41,7 @@
             <span class="fa fa-check-circle"></span>
             <p translate>select.mode.start</p>
           </a>
-          <a class="mm-icon mm-icon-inverse mm-icon-caption" ng-show="isAdmin" ng-click="actionBar.left.exportFn()">
+          <a class="mm-icon mm-icon-inverse mm-icon-caption" ng-show="isAdmin" ng-click="actionBar.left.exportFn($event)">
             <span class="fa fa-arrow-down"></span>
             <p translate>Export</p>
           </a>


### PR DESCRIPTION
We can't (easily?) tell when a download has actually returned to the
user, so disable the button for 2 seconds and hope that 2s is enough
time.

medic/medic-webapp#3594

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.