### PR TITLE
Provide patient in template context for sentinel transitions error messages.

### DIFF
--- a/sentinel/lib/messages.js
+++ b/sentinel/lib/messages.js
@@ -92,8 +92,8 @@ module.exports = {
         return from.toLowerCase().indexOf(s.trim().toLowerCase()) !== 0;
       });
     },
-    addErrors: function(config, doc, errors) {
-        errors.forEach(error => module.exports.addError(doc, error));
+    addErrors: function(config, doc, errors, context) {
+        errors.forEach(error => module.exports.addError(doc, error, context));
         let reply;
         if (config.validations.join_responses) {
             reply = errors
@@ -105,7 +105,7 @@ module.exports = {
         }
         module.exports.addMessage(doc, { message: reply }, 'clinic');
     },
-    addError: function(doc, error) {
+    addError: function(doc, error, context) {
         if (_.isString(error)){
             error = {
                 message: error
@@ -123,7 +123,7 @@ module.exports = {
         }
         // support mustache template syntax in error messages
         try {
-            error.message = messageUtils.template(config, utils.translate, doc, error);
+            error.message = messageUtils.template(config, utils.translate, doc, error, context);
             utils.addError(doc, error);
         } catch(e) {
             utils.addError(doc, {

--- a/sentinel/test/unit/patient_registration.js
+++ b/sentinel/test/unit/patient_registration.js
@@ -65,6 +65,19 @@ exports.setUp = callback => {
         recipient: 'caregiver_phone',
       }
     ]
+  }, {
+    form: 'P',
+    validations: {
+      join_responses: true,
+      list: [{
+        property: 'last_menstrual_period',
+        rule: 'integer && between(2,42)',
+        message: [{
+          content: 'Something something {{patient_name}}',
+          locale: 'en'
+        }]
+      }]
+    }
   }]);
   callback();
 };
@@ -308,6 +321,39 @@ exports['registration responses support locale'] = test => {
         message: 'gracias Sam'
       });
     }
+    test.done();
+  });
+};
+
+exports['registration errors receive patient context'] = test => {
+  const doc = {
+    form: 'P',
+    fields: {
+      patient_id: '123456',
+      last_menstrual_period: 60
+    },
+    contact: {
+      phone: '+1234',
+      name: 'Julie',
+      parent: {
+        contact: {
+          phone: '+1234',
+          name: 'Julie'
+        }
+      }
+    },
+    patient: {
+      name: 'Maria'
+    }
+  };
+
+  transition.onMatch({ doc: doc }).then(changed => {
+    test.equal(changed, true);
+
+    test.ok(doc.errors);
+    test.equal(doc.errors.length, 1);
+    test.equal(doc.errors[0].code, 'invalid_last_menstrual_period');
+    test.equal(doc.errors[0].message, 'Something something Maria');
     test.done();
   });
 };

--- a/sentinel/transitions/accept_patient_reports.js
+++ b/sentinel/transitions/accept_patient_reports.js
@@ -203,7 +203,7 @@ module.exports = {
         return new Promise((resolve, reject) => {
             validate(config, doc, function(errors) {
                 if (errors && errors.length > 0) {
-                    messages.addErrors(config, doc, errors);
+                    messages.addErrors(config, doc, errors, { patient: doc.patient });
                     return resolve(true);
                 }
 

--- a/sentinel/transitions/registration.js
+++ b/sentinel/transitions/registration.js
@@ -219,7 +219,7 @@ module.exports = {
     return new Promise((resolve, reject) => {
       self.validate(registrationConfig, doc, errors => {
         if (errors && errors.length > 0) {
-          messages.addErrors(registrationConfig, doc, errors);
+          messages.addErrors(registrationConfig, doc, errors, { patient: doc.patient });
           return resolve(true);
         }
 

--- a/sentinel/transitions/update_notifications.js
+++ b/sentinel/transitions/update_notifications.js
@@ -107,7 +107,7 @@ module.exports = {
             self.validate(config, doc, function(errors) {
 
                 if (errors && errors.length > 0) {
-                    messages.addErrors(config, doc, errors);
+                    messages.addErrors(config, doc, errors, { patient: doc.patient });
                     return resolve(true);
                 }
 


### PR DESCRIPTION
# Description

Provide `patient` information as template context for sentinel transitions error messages, so `{{patient_name}}` is resolved. 

medic/medic-webapp#4373

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.