### PR TITLE
Mocks the entire db rather than individual properties

### DIFF
--- a/api/db-pouch.js
+++ b/api/db-pouch.js
@@ -5,23 +5,11 @@ PouchDB.plugin(require('pouchdb-mapreduce'));
 const { COUCH_URL, UNIT_TEST_ENV } = process.env;
 
 if(UNIT_TEST_ENV) {
-  const stubMe = functionName => () => {
-    console.error(new Error(`db.${functionName}() not stubbed!  UNIT_TEST_ENV=${UNIT_TEST_ENV}.  Please stub PouchDB functions that will be interacted with in unit tests.`));
-    process.exit(1);
-  };
-
-  module.exports.medic = {
-    allDocs: stubMe('allDocs'),
-    bulkDocs: stubMe('bulkDocs'),
-    put: stubMe('put'),
-    query: stubMe('query'),
-  };
+  module.exports.medic = {};
 } else if(COUCH_URL) {
   // strip trailing slash from to prevent bugs in path matching
   const couchUrl = COUCH_URL && COUCH_URL.replace(/\/$/, '');
-  const DB = new PouchDB(couchUrl);
-
-  module.exports.medic = DB;
+  module.exports.medic = new PouchDB(couchUrl);
 } else {
   console.log(
     'Please define a COUCH_URL in your environment e.g. \n' +

--- a/api/services/upgrade.js
+++ b/api/services/upgrade.js
@@ -1,10 +1,10 @@
-const DB = require('../db-pouch').medic;
+const db = require('../db-pouch');
 
 const HORTI_UPGRADE_DOC = 'horti-upgrade';
 
 module.exports = {
   upgrade: (buildInfo, user) => {
-    return DB.put({
+    return db.medic.put({
       _id: HORTI_UPGRADE_DOC,
       user: user,
       created: new Date().getTime(),

--- a/api/tests/mocha/services/upgrade.js
+++ b/api/tests/mocha/services/upgrade.js
@@ -1,9 +1,8 @@
 require('chai').should();
 
-const sinon = require('sinon').sandbox.create();
-
-const DB = require('../../../db-pouch').medic;
-const service = require('../../../services/upgrade');
+const sinon = require('sinon').sandbox.create(),
+      db = require('../../../db-pouch'),
+      service = require('../../../services/upgrade');
 
 describe('Upgrade service', () => {
   const buildInfo = {
@@ -15,13 +14,12 @@ describe('Upgrade service', () => {
   afterEach(() => sinon.restore());
 
   it('creates a work doc for horti to pick up', () => {
-    DB.put = sinon.stub();
-    DB.put.resolves();
-
-    service.upgrade(buildInfo, 'admin')
-    .then(() => {
-      DB.put.callCount.should.equal(1);
-      DB.put.args[0][0].build_info.should.deep.equal(buildInfo);
+    sinon.stub(db, 'medic').value({
+      put: sinon.stub().resolves()
+    });
+    service.upgrade(buildInfo, 'admin').then(() => {
+      db.medic.put.callCount.should.equal(1);
+      db.medic.put.args[0][0].build_info.should.deep.equal(buildInfo);
     });
   });
 });

--- a/api/tests/unit/controllers/records.js
+++ b/api/tests/unit/controllers/records.js
@@ -32,7 +32,9 @@ exports['create returns error when unsupported content type'] = test => {
 exports['create calls createRecordByJSON if json type'] = test => {
   const createRecordByJSON = sinon.stub(recordUtils, 'createRecordByJSON').returns({ message: 'one' });
   const createByForm = sinon.stub(recordUtils, 'createByForm');
-  const put = sinon.stub(db.medic, 'put').returns(Promise.resolve({ ok: true }));
+  sinon.stub(db, 'medic').value({
+    put: sinon.stub().returns(Promise.resolve({ ok: true }))
+  });
   const req = {
     body: {
       message: 'test',
@@ -44,8 +46,8 @@ exports['create calls createRecordByJSON if json type'] = test => {
     test.equals(createRecordByJSON.callCount, 1);
     test.deepEqual(createRecordByJSON.args[0][0], req.body);
     test.equals(createByForm.callCount, 0);
-    test.equals(put.callCount, 1);
-    test.deepEqual(put.args[0][0], { message: 'one' });
+    test.equals(db.medic.put.callCount, 1);
+    test.deepEqual(db.medic.put.args[0][0], { message: 'one' });
     test.done();
   });
 };
@@ -53,7 +55,9 @@ exports['create calls createRecordByJSON if json type'] = test => {
 exports['create calls createByForm if urlencoded type'] = test => {
   const createRecordByJSON = sinon.stub(recordUtils, 'createRecordByJSON');
   const createByForm = sinon.stub(recordUtils, 'createByForm').returns({ message: 'one' });
-  const put = sinon.stub(db.medic, 'put').returns(Promise.resolve({ ok: true }));
+  sinon.stub(db, 'medic').value({
+    put: sinon.stub().returns(Promise.resolve({ ok: true }))
+  });
   const req = {
     body: {
       message: 'test',
@@ -69,8 +73,8 @@ exports['create calls createByForm if urlencoded type'] = test => {
     test.equals(createByForm.callCount, 1);
     test.deepEqual(createByForm.args[0][0], req.body);
     test.deepEqual(createByForm.args[0][1], req.query);
-    test.equals(put.callCount, 1);
-    test.deepEqual(put.args[0][0], { message: 'one' });
+    test.equals(db.medic.put.callCount, 1);
+    test.deepEqual(db.medic.put.args[0][0], { message: 'one' });
     test.done();
   });
 };

--- a/api/tests/unit/message-utils.spec.js
+++ b/api/tests/unit/message-utils.spec.js
@@ -10,44 +10,51 @@ exports.tearDown = function (callback) {
 
 exports['getMessages returns errors'] = function(test) {
   test.expect(2);
-  var getView = sinon.stub(db.medic, 'query').callsArgWith(2, 'bang');
+  sinon.stub(db, 'medic').value({
+    query: sinon.stub().callsArgWith(2, 'bang')
+  });
   controller.getMessages(null, function(err) {
     test.equals(err, 'bang');
-    test.equals(getView.callCount, 1);
+    test.equals(db.medic.query.callCount, 1);
     test.done();
   });
 };
 
 exports['getMessages passes limit param value of 100 to view'] = function(test) {
   test.expect(2);
-  var getView = sinon.stub(db.medic, 'query').callsArgWith(2, null, { rows: [] });
+  sinon.stub(db, 'medic').value({
+    query: sinon.stub().callsArgWith(2, null, { rows: [] })
+  });
   controller.getMessages({ limit: 500 }, function() {
-    test.equals(getView.callCount, 1);
+    test.equals(db.medic.query.callCount, 1);
     // assert query parameters on view call use right limit value
-    test.deepEqual({ limit: 500 }, getView.getCall(0).args[1]);
+    test.deepEqual({ limit: 500 }, db.medic.query.getCall(0).args[1]);
     test.done();
   });
 };
 
 exports['getMessages returns 500 error if limit over 100'] = function(test) {
   test.expect(3);
-  var getView = sinon.stub(db.medic, 'query');
+  sinon.stub(db, 'medic').value({
+    query: sinon.stub().callsArgWith(2, null, { rows: [] })
+  });
   controller.getMessages({ limit: 9999 }, function(err) {
     test.equals(err.code, 500);
     test.equals(err.message, 'Limit max is 1000');
-    test.equals(getView.callCount, 0);
+    test.equals(db.medic.query.callCount, 0);
     test.done();
   });
 };
 
 exports['getMessages passes state param'] = function(test) {
   test.expect(4);
-  sinon.stub(db.medic, 'query').callsArgWith(2, null, { rows: [
-    { key: 'yayaya', value: { sending_due_date: 456 } },
-    { key: 'pending', value: { sending_due_date: 123 } },
-    { key: 'pending', value: { sending_due_date: 789 } }
-  ] });
-
+  sinon.stub(db, 'medic').value({
+    query: sinon.stub().callsArgWith(2, null, { rows: [
+      { key: 'yayaya', value: { sending_due_date: 456 } },
+      { key: 'pending', value: { sending_due_date: 123 } },
+      { key: 'pending', value: { sending_due_date: 789 } }
+    ] })
+  });
   controller.getMessages({}, function(err, messages) {
     test.ok(!err);
     test.equals(messages.length, 3);
@@ -59,34 +66,36 @@ exports['getMessages passes state param'] = function(test) {
 
 exports['getMessages passes states param'] = function(test) {
   test.expect(3);
-  var getView = sinon.stub(db.medic, 'query').callsArgWith(2, null, { rows: [] });
+  sinon.stub(db, 'medic').value({
+    query: sinon.stub().callsArgWith(2, null, { rows: [] })
+  });
   controller.getMessages({ states: ['happy', 'angry'] }, function(err) {
-    console.log(err);
     test.ok(!err);
-    test.equals(getView.callCount, 1);
-    test.deepEqual(['happy', 'angry'], getView.getCall(0).args[1].keys);
+    test.equals(db.medic.query.callCount, 1);
+    test.deepEqual(['happy', 'angry'], db.medic.query.getCall(0).args[1].keys);
     test.done();
   });
 };
 
 exports['getMessages sorts results'] = function(test) {
   test.expect(3);
-  var getView = sinon.stub(db.medic, 'query').callsArgWith(2, null, { rows: [] });
+  sinon.stub(db, 'medic').value({
+    query: sinon.stub().callsArgWith(2, null, { rows: [] })
+  });
   controller.getMessages({ states: ['happy', 'angry'] }, function(err) {
-    console.log(err);
     test.ok(!err);
-    test.equals(getView.callCount, 1);
-    test.deepEqual(['happy', 'angry'], getView.getCall(0).args[1].keys);
+    test.equals(db.medic.query.callCount, 1);
+    test.deepEqual(['happy', 'angry'], db.medic.query.getCall(0).args[1].keys);
     test.done();
   });
 };
 
 exports['updateMessageTaskStates takes a collection of state changes and saves it to docs'] = test => {
-  sinon.stub(db.medic, 'query').callsArgWith(2, null, {rows: [
+  const query = sinon.stub().callsArgWith(2, null, {rows: [
     {id: 'testMessageId1'},
-    {id: 'testMessageId2'}]});
-
-  sinon.stub(db.medic, 'allDocs').callsArgWith(1, null, {rows: [
+    {id: 'testMessageId2'}
+  ]});
+  const allDocs = sinon.stub().callsArgWith(1, null, {rows: [
     {doc: {
       _id: 'testDoc',
       tasks: [{
@@ -101,8 +110,13 @@ exports['updateMessageTaskStates takes a collection of state changes and saves i
       }]
     }}
   ]});
+  const bulkDocs = sinon.stub().callsArgWith(1, null, []);
+  sinon.stub(db, 'medic').value({
+    query: query,
+    allDocs: allDocs,
+    bulkDocs: bulkDocs
+  });
 
-  const bulk = sinon.stub(db.medic, 'bulkDocs').callsArgWith(1, null, []);
   const setTaskState = sinon.stub(taskUtils, 'setTaskState');
 
   controller.updateMessageTaskStates([
@@ -122,7 +136,7 @@ exports['updateMessageTaskStates takes a collection of state changes and saves i
     test.deepEqual(setTaskState.getCall(0).args, [{ messages: [{uuid: 'testMessageId1'}]}, 'testState1', undefined]);
     test.deepEqual(setTaskState.getCall(1).args, [{ messages: [{uuid: 'testMessageId2'}]}, 'testState2', 'Just because.']);
 
-    const doc = bulk.args[0][0][0];
+    const doc = bulkDocs.args[0][0][0];
     test.equal(doc._id, 'testDoc');
 
     test.done();
@@ -130,10 +144,8 @@ exports['updateMessageTaskStates takes a collection of state changes and saves i
 };
 
 exports['updateMessageTaskStates DOES NOT throw an error if it cant find the message'] = test => {
-  sinon.stub(db.medic, 'query').callsArgWith(2, null, {rows: [
-    {id: 'testMessageId1'}]});
-
-  sinon.stub(db.medic, 'allDocs').callsArgWith(1, null, {rows: [
+  const query = sinon.stub().callsArgWith(2, null, {rows: [{id: 'testMessageId1'}]});
+  const allDocs = sinon.stub().callsArgWith(1, null, {rows: [
     {doc: {
       _id: 'testDoc',
       tasks: [{
@@ -143,8 +155,13 @@ exports['updateMessageTaskStates DOES NOT throw an error if it cant find the mes
       }]
     }}
   ]});
+  const bulkDocs = sinon.stub().callsArgWith(1, null, []);
 
-  sinon.stub(db.medic, 'bulkDocs').callsArgWith(1, null, []);
+  sinon.stub(db, 'medic').value({
+    query: query,
+    allDocs: allDocs,
+    bulkDocs: bulkDocs
+  });
 
   controller.updateMessageTaskStates([
     {
@@ -165,49 +182,55 @@ exports['updateMessageTaskStates DOES NOT throw an error if it cant find the mes
 };
 
 exports['updateMessageTaskStates re-applies changes if it errored'] = test => {
-  const view = sinon.stub(db.medic, 'query')
-  .onFirstCall().callsArgWith(2, null, {rows: [
-    {id: 'testMessageId1'},
-    {id: 'testMessageId2'}]})
-  .onSecondCall().callsArgWith(2, null, {rows: [
-    {id: 'testMessageId2'}]});
+  const query = sinon.stub()
+    .onFirstCall().callsArgWith(2, null, {rows: [
+      {id: 'testMessageId1'},
+      {id: 'testMessageId2'}]})
+    .onSecondCall().callsArgWith(2, null, {rows: [
+      {id: 'testMessageId2'}]});
 
-  sinon.stub(db.medic, 'allDocs')
-  .onFirstCall().callsArgWith(1, null, {rows: [
-    {doc: {
-      _id: 'testDoc',
-      tasks: [{
-        messages: [{
-          uuid: 'testMessageId1'
+  const allDocs = sinon.stub()
+    .onFirstCall().callsArgWith(1, null, {rows: [
+      {doc: {
+        _id: 'testDoc',
+        tasks: [{
+          messages: [{
+            uuid: 'testMessageId1'
+          }]
         }]
-      }]
-    }},
-    {doc: {
-      _id: 'testDoc2',
-      tasks: [{
-        messages: [{
-          uuid: 'testMessageId2'
+      }},
+      {doc: {
+        _id: 'testDoc2',
+        tasks: [{
+          messages: [{
+            uuid: 'testMessageId2'
+          }]
         }]
-      }]
-    }}
-  ]})
-  .onSecondCall().callsArgWith(1, null, {rows: [
-    {doc: {
-      _id: 'testDoc2',
-      tasks: [{
-        messages: [{
-          uuid: 'testMessageId2'
+      }}
+    ]})
+    .onSecondCall().callsArgWith(1, null, {rows: [
+      {doc: {
+        _id: 'testDoc2',
+        tasks: [{
+          messages: [{
+            uuid: 'testMessageId2'
+          }]
         }]
-      }]
-    }}
-  ]});
+      }}
+    ]});
 
-  const bulk = sinon.stub(db.medic, 'bulkDocs')
-  .onFirstCall().callsArgWith(1, null, [
-    {id: 'testDoc', ok: true},
-    {id: 'testDoc2', error: 'oh no!'}])
-  .onSecondCall().callsArgWith(1, null, [
-    {id: 'testDoc2', ok: true}]);
+  const bulkDocs = sinon.stub()
+    .onFirstCall().callsArgWith(1, null, [
+      {id: 'testDoc', ok: true},
+      {id: 'testDoc2', error: 'oh no!'}])
+    .onSecondCall().callsArgWith(1, null, [
+      {id: 'testDoc2', ok: true}]);
+  
+  sinon.stub(db, 'medic').value({
+    query: query,
+    allDocs: allDocs,
+    bulkDocs: bulkDocs
+  });
 
   controller.updateMessageTaskStates([
     {
@@ -223,15 +246,15 @@ exports['updateMessageTaskStates re-applies changes if it errored'] = test => {
     test.equal(err, null);
     test.deepEqual(result, {success: true});
 
-    test.equal(view.callCount, 2);
-    test.deepEqual(view.args[0][1], {keys: ['testMessageId1', 'testMessageId2']});
-    test.deepEqual(view.args[1][1], {keys: ['testMessageId2']});
+    test.equal(query.callCount, 2);
+    test.deepEqual(query.args[0][1], {keys: ['testMessageId1', 'testMessageId2']});
+    test.deepEqual(query.args[1][1], {keys: ['testMessageId2']});
 
-    test.equal(bulk.args[0][0].length, 2);
-    test.equal(bulk.args[0][0][0]._id, 'testDoc');
-    test.equal(bulk.args[0][0][1]._id, 'testDoc2');
-    test.equal(bulk.args[1][0].length, 1);
-    test.equal(bulk.args[1][0][0]._id, 'testDoc2');
+    test.equal(bulkDocs.args[0][0].length, 2);
+    test.equal(bulkDocs.args[0][0][0]._id, 'testDoc');
+    test.equal(bulkDocs.args[0][0][1]._id, 'testDoc2');
+    test.equal(bulkDocs.args[1][0].length, 1);
+    test.equal(bulkDocs.args[1][0][0]._id, 'testDoc2');
 
     test.done();
   });


### PR DESCRIPTION
# Description

Just a spike to see what you think... This changes how we mock db-pouch properties using a sinon sandbox feature that lets us mock a non-function property, in this case db.medic.

I think it's a better pattern overall. If you agree I can roll it out to sentinel as well.

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.