### PR TITLE
Fixes tests including changesFeed.stop and unit tests for us timezone

### DIFF
--- a/sentinel/src/lib/feed.js
+++ b/sentinel/src/lib/feed.js
@@ -22,8 +22,7 @@ const followFeed = (seq, queue) => {
       logger.info(`Sentinel caught up to ${seq}`);
     }
   });
-  feed.follow();
-  return feed;
+  return feed.follow();
 };
 
 module.exports = {

--- a/shared-libs/message-utils/src/index.js
+++ b/shared-libs/message-utils/src/index.js
@@ -168,7 +168,7 @@ var formatDate = function(config, text, view, formatString) {
   if (!isNaN(date)) {
     date = parseInt(date, 10);
   }
-  return moment(date).format(formatString);
+  return moment.utc(date).format(formatString);
 };
 
 var render = function(config, template, view) {

--- a/shared-libs/message-utils/test/index.js
+++ b/shared-libs/message-utils/test/index.js
@@ -201,7 +201,7 @@ describe('messageUtils', () => {
         const doc = { reported_date: date };
         const config = { date_format: 'DD-MMM-YYYY' };
         const actual = utils.template(config, null, doc, { message: input });
-        expect(actual).to.equal(moment(date).format(config.date_format));
+        expect(actual).to.equal(moment.utc(date).format(config.date_format));
       });
 
       it('integer', () => {
@@ -210,7 +210,7 @@ describe('messageUtils', () => {
         const doc = { reported_date: date };
         const config = { date_format: 'DD-MMM-YYYY' };
         const actual = utils.template(config, null, doc, { message: input });
-        expect(actual).to.equal(moment(date).format(config.date_format));
+        expect(actual).to.equal(moment.utc(date).format(config.date_format));
       });
 
       it('Date object', () => {
@@ -219,7 +219,7 @@ describe('messageUtils', () => {
         const doc = { reported_date: date };
         const config = { date_format: 'DD-MMM-YYYY' };
         const actual = utils.template(config, null, doc, { message: input });
-        expect(actual).to.equal(moment(date).format(config.date_format));
+        expect(actual).to.equal(moment.utc(date).format(config.date_format));
       });
 
     });
@@ -232,7 +232,7 @@ describe('messageUtils', () => {
         const doc = { reported_date: date };
         const config = { reported_date_format: 'DD-MMMM-YYYY HH:mm:ss' };
         const actual = utils.template(config, null, doc, { message: input });
-        expect(actual).to.equal(moment(date).format(config.reported_date_format));
+        expect(actual).to.equal(moment.utc(date).format(config.reported_date_format));
       });
 
       it('Date object', () => {
@@ -241,7 +241,7 @@ describe('messageUtils', () => {
         const doc = { reported_date: date };
         const config = { reported_date_format: 'DD-MMMM-YYYY HH:mm:ss' };
         const actual = utils.template(config, null, doc, { message: input });
-        expect(actual).to.equal(moment(date).format(config.reported_date_format));
+        expect(actual).to.equal(moment.utc(date).format(config.reported_date_format));
       });
 
     });

--- a/webapp/tests/mocha/unit/filters/date.spec.js
+++ b/webapp/tests/mocha/unit/filters/date.spec.js
@@ -1,12 +1,13 @@
-const assert = require('chai').assert;
+const assert = require('chai').assert,
+      moment = require('moment');
 
 const mockAngular = require('../mock-angular');
 require('../../../../src/js/filters/date');
 const filter = mockAngular.modules.inboxFilters.filters;
 
 describe('date filter', function() {
-  
-  const TEST_DATE = new Date(2398472085558);
+
+  const TEST_DATE = moment.utc(2398472085558);
 
   const TEST_TASK = {
     messages: [


### PR DESCRIPTION
# Description

Fixes broken unit tests. Including:
- bug introduced lately with changesFeed refactor
- timezone related issues  that have been there in the code for a while. 

This does not yet cover all fixes needed for 4232.

medic/medic-webapp#4232

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.