### PR TITLE
Limits the v1 exports to 1000 records

### DIFF
--- a/api/services/export-data.js
+++ b/api/services/export-data.js
@@ -549,6 +549,7 @@ var getRecordsFti = function(type, params, callback) {
     q: params.query,
     schema: params.schema,
     sort: type.orderBy,
+    limit: 1000,
     include_docs: true
   };
   fti.get(type.index, options, params.district, callback);
@@ -558,7 +559,8 @@ var getRecordsView = function(type, params, callback) {
   var districtId = params.district;
   var options = {
     include_docs: true,
-    descending: true
+    descending: true,
+    limit: 1000
   };
   if (params.type === 'messages') {
     if (districtId) {


### PR DESCRIPTION
# Description

This allows the exports to return something useful until streaming
lands in 3.0.

medic/medic-webapp#4455

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.