### PR TITLE
Foots

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ jobs:
 after_failure:
   - |
       (cd logs
-        for log in "$(ls *.log)"; do
+        for log in $(ls *.log); do
           echo "---------- $log ----------"
           tail "$log"
           echo "--------------------------"

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,14 @@ jobs:
 
 after_failure:
   - |
+      (cd logs
+        for log in "$(ls *.log)"; do
+          echo "---------- $log ----------"
+          tail "$log"
+          echo "--------------------------"
+        done
+      )
+
       [[ "$TRAVIS_BUILD_STAGE_NAME" = "Test" ]] || return
 
       if [[ "$TRAVIS_PULL_REQUEST" = true ]]; then


### PR DESCRIPTION
I think you'll like this one - this will dump the end of the api, sentinel and webdriver logs to the console at the end of a failed build.  However, by some wonderful quirk of travis, this output is collapsed (see https://travis-ci.org/medic/medic-webapp/jobs/363026627#L6009, although this example is a bit broken).