### PR TITLE
Adds error handling for Contact selection

### DIFF
--- a/static/js/controllers/contacts.js
+++ b/static/js/controllers/contacts.js
@@ -225,6 +225,8 @@ var _ = require('underscore'),
           .catch(function(e) {
             $log.error('Error setting selected contact');
             $log.error(e);
+            $scope.selected.error = true;
+            $scope.setRightActionBar();
           });
       };
 

--- a/static/js/services/contact-summary.js
+++ b/static/js/services/contact-summary.js
@@ -60,6 +60,7 @@ angular.module('inboxServices').service('ContactSummary',
     };
 
     return function(contact, reports, lineage) {
+      contact.parent = contact.parent || '';
       return getGeneratorFunction()
         .then(function(fn) {
           return fn(contact, reports || [], lineage || []);

--- a/static/js/services/contact-summary.js
+++ b/static/js/services/contact-summary.js
@@ -60,10 +60,14 @@ angular.module('inboxServices').service('ContactSummary',
     };
 
     return function(contact, reports, lineage) {
-      contact.parent = contact.parent || '';
       return getGeneratorFunction()
         .then(function(fn) {
-          return fn(contact, reports || [], lineage || []);
+          try {
+            return fn(contact, reports || [], lineage || []);
+          } catch (e) {
+            $log.error('Configuration error in contact-summary function: ' + e.message);
+            throw new Error('Configuration error');
+          }
         })
         .then(applyFilters);
     };

--- a/templates/partials/contacts_content.html
+++ b/templates/partials/contacts_content.html
@@ -10,7 +10,11 @@
     <div translate>No contact selected</div>
   </div>
 
-  <div class="col-sm-8 item-content" ng-show="selected && !loadingContent">
+  <div class="col-sm-8 item-content empty-selection" ng-show="selected && selected.error && !loadingContent">
+    <div translate>contact.select.error</div>
+  </div>
+
+  <div class="col-sm-8 item-content" ng-show="selected && !selected.error && !loadingContent">
     <div class="material">
       <div class="body meta">
         <div class="card">

--- a/tests/karma/unit/services/contact-summary.js
+++ b/tests/karma/unit/services/contact-summary.js
@@ -103,16 +103,17 @@ describe('ContactSummary service', () => {
     });
   });
 
-  it('does not crash when contact-summary function references `contact.parent.parent` while `contact.parent` is undefined #4301', () => {
-    const script = `return contact.parent.parent;`;
+  it('does crash when contact summary throws an error', () => {
+    const script = `return contact.some.field;`;
 
     Settings.returns(Promise.resolve({ contact_summary: script }));
     const contact = {};
-    return service(contact).then(actual => {
-      chai.expect(actual.fields).to.be.an('array');
-      chai.expect(actual.fields.length).to.equal(0);
-      chai.expect(actual.cards).to.be.an('array');
-      chai.expect(actual.cards.length).to.equal(0);
-    });
+    return service(contact)
+      .then(function() {
+        throw new Error('Expected error to be thrown');
+      })
+      .catch(function(err) {
+        chai.expect(err.message).to.equal('Configuration error');
+      });
   });
 });

--- a/tests/karma/unit/services/contact-summary.js
+++ b/tests/karma/unit/services/contact-summary.js
@@ -102,4 +102,17 @@ describe('ContactSummary service', () => {
       chai.expect(actual.cards[0].fields).to.equal('beta');
     });
   });
+
+  it('does not crash when contact-summary function references `contact.parent.parent` while `contact.parent` is undefined #4301', () => {
+    const script = `return contact.parent.parent;`;
+
+    Settings.returns(Promise.resolve({ contact_summary: script }));
+    const contact = {};
+    return service(contact).then(actual => {
+      chai.expect(actual.fields).to.be.an('array');
+      chai.expect(actual.fields.length).to.equal(0);
+      chai.expect(actual.cards).to.be.an('array');
+      chai.expect(actual.cards.length).to.equal(0);
+    });
+  });
 });

--- a/translations/messages-en.properties
+++ b/translations/messages-en.properties
@@ -980,3 +980,4 @@ confirm.delete.progress = Deletion in progress
 confirm.delete.totals = {{totalDeleted}}/{{totalSelected}} deleted...
 messages.unknown.sender = Unknown sender
 messages.sent.by = Sent by {{senderName}}
+contact.select.error = Error selecting contact.


### PR DESCRIPTION
# Description

When setting the selected contact fails, displays an error message, clears the right action bar and logs the error instead of displaying an incomplete/incorrect `ContactContent` / action bar. 
Adds error handling for configuration function `contact-summary`.

medic/medic-webapp#4301

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.