### PR TITLE
Updates GetSubjectSummaries to double check patient_id fields

### DIFF
--- a/static/js/services/get-subject-summaries.js
+++ b/static/js/services/get-subject-summaries.js
@@ -25,6 +25,9 @@ angular.module('inboxServices').factory('GetSubjectSummaries',
               value: id,
               type: 'id'
             };
+          } else {
+            //update the type only, in case patient_id contains a doc UUID
+            summary.subject.type = 'id';
           }
         }
       });

--- a/tests/karma/unit/services/get-subject-summaries.js
+++ b/tests/karma/unit/services/get-subject-summaries.js
@@ -90,7 +90,7 @@ describe('GetSubjectSummaries service', () => {
       chai.expect(actual[2]).to.deep.equal({
         form: 'a',
         subject: {
-          type: 'reference',
+          type: 'id',
           value: '11111'
         },
         validSubject: false
@@ -221,7 +221,7 @@ describe('GetSubjectSummaries service', () => {
       chai.expect(actual[3]).to.deep.equal({
         form: 'a',
         subject: {
-          type: 'reference',
+          type: 'id',
           value: '11111'
         },
         validSubject: false


### PR DESCRIPTION
# Description

When an XML form uses patient_id as uuid field and lacks an actual
patient_uuid field, the code returned a false Unknown Subject.
This change adds a double check for "reference" type values, both
as an actual reference and as an UUID to avoid this from happening.

medic/medic-webapp#4053
# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.