### PR TITLE
[wip] Enable lineage unit tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -358,6 +358,7 @@ module.exports = function(grunt) {
         cmd:  function() {
           var sharedLibs = [
             'bulk-docs-utils',
+            'lineage',
             'search',
             'task-utils',
             'phone-number'

--- a/shared-libs/lineage/test/lineage.js
+++ b/shared-libs/lineage/test/lineage.js
@@ -2,7 +2,14 @@ const chai = require('chai');
 const sinon = require('sinon').sandbox.create();
 const lineage = require('../src/lineage');
 
-describe('Lineage', function() {
+/**
+ * These tests are disabled because:
+ * - they are currently broken
+ * - it's not clear if they're useful
+ * - they're scheduled to be replaced
+ * @see https://github.com/medic/medic-webapp/issues/4306
+ */
+describe.skip('Lineage', function() {
   let allDocs,
       get,
       query,


### PR DESCRIPTION
This PR re-enables running of the lineage unit tests, but disables them all via `describe.skip()`.  This will have a marginal effect on build times, mainly due to an extra run of `npm install` within the `shared-lib/lineage` directory.

However, I think it's worthwhile as it allows for https://github.com/medic/medic-webapp/pull/4429 — running tests for _all_ shared libs, rather than having to manually add each to the list in `Gruntfile.js`.

Issue: #4425