### PR TITLE
sms api: don't save duplicates; don't error on bad content

### DIFF
--- a/api/controllers/record-utils.js
+++ b/api/controllers/record-utils.js
@@ -217,25 +217,21 @@ const createByForm = (data, { locale }={}) => {
     throw new PublicError('Missing required field: message');
   }
 
-  const fields = ['from', 'message', 'reported_date', 'locale', 'gateway_ref'];
-
-  // filter out any unwanted fields
-  const content = _.pick(data, fields);
-
-  const options = {
+  const content = {
     type: 'sms_message',
-    message: content.message,
-    form: smsparser.getFormCode(content.message),
+    message: data.message,
+    form: smsparser.getFormCode(data.message),
     sent_timestamp: data.sent_timestamp,
     locale: data.locale || locale,
-    from: content.from
+    from: data.from,
+    gateway_ref: data.gateway_ref,
   };
-  const formDefinition = getForm(options.form);
+  const formDefinition = getForm(content.form);
   let formData;
-  if (options.form && formDefinition) {
+  if (content.form && formDefinition) {
     formData = smsparser.parse(formDefinition, data);
   }
-  return getDataRecord(formData, options);
+  return getDataRecord(formData, content);
 };
 
 const createRecordByJSON = data => {

--- a/api/tests/unit/controllers/sms-gateway.js
+++ b/api/tests/unit/controllers/sms-gateway.js
@@ -22,7 +22,7 @@ exports['post() should save WT messages to DB'] = test => {
     .onCall(1).returns({ message: 'two' })
     .onCall(2).returns({ message: 'three' });
   const bulkDocs = sinon.stub().returns(Promise.resolve([ { ok: true, id: 'some-id' } ]));
-  db.medic = { bulkDocs: bulkDocs };
+  db.medic = { bulkDocs: bulkDocs, query: () => Promise.resolve({ rows: [] }) };
   const getMessages = sinon.stub(messageUtils, 'getMessages').callsArgWith(1, null, []);
   const updateMessageTaskStates = sinon.stub(messageUtils, 'updateMessageTaskStates');
   updateMessageTaskStates.callsArgWith(1, null, {});
@@ -144,7 +144,7 @@ exports['post() returns err if something goes wrong'] = test => {
   sinon.stub(recordUtils, 'createByForm')
     .onCall(0).returns({ message: 'one' });
   const bulkDocs = sinon.stub().returns(Promise.reject(new Error('oh no!')));
-  db.medic = { bulkDocs: bulkDocs };
+  db.medic = { bulkDocs: bulkDocs, query: () => Promise.resolve({ rows: [] }) };
   sinon.stub(messageUtils, 'getMessages').callsArgWith(1, null, []);
   const updateMessageTaskStates = sinon.stub(messageUtils, 'updateMessageTaskStates');
   updateMessageTaskStates.callsArgWith(1, null, {});

--- a/ddocs/medic-sms/_id
+++ b/ddocs/medic-sms/_id
@@ -1,0 +1,1 @@
+_design/medic-sms

--- a/ddocs/medic-sms/views/sms-messages/map.js
+++ b/ddocs/medic-sms/views/sms-messages/map.js
@@ -1,0 +1,5 @@
+function(doc) {
+  if (doc.type === 'data_record' && doc.sms_message && doc.sms_message.gateway_ref) {
+    emit(doc.sms_message.gateway_ref);
+  }
+}

--- a/tests/protractor/gateway-api.utils.js
+++ b/tests/protractor/gateway-api.utils.js
@@ -7,6 +7,7 @@ module.exports = {
   api: {
     get: get,
     post: post,
+    postMessage: postMessage,
     postMessages: postMessages,
     postStatus: postStatus,
     postStatuses: postStatuses,
@@ -47,6 +48,10 @@ function post(body) {
     headers: { 'Content-Type':'application/json' },
     body: body,
   });
+}
+
+function postMessage(...messages) {
+  return postMessages(...messages);
 }
 
 function postMessages(...messages) {


### PR DESCRIPTION
Issue: #4110

Reject already-seen webapp-terminating SMS messages.

This is done by maintaining a new couch view whose key is the `gateway_ref` of a message.  This is the UUID created in medic-gateway to uniquely identify each message at that end.

This PR also fixes a bug which had been introduced - the `gateway_ref` was previously being discarded.
