### PR TITLE
ContactChangeFilter undefined lineage bugfix

### DIFF
--- a/static/js/services/contact-change-filter.js
+++ b/static/js/services/contact-change-filter.js
@@ -53,7 +53,7 @@ angular.module('inboxServices').factory('ContactChangeFilter',
 
     var isAncestor = function(change, contact) {
      return _.some(contact.lineage, function(lineage) {
-        return lineage._id === change.doc._id;
+        return !!lineage && lineage._id === change.doc._id;
       });
     };
 

--- a/tests/karma/unit/services/contact-change-filter.js
+++ b/tests/karma/unit/services/contact-change-filter.js
@@ -131,6 +131,34 @@ describe('ContactChangeFilter service', () => {
 
       chai.expect(service.isRelevantContact(change, contact)).to.equal(false);
     });
+
+    it('does not crash when lineage is undefined', () => {
+      const change = { doc: { _id: 'oid', parent: { _id: 'opid' } } };
+
+      const contact = {
+        doc: {_id: 'id', parent: {_id: 'pid'}},
+        children: {
+          persons: [
+            {doc: {_id: 'p1'}},
+            {doc: {_id: 'p2'}}
+          ],
+          other: [
+            {doc: {_id: 'o1'}},
+            {doc: {_id: 'o2'}}
+          ],
+          someProperty: 'someValue'
+        },
+        lineage: [
+          {_id: '123'},
+          {_id: '456'},
+          {_id: '789'},
+          undefined,
+          undefined
+        ]
+      };
+
+      chai.expect(service.isRelevantContact(change, contact)).to.equal(false);
+    });
   });
 
   describe('isRelevantReport', () => {


### PR DESCRIPTION
# Description

Fixes error thrown in ContactChangeFilter when contact lineage is undefined. 

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.