### PR TITLE
Switches to use npm pack

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -357,7 +357,8 @@ module.exports = function(grunt) {
              ' && curl -X POST http://admin:pass@localhost:5984/_users ' +
                  ' -H "Content-Type: application/json" ' +
                  ' -d \'{"_id": "org.couchdb.user:admin", "name": "admin", "password":"pass", "type":"user", "roles":[]}\' ' +
-             ' && curl -X PUT --data \'"true"\' http://admin:pass@localhost:5984/_node/${COUCH_NODE_NAME}/_config/chttpd/require_valid_user'
+             ' && curl -X PUT --data \'"true"\' http://admin:pass@localhost:5984/_node/${COUCH_NODE_NAME}/_config/chttpd/require_valid_user' +
+             ' && curl -X PUT --data \'"4294967296"\' http://admin:pass@localhost:5984/_node/${COUCH_NODE_NAME}/_config/httpd/max_http_request_size'
       },
       resetTestDatabases: {
         stderr: false,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -287,7 +287,7 @@ module.exports = function(grunt) {
     },
     exec: {
       'debug': {
-        cmd: 'ls -lR webapp/dist/ddocs/medic/ && curl http://admin:pass@localhost:5984 && http://admin:pass@localhost:5984/_node/${COUCH_NODE_NAME}/_config'
+        cmd: 'ls -lR webapp/dist/ddocs/medic/ && curl http://localhost:5984 && http://localhost:5984/_node/${COUCH_NODE_NAME}/_config'
       },
       'clean-dist': {
         cmd: 'rm -rf webapp/dist && mkdir webapp/dist'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -287,7 +287,7 @@ module.exports = function(grunt) {
     },
     exec: {
       'debug': {
-        cmd: 'ls -lR webapp/dist/ddocs/medic/ && curl http://localhost:5984 && http://localhost:5984/_node/${COUCH_NODE_NAME}/_config'
+        cmd: 'ls -lR webapp/dist/ddocs/medic/ && curl http://localhost:5984 && http://admin:pass@localhost:5984/_node/${COUCH_NODE_NAME}/_config'
       },
       'clean-dist': {
         cmd: 'rm -rf webapp/dist && mkdir webapp/dist'
@@ -715,8 +715,7 @@ module.exports = function(grunt) {
     'couch-compile:client',
     'copy:ddocAttachments',
     'appcache',
-    'couch-compile:app',
-    'exec:debug',
+    'couch-compile:app'
   ]);
 
   grunt.registerTask('build-admin', 'Build the admin app', [
@@ -811,6 +810,7 @@ module.exports = function(grunt) {
   grunt.registerTask('ci-integration-e2e', 'Run further tests for CI', [
     'env:general',
     'exec:setupAdmin',
+    'exec:debug',
     'deploy',
     'test_api_integration',
     'exec:start_webdriver',
@@ -820,6 +820,7 @@ module.exports = function(grunt) {
   grunt.registerTask('ci-performance', 'Run performance tests on CI', [
     'env:general',
     'exec:setupAdmin',
+    'exec:debug',
     'deploy',
     'test_perf',
   ]);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -349,9 +349,6 @@ module.exports = function(grunt) {
                       grep -Ev '^\s*//' &&
                   echo 'ERROR: Links found with target="_blank" but no rel="noopener noreferrer" set.  Please add required rel attribute.')`,
       },
-      'debug': {
-        cmd: 'curl http://admin:pass@localhost:5984/_node/${COUCH_NODE_NAME}/_config'
-      },
       setupAdmin: {
         cmd: 'curl -X PUT http://localhost:5984/_node/${COUCH_NODE_NAME}/_config/admins/admin -d \'"pass"\'' +
              ' && curl -X POST http://admin:pass@localhost:5984/_users ' +
@@ -716,7 +713,7 @@ module.exports = function(grunt) {
     'couch-compile:client',
     'copy:ddocAttachments',
     'appcache',
-    'couch-compile:app'
+    'couch-compile:app',
   ]);
 
   grunt.registerTask('build-admin', 'Build the admin app', [
@@ -811,7 +808,6 @@ module.exports = function(grunt) {
   grunt.registerTask('ci-integration-e2e', 'Run further tests for CI', [
     'env:general',
     'exec:setupAdmin',
-    'exec:debug',
     'deploy',
     'test_api_integration',
     'exec:start_webdriver',
@@ -821,7 +817,6 @@ module.exports = function(grunt) {
   grunt.registerTask('ci-performance', 'Run performance tests on CI', [
     'env:general',
     'exec:setupAdmin',
-    'exec:debug',
     'deploy',
     'test_perf',
   ]);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -287,7 +287,7 @@ module.exports = function(grunt) {
     },
     exec: {
       'debug': {
-        cmd: 'ls -l webapp/dist/ddocs/medic/_attachments/ && ls -l webapp/dist/ddocs/'
+        cmd: 'ls -lR webapp/dist/ddocs/medic/'
       },
       'clean-dist': {
         cmd: 'rm -rf webapp/dist && mkdir webapp/dist'
@@ -295,6 +295,7 @@ module.exports = function(grunt) {
       packNodeModules: {
         cmd: ['api', 'sentinel'].map(module => [
               `cd ${module}`,
+              `rm -rf node_modules`,
               `yarn install --production`,
               `npm pack`, // Use npm until yarn pack is fixed: https://github.com/medic/medic-webapp/issues/4489
               `mv medic-*.tgz ../webapp/dist/ddocs/medic/_attachments/`,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -286,9 +286,6 @@ module.exports = function(grunt) {
       }
     },
     exec: {
-      'debug': {
-        cmd: 'ls -lR webapp/dist/ddocs/medic/ && curl http://localhost:5984 && http://admin:pass@localhost:5984/_node/${COUCH_NODE_NAME}/_config'
-      },
       'clean-dist': {
         cmd: 'rm -rf webapp/dist && mkdir webapp/dist'
       },
@@ -351,6 +348,9 @@ module.exports = function(grunt) {
                       grep -Ev 'target\\\\?="_blank" rel\\\\?="noopener noreferrer"' |
                       grep -Ev '^\s*//' &&
                   echo 'ERROR: Links found with target="_blank" but no rel="noopener noreferrer" set.  Please add required rel attribute.')`,
+      },
+      'debug': {
+        cmd: 'curl http://admin:pass@localhost:5984/_node/${COUCH_NODE_NAME}/_config'
       },
       setupAdmin: {
         cmd: 'curl -X PUT http://localhost:5984/_node/${COUCH_NODE_NAME}/_config/admins/admin -d \'"pass"\'' +

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -287,7 +287,7 @@ module.exports = function(grunt) {
     },
     exec: {
       'debug': {
-        cmd: 'ls -lR webapp/dist/ddocs/medic/'
+        cmd: 'ls -lR webapp/dist/ddocs/medic/ && curl http://admin:pass@localhost:5984 && http://admin:pass@localhost:5984/_node/${COUCH_NODE_NAME}/_config'
       },
       'clean-dist': {
         cmd: 'rm -rf webapp/dist && mkdir webapp/dist'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -286,6 +286,9 @@ module.exports = function(grunt) {
       }
     },
     exec: {
+      'debug': {
+        cmd: 'ls -l webapp/dist/ddocs/medic/_attachments/ && ls -l webapp/dist/ddocs/'
+      },
       'clean-dist': {
         cmd: 'rm -rf webapp/dist && mkdir webapp/dist'
       },
@@ -712,6 +715,7 @@ module.exports = function(grunt) {
     'copy:ddocAttachments',
     'appcache',
     'couch-compile:app',
+    'exec:debug',
   ]);
 
   grunt.registerTask('build-admin', 'Build the admin app', [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -293,7 +293,7 @@ module.exports = function(grunt) {
         cmd: ['api', 'sentinel'].map(module => [
               `cd ${module}`,
               `yarn install --production`,
-              `yarn pack`,
+              `npm pack`, // Use npm until yarn pack is fixed: https://github.com/medic/medic-webapp/issues/4489
               `mv medic-*.tgz ../webapp/dist/ddocs/medic/_attachments/`,
               `cd ..`,
             ].join(' && ')).join(' && ')

--- a/webapp/src/ddocs/medic/build_info/node_modules.json
+++ b/webapp/src/ddocs/medic/build_info/node_modules.json
@@ -1,1 +1,4 @@
-["medic-api-v0.1.0.tgz", "medic-sentinel-v0.1.0.tgz"]
+[
+  "medic-api-0.1.0.tgz",
+  "medic-sentinel-0.1.0.tgz"
+]


### PR DESCRIPTION
# Description

yarn pack has a bug where it doesn't include the node_modules so we
should use npm pack until that bug is fixed.

medic/medic-webapp#4489

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.