### PR TITLE
Replaces report summary info from submitter to subject

### DIFF
--- a/static/js/directives/sender.js
+++ b/static/js/directives/sender.js
@@ -2,7 +2,7 @@ angular.module('inboxDirectives').directive('mmSender', function() {
   'use strict';
   return {
     restrict: 'E',
-    scope: { message: '=' },
+    scope: { message: '=', sentBy: '=', hideLineage: '=' },
     templateUrl: 'templates/directives/sender.html'
   };
 });

--- a/static/js/services/get-subject-summaries.js
+++ b/static/js/services/get-subject-summaries.js
@@ -10,7 +10,6 @@ angular.module('inboxServices').factory('GetSubjectSummaries',
     'use strict';
     'ngInject';
 
-    var detailedLineage = false;
     var findSubjectId = function(response, id) {
       var parent = _.find(response.rows, function(row) {
         return id && row.key[1] === id.toString() || false;
@@ -132,13 +131,9 @@ angular.module('inboxServices').factory('GetSubjectSummaries',
       return $q
         .all(promises)
         .then(function() {
-          if (detailedLineage) {
-            return summaries;
-          }
-
           return $q.resolve(_.each(summaries, function(summary) {
             if (summary.subject && summary.subject.lineage) {
-              summary.subject.lineage = _.compact(_.map(summary.subject.lineage, function(parent) {
+              summary.subject.compactLineage = _.compact(_.map(summary.subject.lineage, function(parent) {
                 return parent && parent.name;
               }));
             }
@@ -146,8 +141,7 @@ angular.module('inboxServices').factory('GetSubjectSummaries',
         });
     };
 
-    return function(summaries, detailed) {
-      detailedLineage = detailed;
+    return function(summaries) {
       var containsReports = false;
       summaries.forEach(function (summary) {
         if (summary.form) {

--- a/static/js/services/lineage-model-generator.js
+++ b/static/js/services/lineage-model-generator.js
@@ -94,6 +94,14 @@ angular.module('inboxServices').factory('LineageModelGenerator',
               lineage: docs
             };
           });
+      },
+      reportPatient: function(id) {
+        return get(id).then(function(docs) {
+            return {
+              doc: docs.shift(),
+              lineage: docs
+            };
+          });
       }
     };
 

--- a/static/js/services/live-list.js
+++ b/static/js/services/live-list.js
@@ -114,7 +114,7 @@ angular.module('inboxServices').factory('LiveListConfig',
           scope.showStatus = true;
           scope.valid = report.valid;
           scope.verified = report.verified;
-          scope.lineage = report.subject && report.subject.lineage || report.lineage;
+          scope.lineage = report.subject && report.subject.compactLineage || report.lineage;
           scope.unread = !report.read;
           var element = renderTemplate(scope);
           if (removedDomElement &&

--- a/static/js/services/live-list.js
+++ b/static/js/services/live-list.js
@@ -114,7 +114,7 @@ angular.module('inboxServices').factory('LiveListConfig',
           scope.showStatus = true;
           scope.valid = report.valid;
           scope.verified = report.verified;
-          scope.lineage = report.lineage;
+          scope.lineage = report.subject && report.subject.lineage || report.lineage;
           scope.unread = !report.read;
           var element = renderTemplate(scope);
           if (removedDomElement &&

--- a/static/js/services/report-view-model-generator.js
+++ b/static/js/services/report-view-model-generator.js
@@ -15,7 +15,9 @@ var _ = require('underscore');
 angular.module('inboxServices').factory('ReportViewModelGenerator',
   function(
     FormatDataRecord,
-    LineageModelGenerator
+    LineageModelGenerator,
+    DB,
+    GetSubjectSummaries
   ) {
     'ngInject';
     'use strict';
@@ -83,6 +85,20 @@ angular.module('inboxServices').factory('ReportViewModelGenerator',
             model.formatted = formatted;
             return model;
           });
+        })
+        .then(function(model) {
+          return DB()
+            .query('medic-client/doc_summaries_by_id', { keys: [model.doc._id] })
+            .then(function(results) {
+              return GetSubjectSummaries(results.rows.map(function(row) { return row.value; }), true);
+            })
+            .then(function(summaries) {
+              if (summaries && summaries.length) {
+                model.formatted.subject = summaries.pop().subject;
+              }
+
+              return model;
+            });
         });
     };
   }

--- a/templates/directives/sender.html
+++ b/templates/directives/sender.html
@@ -1,4 +1,4 @@
-<div class="ng-class: {sender, 'small-font': sentBy}" ng-if="message">
+<div ng-class="{sender: true, 'small-font': sentBy}" ng-if="message">
   <div>
     <span ng-if="sentBy" ng-bind="'report.sent.by' | translate"></span>
     <span class="name"

--- a/templates/directives/sender.html
+++ b/templates/directives/sender.html
@@ -1,5 +1,6 @@
-<div class="sender" ng-if="message">
+<div class="ng-class: {sender, 'small-font': sentBy}" ng-if="message">
   <div>
+    <span ng-if="sentBy" ng-bind="'report.sent.by' | translate"></span>
     <span class="name"
     ng-bind="message.doc.name || message.contact.name || message.contact || (!message.form && message.name) || message.from || message.sent_by || ('messages.unknown.sender' | translate)"></span>
     <span class="phone"
@@ -7,7 +8,7 @@
     ng-bind="message.doc.phone || message.contact.phone || message.phone"></span>
   </div>
   <div class="position small-font"
-    ng-if="message.lineage || message.contact.parent || message.place || (!message.form && message.name)"
+    ng-if="!hideLineage && (message.lineage || message.contact.parent || message.place || (!message.form && message.name))"
     ng-bind-html="message.lineage || message.contact.parent || message.place | lineage">
   </div>
 </div>

--- a/templates/partials/reports_content.html
+++ b/templates/partials/reports_content.html
@@ -33,7 +33,7 @@
             <i ng-show="!valid && summary.verified" class="fa fa-check-circle red-dot"></i>
           </div>
 
-          <div ng-if="summary.subject.type">
+          <div ng-if="summary.subject.type" class="subject">
             <span class="name"
                   ng-bind="(summary.subject.type === 'name' && summary.subject.value) || ('report.subject.unknown' | translate)"></span>
           </div>

--- a/templates/partials/reports_content.html
+++ b/templates/partials/reports_content.html
@@ -33,8 +33,17 @@
             <i ng-show="!valid && summary.verified" class="fa fa-check-circle red-dot"></i>
           </div>
 
-          <mm-sender message="selection"></mm-sender>
+          <div ng-if="summary.subject.type">
+            <span class="name"
+                  ng-bind="(summary.subject.type === 'name' && summary.subject.value) || ('report.subject.unknown' | translate)"></span>
+          </div>
+          <mm-sender ng-if="!summary.subject.type" message="selection" hide-lineage="true"></mm-sender>
           <div>{{summary | title:forms}}</div>
+          <div class="position small-font"
+               ng-if="summary.subject.lineage || selection.lineage || selection.contact.parent || selection.place || (!selection.form && selection.name)"
+               ng-bind-html="summary.subject.lineage || selection.lineage || selection.contact.parent || selection.place | lineage">
+          </div>
+          <mm-sender ng-if="summary.subject.type" message="selection" hide-lineage="true" sent-by="true"></mm-sender>
         </div>
       </div>
 

--- a/tests/karma/unit/services/get-subject-summaries.js
+++ b/tests/karma/unit/services/get-subject-summaries.js
@@ -6,6 +6,7 @@ describe('GetSubjectSummaries service', () => {
       query,
       lineageModelGenerator;
 
+  const doc = { _id: 'result' };
   const lineage = [
     { _id: '1', name: 'one' },
     { _id: '2', name: 'two' },
@@ -17,7 +18,7 @@ describe('GetSubjectSummaries service', () => {
     lineageModelGenerator = {
       reportPatient: sinon.stub()
     };
-    lineageModelGenerator.reportPatient.returns(Promise.resolve({ doc: {}, lineage: [] }));
+    lineageModelGenerator.reportPatient.returns(Promise.resolve({ doc: doc, lineage: lineage }));
 
     module('inboxApp');
     module($provide => {
@@ -134,8 +135,9 @@ describe('GetSubjectSummaries service', () => {
           id: 'a',
           type: 'name',
           value: 'tom',
-          lineage: [],
-          doc: {}
+          lineage: lineage,
+          compactLineage: ['one', 'two', 'three'],
+          doc: doc
         },
         validSubject: true
       });
@@ -146,8 +148,9 @@ describe('GetSubjectSummaries service', () => {
           id: 'b',
           type: 'name',
           value: 'helen',
-          lineage: [],
-          doc: {}
+          lineage: lineage,
+          compactLineage: ['one', 'two', 'three'],
+          doc: doc
         },
         validSubject: true
       });
@@ -217,8 +220,9 @@ describe('GetSubjectSummaries service', () => {
           id: 'a',
           type: 'name',
           value: 'tom',
-          lineage: [],
-          doc: {}
+          lineage: lineage,
+          compactLineage: ['one', 'two', 'three'],
+          doc: doc
         },
         validSubject: true
       });
@@ -229,8 +233,9 @@ describe('GetSubjectSummaries service', () => {
           id: 'b',
           type: 'name',
           value: 'helen',
-          lineage: [],
-          doc: {}
+          lineage: lineage,
+          compactLineage: ['one', 'two', 'three'],
+          doc: doc
         },
         validSubject: true
       });
@@ -326,114 +331,6 @@ describe('GetSubjectSummaries service', () => {
         },
         validSubject: false
       });
-    });
-  });
-
-  it('hydrate report lineage - names only', () => {
-    const given = [
-      { form: 'a', subject: { type: 'id', value: 'a' } },
-      { form: 'a', subject: { type: 'id', value: 'b' } },
-      { form: 'a', subject: { type: 'id', value: 'c' } }
-    ];
-
-    const summaries = [
-      {id: 'a', value: { name: 'tom' } },
-      {id: 'b', value: { name: 'helen' } }
-    ];
-
-    const doc = {_id: 'result'};
-
-    query.returns(Promise.resolve({ rows: summaries }));
-    lineageModelGenerator.reportPatient.returns(Promise.resolve({ doc, lineage }));
-    return service(given).then(actual => {
-      chai.expect(actual[0]).to.deep.equal({
-        form: 'a',
-        subject: {
-          id: 'a',
-          type: 'name',
-          value: 'tom',
-          lineage: ['one', 'two', 'three'],
-          doc: doc
-        },
-        validSubject: true
-      });
-
-      chai.expect(actual[1]).to.deep.equal({
-        form: 'a',
-        subject: {
-          id: 'b',
-          type: 'name',
-          value: 'helen',
-          lineage: ['one', 'two', 'three'],
-          doc: doc
-        },
-        validSubject: true
-      });
-
-      chai.expect(actual[2]).to.deep.equal({
-        form: 'a',
-        subject: {
-          type: 'id',
-          value: 'c'
-        },
-        validSubject: false
-      });
-
-      chai.expect(query.callCount).to.equal(1);
-    });
-  });
-
-  it('hydrate report lineage - detailed', () => {
-    const given = [
-      { form: 'a', subject: { type: 'id', value: 'a' } },
-      { form: 'a', subject: { type: 'id', value: 'b' } },
-      { form: 'a', subject: { type: 'id', value: 'c' } }
-    ];
-
-    const summaries = [
-      {id: 'a', value: { name: 'tom' } },
-      {id: 'b', value: { name: 'helen' } }
-    ];
-
-    const doc = {_id: 'result'};
-
-    query.returns(Promise.resolve({ rows: summaries }));
-    lineageModelGenerator.reportPatient.returns(Promise.resolve({ doc, lineage }));
-    return service(given, true).then(actual => {
-      chai.expect(actual[0]).to.deep.equal({
-        form: 'a',
-        subject: {
-          id: 'a',
-          type: 'name',
-          value: 'tom',
-          lineage: lineage,
-          doc: doc
-        },
-        validSubject: true
-      });
-
-      chai.expect(actual[1]).to.deep.equal({
-        form: 'a',
-        subject: {
-          id: 'b',
-          type: 'name',
-          value: 'helen',
-          lineage: lineage,
-          doc: doc
-        },
-        validSubject: true
-      });
-
-      chai.expect(actual[2]).to.deep.equal({
-        form: 'a',
-        subject: {
-          type: 'id',
-          value: 'c'
-        },
-        validSubject: false
-      });
-
-      chai.expect(query.callCount).to.equal(1);
     });
   });
 });

--- a/tests/protractor/base.conf.js
+++ b/tests/protractor/base.conf.js
@@ -7,7 +7,8 @@ class BaseConfig {
     this.config = {
       seleniumAddress: 'http://localhost:4444/wd/hub',
 
-      specs: ['e2e/**/*.js'],
+      //specs: ['e2e/**/*.js'],
+      specs: ['e2e/**/reports-subject.js'],
 
       framework: 'jasmine2',
       capabilities: {

--- a/tests/protractor/base.conf.js
+++ b/tests/protractor/base.conf.js
@@ -7,8 +7,7 @@ class BaseConfig {
     this.config = {
       seleniumAddress: 'http://localhost:4444/wd/hub',
 
-      //specs: ['e2e/**/*.js'],
-      specs: ['e2e/**/reports-subject.js'],
+      specs: ['e2e/**/*.js'],
 
       framework: 'jasmine2',
       capabilities: {

--- a/tests/protractor/e2e/registration-by-sms.js
+++ b/tests/protractor/e2e/registration-by-sms.js
@@ -220,8 +220,9 @@ describe('registration transition', () => {
 
     const checkItemSummary = () => {
       const summaryElement = element(by.css('#reports-content .item-summary'));
-      expect(summaryElement.element(by.css('.name')).getText()).toBe(CAROL.name);
-      expect(summaryElement.element(by.css('.phone')).getText()).toBe(CAROL.phone);
+      expect(summaryElement.element(by.css('.sender .name')).getText()).toBe(CAROL.name);
+      expect(summaryElement.element(by.css('.subject .name')).getText()).toBe('Siobhan');
+      expect(summaryElement.element(by.css('.sender .phone')).getText()).toBe(CAROL.phone);
       expect(summaryElement.element(by.css('.position a')).getText()).toBe(BOB_PLACE.name);
       expect(summaryElement.element(by.css('.detail .status .fa-circle.green-dot')).isDisplayed()).toBeTruthy();
     };
@@ -244,7 +245,7 @@ describe('registration transition', () => {
     it('shows content', () => {
       commonElements.goToReports();
       helper.waitElementToBeClickable(element(by.css('.action-container .general-actions:not(.ng-hide) .fa-plus')));
-      helper.waitElementToBeVisible(element(by.css('#reports-list .unfiltered li:first-child')));
+      helper.waitElementToBeClickable(element(by.css('#reports-list .unfiltered li:first-child')));
       browser.wait(() => element(by.cssContainingText('#reports-list .unfiltered li:first-child h4 span', 'Siobhan')).isPresent(), 10000);
 
       helper.clickElement(element(by.css('#reports-list .unfiltered li:first-child .summary')));

--- a/tests/protractor/e2e/reports-subject.js
+++ b/tests/protractor/e2e/reports-subject.js
@@ -322,187 +322,237 @@ describe('Reports Summary', () => {
     reported_date: moment().subtract(2, 'hours').valueOf()
   };
 
-  const REPORTS = [
-    REF_REF_V1,
-    REF_REF_V2,
-    REF_REF_I,
-    NAM_NAM_V,
-    NAM_NAM_I,
-    PREF_PREF_V,
-    PREF_PREF_I
-  ];
-
-  const getListElement = (report) => {
-    return element(by.css('#reports-list .unfiltered li[data-record-id="'+ report._id +'"]'));
+  const testListLineage = (expected) => {
+    expected.forEach((parent, key) => {
+      element(by.css('#reports-list .unfiltered li .detail .lineage li:nth-child('+ (key + 1) +')'))
+        .getText()
+        .then(text => expect(text).toBe(parent));
+    });
   };
 
-  const compareLineage = (report, expectedLineage, links) => {
-    if (links) {
-      expectedLineage.forEach((parent, key) => {
-        expect(element(by.css('#reports-content .item-summary .position .lineage')).all(by.css('a')).get(key).getText()).toBe(parent);
-      });
-    } else {
-      expectedLineage.forEach((parent, key) => {
-        expect(getListElement(report).all(by.css('li')).get(key).getText()).toBe(parent);
-      });
-    }
+  const testSummaryLineage = (expected) => {
+    expected.forEach((parent, key) => {
+      element(by.css('#reports-content .item-summary .position .lineage li:nth-child('+ (key + 1) +')'))
+        .getText()
+        .then(text => expect(text).toBe(parent));
+    });
   };
 
-  const checkItemListSummary = (report) => {
-    switch (report._id) {
-      case REF_REF_V1._id:
-      case REF_REF_V2._id:
-        expect(getListElement(report).element(by.css('.content .heading h4 span')).getText()).toBe(MARIA.name);
-        expect(getListElement(report).element(by.css('.content .summary p')).getText()).toBe('REF_REF');
-        //shows subject lineage breadcrumbs
-        compareLineage(report, ['TAG Place', 'Health Center', 'District']);
-        break;
-      case REF_REF_I._id:
-        expect(getListElement(report).element(by.css('.content .heading h4 span')).getText()).toBe('Unknown subject');
-        expect(getListElement(report).element(by.css('.content .summary p')).getText()).toBe('REF_REF');
-        //shows submitter lineage breadcrumbs
-        compareLineage(report, ['Bob Place', 'Health Center', 'District']);
-        break;
-      case NAM_NAM_V._id:
-        expect(getListElement(report).element(by.css('.content .heading h4 span')).getText()).toBe(GEORGE.name);
-        expect(getListElement(report).element(by.css('.content .summary p')).getText()).toBe('NAM_NAM');
-        //shows submitter lineage breadcrumbs
-        compareLineage(report, ['Bob Place', 'Health Center', 'District']);
-        break;
-      case NAM_NAM_I._id:
-        expect(getListElement(report).element(by.css('.content .heading h4 span')).getText()).toBe('Unknown subject');
-        expect(getListElement(report).element(by.css('.content .summary p')).getText()).toBe('NAM_NAM');
-        //shows submitter lineage breadcrumbs
-        compareLineage(report, ['Bob Place', 'Health Center', 'District']);
-        break;
-      case PREF_PREF_V._id:
-        expect(getListElement(report).element(by.css('.content .heading h4 span')).getText()).toBe(TAG_PLACE.name);
-        expect(getListElement(report).element(by.css('.content .summary p')).getText()).toBe('PID_PID');
-        //shows subject lineage breadcrumbs
-        compareLineage(report, ['Health Center', 'District']);
-        break;
-      case PREF_PREF_I._id:
-        expect(getListElement(report).element(by.css('.content .heading h4 span')).getText()).toBe('Unknown subject');
-        expect(getListElement(report).element(by.css('.content .summary p')).getText()).toBe('PID_PID');
-        //shows submitter lineage breadcrumbs
-        compareLineage(report, ['Bob Place', 'Health Center', 'District']);
-        break;
-    }
+  const saveReport = (report) => {
+    return protractor.promise.all(utils.saveDoc(report));
   };
 
-  const checkItemContentSummary = (report) => {
-    const summaryElement = element(by.css('#reports-content .item-summary'));
-    browser.wait(() => summaryElement.isPresent(), 10000);
-
-    switch (report._id) {
-      case REF_REF_V1._id:
-      case REF_REF_V2._id:
-        expect(summaryElement.element(by.css('.subject .name')).getText()).toBe(MARIA.name);
-        expect(summaryElement.element(by.css('.subject + div')).getText()).toBe('REF_REF');
-
-        compareLineage(report, ['TAG Place', 'Health Center', 'District'], true);
-
-        browser.wait(() => element(by.cssContainingText('#reports-content .item-summary .name', CAROL.name)).isPresent(), 20000);
-        expect(summaryElement.element(by.css('.sender .name')).getText()).toBe(CAROL.name);
-        expect(summaryElement.element(by.css('.sender .phone')).getText()).toBe(CAROL.phone);
-        break;
-      case REF_REF_I._id:
-        expect(summaryElement.element(by.css('.subject .name')).getText()).toBe('Unknown subject');
-        expect(summaryElement.element(by.css('.subject + div')).getText()).toBe('REF_REF');
-
-        browser.wait(() => element(by.cssContainingText('#reports-content .item-summary .name', CAROL.name)).isPresent(), 20000);
-        compareLineage(report, ['Bob Place', 'Health Center', 'District'], true);
-        expect(summaryElement.element(by.css('.sender .name')).getText()).toBe(CAROL.name);
-        expect(summaryElement.element(by.css('.sender .phone')).getText()).toBe(CAROL.phone);
-        break;
-      case NAM_NAM_V._id:
-        expect(summaryElement.element(by.css('.subject .name')).getText()).toBe(GEORGE.name);
-        expect(summaryElement.element(by.css('.subject + div')).getText()).toBe('NAM_NAM');
-
-        browser.wait(() => element(by.cssContainingText('#reports-content .item-summary .name', CAROL.name)).isPresent(), 20000);
-        compareLineage(report, ['Bob Place', 'Health Center', 'District'], true);
-        expect(summaryElement.element(by.css('.sender .name')).getText()).toBe(CAROL.name);
-        expect(summaryElement.element(by.css('.sender .phone')).getText()).toBe(CAROL.phone);
-        break;
-      case NAM_NAM_I._id:
-        expect(summaryElement.element(by.css('.subject .name')).getText()).toBe('Unknown subject');
-        expect(summaryElement.element(by.css('.subject + div')).getText()).toBe('NAM_NAM');
-
-        browser.wait(() => element(by.cssContainingText('#reports-content .item-summary .name', CAROL.name)).isPresent(), 20000);
-        compareLineage(report, ['Bob Place', 'Health Center', 'District'], true);
-        expect(summaryElement.element(by.css('.sender .name')).getText()).toBe(CAROL.name);
-        expect(summaryElement.element(by.css('.sender .phone')).getText()).toBe(CAROL.phone);
-        break;
-      case PREF_PREF_V._id:
-        expect(summaryElement.element(by.css('.subject .name')).getText()).toBe(TAG_PLACE.name);
-        expect(summaryElement.element(by.css('.subject + div')).getText()).toBe('PID_PID');
-
-        compareLineage(report, ['Health Center', 'District'], true);
-
-        browser.wait(() => element(by.cssContainingText('#reports-content .item-summary .name', CAROL.name)).isPresent(), 20000);
-        expect(summaryElement.element(by.css('.sender .name')).getText()).toBe(CAROL.name);
-        expect(summaryElement.element(by.css('.sender .phone')).getText()).toBe(CAROL.phone);
-        break;
-      case PREF_PREF_I._id:
-        expect(summaryElement.element(by.css('.subject .name')).getText()).toBe('Unknown subject');
-        expect(summaryElement.element(by.css('.subject + div')).getText()).toBe('PID_PID');
-
-        browser.wait(() => element(by.cssContainingText('#reports-content .item-summary .name', CAROL.name)).isPresent(), 20000);
-        compareLineage(report, ['Bob Place', 'Health Center', 'District'], true);
-        expect(summaryElement.element(by.css('.sender .name')).getText()).toBe(CAROL.name);
-        expect(summaryElement.element(by.css('.sender .phone')).getText()).toBe(CAROL.phone);
-        break;
-    }
-  };
-
-  const runTest = (report) => {
+  const loadReport = () => {
     commonElements.goToReports();
 
     helper.waitElementToBeClickable(element(by.css('.action-container .general-actions:not(.ng-hide) .fa-plus')));
-    helper.waitElementToBeClickable(getListElement(report).element(by.css('.summary')));
+    helper.waitElementToBeClickable(element(by.css('#reports-list .unfiltered li .summary')));
 
-    helper.clickElement(getListElement(report).element(by.css('.summary')));
-    checkItemListSummary(report);
-    checkItemContentSummary(report);
+    helper.clickElement(element(by.css('#reports-list .unfiltered li .summary')));
+    browser.wait(() => element(by.css('#reports-content .item-summary')).isPresent(), 10000);
+    return Promise.resolve();
   };
 
   beforeAll(done => {
     utils.updateSettings(CONFIG)
       .then(() => protractor.promise.all(CONTACTS.map(utils.saveDoc)))
-      .then(() => protractor.promise.all(REPORTS.map(utils.saveDoc)))
-      .then(done)
+      .then(() => {
+        //wait till change feed sends all the contacts we created
+        setTimeout(done, 10000);
+      })
       .catch(done.fail);
   });
 
   afterAll(utils.afterEach);
 
+  afterEach((done) => {
+    utils
+      .deleteAllDocs(CONTACTS.map(contact => contact._id))
+      .then(done);
+  });
+
   describe('Displays correct LHS and RHS summary', () => {
     it('Concerning reports using patient_id', () => {
-      runTest(REF_REF_V1);
+      return saveReport(REF_REF_V1)
+        .then(loadReport)
+        .then(() => {
+          //wait till report was seen by sentinel
+          return browser
+            .wait(() => element(by.cssContainingText('#reports-content .item-summary .sender .name', CAROL.name)).isPresent(), 10000)
+            .then(Promise.resolve)
+            .catch(loadReport);
+        })
+        .then(() => {
+          //LHS
+          expect(element(by.css('#reports-list .unfiltered li .content .heading h4 span')).getText()).toBe(MARIA.name);
+          expect(element(by.css('#reports-list .unfiltered li .summary')).getText()).toBe('REF_REF');
+          //shows subject lineage breadcrumbs
+          testListLineage(['TAG Place', 'Health Center', 'District']);
+
+          //RHS
+          expect(element(by.css('#reports-content .item-summary .subject .name')).getText()).toBe(MARIA.name);
+          expect(element(by.css('#reports-content .item-summary .subject + div')).getText()).toBe('REF_REF');
+          testSummaryLineage(['TAG Place', 'Health Center', 'District']);
+          expect(element(by.css('#reports-content .item-summary .sender .name')).getText()).toBe(CAROL.name);
+          expect(element(by.css('#reports-content .item-summary .sender .phone')).getText()).toBe(CAROL.phone);
+        });
     });
 
     it('Concerning reports using doc id', () => {
-      runTest(REF_REF_V2);
+      return saveReport(REF_REF_V2)
+        .then(loadReport)
+        .then(() => {
+          //wait till report was seen by sentinel
+          return browser
+            .wait(() => element(by.cssContainingText('#reports-content .item-summary .sender .name', CAROL.name)).isPresent(), 10000)
+            .then(Promise.resolve)
+            .catch(loadReport);
+        })
+        .then(() => {
+          //LHS
+          expect(element(by.css('#reports-list .unfiltered li .content .heading h4 span')).getText()).toBe(MARIA.name);
+          expect(element(by.css('#reports-list .unfiltered li .summary')).getText()).toBe('REF_REF');
+          //shows subject lineage breadcrumbs
+          testListLineage(['TAG Place', 'Health Center', 'District']);
+
+          //RHS
+          expect(element(by.css('#reports-content .item-summary .subject .name')).getText()).toBe(MARIA.name);
+
+          expect(element(by.css('#reports-content .item-summary .subject + div')).getText()).toBe('REF_REF');
+          testSummaryLineage(['TAG Place', 'Health Center', 'District']);
+          expect(element(by.css('#reports-content .item-summary .sender .name')).getText()).toBe(CAROL.name);
+          expect(element(by.css('#reports-content .item-summary .sender .phone')).getText()).toBe(CAROL.phone);
+        });
     });
 
     it('Concerning reports with unknown patient_id', () => {
-      runTest(REF_REF_I);
+      return saveReport(REF_REF_I)
+        .then(loadReport)
+        .then(() => {
+          //wait till report was seen by sentinel
+          return browser
+            .wait(() => element(by.cssContainingText('#reports-content .item-summary .sender .name', CAROL.name)).isPresent(), 10000)
+            .then(Promise.resolve)
+            .catch(loadReport);
+        })
+        .then(() => {
+          //LHS
+          expect(element(by.css('#reports-list .unfiltered li .content .heading h4 span')).getText()).toBe('Unknown subject');
+          expect(element(by.css('#reports-list .unfiltered li .summary')).getText()).toBe('REF_REF');
+          //shows submitter lineage breadcrumbs
+          testListLineage(['Bob Place', 'Health Center', 'District']);
+
+          //RHS
+          expect(element(by.css('#reports-content .item-summary .subject .name')).getText()).toBe('Unknown subject');
+          expect(element(by.css('#reports-content .item-summary .subject + div')).getText()).toBe('REF_REF');
+          testSummaryLineage(['Bob Place', 'Health Center', 'District']);
+          expect(element(by.css('#reports-content .item-summary .sender .name')).getText()).toBe(CAROL.name);
+          expect(element(by.css('#reports-content .item-summary .sender .phone')).getText()).toBe(CAROL.phone);
+        });
     });
 
     it('Concerning reports using patient name', () => {
-      runTest(NAM_NAM_V);
+      return saveReport(NAM_NAM_V)
+        .then(loadReport)
+        .then(() => {
+          //wait till report was seen by sentinel
+          return browser
+            .wait(() => element(by.cssContainingText('#reports-content .item-summary .sender .name', CAROL.name)).isPresent(), 10000)
+            .then(Promise.resolve)
+            .catch(loadReport);
+        })
+        .then(() => {
+          //LHS
+          expect(element(by.css('#reports-list .unfiltered li .content .heading h4 span')).getText()).toBe(GEORGE.name);
+          expect(element(by.css('#reports-list .unfiltered li .summary')).getText()).toBe('NAM_NAM');
+          //shows submitter lineage breadcrumbs
+          testListLineage(['Bob Place', 'Health Center', 'District']);
+
+          //RHS
+          expect(element(by.css('#reports-content .item-summary .subject .name')).getText()).toBe(GEORGE.name);
+          expect(element(by.css('#reports-content .item-summary .subject + div')).getText()).toBe('NAM_NAM');
+          testSummaryLineage(['Bob Place', 'Health Center', 'District']);
+          expect(element(by.css('#reports-content .item-summary .sender .name')).getText()).toBe(CAROL.name);
+          expect(element(by.css('#reports-content .item-summary .sender .phone')).getText()).toBe(CAROL.phone);
+        });
     });
 
     it('Concerning reports using missing required patient name', () => {
-      runTest(NAM_NAM_I);
+      return saveReport(NAM_NAM_I)
+        .then(loadReport)
+        .then(() => {
+          //wait till report was seen by sentinel
+          return browser
+            .wait(() => element(by.cssContainingText('#reports-content .item-summary .sender .name', CAROL.name)).isPresent(), 10000)
+            .then(Promise.resolve)
+            .catch(loadReport);
+        })
+        .then(() => {
+          //LHS
+          expect(element(by.css('#reports-list .unfiltered li .content .heading h4 span')).getText()).toBe('Unknown subject');
+          expect(element(by.css('#reports-list .unfiltered li .summary')).getText()).toBe('NAM_NAM');
+          //shows subject lineage breadcrumbs
+          testListLineage(['Bob Place', 'Health Center', 'District']);
+
+          //RHS
+          expect(element(by.css('#reports-content .item-summary .subject .name')).getText()).toBe('Unknown subject');
+          expect(element(by.css('#reports-content .item-summary .subject + div')).getText()).toBe('NAM_NAM');
+          testSummaryLineage(['Bob Place', 'Health Center', 'District']);
+          expect(element(by.css('#reports-content .item-summary .sender .name')).getText()).toBe(CAROL.name);
+          expect(element(by.css('#reports-content .item-summary .sender .phone')).getText()).toBe(CAROL.phone);
+        });
     });
 
     it('Concerning reports using place_id', () => {
-      runTest(PREF_PREF_V);
+      return saveReport(PREF_PREF_V)
+        .then(loadReport)
+        .then(() => {
+          //wait till report was seen by sentinel
+          return browser
+            .wait(() => element(by.cssContainingText('#reports-content .item-summary .sender .name', CAROL.name)).isPresent(), 10000)
+            .then(Promise.resolve)
+            .catch(loadReport);
+        })
+        .then(() => {
+          //LHS
+          expect(element(by.css('#reports-list .unfiltered li .content .heading h4 span')).getText()).toBe(TAG_PLACE.name);
+          expect(element(by.css('#reports-list .unfiltered li .summary')).getText()).toBe('PID_PID');
+          //shows subject lineage breadcrumbs
+          testListLineage(['Health Center', 'District']);
+
+          //RHS
+          expect(element(by.css('#reports-content .item-summary .subject .name')).getText()).toBe(TAG_PLACE.name);
+          expect(element(by.css('#reports-content .item-summary .subject + div')).getText()).toBe('PID_PID');
+          testSummaryLineage(['Health Center', 'District']);
+          expect(element(by.css('#reports-content .item-summary .sender .name')).getText()).toBe(CAROL.name);
+          expect(element(by.css('#reports-content .item-summary .sender .phone')).getText()).toBe(CAROL.phone);
+        });
     });
 
     it('Concerning reports using unknown place_id', () => {
-      runTest(PREF_PREF_I);
+      return saveReport(PREF_PREF_I)
+        .then(loadReport)
+        .then(() => {
+          //wait till report was seen by sentinel
+          return browser
+            .wait(() => element(by.cssContainingText('#reports-content .item-summary .sender .name', CAROL.name)).isPresent(), 10000)
+            .then(Promise.resolve)
+            .catch(loadReport);
+        })
+        .then(() => {
+          //LHS
+          expect(element(by.css('#reports-list .unfiltered li .content .heading h4 span')).getText()).toBe('Unknown subject');
+          expect(element(by.css('#reports-list .unfiltered li .summary')).getText()).toBe('PID_PID');
+          //shows submitter lineage breadcrumbs
+          testListLineage(['Bob Place', 'Health Center', 'District']);
+
+          //RHS
+          expect(element(by.css('#reports-content .item-summary .subject .name')).getText()).toBe('Unknown subject');
+          expect(element(by.css('#reports-content .item-summary .subject + div')).getText()).toBe('PID_PID');
+          testSummaryLineage(['Bob Place', 'Health Center', 'District']);
+          expect(element(by.css('#reports-content .item-summary .sender .name')).getText()).toBe(CAROL.name);
+          expect(element(by.css('#reports-content .item-summary .sender .phone')).getText()).toBe(CAROL.phone);
+        });
     });
   });
 });

--- a/tests/protractor/e2e/reports-subject.js
+++ b/tests/protractor/e2e/reports-subject.js
@@ -324,17 +324,13 @@ describe('Reports Summary', () => {
 
   const testListLineage = (expected) => {
     expected.forEach((parent, key) => {
-      element(by.css('#reports-list .unfiltered li .detail .lineage li:nth-child('+ (key + 1) +')'))
-        .getText()
-        .then(text => expect(text).toBe(parent));
+      expect(element(by.css('#reports-list .unfiltered li .detail .lineage li:nth-child('+ (key + 1) +')')).getText()).toBe(parent);
     });
   };
 
   const testSummaryLineage = (expected) => {
     expected.forEach((parent, key) => {
-      element(by.css('#reports-content .item-summary .position .lineage li:nth-child('+ (key + 1) +')'))
-        .getText()
-        .then(text => expect(text).toBe(parent));
+      expect(element(by.css('#reports-content .item-summary .position .lineage li:nth-child('+ (key + 1) +')')).getText()).toBe(parent);
     });
   };
 

--- a/tests/protractor/e2e/reports-subject.js
+++ b/tests/protractor/e2e/reports-subject.js
@@ -1,0 +1,508 @@
+const utils = require('../utils'),
+      commonElements = require('../page-objects/common/common.po.js'),
+      helper = require('../helper'),
+      moment = require('moment');
+
+describe('Reports Summary', () => {
+
+  'use strict';
+
+  const PHONE = '+64271234567';
+
+  // contacts
+  const DISTRICT = {
+    _id: 'district',
+    type: 'district_hospital',
+    parent: '',
+    name: 'District'
+  };
+
+  const HEALTH_CENTER = {
+    _id: 'health-center',
+    type: 'health_center',
+    name: 'Health Center',
+    parent: { _id: DISTRICT._id }
+  };
+
+  const BOB_PLACE = {
+    _id: 'bob-contact',
+    reported_date: 1,
+    type: 'clinic',
+    name: 'Bob Place',
+    parent: { _id: HEALTH_CENTER._id, parent: { _id: DISTRICT._id } }
+  };
+
+  const TAG_PLACE = {
+    _id: 'tag-contact',
+    reported_date: 1,
+    type: 'clinic',
+    name: 'TAG Place',
+    parent: { _id: HEALTH_CENTER._id, parent: { _id: DISTRICT._id } }
+  };
+
+  const CAROL = {
+    _id: 'carol-contact',
+    reported_date: 1,
+    type: 'person',
+    phone: PHONE,
+    name: 'Carol Carolina',
+    parent: { _id: BOB_PLACE._id, parent: { _id: HEALTH_CENTER._id, parent: { _id: DISTRICT._id } } },
+    patient_id: '05946',
+    sex: 'f',
+    date_of_birth: 1462333250374
+  };
+
+  const MARIA = {
+    _id: 'maria-patient',
+    reported_date: 1,
+    type: 'person',
+    name: 'Maria Pecan',
+    parent: { _id: TAG_PLACE._id, parent: { _id: HEALTH_CENTER._id, parent: { _id: DISTRICT._id } } },
+    patient_id: '123456',
+    sex: 'f',
+    date_of_birth: 1462333250374
+  };
+
+  const GEORGE = {
+    name: 'George'
+  };
+
+  const CONTACTS = [DISTRICT, HEALTH_CENTER, BOB_PLACE, TAG_PLACE, CAROL, MARIA];
+  const CONFIG = {
+    transitions: {
+      accept_patient_reports: {
+        load: './transitions/accept_patient_reports.js'
+      },
+      conditional_alerts: {
+        load: './transitions/conditional_alerts.js'
+      },
+      default_responses: {
+        load: './transitions/default_responses.js'
+      },
+      update_sent_by: {
+        load: './transitions/update_sent_by.js'
+      },
+      registration: {
+        load: './transitions/registration.js'
+      },
+      update_clinics: {
+        load: './transitions/update_clinics.js'
+      },
+      update_notifications: {
+        load: './transitions/update_notifications.js'
+      },
+      update_scheduled_reports: {
+        load: './transitions/update_scheduled_reports.js'
+      },
+      update_sent_forms: {
+        load: './transitions/update_sent_forms.js'
+      }
+    },
+    forms: {
+      R: {
+        meta: {
+          code: 'RR',
+          label: {
+            en: 'REF_REF'
+          }
+        },
+        fields: {
+          patient_id: {
+            labels: {
+              tiny: {
+                en: 'R'
+              },
+              description: {
+                en: 'Patient ID'
+              },
+              short: {
+                en: 'ID'
+              }
+            },
+            position: 0,
+            type: 'string',
+            length: [1, 30],
+            required: true
+          },
+        },
+        public_form: true,
+        use_sentinel: true
+      },
+      N: {
+        meta: {
+          code: 'NN',
+          label: {
+            en: 'NAM_NAM'
+          }
+        },
+        fields: {
+          patient_name: {
+            labels: {
+              tiny: {
+                en: 'N'
+              },
+              description: {
+                en: 'Patient name'
+              },
+              short: {
+                en: 'Name'
+              }
+            },
+            position: 0,
+            type: 'string',
+            length: [1, 30],
+            required: true
+          },
+        },
+        public_form: true,
+        use_sentinel: true
+      },
+      P: {
+        meta: {
+          code: 'P',
+          label: {
+            en: 'PID_PID'
+          }
+        },
+        fields: {
+          place_id: {
+            labels: {
+              tiny: {
+                en: 'P'
+              },
+              description: {
+                en: 'Place ID'
+              },
+              short: {
+                en: 'Place'
+              }
+            },
+            position: 0,
+            type: 'string',
+            length: [1, 30],
+            required: true
+          },
+        },
+        public_form: true,
+        use_sentinel: true
+      }
+    },
+    registrations: []
+  };
+
+  const REF_REF_V1 = {
+    _id: 'REF_REF_V1',
+    form: 'RR',
+    type: 'data_record',
+    from: PHONE,
+    fields: {
+      patient_id: MARIA.patient_id
+    },
+    sms_message: {
+      message_id: 23,
+      from: PHONE,
+      message: `1!RR!${MARIA.patient_id}`,
+      form: 'RR',
+      locale: 'en'
+    },
+    reported_date: moment().subtract(10, 'minutes').valueOf()
+  };
+
+  const REF_REF_V2 = {
+    _id: 'REF_REF_V2',
+    form: 'RR',
+    type: 'data_record',
+    from: PHONE,
+    fields: {
+      patient_id: MARIA._id
+    },
+    sms_message: {
+      message_id: 23,
+      from: PHONE,
+      message: `1!RR!${MARIA._id}`,
+      form: 'RR',
+      locale: 'en'
+    },
+    reported_date: moment().subtract(20, 'minutes').valueOf()
+  };
+
+  const REF_REF_I = {
+    _id: 'REF_REF_I',
+    form: 'RR',
+    type: 'data_record',
+    from: PHONE,
+    fields: {
+      patient_id: '111111'
+    },
+    sms_message: {
+      message_id: 23,
+      from: PHONE,
+      message: `1!RR!${MARIA.patient_id}`,
+      form: 'RR',
+      locale: 'en'
+    },
+    reported_date: moment().subtract(30, 'minutes').valueOf()
+  };
+
+  const NAM_NAM_V = {
+    _id: 'NAM_NAM_V',
+    form: 'NN',
+    type: 'data_record',
+    from: PHONE,
+    fields: {
+      patient_name: GEORGE.name
+    },
+    sms_message: {
+      message_id: 23,
+      from: PHONE,
+      message: `1!NN!${GEORGE.name}`,
+      form: 'NN',
+      locale: 'en'
+    },
+    reported_date: moment().subtract(40, 'minutes').valueOf()
+  };
+
+  const NAM_NAM_I = {
+    _id: 'NAM_NAM_I',
+    form: 'NN',
+    type: 'data_record',
+    from: PHONE,
+    errors: [
+      {
+        fields: 'patient_name',
+        code: 'sys.missing_fields'
+      }
+    ],
+    fields: {
+      patient_name: ''
+    },
+    sms_message: {
+      message_id: 23,
+      from: PHONE,
+      message: `1!RR!${MARIA._id}`,
+      form: 'NN',
+      locale: 'en'
+    },
+    reported_date: moment().subtract(50, 'minutes').valueOf()
+  };
+
+  const PREF_PREF_V = {
+    _id: 'PREF_PREF_V',
+    form: 'P',
+    type: 'data_record',
+    from: PHONE,
+    fields: {
+      place_id: TAG_PLACE._id
+    },
+    sms_message: {
+      message_id: 23,
+      from: PHONE,
+      message: `1!P!${TAG_PLACE._id}`,
+      form: 'RR',
+      locale: 'en'
+    },
+    reported_date: moment().subtract(60, 'minutes').valueOf()
+  };
+
+  const PREF_PREF_I = {
+    _id: 'PREF_PREF_I',
+    form: 'P',
+    type: 'data_record',
+    from: PHONE,
+    fields: {
+      place_id: '12'
+    },
+    sms_message: {
+      message_id: 23,
+      from: PHONE,
+      message: `1!P!12`,
+      form: 'RR',
+      locale: 'en'
+    },
+    reported_date: moment().subtract(2, 'hours').valueOf()
+  };
+
+  const REPORTS = [
+    REF_REF_V1,
+    REF_REF_V2,
+    REF_REF_I,
+    NAM_NAM_V,
+    NAM_NAM_I,
+    PREF_PREF_V,
+    PREF_PREF_I
+  ];
+
+  const getListElement = (report) => {
+    return element(by.css('#reports-list .unfiltered li[data-record-id="'+ report._id +'"]'));
+  };
+
+  const compareLineage = (lineageListElement, expectedLineage, links) => {
+    let element = 'li';
+    if (links) {
+      element = 'a';
+    }
+    lineageListElement.all(by.css(element)).each((item, key) => {
+      expect(item.getText()).toBe(expectedLineage[key]);
+    });
+  };
+
+  const checkItemListSummary = (report) => {
+    const listElement = getListElement(report);
+
+    switch (report._id) {
+      case REF_REF_V1._id:
+      case REF_REF_V2._id:
+        expect(listElement.element(by.css('.content .heading h4 span')).getText()).toBe(MARIA.name);
+        expect(listElement.element(by.css('.content .summary p')).getText()).toBe('REF_REF');
+        //shows subject lineage breadcrumbs
+        compareLineage(listElement.element(by.css('.content .detail ol.lineage')), ['TAG Place', 'Health Center', 'District']);
+        break;
+      case REF_REF_I._id:
+        expect(listElement.element(by.css('.content .heading h4 span')).getText()).toBe('Unknown subject');
+        expect(listElement.element(by.css('.content .summary p')).getText()).toBe('REF_REF');
+        //shows submitter lineage breadcrumbs
+        compareLineage(listElement.element(by.css('.content .detail ol.lineage')), ['Bob Place', 'Health Center', 'District']);
+        break;
+      case NAM_NAM_V._id:
+        expect(listElement.element(by.css('.content .heading h4 span')).getText()).toBe(GEORGE.name);
+        expect(listElement.element(by.css('.content .summary p')).getText()).toBe('NAM_NAM');
+        //shows submitter lineage breadcrumbs
+        compareLineage(listElement.element(by.css('.content .detail ol.lineage')), ['Bob Place', 'Health Center', 'District']);
+        break;
+      case NAM_NAM_I._id:
+        expect(listElement.element(by.css('.content .heading h4 span')).getText()).toBe('Unknown subject');
+        expect(listElement.element(by.css('.content .summary p')).getText()).toBe('NAM_NAM');
+        //shows submitter lineage breadcrumbs
+        compareLineage(listElement.element(by.css('.content .detail ol.lineage')), ['Bob Place', 'Health Center', 'District']);
+        break;
+      case PREF_PREF_V._id:
+        expect(listElement.element(by.css('.content .heading h4 span')).getText()).toBe(TAG_PLACE.name);
+        expect(listElement.element(by.css('.content .summary p')).getText()).toBe('PID_PID');
+        //shows subject lineage breadcrumbs
+        compareLineage(listElement.element(by.css('.content .detail ol.lineage')), ['Health Center', 'District']);
+        break;
+      case PREF_PREF_I._id:
+        expect(listElement.element(by.css('.content .heading h4 span')).getText()).toBe('Unknown subject');
+        expect(listElement.element(by.css('.content .summary p')).getText()).toBe('PID_PID');
+        //shows submitter lineage breadcrumbs
+        compareLineage(listElement.element(by.css('.content .detail ol.lineage')), ['Bob Place', 'Health Center', 'District']);
+        break;
+    }
+  };
+
+  const checkItemContentSummary = (report) => {
+    const summaryElement = element(by.css('#reports-content .item-summary'));
+    browser.wait(() => summaryElement.isPresent(), 10000);
+
+    switch (report._id) {
+      case REF_REF_V1._id:
+      case REF_REF_V2._id:
+        expect(summaryElement.element(by.css('.subject .name')).getText()).toBe(MARIA.name);
+        expect(summaryElement.element(by.css('.subject + div')).getText()).toBe('REF_REF');
+
+        compareLineage(summaryElement.element(by.css('.position .lineage')), ['TAG Place', 'Health Center', 'District'], true);
+
+        browser.wait(() => element(by.cssContainingText('#reports-content .item-summary .name', CAROL.name)).isPresent(), 10000);
+        expect(summaryElement.element(by.css('.sender .name')).getText()).toBe(CAROL.name);
+        expect(summaryElement.element(by.css('.sender .phone')).getText()).toBe(CAROL.phone);
+        break;
+      case REF_REF_I._id:
+        expect(summaryElement.element(by.css('.subject .name')).getText()).toBe('Unknown subject');
+        expect(summaryElement.element(by.css('.subject + div')).getText()).toBe('REF_REF');
+
+        browser.wait(() => element(by.cssContainingText('#reports-content .item-summary .name', CAROL.name)).isPresent(), 10000);
+        compareLineage(summaryElement.element(by.css('.position .lineage')), ['Bob Place', 'Health Center', 'District'], true);
+        expect(summaryElement.element(by.css('.sender .name')).getText()).toBe(CAROL.name);
+        expect(summaryElement.element(by.css('.sender .phone')).getText()).toBe(CAROL.phone);
+        break;
+      case NAM_NAM_V._id:
+        expect(summaryElement.element(by.css('.subject .name')).getText()).toBe(GEORGE.name);
+        expect(summaryElement.element(by.css('.subject + div')).getText()).toBe('NAM_NAM');
+
+        browser.wait(() => element(by.cssContainingText('#reports-content .item-summary .name', CAROL.name)).isPresent(), 10000);
+        compareLineage(summaryElement.element(by.css('.position .lineage')), ['Bob Place', 'Health Center', 'District'], true);
+        expect(summaryElement.element(by.css('.sender .name')).getText()).toBe(CAROL.name);
+        expect(summaryElement.element(by.css('.sender .phone')).getText()).toBe(CAROL.phone);
+        break;
+      case NAM_NAM_I._id:
+        expect(summaryElement.element(by.css('.subject .name')).getText()).toBe('Unknown subject');
+        expect(summaryElement.element(by.css('.subject + div')).getText()).toBe('NAM_NAM');
+
+        browser.wait(() => element(by.cssContainingText('#reports-content .item-summary .name', CAROL.name)).isPresent(), 10000);
+        compareLineage(summaryElement.element(by.css('.position .lineage')), ['Bob Place', 'Health Center', 'District'], true);
+        expect(summaryElement.element(by.css('.sender .name')).getText()).toBe(CAROL.name);
+        expect(summaryElement.element(by.css('.sender .phone')).getText()).toBe(CAROL.phone);
+        break;
+      case PREF_PREF_V._id:
+        expect(summaryElement.element(by.css('.subject .name')).getText()).toBe(TAG_PLACE.name);
+        expect(summaryElement.element(by.css('.subject + div')).getText()).toBe('PID_PID');
+
+        compareLineage(summaryElement.element(by.css('.position .lineage')), ['Health Center', 'District'], true);
+
+        browser.wait(() => element(by.cssContainingText('#reports-content .item-summary .name', CAROL.name)).isPresent(), 10000);
+        expect(summaryElement.element(by.css('.sender .name')).getText()).toBe(CAROL.name);
+        expect(summaryElement.element(by.css('.sender .phone')).getText()).toBe(CAROL.phone);
+        break;
+      case PREF_PREF_I._id:
+        expect(summaryElement.element(by.css('.subject .name')).getText()).toBe('Unknown subject');
+        expect(summaryElement.element(by.css('.subject + div')).getText()).toBe('PID_PID');
+
+        browser.wait(() => element(by.cssContainingText('#reports-content .item-summary .name', CAROL.name)).isPresent(), 10000);
+        compareLineage(summaryElement.element(by.css('.position .lineage')), ['Bob Place', 'Health Center', 'District'], true);
+        expect(summaryElement.element(by.css('.sender .name')).getText()).toBe(CAROL.name);
+        expect(summaryElement.element(by.css('.sender .phone')).getText()).toBe(CAROL.phone);
+        break;
+    }
+  };
+
+  const runTest = (report) => {
+    commonElements.goToReports();
+
+    helper.waitElementToBeClickable(element(by.css('.action-container .general-actions:not(.ng-hide) .fa-plus')));
+    helper.waitElementToBeClickable(getListElement(report).element(by.css('.summary')));
+
+    helper.clickElement(getListElement(report).element(by.css('.summary')));
+    checkItemListSummary(report);
+    checkItemContentSummary(report);
+  };
+
+  beforeAll(done => {
+    utils.updateSettings(CONFIG)
+      .then(() => protractor.promise.all(CONTACTS.map(utils.saveDoc)))
+      .then(() => protractor.promise.all(REPORTS.map(utils.saveDoc)))
+      .then(done)
+      .catch(done.fail);
+  });
+
+  afterAll(utils.afterEach);
+
+  describe('Displays correct LHS and RHS summary', () => {
+    it('Concerning reports using patient_id', () => {
+      runTest(REF_REF_V1);
+    });
+
+    it('Concerning reports using doc id', () => {
+      runTest(REF_REF_V2);
+    });
+
+    it('Concerning reports with unknown patient_id', () => {
+      runTest(REF_REF_I);
+    });
+
+    it('Concerning reports using patient name', () => {
+      runTest(NAM_NAM_V);
+    });
+
+    it('Concerning reports using missing required patient name', () => {
+      runTest(NAM_NAM_I);
+    });
+
+    it('Concerning reports using place_id', () => {
+      runTest(PREF_PREF_V);
+    });
+
+    it('Concerning reports using unknown place_id', () => {
+      runTest(PREF_PREF_I);
+    });
+  });
+});

--- a/tests/protractor/e2e/reports-subject.js
+++ b/tests/protractor/e2e/reports-subject.js
@@ -349,11 +349,22 @@ describe('Reports Summary', () => {
     return Promise.resolve();
   };
 
+  const waitForSentinel = () => {
+    // wait till report was seen by sentinel
+    // Sometimes, sentinel processes the report after the report is set as selected, but before the report-content
+    // controller change feed listener is set up. Result is that the report-content is never updated with the new data
+    // To counter this, we reload the page after we wait for the change for the first time.
+    return browser
+      .wait(() => element(by.cssContainingText('#reports-content .item-summary .sender .name', CAROL.name)).isPresent(), 10000)
+      .then(Promise.resolve)
+      .catch(loadReport);
+  };
+
   beforeAll(done => {
     utils.updateSettings(CONFIG)
       .then(() => protractor.promise.all(CONTACTS.map(utils.saveDoc)))
       .then(() => {
-        //wait till change feed sends all the contacts we created
+        //wait till change feed receives all the contacts we created
         setTimeout(done, 10000);
       })
       .catch(done.fail);
@@ -371,13 +382,7 @@ describe('Reports Summary', () => {
     it('Concerning reports using patient_id', () => {
       return saveReport(REF_REF_V1)
         .then(loadReport)
-        .then(() => {
-          //wait till report was seen by sentinel
-          return browser
-            .wait(() => element(by.cssContainingText('#reports-content .item-summary .sender .name', CAROL.name)).isPresent(), 10000)
-            .then(Promise.resolve)
-            .catch(loadReport);
-        })
+        .then(waitForSentinel)
         .then(() => {
           //LHS
           expect(element(by.css('#reports-list .unfiltered li .content .heading h4 span')).getText()).toBe(MARIA.name);
@@ -397,13 +402,7 @@ describe('Reports Summary', () => {
     it('Concerning reports using doc id', () => {
       return saveReport(REF_REF_V2)
         .then(loadReport)
-        .then(() => {
-          //wait till report was seen by sentinel
-          return browser
-            .wait(() => element(by.cssContainingText('#reports-content .item-summary .sender .name', CAROL.name)).isPresent(), 10000)
-            .then(Promise.resolve)
-            .catch(loadReport);
-        })
+        .then(waitForSentinel)
         .then(() => {
           //LHS
           expect(element(by.css('#reports-list .unfiltered li .content .heading h4 span')).getText()).toBe(MARIA.name);
@@ -424,13 +423,7 @@ describe('Reports Summary', () => {
     it('Concerning reports with unknown patient_id', () => {
       return saveReport(REF_REF_I)
         .then(loadReport)
-        .then(() => {
-          //wait till report was seen by sentinel
-          return browser
-            .wait(() => element(by.cssContainingText('#reports-content .item-summary .sender .name', CAROL.name)).isPresent(), 10000)
-            .then(Promise.resolve)
-            .catch(loadReport);
-        })
+        .then(waitForSentinel)
         .then(() => {
           //LHS
           expect(element(by.css('#reports-list .unfiltered li .content .heading h4 span')).getText()).toBe('Unknown subject');
@@ -450,13 +443,7 @@ describe('Reports Summary', () => {
     it('Concerning reports using patient name', () => {
       return saveReport(NAM_NAM_V)
         .then(loadReport)
-        .then(() => {
-          //wait till report was seen by sentinel
-          return browser
-            .wait(() => element(by.cssContainingText('#reports-content .item-summary .sender .name', CAROL.name)).isPresent(), 10000)
-            .then(Promise.resolve)
-            .catch(loadReport);
-        })
+        .then(waitForSentinel)
         .then(() => {
           //LHS
           expect(element(by.css('#reports-list .unfiltered li .content .heading h4 span')).getText()).toBe(GEORGE.name);
@@ -476,13 +463,7 @@ describe('Reports Summary', () => {
     it('Concerning reports using missing required patient name', () => {
       return saveReport(NAM_NAM_I)
         .then(loadReport)
-        .then(() => {
-          //wait till report was seen by sentinel
-          return browser
-            .wait(() => element(by.cssContainingText('#reports-content .item-summary .sender .name', CAROL.name)).isPresent(), 10000)
-            .then(Promise.resolve)
-            .catch(loadReport);
-        })
+        .then(waitForSentinel)
         .then(() => {
           //LHS
           expect(element(by.css('#reports-list .unfiltered li .content .heading h4 span')).getText()).toBe('Unknown subject');
@@ -502,13 +483,7 @@ describe('Reports Summary', () => {
     it('Concerning reports using place_id', () => {
       return saveReport(PREF_PREF_V)
         .then(loadReport)
-        .then(() => {
-          //wait till report was seen by sentinel
-          return browser
-            .wait(() => element(by.cssContainingText('#reports-content .item-summary .sender .name', CAROL.name)).isPresent(), 10000)
-            .then(Promise.resolve)
-            .catch(loadReport);
-        })
+        .then(waitForSentinel)
         .then(() => {
           //LHS
           expect(element(by.css('#reports-list .unfiltered li .content .heading h4 span')).getText()).toBe(TAG_PLACE.name);
@@ -528,13 +503,7 @@ describe('Reports Summary', () => {
     it('Concerning reports using unknown place_id', () => {
       return saveReport(PREF_PREF_I)
         .then(loadReport)
-        .then(() => {
-          //wait till report was seen by sentinel
-          return browser
-            .wait(() => element(by.cssContainingText('#reports-content .item-summary .sender .name', CAROL.name)).isPresent(), 10000)
-            .then(Promise.resolve)
-            .catch(loadReport);
-        })
+        .then(waitForSentinel)
         .then(() => {
           //LHS
           expect(element(by.css('#reports-list .unfiltered li .content .heading h4 span')).getText()).toBe('Unknown subject');

--- a/tests/protractor/e2e/reports-subject.js
+++ b/tests/protractor/e2e/reports-subject.js
@@ -336,56 +336,56 @@ describe('Reports Summary', () => {
     return element(by.css('#reports-list .unfiltered li[data-record-id="'+ report._id +'"]'));
   };
 
-  const compareLineage = (lineageListElement, expectedLineage, links) => {
-    let element = 'li';
+  const compareLineage = (report, expectedLineage, links) => {
     if (links) {
-      element = 'a';
+      expectedLineage.forEach((parent, key) => {
+        expect(element(by.css('#reports-content .item-summary .position .lineage')).all(by.css('a')).get(key).getText()).toBe(parent);
+      });
+    } else {
+      expectedLineage.forEach((parent, key) => {
+        expect(getListElement(report).all(by.css('li')).get(key).getText()).toBe(parent);
+      });
     }
-    lineageListElement.all(by.css(element)).each((item, key) => {
-      expect(item.getText()).toBe(expectedLineage[key]);
-    });
   };
 
   const checkItemListSummary = (report) => {
-    const listElement = getListElement(report);
-
     switch (report._id) {
       case REF_REF_V1._id:
       case REF_REF_V2._id:
-        expect(listElement.element(by.css('.content .heading h4 span')).getText()).toBe(MARIA.name);
-        expect(listElement.element(by.css('.content .summary p')).getText()).toBe('REF_REF');
+        expect(getListElement(report).element(by.css('.content .heading h4 span')).getText()).toBe(MARIA.name);
+        expect(getListElement(report).element(by.css('.content .summary p')).getText()).toBe('REF_REF');
         //shows subject lineage breadcrumbs
-        compareLineage(listElement.element(by.css('.content .detail ol.lineage')), ['TAG Place', 'Health Center', 'District']);
+        compareLineage(report, ['TAG Place', 'Health Center', 'District']);
         break;
       case REF_REF_I._id:
-        expect(listElement.element(by.css('.content .heading h4 span')).getText()).toBe('Unknown subject');
-        expect(listElement.element(by.css('.content .summary p')).getText()).toBe('REF_REF');
+        expect(getListElement(report).element(by.css('.content .heading h4 span')).getText()).toBe('Unknown subject');
+        expect(getListElement(report).element(by.css('.content .summary p')).getText()).toBe('REF_REF');
         //shows submitter lineage breadcrumbs
-        compareLineage(listElement.element(by.css('.content .detail ol.lineage')), ['Bob Place', 'Health Center', 'District']);
+        compareLineage(report, ['Bob Place', 'Health Center', 'District']);
         break;
       case NAM_NAM_V._id:
-        expect(listElement.element(by.css('.content .heading h4 span')).getText()).toBe(GEORGE.name);
-        expect(listElement.element(by.css('.content .summary p')).getText()).toBe('NAM_NAM');
+        expect(getListElement(report).element(by.css('.content .heading h4 span')).getText()).toBe(GEORGE.name);
+        expect(getListElement(report).element(by.css('.content .summary p')).getText()).toBe('NAM_NAM');
         //shows submitter lineage breadcrumbs
-        compareLineage(listElement.element(by.css('.content .detail ol.lineage')), ['Bob Place', 'Health Center', 'District']);
+        compareLineage(report, ['Bob Place', 'Health Center', 'District']);
         break;
       case NAM_NAM_I._id:
-        expect(listElement.element(by.css('.content .heading h4 span')).getText()).toBe('Unknown subject');
-        expect(listElement.element(by.css('.content .summary p')).getText()).toBe('NAM_NAM');
+        expect(getListElement(report).element(by.css('.content .heading h4 span')).getText()).toBe('Unknown subject');
+        expect(getListElement(report).element(by.css('.content .summary p')).getText()).toBe('NAM_NAM');
         //shows submitter lineage breadcrumbs
-        compareLineage(listElement.element(by.css('.content .detail ol.lineage')), ['Bob Place', 'Health Center', 'District']);
+        compareLineage(report, ['Bob Place', 'Health Center', 'District']);
         break;
       case PREF_PREF_V._id:
-        expect(listElement.element(by.css('.content .heading h4 span')).getText()).toBe(TAG_PLACE.name);
-        expect(listElement.element(by.css('.content .summary p')).getText()).toBe('PID_PID');
+        expect(getListElement(report).element(by.css('.content .heading h4 span')).getText()).toBe(TAG_PLACE.name);
+        expect(getListElement(report).element(by.css('.content .summary p')).getText()).toBe('PID_PID');
         //shows subject lineage breadcrumbs
-        compareLineage(listElement.element(by.css('.content .detail ol.lineage')), ['Health Center', 'District']);
+        compareLineage(report, ['Health Center', 'District']);
         break;
       case PREF_PREF_I._id:
-        expect(listElement.element(by.css('.content .heading h4 span')).getText()).toBe('Unknown subject');
-        expect(listElement.element(by.css('.content .summary p')).getText()).toBe('PID_PID');
+        expect(getListElement(report).element(by.css('.content .heading h4 span')).getText()).toBe('Unknown subject');
+        expect(getListElement(report).element(by.css('.content .summary p')).getText()).toBe('PID_PID');
         //shows submitter lineage breadcrumbs
-        compareLineage(listElement.element(by.css('.content .detail ol.lineage')), ['Bob Place', 'Health Center', 'District']);
+        compareLineage(report, ['Bob Place', 'Health Center', 'District']);
         break;
     }
   };
@@ -400,9 +400,9 @@ describe('Reports Summary', () => {
         expect(summaryElement.element(by.css('.subject .name')).getText()).toBe(MARIA.name);
         expect(summaryElement.element(by.css('.subject + div')).getText()).toBe('REF_REF');
 
-        compareLineage(summaryElement.element(by.css('.position .lineage')), ['TAG Place', 'Health Center', 'District'], true);
+        compareLineage(report, ['TAG Place', 'Health Center', 'District'], true);
 
-        browser.wait(() => element(by.cssContainingText('#reports-content .item-summary .name', CAROL.name)).isPresent(), 10000);
+        browser.wait(() => element(by.cssContainingText('#reports-content .item-summary .name', CAROL.name)).isPresent(), 20000);
         expect(summaryElement.element(by.css('.sender .name')).getText()).toBe(CAROL.name);
         expect(summaryElement.element(by.css('.sender .phone')).getText()).toBe(CAROL.phone);
         break;
@@ -410,8 +410,8 @@ describe('Reports Summary', () => {
         expect(summaryElement.element(by.css('.subject .name')).getText()).toBe('Unknown subject');
         expect(summaryElement.element(by.css('.subject + div')).getText()).toBe('REF_REF');
 
-        browser.wait(() => element(by.cssContainingText('#reports-content .item-summary .name', CAROL.name)).isPresent(), 10000);
-        compareLineage(summaryElement.element(by.css('.position .lineage')), ['Bob Place', 'Health Center', 'District'], true);
+        browser.wait(() => element(by.cssContainingText('#reports-content .item-summary .name', CAROL.name)).isPresent(), 20000);
+        compareLineage(report, ['Bob Place', 'Health Center', 'District'], true);
         expect(summaryElement.element(by.css('.sender .name')).getText()).toBe(CAROL.name);
         expect(summaryElement.element(by.css('.sender .phone')).getText()).toBe(CAROL.phone);
         break;
@@ -419,8 +419,8 @@ describe('Reports Summary', () => {
         expect(summaryElement.element(by.css('.subject .name')).getText()).toBe(GEORGE.name);
         expect(summaryElement.element(by.css('.subject + div')).getText()).toBe('NAM_NAM');
 
-        browser.wait(() => element(by.cssContainingText('#reports-content .item-summary .name', CAROL.name)).isPresent(), 10000);
-        compareLineage(summaryElement.element(by.css('.position .lineage')), ['Bob Place', 'Health Center', 'District'], true);
+        browser.wait(() => element(by.cssContainingText('#reports-content .item-summary .name', CAROL.name)).isPresent(), 20000);
+        compareLineage(report, ['Bob Place', 'Health Center', 'District'], true);
         expect(summaryElement.element(by.css('.sender .name')).getText()).toBe(CAROL.name);
         expect(summaryElement.element(by.css('.sender .phone')).getText()).toBe(CAROL.phone);
         break;
@@ -428,8 +428,8 @@ describe('Reports Summary', () => {
         expect(summaryElement.element(by.css('.subject .name')).getText()).toBe('Unknown subject');
         expect(summaryElement.element(by.css('.subject + div')).getText()).toBe('NAM_NAM');
 
-        browser.wait(() => element(by.cssContainingText('#reports-content .item-summary .name', CAROL.name)).isPresent(), 10000);
-        compareLineage(summaryElement.element(by.css('.position .lineage')), ['Bob Place', 'Health Center', 'District'], true);
+        browser.wait(() => element(by.cssContainingText('#reports-content .item-summary .name', CAROL.name)).isPresent(), 20000);
+        compareLineage(report, ['Bob Place', 'Health Center', 'District'], true);
         expect(summaryElement.element(by.css('.sender .name')).getText()).toBe(CAROL.name);
         expect(summaryElement.element(by.css('.sender .phone')).getText()).toBe(CAROL.phone);
         break;
@@ -437,9 +437,9 @@ describe('Reports Summary', () => {
         expect(summaryElement.element(by.css('.subject .name')).getText()).toBe(TAG_PLACE.name);
         expect(summaryElement.element(by.css('.subject + div')).getText()).toBe('PID_PID');
 
-        compareLineage(summaryElement.element(by.css('.position .lineage')), ['Health Center', 'District'], true);
+        compareLineage(report, ['Health Center', 'District'], true);
 
-        browser.wait(() => element(by.cssContainingText('#reports-content .item-summary .name', CAROL.name)).isPresent(), 10000);
+        browser.wait(() => element(by.cssContainingText('#reports-content .item-summary .name', CAROL.name)).isPresent(), 20000);
         expect(summaryElement.element(by.css('.sender .name')).getText()).toBe(CAROL.name);
         expect(summaryElement.element(by.css('.sender .phone')).getText()).toBe(CAROL.phone);
         break;
@@ -447,8 +447,8 @@ describe('Reports Summary', () => {
         expect(summaryElement.element(by.css('.subject .name')).getText()).toBe('Unknown subject');
         expect(summaryElement.element(by.css('.subject + div')).getText()).toBe('PID_PID');
 
-        browser.wait(() => element(by.cssContainingText('#reports-content .item-summary .name', CAROL.name)).isPresent(), 10000);
-        compareLineage(summaryElement.element(by.css('.position .lineage')), ['Bob Place', 'Health Center', 'District'], true);
+        browser.wait(() => element(by.cssContainingText('#reports-content .item-summary .name', CAROL.name)).isPresent(), 20000);
+        compareLineage(report, ['Bob Place', 'Health Center', 'District'], true);
         expect(summaryElement.element(by.css('.sender .name')).getText()).toBe(CAROL.name);
         expect(summaryElement.element(by.css('.sender .phone')).getText()).toBe(CAROL.phone);
         break;

--- a/translations/messages-en.properties
+++ b/translations/messages-en.properties
@@ -979,3 +979,4 @@ instance.upgrade.confirm.warning.text = This action cannot be undone, make sure 
 confirm.delete.progress = Deletion in progress
 confirm.delete.totals = {{totalDeleted}}/{{totalSelected}} deleted...
 messages.unknown.sender = Unknown sender
+report.sent.by = Sent by


### PR DESCRIPTION
# Description

Replaces location breadcrumbs in LHS Reports list to describe subject location instead of 
submitter location. I case the subject is not found, displays submitter location as a fallback.
Replaces RHS Report Content to contain:
 - Subject (patient) name
 - Form name
 - Subject location (breadcrumbs) - with fallback to submitter location in case the subject is not found
 - "Sent by {submitter name} {submitter phone}"

medic/medic-webapp#4053

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.