### PR TITLE
Removes _rev from doc when moving between dbs

### DIFF
--- a/sentinel/src/lib/infodoc.js
+++ b/sentinel/src/lib/infodoc.js
@@ -16,7 +16,17 @@ const findInfoDoc = (db, change) => {
 const getInfoDoc = change => {
   return findInfoDoc(dbPouch.sentinel, change)
     .then(doc => {
-      return doc ? doc : findInfoDoc(dbPouch.medic, change);
+      if (doc) {
+        return doc;
+      }
+      return findInfoDoc(dbPouch.medic, change)
+        .then(doc => {
+          if (doc) {
+            // prepare the doc for saving into the new db
+            delete doc._rev;
+          }
+          return doc;
+        });
     })
     .then(doc => {
       if (doc) {

--- a/sentinel/src/transitions/index.js
+++ b/sentinel/src/transitions/index.js
@@ -86,7 +86,7 @@ const processChange = (change, callback) => {
   lineage.fetchHydratedDoc(change.id)
     .then(doc => {
       change.doc = doc;
-      infodoc.get(change)
+      return infodoc.get(change)
         .then(infoDoc => {
           change.info = infoDoc;
           // Remove transitions from doc since those


### PR DESCRIPTION
# Description

Removes _rev from doc when moving between dbs.

medic/medic-webapp#4465

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.