### PR TITLE
Use PouchDB in message-utils; fix unit test envs on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,8 @@ before_script:
 script:
   - |
     if [[ "$TEST_SUITE" = 'normal' ]]; then
-      node --stack_size=10000 `which grunt` ci-test
+      node --stack_size=10000 `which grunt` ci-unit &&
+      node --stack_size=10000 `which grunt` ci-integration-e2e
     elif [[ "$TEST_SUITE" = 'performance' ]]; then
       node --stack_size=10000 `which grunt` ci-performance
     else

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -717,12 +717,15 @@ module.exports = function(grunt) {
     'build',
   ]);
 
-  grunt.registerTask('ci-test', 'Lint, deploy and test for CI', [
+  grunt.registerTask('ci-unit', 'Lint, deploy and test for CI', [
     'precommit',
     'karma:unit_ci',
     'env:unitTest',
     'nodeunit',
     'mochaTest:unit',
+  ]);
+
+  grunt.registerTask('ci-integration-e2e', 'Run further tests for CI', [
     'env:general',
     'exec:setupAdmin',
     'deploy',

--- a/api/db-nano.js
+++ b/api/db-nano.js
@@ -8,7 +8,7 @@ var path = require('path'),
     url = require('url'),
     nano = require('nano');
 
-var couchUrl = process.env.COUCH_URL;
+const { COUCH_URL, UNIT_TEST_ENV } = process.env;
 
 var sanitizeResponse = function(err, body, headers, callback) {
   // Remove the `uri` and `statusCode` headers passed in from nano.  This
@@ -23,9 +23,52 @@ var sanitizeResponse = function(err, body, headers, callback) {
   callback(err, body, headers);
 };
 
-if (couchUrl) {
+if (UNIT_TEST_ENV) {
+  // Running tests only
+  module.exports = {
+    fti: function() {},
+    request: function() {},
+    getPath: function() {},
+    settings: {
+      protocol: 'http',
+      port: '123',
+      host: 'local',
+      db: 'medic',
+      ddoc: 'medic'
+    },
+    sanitizeResponse: sanitizeResponse,
+    use: function() {},
+    medic: {
+      view: function() {},
+      get: function() {},
+      insert: function() {},
+      updateWithHandler: function() {},
+      fetch: function() {},
+      fetchRevs: function() {},
+      bulk: function() {},
+      changes: function() {},
+      attachment: {
+        get: function() {}
+      }
+    },
+    audit: {
+      view: function() {},
+      list: function() {}
+    },
+    db: {
+      get: function() {},
+      create: function() {},
+      replicate:  function() {}
+    },
+    _users: {
+      get: function() {},
+      list: function() {},
+      insert: function() {}
+    }
+  };
+} else if (COUCH_URL) {
   // strip trailing slash from to prevent bugs in path matching
-  couchUrl = couchUrl.replace(/\/$/, '');
+  const couchUrl = COUCH_URL.replace(/\/$/, '');
   var baseUrl = couchUrl.substring(0, couchUrl.indexOf('/', 10));
   var parsedUrl = url.parse(couchUrl);
   var dbName = parsedUrl.path.replace('/','');
@@ -72,48 +115,6 @@ if (couchUrl) {
   };
 
   module.exports.sanitizeResponse = sanitizeResponse;
-} else if (process.env.UNIT_TEST_ENV) {
-  // Running tests only
-  module.exports = {
-    request: function() {},
-    getPath: function() {},
-    settings: {
-      protocol: 'http',
-      port: '123',
-      host: 'local',
-      db: 'medic',
-      ddoc: 'medic'
-    },
-    sanitizeResponse: sanitizeResponse,
-    use: function() {},
-    medic: {
-      view: function() {},
-      get: function() {},
-      insert: function() {},
-      updateWithHandler: function() {},
-      fetch: function() {},
-      fetchRevs: function() {},
-      bulk: function() {},
-      changes: function() {},
-      attachment: {
-        get: function() {}
-      }
-    },
-    audit: {
-      view: function() {},
-      list: function() {}
-    },
-    db: {
-      get: function() {},
-      create: function() {},
-      replicate:  function() {}
-    },
-    _users: {
-      get: function() {},
-      list: function() {},
-      insert: function() {}
-    }
-  };
 } else {
   console.log(
     'Please define a COUCH_URL in your environment e.g. \n' +

--- a/api/db-pouch.js
+++ b/api/db-pouch.js
@@ -2,17 +2,31 @@ const PouchDB = require('pouchdb-core');
 PouchDB.plugin(require('pouchdb-adapter-http'));
 PouchDB.plugin(require('pouchdb-mapreduce'));
 
-const { COUCH_URL } = process.env;
-// strip trailing slash from to prevent bugs in path matching
-const couchUrl = COUCH_URL && COUCH_URL.replace(/\/$/, '');
+const { COUCH_URL, UNIT_TEST_ENV } = process.env;
 
-const db = {};
+if(UNIT_TEST_ENV) {
+  const stubMe = functionName => () => {
+    console.error(new Error(`db.${functionName}() not stubbed!  UNIT_TEST_ENV=${UNIT_TEST_ENV}.  Please stub PouchDB functions that will be interacted with in unit tests.`));
+    process.exit(1);
+  };
 
-if (couchUrl) {
-  // couchUrl isn't supplied in testing
-  db._url = couchUrl;
-  db.medic = new PouchDB(couchUrl);
-  db.audit = new PouchDB(`${couchUrl}-audit`);
+  module.exports.medic = {
+    allDocs: stubMe('allDocs'),
+    bulkDocs: stubMe('bulkDocs'),
+    put: stubMe('put'),
+    query: stubMe('query'),
+  };
+} else if(COUCH_URL) {
+  // strip trailing slash from to prevent bugs in path matching
+  const couchUrl = COUCH_URL && COUCH_URL.replace(/\/$/, '');
+  const DB = new PouchDB(couchUrl);
+
+  module.exports.medic = DB;
+} else {
+  console.log(
+    'Please define a COUCH_URL in your environment e.g. \n' +
+    'export COUCH_URL=\'http://admin:123qwe@localhost:5984/medic\'\n\n' +
+    'If you are running unit tests use UNIT_TEST_ENV=1 in your environment.\n'
+  );
+  process.exit(1);
 }
-
-module.exports = db;

--- a/api/tests/integration/migrations/utils.js
+++ b/api/tests/integration/migrations/utils.js
@@ -145,18 +145,19 @@ function matchDbs(expected, actual) {
 
 const dbPath = db.getPath,
       dbRequest = db.request;
+const realPouchDb = dbPouch.medic;
 const switchToRealDbs = () => {
   db.request = dbRequest;
   db.getPath = dbPath;
   db.audit = db.use('audit');
   db.medic = db.use('medic');
-  dbPouch.medic = new PouchDB(dbPouch._url);
+  dbPouch.medic = realPouchDb;
 };
 
 const switchToTestDbs = () => {
   db.audit = db.use(DB_PREFIX + 'audit');
   db.medic = db.use(DB_PREFIX + 'medic');
-  dbPouch.medic = new PouchDB(dbPouch._url.replace(/medic$/, DB_PREFIX + 'medic'));
+  dbPouch.medic = new PouchDB(realPouchDb.name.replace(/medic$/, DB_PREFIX + 'medic'));
 
   // hijack calls to db.request and make sure that they are made to the correct
   // database.

--- a/api/tests/unit/controllers/records.js
+++ b/api/tests/unit/controllers/records.js
@@ -32,8 +32,7 @@ exports['create returns error when unsupported content type'] = test => {
 exports['create calls createRecordByJSON if json type'] = test => {
   const createRecordByJSON = sinon.stub(recordUtils, 'createRecordByJSON').returns({ message: 'one' });
   const createByForm = sinon.stub(recordUtils, 'createByForm');
-  const put = sinon.stub().returns(Promise.resolve({ ok: true }));
-  db.medic = { put: put };
+  const put = sinon.stub(db.medic, 'put').returns(Promise.resolve({ ok: true }));
   const req = {
     body: {
       message: 'test',
@@ -54,8 +53,7 @@ exports['create calls createRecordByJSON if json type'] = test => {
 exports['create calls createByForm if urlencoded type'] = test => {
   const createRecordByJSON = sinon.stub(recordUtils, 'createRecordByJSON');
   const createByForm = sinon.stub(recordUtils, 'createByForm').returns({ message: 'one' });
-  const put = sinon.stub().returns(Promise.resolve({ ok: true }));
-  db.medic = { put: put };
+  const put = sinon.stub(db.medic, 'put').returns(Promise.resolve({ ok: true }));
   const req = {
     body: {
       message: 'test',

--- a/api/tests/unit/controllers/sms-gateway.js
+++ b/api/tests/unit/controllers/sms-gateway.js
@@ -21,11 +21,13 @@ exports['post() should save WT messages to DB'] = test => {
     .onCall(0).returns({ message: 'one' })
     .onCall(1).returns({ message: 'two' })
     .onCall(2).returns({ message: 'three' });
-  const bulkDocs = sinon.stub().returns(Promise.resolve([ { ok: true, id: 'some-id' } ]));
-  db.medic = { bulkDocs: bulkDocs, query: () => Promise.resolve({ rows: [] }) };
+  const bulkDocs = sinon.stub(db.medic, 'bulkDocs').returns(Promise.resolve([ { ok: true, id: 'some-id' } ]));
   const getMessages = sinon.stub(messageUtils, 'getMessages').callsArgWith(1, null, []);
   const updateMessageTaskStates = sinon.stub(messageUtils, 'updateMessageTaskStates');
   updateMessageTaskStates.callsArgWith(1, null, {});
+
+  sinon.stub(db.medic, 'query')
+      .returns(Promise.resolve({ offset:0, total_rows:0, rows:[] }));
 
   const req = { body: {
     messages: [
@@ -143,8 +145,9 @@ exports['post() should provide WO messages in response'] = test => {
 exports['post() returns err if something goes wrong'] = test => {
   sinon.stub(recordUtils, 'createByForm')
     .onCall(0).returns({ message: 'one' });
-  const bulkDocs = sinon.stub().returns(Promise.reject(new Error('oh no!')));
-  db.medic = { bulkDocs: bulkDocs, query: () => Promise.resolve({ rows: [] }) };
+  sinon.stub(db.medic, 'bulkDocs').returns(Promise.reject(new Error('oh no!')));
+  sinon.stub(db.medic, 'query')
+      .returns(Promise.resolve({ offset:0, total_rows:0, rows:[] }));
   sinon.stub(messageUtils, 'getMessages').callsArgWith(1, null, []);
   const updateMessageTaskStates = sinon.stub(messageUtils, 'updateMessageTaskStates');
   updateMessageTaskStates.callsArgWith(1, null, {});

--- a/api/tests/unit/message-utils.spec.js
+++ b/api/tests/unit/message-utils.spec.js
@@ -1,5 +1,5 @@
 var controller = require('../../message-utils'),
-    db = require('../../db-nano'),
+    db = require('../../db-pouch'),
     sinon = require('sinon').sandbox.create(),
     taskUtils = require('task-utils');
 
@@ -10,7 +10,7 @@ exports.tearDown = function (callback) {
 
 exports['getMessages returns errors'] = function(test) {
   test.expect(2);
-  var getView = sinon.stub(db.medic, 'view').callsArgWith(3, 'bang');
+  var getView = sinon.stub(db.medic, 'query').callsArgWith(2, 'bang');
   controller.getMessages(null, function(err) {
     test.equals(err, 'bang');
     test.equals(getView.callCount, 1);
@@ -20,18 +20,18 @@ exports['getMessages returns errors'] = function(test) {
 
 exports['getMessages passes limit param value of 100 to view'] = function(test) {
   test.expect(2);
-  var getView = sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [] });
+  var getView = sinon.stub(db.medic, 'query').callsArgWith(2, null, { rows: [] });
   controller.getMessages({ limit: 500 }, function() {
     test.equals(getView.callCount, 1);
     // assert query parameters on view call use right limit value
-    test.deepEqual({ limit: 500 }, getView.getCall(0).args[2]);
+    test.deepEqual({ limit: 500 }, getView.getCall(0).args[1]);
     test.done();
   });
 };
 
 exports['getMessages returns 500 error if limit over 100'] = function(test) {
   test.expect(3);
-  var getView = sinon.stub(db.medic, 'view');
+  var getView = sinon.stub(db.medic, 'query');
   controller.getMessages({ limit: 9999 }, function(err) {
     test.equals(err.code, 500);
     test.equals(err.message, 'Limit max is 1000');
@@ -42,11 +42,12 @@ exports['getMessages returns 500 error if limit over 100'] = function(test) {
 
 exports['getMessages passes state param'] = function(test) {
   test.expect(4);
-  sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [
+  sinon.stub(db.medic, 'query').callsArgWith(2, null, { rows: [
     { key: 'yayaya', value: { sending_due_date: 456 } },
     { key: 'pending', value: { sending_due_date: 123 } },
     { key: 'pending', value: { sending_due_date: 789 } }
   ] });
+
   controller.getMessages({}, function(err, messages) {
     test.ok(!err);
     test.equals(messages.length, 3);
@@ -58,34 +59,34 @@ exports['getMessages passes state param'] = function(test) {
 
 exports['getMessages passes states param'] = function(test) {
   test.expect(3);
-  var getView = sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [] });
+  var getView = sinon.stub(db.medic, 'query').callsArgWith(2, null, { rows: [] });
   controller.getMessages({ states: ['happy', 'angry'] }, function(err) {
     console.log(err);
     test.ok(!err);
     test.equals(getView.callCount, 1);
-    test.deepEqual(['happy', 'angry'], getView.getCall(0).args[2].keys);
+    test.deepEqual(['happy', 'angry'], getView.getCall(0).args[1].keys);
     test.done();
   });
 };
 
 exports['getMessages sorts results'] = function(test) {
   test.expect(3);
-  var getView = sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [] });
+  var getView = sinon.stub(db.medic, 'query').callsArgWith(2, null, { rows: [] });
   controller.getMessages({ states: ['happy', 'angry'] }, function(err) {
     console.log(err);
     test.ok(!err);
     test.equals(getView.callCount, 1);
-    test.deepEqual(['happy', 'angry'], getView.getCall(0).args[2].keys);
+    test.deepEqual(['happy', 'angry'], getView.getCall(0).args[1].keys);
     test.done();
   });
 };
 
 exports['updateMessageTaskStates takes a collection of state changes and saves it to docs'] = test => {
-  sinon.stub(db.medic, 'view').callsArgWith(3, null, {rows: [
+  sinon.stub(db.medic, 'query').callsArgWith(2, null, {rows: [
     {id: 'testMessageId1'},
     {id: 'testMessageId2'}]});
 
-  sinon.stub(db.medic, 'fetch').callsArgWith(1, null, {rows: [
+  sinon.stub(db.medic, 'allDocs').callsArgWith(1, null, {rows: [
     {doc: {
       _id: 'testDoc',
       tasks: [{
@@ -101,7 +102,7 @@ exports['updateMessageTaskStates takes a collection of state changes and saves i
     }}
   ]});
 
-  const bulk = sinon.stub(db.medic, 'bulk').callsArgWith(1, null, []);
+  const bulk = sinon.stub(db.medic, 'bulkDocs').callsArgWith(1, null, []);
   const setTaskState = sinon.stub(taskUtils, 'setTaskState');
 
   controller.updateMessageTaskStates([
@@ -121,7 +122,7 @@ exports['updateMessageTaskStates takes a collection of state changes and saves i
     test.deepEqual(setTaskState.getCall(0).args, [{ messages: [{uuid: 'testMessageId1'}]}, 'testState1', undefined]);
     test.deepEqual(setTaskState.getCall(1).args, [{ messages: [{uuid: 'testMessageId2'}]}, 'testState2', 'Just because.']);
 
-    const doc = bulk.args[0][0].docs[0];
+    const doc = bulk.args[0][0][0];
     test.equal(doc._id, 'testDoc');
 
     test.done();
@@ -129,10 +130,10 @@ exports['updateMessageTaskStates takes a collection of state changes and saves i
 };
 
 exports['updateMessageTaskStates DOES NOT throw an error if it cant find the message'] = test => {
-  sinon.stub(db.medic, 'view').callsArgWith(3, null, {rows: [
+  sinon.stub(db.medic, 'query').callsArgWith(2, null, {rows: [
     {id: 'testMessageId1'}]});
 
-  sinon.stub(db.medic, 'fetch').callsArgWith(1, null, {rows: [
+  sinon.stub(db.medic, 'allDocs').callsArgWith(1, null, {rows: [
     {doc: {
       _id: 'testDoc',
       tasks: [{
@@ -143,7 +144,7 @@ exports['updateMessageTaskStates DOES NOT throw an error if it cant find the mes
     }}
   ]});
 
-  sinon.stub(db.medic, 'bulk').callsArgWith(1, null, []);
+  sinon.stub(db.medic, 'bulkDocs').callsArgWith(1, null, []);
 
   controller.updateMessageTaskStates([
     {
@@ -164,14 +165,14 @@ exports['updateMessageTaskStates DOES NOT throw an error if it cant find the mes
 };
 
 exports['updateMessageTaskStates re-applies changes if it errored'] = test => {
-  const view = sinon.stub(db.medic, 'view')
-  .onFirstCall().callsArgWith(3, null, {rows: [
+  const view = sinon.stub(db.medic, 'query')
+  .onFirstCall().callsArgWith(2, null, {rows: [
     {id: 'testMessageId1'},
     {id: 'testMessageId2'}]})
-  .onSecondCall().callsArgWith(3, null, {rows: [
+  .onSecondCall().callsArgWith(2, null, {rows: [
     {id: 'testMessageId2'}]});
 
-  sinon.stub(db.medic, 'fetch')
+  sinon.stub(db.medic, 'allDocs')
   .onFirstCall().callsArgWith(1, null, {rows: [
     {doc: {
       _id: 'testDoc',
@@ -201,7 +202,7 @@ exports['updateMessageTaskStates re-applies changes if it errored'] = test => {
     }}
   ]});
 
-  const bulk = sinon.stub(db.medic, 'bulk')
+  const bulk = sinon.stub(db.medic, 'bulkDocs')
   .onFirstCall().callsArgWith(1, null, [
     {id: 'testDoc', ok: true},
     {id: 'testDoc2', error: 'oh no!'}])
@@ -223,14 +224,14 @@ exports['updateMessageTaskStates re-applies changes if it errored'] = test => {
     test.deepEqual(result, {success: true});
 
     test.equal(view.callCount, 2);
-    test.deepEqual(view.args[0][2], {keys: ['testMessageId1', 'testMessageId2']});
-    test.deepEqual(view.args[1][2], {keys: ['testMessageId2']});
+    test.deepEqual(view.args[0][1], {keys: ['testMessageId1', 'testMessageId2']});
+    test.deepEqual(view.args[1][1], {keys: ['testMessageId2']});
 
-    test.equal(bulk.args[0][0].docs.length, 2);
-    test.equal(bulk.args[0][0].docs[0]._id, 'testDoc');
-    test.equal(bulk.args[0][0].docs[1]._id, 'testDoc2');
-    test.equal(bulk.args[1][0].docs.length, 1);
-    test.equal(bulk.args[1][0].docs[0]._id, 'testDoc2');
+    test.equal(bulk.args[0][0].length, 2);
+    test.equal(bulk.args[0][0][0]._id, 'testDoc');
+    test.equal(bulk.args[0][0][1]._id, 'testDoc2');
+    test.equal(bulk.args[1][0].length, 1);
+    test.equal(bulk.args[1][0][0]._id, 'testDoc2');
 
     test.done();
   });


### PR DESCRIPTION
Previously, changes made to core libraries in unit tests could leak through into integration tests.

This also switches `api/message-utils` to use pouch instead of nano, but there appears to be no change in performance due to this switch.