### PR TITLE
Handle unrecognised roles in api's user controller

### DIFF
--- a/api/src/controllers/users.js
+++ b/api/src/controllers/users.js
@@ -6,6 +6,7 @@ const async = require('async'),
       db = require('../db-nano'),
       dbPouch = require('../db-pouch'),
       lineage = require('lineage')(Promise, dbPouch.medic);
+const getRoles = require('../services/types-and-roles');
 
 const USER_PREFIX = 'org.couchdb.user:';
 
@@ -344,35 +345,6 @@ var mapUsers = function(users, settings, facilities) {
       known: user.doc.known
     };
   });
-};
-
-/*
- * TODO: formalise this relationship in a shared library
- *
- * Specifically:
- *  - getRoles converts a supposed "type" in a collection of roles (that includes itself)
- *  - By convention, the type is always the first role
- *  - Thus, you can get the original type (in theory) back out by getting the first role
- *
- *  This may need to change once we makes roles more flexible, if the end result is that
- *  types are initial collections of roles but users can gain or lose any role manually.
- *
- *  NB: these are also documented in /api/README.md
- *
- *  Related to: https://github.com/medic/medic-webapp/issues/2583
- */
-var rolesMap = {
-  'national-manager': ['kujua_user', 'data_entry', 'national_admin'],
-  'district-manager': ['kujua_user', 'data_entry', 'district_admin'],
-  'facility-manager': ['kujua_user', 'data_entry'],
-  'data-entry': ['data_entry'],
-  'analytics': ['kujua_analytics'],
-  'gateway': ['kujua_gateway']
-};
-
-var getRoles = function(type) {
-  // create a new array with the type first, by convention
-  return type ? [type].concat(rolesMap[type]) : [];
 };
 
 var getSettingsUpdates = function(username, data) {

--- a/api/src/services/types-and-roles.js
+++ b/api/src/services/types-and-roles.js
@@ -1,0 +1,35 @@
+/*
+ * TODO: formalise this relationship in a shared library
+ *
+ * Specifically:
+ *  - getRoles converts a supposed "type" in a collection of roles (that includes itself)
+ *  - By convention, the type is always the first role
+ *  - Thus, you can get the original type (in theory) back out by getting the first role
+ *
+ *  This may need to change once we makes roles more flexible, if the end result is that
+ *  types are initial collections of roles but users can gain or lose any role manually.
+ *
+ *  NB: these are also documented in /api/README.md
+ *
+ *  Related to: https://github.com/medic/medic-webapp/issues/2583
+ */
+var rolesMap = {
+  'national-manager': ['kujua_user', 'data_entry', 'national_admin'],
+  'district-manager': ['kujua_user', 'data_entry', 'district_admin'],
+  'facility-manager': ['kujua_user', 'data_entry'],
+  'data-entry': ['data_entry'],
+  'analytics': ['kujua_analytics'],
+  'gateway': ['kujua_gateway']
+};
+
+module.exports = function(type) {
+  // create a new array with the type first, by convention
+  if (!type) {
+    return [];
+  }
+  if (type in rolesMap) {
+    return [type].concat(rolesMap[type]);
+  }
+  return [type];
+};
+

--- a/api/tests/mocha/services/types-and-roles.js
+++ b/api/tests/mocha/services/types-and-roles.js
@@ -1,0 +1,21 @@
+const assert = require('chai').assert;
+
+const getRoles = require('../../../src/services/types-and-roles');
+
+describe('types-and-roles', function() {
+
+  it('should return an empty list for a blank type', function() {
+    assert.deepEqual(getRoles(),     []);
+    assert.deepEqual(getRoles(null), []);
+    assert.deepEqual(getRoles(''),   []);
+  });
+
+  it('should return the type alone for an unmapped type', function() {
+    assert.deepEqual(getRoles('unmapped-type'), ['unmapped-type']);
+  });
+
+  it('should return the type and other roles for a mapped type', function() {
+    assert.deepEqual(getRoles('gateway'), ['gateway', 'kujua_gateway']);
+  });
+
+});

--- a/api/tests/unit/controllers/users.js
+++ b/api/tests/unit/controllers/users.js
@@ -941,11 +941,11 @@ exports['updateUser type param updates roles on user and user-settings doc'] = f
   sinon.stub(controller, '_validateUser').callsArgWith(1, null, {});
   sinon.stub(controller, '_validateUserSettings').callsArgWith(1, null, {});
   var update = sinon.stub(controller, '_storeUpdatedUser').callsFake(function(id, data, callback) {
-    test.deepEqual(data.roles, ['rebel', undefined]);
+    test.deepEqual(data.roles, ['rebel']);
     callback();
   });
   var updateSettings = sinon.stub(controller, '_storeUpdatedUserSettings').callsFake(function(id, data, callback) {
-    test.deepEqual(data.roles, ['rebel', undefined]);
+    test.deepEqual(data.roles, ['rebel']);
     callback();
   });
   controller.updateUser('paul', data, true, function(err) {
@@ -1057,7 +1057,7 @@ exports['updateUser updates user and user settings doc'] = function(test) {
   sinon.stub(places, 'getPlace').callsArg(1);
   var update = sinon.stub(controller, '_storeUpdatedUser').callsFake(function(id, user, cb) {
     test.equal(user.facility_id, 'el paso');
-    test.deepEqual(user.roles, ['rambler', undefined]);
+    test.deepEqual(user.roles, ['rambler']);
     test.equal(user.shoes, 'dusty boots');
     test.equal(user.password, COMPLEX_PASSWORD);
     test.equal(user.type, 'user');


### PR DESCRIPTION
Previously if you passed an unknown type into `getRoles()` it would return `[ 'your-unkown-type', undefined ]`, which couchdb would then reject as an invalid list of roles.