### PR TITLE
Reverts setting task timestamp every time task state is updated

### DIFF
--- a/api/services/export-data.js
+++ b/api/services/export-data.js
@@ -366,7 +366,6 @@ var normalizeTasks = function(doc, options) {
   return tasks;
 };
 
-//this seems broken. should I fix it ?
 var getStateDate = function(state, task, history) {
   if (state === 'scheduled' && task.due) {
     return task.due;

--- a/api/services/export-data.js
+++ b/api/services/export-data.js
@@ -366,6 +366,7 @@ var normalizeTasks = function(doc, options) {
   return tasks;
 };
 
+//this seems broken. should I fix it ?
 var getStateDate = function(state, task, history) {
   if (state === 'scheduled' && task.due) {
     return task.due;

--- a/packages/kujua-sms/kujua-sms/lists.js
+++ b/packages/kujua-sms/kujua-sms/lists.js
@@ -46,6 +46,7 @@ exports.tasks_pending = function (head, req) {
                     // if to and message is defined then append messages
                     if (msg.to && msg.message) {
                         utils.setTaskState(task, 'sent');
+                        task.timestamp = new Date().toISOString();
                         // append outgoing message data payload for smsssync
                         respBody.payload.messages.push(msg);
                         includeDoc = true;
@@ -62,6 +63,7 @@ exports.tasks_pending = function (head, req) {
                         // if to and message is defined then append messages
                         if (msg.to && msg.message) {
                             utils.setTaskState(task, 'sent');
+                            task.timestamp = new Date().toISOString();
                             // append outgoing message data payload for smsssync
                             respBody.payload.messages.push(msg);
                             includeDoc = true;

--- a/sentinel/transitions/resolve_pending.js
+++ b/sentinel/transitions/resolve_pending.js
@@ -39,6 +39,7 @@ const setStateOnTasks = function(tasks, state) {
     let updated = false;
     tasks.forEach(task => {
         if (utils.setTaskState(task, state)) {
+          task.timestamp = new Date().toISOString();
           updated = true;
         }
     });

--- a/shared-libs/task-utils/src/task-utils.js
+++ b/shared-libs/task-utils/src/task-utils.js
@@ -11,8 +11,6 @@ var matchedLastHistory = function(task, state) {
  * @returns {boolean} Returns true if task state or task history is changed, otherwise returns false.
  */
 var setTaskState = function(task, state, details) {
-  var timestamp = (new Date()).toISOString();
-
   task.state_history = task.state_history || [];
 
   if (task.state === state && (!details || task.state_details === details) && matchedLastHistory(task, state)) {
@@ -20,12 +18,11 @@ var setTaskState = function(task, state, details) {
   }
 
   task.state = state;
-  task.timestamp = timestamp;
   task.state_details = details;
   task.state_history.push({
     state: state,
     state_details: details,
-    timestamp: timestamp
+    timestamp: (new Date()).toISOString()
   });
 
   return true;

--- a/shared-libs/task-utils/test/set-task-state.js
+++ b/shared-libs/task-utils/test/set-task-state.js
@@ -24,7 +24,6 @@ describe('TaskUtils shared lib - setTaskState function', function() {
     chai.expect(result).to.equal(true);
     chai.expect(task.state).to.equal('newState');
     chai.expect(task.state_details).to.equal('details');
-    chai.expect(task.timestamp).to.equal('000');
     chai.expect(task.state_history.length).to.equal(1);
     chai.expect(task.state_history[0]).to.deep.equal({ state: 'newState', state_details: 'details', timestamp: '000'});
   });
@@ -45,7 +44,6 @@ describe('TaskUtils shared lib - setTaskState function', function() {
     chai.expect(result).to.equal(true);
     chai.expect(task.state).to.equal('newState');
     chai.expect(task.state_details).to.equal('details');
-    chai.expect(task.timestamp).to.equal('000');
     chai.expect(task.state_history.length).to.equal(2);
     chai.expect(task.state_history[0]).to.deep.equal({ state: 'oldState', state_details: 'oldDetails', timestamp: '111'});
     chai.expect(task.state_history[1]).to.deep.equal({ state: 'newState', state_details: 'details', timestamp: '000'});
@@ -82,14 +80,12 @@ describe('TaskUtils shared lib - setTaskState function', function() {
     chai.expect(result1).to.equal(true);
     chai.expect(task1.state).to.equal('oldState');
     chai.expect(task1.state_details).to.equal('details');
-    chai.expect(task1.timestamp).to.equal('000');
     chai.expect(task1.state_history[0]).to.deep.equal({ state: 'oldState', state_details: 'oldDetails', timestamp: '111'});
     chai.expect(task1.state_history[1]).to.deep.equal({ state: 'oldState', state_details: 'details', timestamp: '000'});
 
     chai.expect(result2).to.equal(true);
     chai.expect(task2.state).to.equal('newState');
     chai.expect(task2.state_details).to.equal('oldDetails');
-    chai.expect(task2.timestamp).to.equal('000');
     chai.expect(task2.state_history[0]).to.deep.equal({ state: 'oldState', state_details: 'oldDetails', timestamp: '111'});
     chai.expect(task2.state_history[1]).to.deep.equal({ state: 'newState', state_details: 'oldDetails', timestamp: '000'});
   });
@@ -122,14 +118,12 @@ describe('TaskUtils shared lib - setTaskState function', function() {
 
     chai.expect(result1).to.equal(false);
     chai.expect(task1.state).to.equal('oldState');
-    chai.expect(task1.timestamp).to.equal('111');
     chai.expect(task1.state_details).to.equal('oldDetails');
     chai.expect(task1.state_history.length).to.equal(1);
     chai.expect(task1.state_history[0]).to.deep.equal({ state: 'oldState', state_details: 'oldDetails', timestamp: '111'});
 
     chai.expect(result2).to.equal(false);
     chai.expect(task2.state).to.equal('oldState');
-    chai.expect(task2.timestamp).to.equal('111');
     chai.expect(task2.state_details).to.equal('oldDetails');
     chai.expect(task2.state_history).to.deep.equal([{ state: 'oldState', state_details: 'oldDetails', timestamp: '111'}]);
   });
@@ -146,7 +140,6 @@ describe('TaskUtils shared lib - setTaskState function', function() {
     chai.expect(result).to.equal(true);
     chai.expect(task.state).to.equal('oldState');
     chai.expect(task.state_details).to.equal('oldDetails');
-    chai.expect(task.timestamp).to.equal('000');
     chai.expect(task.state_history.length).to.equal(1);
     chai.expect(task.state_history[0]).to.deep.equal({ state: 'oldState', state_details: 'oldDetails', timestamp: '000' });
   });

--- a/tests/nodeunit/unit/kujua-sms/lists.js
+++ b/tests/nodeunit/unit/kujua-sms/lists.js
@@ -90,6 +90,10 @@ exports.tasks_pending_callback = function(test) {
     var resp = fakerequest.list(lists.tasks_pending, viewdata, req);
     var resp_body = JSON.parse(resp.body);
 
+    // remove timestamp for this test
+    delete resp_body.callback.data.docs[0].tasks[0].timestamp;
+    delete resp_body.callback.data.docs[0].tasks[0].state_history[0].timestamp;
+
     test.same(expResp.callback.data, resp_body.callback.data);
     test.same(expResp.callback.options, resp_body.callback.options);
     test.same(expResp.callback, resp_body.callback);


### PR DESCRIPTION
# Description

Reverts setting task timestamp everytime the task state is updated to 
only when the task receives 'sent' status. 

medic/medic-webapp#4281

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.