### PR TITLE
Fixes how select2 inits

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -248,8 +248,8 @@ module.exports = function(grunt) {
           {
             expand: true,
             flatten: true,
-            src: 'admin/src/templates/**/*',
-            dest: 'webapp/dist/ddocs/medic-admin/_attachments/templates/'
+            src: 'admin/src/templates/index.html',
+            dest: 'webapp/dist/ddocs/medic-admin/_attachments/'
           },
           {
             expand: true,
@@ -557,6 +557,26 @@ module.exports = function(grunt) {
             removeStyleLinkTypeAttributes: true
           }
         }
+      },
+      adminApp: {
+        cwd: 'admin/src',
+        src: [
+          'templates/**/*.html',
+          '!templates/index.html',
+        ],
+        dest: 'webapp/dist/ddocs/medic-admin/_attachments/templates.js',
+        options: {
+          htmlmin: {
+            collapseBooleanAttributes: true,
+            collapseWhitespace: true,
+            removeAttributeQuotes: true,
+            removeComments: true,
+            removeEmptyAttributes: true,
+            removeRedundantAttributes: true,
+            removeScriptTypeAttributes: true,
+            removeStyleLinkTypeAttributes: true
+          }
+        }
       }
     },
     appcache: {
@@ -644,7 +664,7 @@ module.exports = function(grunt) {
   grunt.registerTask('mmjs', 'Build the JS resources', [
     'browserify:dist',
     'replace:hardcodeappsettings',
-    'ngtemplates'
+    'ngtemplates:inboxApp'
   ]);
 
   grunt.registerTask('mmcss', 'Build the CSS resources', [
@@ -695,6 +715,7 @@ module.exports = function(grunt) {
 
   grunt.registerTask('build-admin', 'Build the admin app', [
     'copy:admin-resources',
+    'ngtemplates:adminApp',
     'browserify:admin',
     'less:admin',
   ]);

--- a/admin/src/js/main.js
+++ b/admin/src/js/main.js
@@ -1,6 +1,6 @@
 window.PouchDB = require('pouchdb-browser');
 window.$ = window.jQuery = require('jquery');
-require('../../node_modules/select2/dist/js/select2.full');
+require('../../node_modules/select2/dist/js/select2.full')(window.jQuery);
 
 require('bootstrap');
 require('angular');

--- a/admin/src/templates/index.html
+++ b/admin/src/templates/index.html
@@ -26,5 +26,6 @@
       <div class="content" ui-view></div>
     </div>
     <script src="main.js"></script>
+    <script src="templates.js"></script>
   </body>
 </html>

--- a/webapp/src/ddocs/medic-admin/rewrites.json
+++ b/webapp/src/ddocs/medic-admin/rewrites.json
@@ -1,6 +1,6 @@
 [
-  {"from": "/",             "to": "templates/index.html"},
+  {"from": "/",             "to": "index.html"},
   {"from": "/main.css",     "to": "main.css"},
   {"from": "/main.js",      "to": "main.js"},
-  {"from": "/templates/*",  "to": "templates/*"}
+  {"from": "/templates.js", "to": "templates.js"}
 ]


### PR DESCRIPTION
# Description

- Pass jquery in to select2 so it binds to the right instance
- Bundle the templates so they don't have to load asynchronously

medic/medic-webapp#4461

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.