### PR TITLE
Replaces usage of patient_uuid with patient_id

### DIFF
--- a/ddocs/medic-client/views/doc_summaries_by_id/map.js
+++ b/ddocs/medic-client/views/doc_summaries_by_id/map.js
@@ -27,10 +27,7 @@ function(doc) {
   var getSubject = function(doc) {
     var subject = {};
 
-    if (doc.fields && doc.fields.patient_uuid) {
-      subject.value = doc.fields.patient_uuid;
-      subject.type = 'id';
-    } else if (doc.patient_id || (doc.fields && doc.fields.patient_id) || doc.place_id) {
+    if (doc.patient_id || (doc.fields && doc.fields.patient_id) || doc.place_id) {
       subject.value = doc.patient_id || (doc.fields && doc.fields.patient_id) || doc.place_id;
       subject.type = 'reference';
     } else if (doc.fields && doc.fields.place_id) {

--- a/static/js/services/contact-change-filter.js
+++ b/static/js/services/contact-change-filter.js
@@ -22,16 +22,17 @@ angular.module('inboxServices').factory('ContactChangeFilter',
 
     var matchReportSubject = function(report, contact) {
       if (report.doc.fields && (
-          (report.doc.fields.patient_uuid && report.doc.fields.patient_uuid === contact.doc._id) ||
+          (report.doc.fields.patient_id && report.doc.fields.patient_id === contact.doc._id) ||
           (report.doc.fields.patient_id && report.doc.fields.patient_id === contact.doc.patient_id) ||
           (report.doc.fields.place_id && report.doc.fields.place_id === contact.doc._id) ||
-          (report.doc.fields.place_id && report.doc.fields.place_id === contact.doc.place_id)
-        )) {
+          (report.doc.fields.place_id && report.doc.fields.place_id === contact.doc.place_id))) {
         return true;
       }
 
       if ((report.doc.patient_id && report.doc.patient_id === contact.doc.patient_id) ||
-        (report.doc.place_id && report.doc.place_id === contact.doc.place_id)) {
+          (report.doc.patient_id && report.doc.patient_id === contact.doc._id) ||
+          (report.doc.place_id && report.doc.place_id === contact.doc.place_id) ||
+          (report.doc.place_id && report.doc.place_id === contact.doc._id)) {
         return true;
       }
 

--- a/tests/karma/unit/services/contact-change-filter.js
+++ b/tests/karma/unit/services/contact-change-filter.js
@@ -167,14 +167,22 @@ describe('ContactChangeFilter service', () => {
       };
     });
 
-    it('returns true for direct contact with matching uuid', () => {
-      change1.doc.fields.patient_uuid = 'id';
+    it('returns true for direct contact with matching doc ID', () => {
+      change1.doc.fields.patient_id = 'id';
       chai.expect(service.isRelevantReport(change1, contact)).to.equal(true);
     });
 
     it('returns true for direct contact with matching patient_id', () => {
       change1.doc.fields.patient_id = 'patient';
       change2.doc.patient_id = 'patient';
+
+      chai.expect(service.isRelevantReport(change1, contact)).to.equal(true);
+      chai.expect(service.isRelevantReport(change2, contact)).to.equal(true);
+    });
+
+    it('returns true for direct contact with matching place_id doc ID', () => {
+      change1.doc.fields.place_id = 'id';
+      change2.doc.place_id = 'id';
 
       chai.expect(service.isRelevantReport(change1, contact)).to.equal(true);
       chai.expect(service.isRelevantReport(change2, contact)).to.equal(true);
@@ -188,10 +196,15 @@ describe('ContactChangeFilter service', () => {
       chai.expect(service.isRelevantReport(change2, contact)).to.equal(true);
     });
 
-    it('returns true for child contact with matching uuid', () => {
-      change1.doc.fields.patient_uuid = 'child_id2';
+    it('returns true for child contact with matching doc ID', () => {
+      change1.doc.fields.patient_id = 'child_id2';
       chai.expect(service.isRelevantReport(change1, contact)).to.equal(true);
-      change1.doc.fields.patient_uuid = 'child_id3';
+      change1.doc.fields.patient_id = 'child_id3';
+      chai.expect(service.isRelevantReport(change1, contact)).to.equal(true);
+
+      change1.doc.patient_id = 'child_id2';
+      chai.expect(service.isRelevantReport(change1, contact)).to.equal(true);
+      change1.doc.patient_id = 'child_id3';
       chai.expect(service.isRelevantReport(change1, contact)).to.equal(true);
     });
 
@@ -207,6 +220,18 @@ describe('ContactChangeFilter service', () => {
       chai.expect(service.isRelevantReport(change2, contact)).to.equal(true);
     });
 
+    it('returns true for child contact with matching place_id doc ID', () => {
+      change1.doc.fields.place_id = 'child_id2';
+      chai.expect(service.isRelevantReport(change1, contact)).to.equal(true);
+      change1.doc.fields.place_id = 'child_id3';
+      chai.expect(service.isRelevantReport(change1, contact)).to.equal(true);
+
+      change2.doc.place_id = 'child_id2';
+      chai.expect(service.isRelevantReport(change2, contact)).to.equal(true);
+      change2.doc.place_id = 'child_id3';
+      chai.expect(service.isRelevantReport(change2, contact)).to.equal(true);
+    });
+
     it('returns true for child contact with matching place_id', () => {
       change1.doc.fields.place_id = 'child_place2';
       chai.expect(service.isRelevantReport(change1, contact)).to.equal(true);
@@ -219,9 +244,12 @@ describe('ContactChangeFilter service', () => {
       chai.expect(service.isRelevantReport(change2, contact)).to.equal(true);
     });
 
-    it('returns false for direct contact with different uuid', () => {
-      change1.doc.fields.patient_uuid = 'nid';
+    it('returns false for direct contact with different doc id', () => {
+      change1.doc.fields.patient_id = 'nid';
       chai.expect(service.isRelevantReport(change1, contact)).to.equal(false);
+
+      change2.doc.patient_id = 'nid';
+      chai.expect(service.isRelevantReport(change2, contact)).to.equal(false);
     });
 
     it('returns false for direct contact with different patient_id', () => {
@@ -240,11 +268,16 @@ describe('ContactChangeFilter service', () => {
       chai.expect(service.isRelevantReport(change2, contact)).to.equal(false);
     });
 
-    it('returns false for child contact with different uuid', () => {
-      change1.doc.fields.patient_uuid = 'nchild_id2';
+    it('returns false for child contact with different doc ID', () => {
+      change1.doc.fields.patient_id = 'nchild_id2';
       chai.expect(service.isRelevantReport(change1,  contact)).to.equal(false);
-      change1.doc.fields.patient_uuid = 'nchild_id3';
+      change1.doc.fields.patient_id = 'nchild_id3';
       chai.expect(service.isRelevantReport(change1, contact)).to.equal(false);
+
+      change2.doc.patient_id = 'nchild_id2';
+      chai.expect(service.isRelevantReport(change2,  contact)).to.equal(false);
+      change2.doc.patient_id = 'nchild_id3';
+      chai.expect(service.isRelevantReport(change2, contact)).to.equal(false);
     });
 
     it('returns false for child contact with different patient_id', () => {
@@ -270,7 +303,6 @@ describe('ContactChangeFilter service', () => {
       change2.doc.place_id = 'nchild_place3';
       chai.expect(service.isRelevantReport(change2, contact)).to.equal(false);
     });
-
   });
 
   describe('isDeleted', () => {

--- a/tests/mocha/unit/views/doc_summaries_by_id.spec.js
+++ b/tests/mocha/unit/views/doc_summaries_by_id.spec.js
@@ -106,7 +106,7 @@ const postNatalVisit = {
     patient_age_in_years: '25',
     patient_phone: '',
     patient_uuid: 'a29c933c-90cb-4cb0-9e25-36403499aee4',
-    patient_id: '',
+    patient_id: 'a29c933c-90cb-4cb0-9e25-36403499aee4',
     patient_name: 'mother',
     meta: {
       instanceID: 'uuid:a53c23dc-eedb-433c-a81d-30c495ce7602'
@@ -117,7 +117,7 @@ const postNatalVisit = {
 const postNatalVisitBis = Object.assign({}, postNatalVisit, {
   _id: '4971a859-bde7-4ff0-a0ed-326925b83038-bis',
   fields: Object.assign({}, postNatalVisit.fields, {
-    patient_uuid: null
+    patient_id: null
   })
 });
 
@@ -342,7 +342,7 @@ describe('doc_summaries_by_id view', () => {
         contact: 'df28f38e-cd3c-475f-96b5-48080d863e34',
         lineage: ['1a1aac55-04d6-40dc-aae2-e67a75a1496d'],
         subject: {
-          type: 'id',
+          type: 'reference',
           value: 'a29c933c-90cb-4cb0-9e25-36403499aee4'
         }
       }


### PR DESCRIPTION
# Description

Replaces usage of `patient_uuid` fields with `patient_id` when trying to determine or compare with report subject. 

medic/medic-webapp#4053
medic/medic-webapp#3530 

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.