### PR TITLE
Hydrates patient by UUID not shortcode

### DIFF
--- a/sentinel/src/schedule/due_tasks.js
+++ b/sentinel/src/schedule/due_tasks.js
@@ -11,10 +11,7 @@ const async = require('async'),
       messageUtils = require('@shared-libs/message-utils');
 
 const getPatient = (db, patientShortcodeId, callback) => {
-    console.log('getting patient', patientShortcodeId);
     utils.getPatientContactUuid(db, patientShortcodeId, (err, uuid) => {
-        console.log('got err', err);
-        console.log('got uuid', uuid);
         if (err || !uuid) {
             return callback(err);
         }
@@ -27,7 +24,6 @@ const getTemplateContext = (db, doc, callback) => {
     if (!patientShortcodeId) {
         return callback();
     }
-    console.log('getting context');
     async.parallel({
         registrations: callback => utils.getRegistrations({ db: db, id: patientShortcodeId }, callback),
         patient: callback => getPatient(db, patientShortcodeId, callback)

--- a/sentinel/tests/unit/due_tasks.js
+++ b/sentinel/tests/unit/due_tasks.js
@@ -1,5 +1,5 @@
 const sinon = require('sinon').sandbox.create(),
-     assert = require('chai').assert,
+      assert = require('chai').assert,
       moment = require('moment'),
       utils = require('../../src/lib/utils'),
       schedule = require('../../src/schedule/due_tasks');
@@ -207,9 +207,11 @@ describe('due tasks', () => {
     const due = moment().toISOString();
     const notDue = moment().add(7, 'days').toISOString();
     const id = 'xyz';
+    const patientUuid = '123-456-789';
     const expectedPhone = '5556918';
     const translate = sinon.stub(utils, 'translate').returns('Please visit {{patient_name}} asap');
     const getRegistrations = sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, []);
+    const getPatientContactUuid = sinon.stub(utils, 'getPatientContactUuid').callsArgWith(2, null, patientUuid);
     const fetchHydratedDoc = sinon.stub(schedule._lineage, 'fetchHydratedDoc').callsArgWith(1, null, { name: 'jim' });
     const setTaskState = sinon.stub(utils, 'setTaskState');
 
@@ -297,8 +299,10 @@ describe('due tasks', () => {
       assert.equal(translate.callCount, 1);
       assert.equal(translate.args[0][0], 'visit-1');
       assert.equal(getRegistrations.callCount, 1);
+      assert.equal(getPatientContactUuid.callCount, 1);
+      assert.equal(getPatientContactUuid.args[0][1], '123');
       assert.equal(fetchHydratedDoc.callCount, 1);
-      assert.equal(fetchHydratedDoc.args[0][0], '123');
+      assert.equal(fetchHydratedDoc.args[0][0], patientUuid);
       assert.equal(setTaskState.callCount, 1);
       const saved = saveDoc.firstCall.args[0];
       assert.equal(saved.scheduled_tasks.length, 2);


### PR DESCRIPTION
# Description

Fixes a bug where the hydration api was being called with the patient shortcode instead of the uuid.

medic/medic-webapp#4453

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.