### PR TITLE
4319 Browser stack overflow bug

### DIFF
--- a/shared-libs/lineage/src/lineage.js
+++ b/shared-libs/lineage/src/lineage.js
@@ -26,7 +26,8 @@ module.exports = function(Promise, DB) {
 
     var parentIds = extractParentIds(currentParent.parent);
     lineage.forEach(function(l, i) {
-      currentParent = currentParent.parent = l || { _id: parentIds[i] };
+      currentParent.parent = l || { _id: parentIds[i] };
+      currentParent = currentParent.parent;
     });
 
     return doc;
@@ -46,7 +47,8 @@ module.exports = function(Promise, DB) {
     });
   };
 
-  var fetchContacts = function(lineage) {
+  var fetchContacts = function(lineage, options) {
+    options = options || {};
     var contactIds = _.uniq(
       lineage
         .map(function(doc) {
@@ -65,7 +67,7 @@ module.exports = function(Promise, DB) {
         return doc && doc._id === id;
       });
       if (contact) {
-        lineageContacts.push(contact);
+        lineageContacts.push(options.generateNewContactObjects ? JSON.parse(JSON.stringify(contact)) : contact);
       } else {
         contactsToFetch.push(id);
       }

--- a/static/js/services/lineage-model-generator.js
+++ b/static/js/services/lineage-model-generator.js
@@ -32,7 +32,7 @@ angular.module('inboxServices').factory('LineageModelGenerator',
     };
 
     var hydrate = function(docs) {
-      return lineage.fetchContacts(docs)
+      return lineage.fetchContacts(docs, { generateNewContactObjects: true })
         .then(function(contacts) {
           lineage.fillContactsInDocs(docs, contacts);
           return docs;


### PR DESCRIPTION
# Description

The bug was caused by a subtle change in lineage function when the shared library was created. Previously when contacts were fetched in order to hydrate docs, the docs were simply fetched every time. In the new library, when contacts are fetched we first check if they already exist as part of the fetched lineage, and if so we re-use the contact object. This can lead to circular references within an object which enketo has difficulty with.

The most sensible option I think would be to never re-use the contact object (just deep clone it if we've already fetched it), however I'm not confident that it might not subtly break existing code, so I think the next most sensible option is to simply add in the option when circular references will be a problem (eg when the object may need to be `JSON.stringify`d).

medic/medic-webapp#4319

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.