### PR TITLE
Replaces 301 with 302 so redirect isn't cached.

### DIFF
--- a/api/server-utils.js
+++ b/api/server-utils.js
@@ -80,7 +80,7 @@ module.exports = {
         pathname: path.join('/', db.settings.db, 'login'),
         query: { redirect: req.url }
       });
-      res.redirect(301, redirectUrl);
+      res.redirect(302, redirectUrl);
     } else {
       promptForBasicAuth(res);
     }

--- a/api/tests/unit/server-utils.js
+++ b/api/tests/unit/server-utils.js
@@ -99,7 +99,7 @@ exports['notLoggedIn redirects to login page for human user'] = test => {
   req.headers = { 'user-agent': 'Mozilla/1.0' };
   serverUtils.notLoggedIn(req, res);
   test.equals(redirect.callCount, 1);
-  test.equals(redirect.args[0][0], 301);
+  test.equals(redirect.args[0][0], 302);
   test.equals(redirect.args[0][1], '/medic/login?redirect=someurl');
   test.done();
 };


### PR DESCRIPTION
# Description

Replaces 301 with 302 so redirect isn't cached.

medic/medic-webapp#4364

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.