### PR TITLE
Don't overwrite already generated messages (2.15.x)

### DIFF
--- a/sentinel/schedule/due_tasks.js
+++ b/sentinel/schedule/due_tasks.js
@@ -61,18 +61,20 @@ module.exports = function(db, audit, callback) {
                         doc.scheduled_tasks.forEach(task => {
                             if (task.due === obj.key) {
                                 utils.setTaskState(task, 'pending');
-                                const content = {
-                                    translationKey: task.message_key,
-                                    message: task.message
-                                };
-                                task.messages = messageUtils.generate(
-                                    config.getAll(),
-                                    utils.translate,
-                                    doc,
-                                    content,
-                                    task.recipient,
-                                    context
-                                );
+                                if (!task.messages) {
+                                    const content = {
+                                        translationKey: task.message_key,
+                                        message: task.message
+                                    };
+                                    task.messages = messageUtils.generate(
+                                        config.getAll(),
+                                        utils.translate,
+                                        doc,
+                                        content,
+                                        task.recipient,
+                                        context
+                                    );
+                                }
                             }
                         });
                         lineage.minify(doc);


### PR DESCRIPTION
# Description

The old style of messages are generated up front and never updated.
For backwards compatibility these messages should be left unchanged.

medic/medic-webapp#4476

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.