### PR TITLE
Defers writing headers for export v1 api

### DIFF
--- a/api/controllers/export-data.js
+++ b/api/controllers/export-data.js
@@ -32,8 +32,6 @@ const writeExportHeaders = (res, type, format) => {
   res
     .set('Content-Type', format.contentType)
     .set('Content-Disposition', 'attachment; filename=' + filename);
-  // To respond as quickly to the request as possible
-  res.flushHeaders();
 };
 
 const getExportPermission = function(type) {
@@ -120,6 +118,9 @@ module.exports = {
     return auth.check(req, ['national_admin', getExportPermission(req.params.type)])
       .then(() => {
         writeExportHeaders(res, req.params.type, formats.csv);
+
+        // To respond as quickly to the request as possible
+        res.flushHeaders();
 
         const d = domain.create();
         d.on('error', err => serverUtils.error(err, req, res));


### PR DESCRIPTION
# Description

The headers were flushed immediately for v2 to support streaming,
but this broke v1 which prepares all the data and sends in a single
command.

medic/medic-webapp#4455

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.