### PR TITLE
Lowercase view request keys

### DIFF
--- a/sentinel/lib/validation.js
+++ b/sentinel/lib/validation.js
@@ -29,16 +29,18 @@ const _executeExistsRequest = (options, callback) => {
     );
 };
 
+const lowerCaseString = obj => typeof obj === 'string' ? obj.toLowerCase() : obj;
+
 const _exists = (doc, fields, options, callback) => {
     options = options || {};
     if (!fields.length) {
         return callback(new Error('No arguments provided to "exists" validation function'));
     }
     const requestOptions = fields.map(field => {
-        return { key: [ `${field}:${doc[field]}` ] };
+        return { key: [ `${field}:${lowerCaseString(doc[field])}` ] };
     });
     if (options.additionalFilter) {
-        requestOptions.push({ key: [ options.additionalFilter ] });
+        requestOptions.push({ key: [ lowerCaseString(options.additionalFilter) ] });
     }
     async.map(requestOptions, _executeExistsRequest, (err, responses) => {
         if (err) {

--- a/sentinel/test/unit/validations.js
+++ b/sentinel/test/unit/validations.js
@@ -183,7 +183,7 @@ exports['fail multiple field unique validation on doc with no errors'] = functio
     var doc = {
         _id: 'same',
         xyz: '444',
-        abc: 'cheese'
+        abc: 'CHeeSE' // value is lowercased as it is in the view map definition
     };
     validation.validate(doc, validations, function(errors) {
         test.equal(view.callCount, 2);
@@ -364,7 +364,7 @@ exports['pass exists validation when matching document'] = function(test) {
         test.deepEqual(view.args[0][2], { key: ['patient_id:444'] });
         test.equal(view.args[1][0], 'medic-client');
         test.equal(view.args[1][1], 'reports_by_freetext');
-        test.deepEqual(view.args[1][2], { key: ['form:REGISTRATION'] });
+        test.deepEqual(view.args[1][2], { key: ['form:registration'] });
         test.deepEqual(errors, []);
         test.done();
     });


### PR DESCRIPTION
# Description

The view map function lowercases the keys it outputs so we need
to lowercase to get the right results.

medic/medic-webapp#651

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.