### PR TITLE
4325 Reverts raw report content translation key

### DIFF
--- a/templates/partials/reports_content.html
+++ b/templates/partials/reports_content.html
@@ -74,7 +74,7 @@
             </ul>
           </li>
           <li ng-if="selection.formatted.sms_message.message">
-            <label translate>selection.formatted.content.raw</label>
+            <label translate>selection.doc.content.raw</label>
             <p>{{selection.formatted.sms_message.message}}</p>
           </li>
           <li ng-if="selection.formatted.tasks.length">


### PR DESCRIPTION
# Description

The translation key was mistakenly updated from `selection.doc.content.raw` to `selection.formatted.content.raw`, this PR reverts it to its correct value.

medic/medic-webapp#4325

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.