### PR TITLE
3826 lineage refactoring fixes

### DIFF
--- a/shared-libs/lineage/src/lineage.js
+++ b/shared-libs/lineage/src/lineage.js
@@ -250,15 +250,17 @@ module.exports = function(Promise, DB) {
     }
 
     var findById = function(id, docs) {
-      return docs.find(function(doc) {
-        return doc._id === id;
-      });
+      if (id) {
+        return docs.find(function(doc) {
+          return doc._id === id;
+        });
+      }
     };
 
     docs.forEach(function(doc) {
       var current = doc;
       if (doc.type === 'data_record') {
-        var contactDoc = findById(current.contact._id, parents);
+        var contactDoc = findById(current.contact && current.contact._id, parents);
         if (contactDoc) {
           doc.contact = contactDoc;
         }


### PR DESCRIPTION
Individual fixes that have come out of testing lineage:

 - Fixing bad revert of a refactor to the v1 export library
 - Fixing v2 export libraries addition of quick head flushing to only effect v2, and for v2 errors to understand that headers have been flushed
 - Fixing lineage so it handles data_records that don't have contacts (ie JSON forms)

medic/medic-webapp3826

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.