### PR TITLE
Shows cleared messages

### DIFF
--- a/static/js/services/format-data-record.js
+++ b/static/js/services/format-data-record.js
@@ -430,8 +430,7 @@ angular.module('inboxServices').factory('FormatDataRecord',
             message: t.message
           };
 
-          if (copy.state === 'scheduled' && // not yet sent
-            !copy.messages) { // backwards compatibility
+          if (!copy.messages) { // backwards compatibility
             copy.messages = messages.generate(
               settings,
               _.partial(translate, settings, _, null, null, true),

--- a/tests/karma/unit/services/format-data-record.js
+++ b/tests/karma/unit/services/format-data-record.js
@@ -1,0 +1,54 @@
+describe('FormatDataRecord service', () => {
+
+  'use strict';
+
+  const sandbox = sinon.sandbox.create();
+
+  let service,
+      Settings = sinon.stub(),
+      Language = sinon.stub();
+
+  beforeEach(() => {
+    module('inboxApp');
+    module(function($provide) {
+      $provide.value('Settings', Settings);
+      $provide.value('Language', Language);
+      $provide.factory('DB', KarmaUtils.mockDB({ }));
+      $provide.value('$q', Q); // bypass $q so we don't have to digest
+    });
+    inject(_FormatDataRecord_ => {
+      service = _FormatDataRecord_;
+    });
+  });
+
+  afterEach(() => sandbox.restore());
+
+  it('generates cleared messages', done => {
+    const doc = {
+      from: '+123456',
+      scheduled_tasks: [
+        {
+          message_key: 'some.message',
+          state: 'cleared',
+          recipient: 'reporting_unit'
+        }
+      ]
+    };
+    const settings = {};
+    Settings.returns(Promise.resolve(settings));
+    Language.returns(Promise.resolve('en'));
+    service(doc)
+      .then(formatted => {
+        chai.expect(formatted.scheduled_tasks_by_group.length).to.equal(1);
+        chai.expect(formatted.scheduled_tasks_by_group[0].rows.length).to.equal(1);
+        const row = formatted.scheduled_tasks_by_group[0].rows[0];
+        chai.expect(row.messages.length).to.equal(1);
+        const message = row.messages[0];
+        chai.expect(message.to).to.equal('+123456');
+        chai.expect(message.message).to.equal('some.message');
+        done();
+      })
+      .catch(done);
+  });
+
+});


### PR DESCRIPTION
# Description

Show the persisted message if possible but otherwise generate the
message. This shows the message that will be or would have been
sent for unsent states such as 'cleared'.

medic/medic-webapp#4388

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.