### PR TITLE
Refresh userCtx cookie when roles are changed

### DIFF
--- a/api/controllers/login.js
+++ b/api/controllers/login.js
@@ -178,5 +178,17 @@ module.exports = {
       }
       setCookies(req, res, sessionRes);
     });
+  },
+  getIdentity: (req, res) => {
+    res.type('application/json');
+    auth.getUserCtx(req, (err, userCtx) => {
+      if (!err) {
+        setUserCtxCookie(res, userCtx);
+        res.send({ success: true });
+        return;
+      }
+      res.status(401);
+      res.send();
+    });
   }
 };

--- a/api/controllers/login.js
+++ b/api/controllers/login.js
@@ -184,8 +184,7 @@ module.exports = {
     auth.getUserCtx(req, (err, userCtx) => {
       if (!err) {
         setUserCtxCookie(res, userCtx);
-        res.send({ success: true });
-        return;
+        return res.send({ success: true });
       }
       res.status(401);
       res.send();

--- a/api/controllers/login.js
+++ b/api/controllers/login.js
@@ -182,12 +182,13 @@ module.exports = {
   getIdentity: (req, res) => {
     res.type('application/json');
     auth.getUserCtx(req, (err, userCtx) => {
-      if (!err) {
-        setUserCtxCookie(res, userCtx);
-        return res.send({ success: true });
+      if (err) {
+        res.status(401);
+        return res.send();
       }
-      res.status(401);
-      res.send();
+
+      setUserCtxCookie(res, userCtx);
+      res.send({ success: true });
     });
   }
 };

--- a/api/routing.js
+++ b/api/routing.js
@@ -100,6 +100,7 @@ app.get('/', function(req, res) {
 
 app.use(express.static(path.join(__dirname, 'public')));
 app.get(pathPrefix + 'login', login.get);
+app.get(pathPrefix + 'login/identity', login.getIdentity);
 app.postJson(pathPrefix + 'login', login.post);
 
 var UNAUDITED_ENDPOINTS = [

--- a/static/js/controllers/inbox.js
+++ b/static/js/controllers/inbox.js
@@ -653,6 +653,18 @@ var feedback = require('../modules/feedback'),
         RecurringProcessManager.stopUpdateRelativeDate();
       });
 
+      Changes({
+        key: 'inbox-user-context',
+        filter: function (change) {
+          return change &&
+                 change.doc &&
+                 change.doc.type === 'user-settings' &&
+                 change.doc.name === Session.userCtx().name;
+        },
+        callback: function () {
+          Session.checkCurrentSession();
+        }
+      });
     }
   );
 

--- a/static/js/controllers/inbox.js
+++ b/static/js/controllers/inbox.js
@@ -657,9 +657,7 @@ var feedback = require('../modules/feedback'),
         key: 'inbox-user-context',
         filter: function (change) {
           var userCtx = Session.userCtx();
-          return change &&
-                 change.doc &&
-                 change.doc.type === 'user-settings' &&
+          return change.doc.type === 'user-settings' &&
                  userCtx &&
                  userCtx.name &&
                  change.doc.name === userCtx.name;

--- a/static/js/controllers/inbox.js
+++ b/static/js/controllers/inbox.js
@@ -656,13 +656,16 @@ var feedback = require('../modules/feedback'),
       Changes({
         key: 'inbox-user-context',
         filter: function (change) {
+          var userCtx = Session.userCtx();
           return change &&
                  change.doc &&
                  change.doc.type === 'user-settings' &&
-                 change.doc.name === Session.userCtx().name;
+                 userCtx &&
+                 userCtx.name &&
+                 change.doc.name === userCtx.name;
         },
         callback: function () {
-          Session.checkCurrentSession();
+          Session.checkCurrentSession(showUpdateReady);
         }
       });
     }

--- a/static/js/controllers/inbox.js
+++ b/static/js/controllers/inbox.js
@@ -663,7 +663,7 @@ var feedback = require('../modules/feedback'),
                  change.doc.name === userCtx.name;
         },
         callback: function () {
-          Session.checkCurrentSession(showUpdateReady);
+          Session.init(showUpdateReady);
         }
       });
     }

--- a/static/js/controllers/inbox.js
+++ b/static/js/controllers/inbox.js
@@ -653,10 +653,10 @@ var feedback = require('../modules/feedback'),
         RecurringProcessManager.stopUpdateRelativeDate();
       });
 
+      var userCtx = Session.userCtx();
       Changes({
         key: 'inbox-user-context',
         filter: function (change) {
-          var userCtx = Session.userCtx();
           return change.doc.type === 'user-settings' &&
                  userCtx &&
                  userCtx.name &&

--- a/static/js/services/session.js
+++ b/static/js/services/session.js
@@ -72,7 +72,7 @@ var COOKIE_NAME = 'userCtx',
             }
             if (_.difference(userCtx.roles, response.data.userCtx.roles).length ||
                 _.difference(response.data.userCtx.roles, userCtx.roles).length) {
-              refreshUserCtx(callback);
+              return refreshUserCtx(callback);
             }
           })
           .catch(function(response) {
@@ -118,7 +118,7 @@ var COOKIE_NAME = 'userCtx',
         isDistrictAdmin: function(userCtx) {
           userCtx = userCtx || getUserCtx();
           return hasRole(userCtx, 'district_admin');
-        },
+        }
       };
 
     }

--- a/static/js/services/session.js
+++ b/static/js/services/session.js
@@ -43,7 +43,20 @@ var COOKIE_NAME = 'userCtx',
         $http.delete('/_session').then(navigateToLogin);
       };
 
-      var checkCurrentSession = function() {
+      var refreshUserCtx = function(callback) {
+        $http
+          .get('/' + Location.dbName + '/login/identity')
+          .then(function() {
+            if (_.isFunction(callback)) {
+              callback();
+            }
+          })
+          .catch(function() {
+            logout();
+          });
+      };
+
+      var checkCurrentSession = function(callback) {
         var userCtx = getUserCtx();
         if (!userCtx || !userCtx.name) {
           return logout();
@@ -55,7 +68,11 @@ var COOKIE_NAME = 'userCtx',
                        response.data.userCtx.name;
             if (name !== userCtx.name) {
               // connected to the internet but server session is different
-              logout();
+              return logout();
+            }
+            if (_.difference(userCtx.roles, response.data.userCtx.roles).length ||
+                _.difference(response.data.userCtx.roles, userCtx.roles).length) {
+              refreshUserCtx(callback);
             }
           })
           .catch(function(response) {
@@ -82,9 +99,7 @@ var COOKIE_NAME = 'userCtx',
 
         navigateToLogin: navigateToLogin,
 
-        init: function() {
-          checkCurrentSession();
-        },
+        init: checkCurrentSession,
 
         /**
          * Returns true if the logged in user has the db or national admin role.
@@ -103,7 +118,7 @@ var COOKIE_NAME = 'userCtx',
         isDistrictAdmin: function(userCtx) {
           userCtx = userCtx || getUserCtx();
           return hasRole(userCtx, 'district_admin');
-        }
+        },
       };
 
     }

--- a/tests/karma/unit/controllers/inbox.js
+++ b/tests/karma/unit/controllers/inbox.js
@@ -173,6 +173,7 @@ describe('InboxCtrl controller', () => {
 
   it('InboxUserContent Changes listener should filter only logged in user, if exists', () => {
     session.userCtx.returns({ name: 'adm', roles: ['alpha', 'omega'] });
+    createController();
     chai.expect(changesListener['inbox-user-context'].filter({ doc: {} })).to.equal(false);
     chai.expect(changesListener['inbox-user-context'].filter({ doc: { type: 'person'} })).to.equal(false);
     chai.expect(changesListener['inbox-user-context'].filter({ doc: { type: 'user-settings'} })).to.equal(false);
@@ -180,6 +181,7 @@ describe('InboxCtrl controller', () => {
     chai.expect(changesListener['inbox-user-context'].filter({ doc: { type: 'user-settings', name: 'adm'} })).to.equal(true);
 
     session.userCtx.returns(false);
+    createController();
     chai.expect(changesListener['inbox-user-context'].filter({ doc: { type: 'user-settings', name: 'a'} })).to.equal(false);
   });
 

--- a/tests/karma/unit/controllers/inbox.js
+++ b/tests/karma/unit/controllers/inbox.js
@@ -186,6 +186,6 @@ describe('InboxCtrl controller', () => {
 
   it('InboxUserContent Changes listener callback should check current session', () => {
     changesListener['inbox-user-context'].callback();
-    chai.expect(session.checkCurrentSession.callCount).to.equal(1);
+    chai.expect(session.init.callCount).to.equal(2);
   });
 });

--- a/tests/karma/unit/controllers/inbox.js
+++ b/tests/karma/unit/controllers/inbox.js
@@ -33,7 +33,6 @@ describe('InboxCtrl controller', () => {
       init: sinon.stub(),
       isAdmin: sinon.stub(),
       userCtx: sinon.stub(),
-      checkCurrentSession: sinon.stub()
     };
 
     module($provide => {

--- a/tests/karma/unit/services/session.js
+++ b/tests/karma/unit/services/session.js
@@ -154,6 +154,40 @@ describe('Session service', function() {
     done();
   });
 
+  it('refreshes user context cookie if a role change is detected', () => {
+    ipCookie.returns({ name: 'adm', roles: ['alpha', 'omega'] });
+    Location.dbName = 'DB_NAME';
+    $httpBackend.when('GET', '/DB_NAME/login/identity').respond(200);
+    $httpBackend.expect('GET', '/_session').respond(200, { userCtx: { name: 'adm', roles: ['beta'] } });
+    $httpBackend.expect('GET', '/_session').respond(200, { userCtx: { name: 'adm', roles: ['beta'] } });
+    $httpBackend.expect('GET', '/_session').respond(200, { userCtx: { name: 'adm', roles: ['beta'] } });
+    $httpBackend.expect('GET', '/_session').respond(200, { userCtx: { name: 'adm', roles: ['alpha', 'omega', 'beta'] } });
+    $httpBackend.expect('GET', '/_session').respond(200, { userCtx: { name: 'adm', roles: ['alpha'] } });
+    const callback = sinon.stub();
+
+    service.init(callback);
+    service.init();
+    service.init('something');
+    service.init(callback);
+    service.init(callback);
+
+    $httpBackend.flush();
+    chai.expect(callback.callCount).to.equal(3);
+  });
+
+  it('does not refresh user context if a role change is not detected', () => {
+    ipCookie.returns({ name: 'adm', roles: ['beta'] });
+    Location.dbName = 'DB_NAME';
+    $httpBackend.expect('GET', '/_session').respond(200, { userCtx: { name: 'adm', roles: ['beta'] } });
+    const callback = sinon.stub();
+
+    service.init(callback);
+    $httpBackend.flush(1);
+
+    chai.expect(callback.callCount).to.equal(0);
+    $httpBackend.verifyNoOutstandingExpectation();
+  });
+
   describe('isAdmin function', function() {
 
     it('returns false if not logged in', function(done) {


### PR DESCRIPTION
# Description

Adds Change feed listener for changes made to current user. If changes in roles are detected, 
the user is notified with a VersionUpdate Modal. 
Adds api endpoint that simply refreshes userCtx cookie. 

medic/medic-webapp#4088

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.