### PR TITLE
Don't add registration_id to registration forms

### DIFF
--- a/sentinel/test/mocha/transitions/accept_patient_reports.js
+++ b/sentinel/test/mocha/transitions/accept_patient_reports.js
@@ -139,6 +139,36 @@ describe('accept_patient_reports', () => {
       });
     });
 
+    it('adds registration_id property', done => {
+      sinon.stub(transition, '_silenceReminders').callsArgWith(3, null, true);
+      const doc = { _id: 'z', fields: { patient_id: 'x' } };
+      const config = { silence_type: 'x', messages: [] };
+      const registrations = [ { _id: 'a', reported_date: '2017-02-05T09:23:07.853Z' } ];
+      sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, registrations);
+      transition._handleReport(doc, config, (err, complete) => {
+        complete.should.equal(true);
+        doc.registration_id.should.equal(registrations[0]._id);
+        done();
+      });
+    });
+
+    it('if there are multiple registrations uses the latest one', done => {
+      sinon.stub(transition, '_silenceReminders').callsArgWith(3, null, true);
+      const doc = { _id: 'z', fields: { patient_id: 'x' } };
+      const config = { silence_type: 'x', messages: [] };
+      const registrations = [
+        { _id: 'a', reported_date: '2017-02-05T09:23:07.853Z' },
+        { _id: 'c', reported_date: '2018-02-05T09:23:07.853Z' },
+        { _id: 'b', reported_date: '2016-02-05T09:23:07.853Z' }
+      ];
+      sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, registrations);
+      transition._handleReport(doc, config, (err, complete) => {
+        complete.should.equal(true);
+        doc.registration_id.should.equal(registrations[1]._id);
+        done();
+      });
+    });
+
   });
 
   describe('silenceReminders', () => {
@@ -264,35 +294,4 @@ describe('accept_patient_reports', () => {
     });
   });
 
-  describe('silenceRegistrations', () => {
-
-    it('adds registration_id property', done => {
-      sinon.stub(transition, '_silenceReminders').callsArgWith(3, null, true);
-      const doc = { _id: 'z', fields: { patient_id: 'x' } };
-      const config = { silence_type: 'x', messages: [] };
-      const registrations = [ { _id: 'a', reported_date: '2017-02-05T09:23:07.853Z' } ];
-      transition.silenceRegistrations(config, doc, registrations, (err, complete) => {
-        complete.should.equal(true);
-        doc.registration_id.should.equal(registrations[0]._id);
-        done();
-      });
-    });
-
-    it('if there are multiple registrations uses the latest one', done => {
-      sinon.stub(transition, '_silenceReminders').callsArgWith(3, null, true);
-      const doc = { _id: 'z', fields: { patient_id: 'x' } };
-      const config = { silence_type: 'x', messages: [] };
-      const registrations = [
-        { _id: 'a', reported_date: '2017-02-05T09:23:07.853Z' },
-        { _id: 'c', reported_date: '2018-02-05T09:23:07.853Z' },
-        { _id: 'b', reported_date: '2016-02-05T09:23:07.853Z' }
-      ];
-      transition.silenceRegistrations(config, doc, registrations, (err, complete) => {
-        complete.should.equal(true);
-        doc.registration_id.should.equal(registrations[1]._id);
-        done();
-      });
-    });
-
-  });
 });

--- a/sentinel/transitions/accept_patient_reports.js
+++ b/sentinel/transitions/accept_patient_reports.js
@@ -113,7 +113,6 @@ const silenceRegistrations = (
     if (!config.silence_type) {
         return callback(null, true);
     }
-    addRegistrationToDoc(doc, registrations);
     async.forEach(
         registrations,
         function(registration, callback) {
@@ -168,6 +167,7 @@ const handleReport = (doc, config, callback) => {
         }
 
         addMessagesToDoc(doc, config, registrations);
+        addRegistrationToDoc(doc, registrations);
 
         module.exports.silenceRegistrations(
             config,


### PR DESCRIPTION
# Description

The registration transition shouldn't add the registration_id field.

medic/medic-webapp#3959

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.