### PR TITLE
Remove reference to national_office in contacts_by_reference

### DIFF
--- a/ddocs/medic-client/views/contacts_by_reference/map.js
+++ b/ddocs/medic-client/views/contacts_by_reference/map.js
@@ -2,7 +2,6 @@ function(doc) {
   if (doc.type === 'clinic' ||
       doc.type === 'health_center' ||
       doc.type === 'district_hospital' ||
-      doc.type === 'national_office' ||
       doc.type === 'person') {
 
     var emitReference = function(prefix, key) {


### PR DESCRIPTION
`national_office` is not used in any other code.

This should be merged in a release when we are already changing the `medic-client` ddoc to avoid unnecessary view rebuilding.

Issue: #4395
