### PR TITLE
4469 Bulk delete retry errors

### DIFF
--- a/api/db-pouch.js
+++ b/api/db-pouch.js
@@ -9,6 +9,7 @@ if(UNIT_TEST_ENV) {
     allDocs: () => Promise.resolve({ offset:0, total_rows:0, rows:[] }),
     bulkDocs: () => Promise.resolve([]),
     query: () => Promise.resolve({ offset:0, total_rows:0, rows:[] }),
+    get: () => Promise.resolve({}),
   };
 } else if(COUCH_URL) {
   // strip trailing slash from to prevent bugs in path matching

--- a/api/routing.js
+++ b/api/routing.js
@@ -47,7 +47,7 @@ const _ = require('underscore'),
 var jsonParser = bodyParser.json({limit: '32mb'});
 
 const handleJsonRequest = (method, path, callback) => {
-  app[method](path, jsonParser, (req, res) => {
+  app[method](path, jsonParser, (req, res, next) => {
     const contentType = req.headers['content-type'];
     if (!contentType || contentType !== 'application/json') {
       return serverUtils.error({
@@ -55,7 +55,7 @@ const handleJsonRequest = (method, path, callback) => {
         message: 'Content-Type must be application/json'
       }, req, res);
     } else {
-      callback(req, res);
+      callback(req, res, next);
     }
   });
 };

--- a/api/services/bulk-docs.js
+++ b/api/services/bulk-docs.js
@@ -89,12 +89,14 @@ module.exports = {
       .then(() => {
         // Retry any failures a maximum of 3 times
         return [1, 2, 3].reduce((promise, attemptNumber) => {
-          if (docsToRetry.length === 0) {
-            return promise;
-          }
-          const batches = generateBatches(docsToRetry, batchSize);
-          docsToRetry.length = 0;
-          return promise.then(() => deleteBatches(batches, res, docsToRetry, attemptNumber));
+          return promise.then(() => {
+            if (docsToRetry.length === 0) {
+              return promise;
+            }
+            const batches = generateBatches(docsToRetry, batchSize);
+            docsToRetry.length = 0;
+            return deleteBatches(batches, res, docsToRetry, attemptNumber);
+          });
         }, Promise.resolve());
       })
       .then(() => {

--- a/api/services/bulk-docs.js
+++ b/api/services/bulk-docs.js
@@ -61,7 +61,7 @@ const deleteBatches = (batches, res, docsToRetry, attemptNumber) => {
         return db.medic.bulkDocs(docsToModify);
       })
       .then(result => {
-        const errors = result.map(docUpdate => docUpdate.error);
+        const errors = result.map(docUpdate => docUpdate.error && docUpdate.status !== 404);
         const errorIds = docsToModify
           .filter((doc, index) => errors[index])
           .map(doc => doc._id);

--- a/api/services/bulk-docs.js
+++ b/api/services/bulk-docs.js
@@ -4,15 +4,9 @@ const utils = require('bulk-docs-utils')({
   DB: db.medic
 });
 
-const markAsDeleted = data => {
+const extractDocs = data => {
   return data.rows
-    .map(row => {
-      const doc = row.doc;
-      if (doc) {
-        doc._deleted = true;
-        return doc;
-      }
-    })
+    .map(row => row.doc)
     .filter(doc => doc);
 };
 
@@ -25,72 +19,70 @@ const checkForDuplicates = docs => {
   }
 };
 
-const updateParentContacts = (docs, batchSize, attemptCounts) => {
-  const batch = docs.splice(0, batchSize);
-  batch.forEach(doc => {
-    attemptCounts[doc._id] = (attemptCounts[doc._id] || 0) + 1;
-  });
-  const parentMap = {};
-  return utils.updateParentContacts(batch, parentMap)
-    .then(docsToUpdate => {
-      if (!docsToUpdate.length) {
-        return [];
-      }
-      return db.medic.bulkDocs(docsToUpdate)
-        .then(result => {
-          const errorIds = result
-            .map((docUpdate, index) => docUpdate.error && docUpdate.status !== 404 && (docUpdate.id || docsToUpdate[index]._id))
-            .filter(id => id);
-          errorIds.forEach(id => {
-            const doc = parentMap[id];
-            if (attemptCounts[doc._id] < 4) {
-              docs.push(doc);
-              result = result.filter(docUpdate => docUpdate.id !== id);
-            }
-          });
-          if (docs.length > 0) {
-            return updateParentContacts(docs, batchSize, attemptCounts);
-          }
-          return result;
-        });
-    });
+const generateBatches = (ids, batchSize) => {
+  const batches = [];
+  while (ids.length > 0) {
+    const batch = ids.splice(0, batchSize);
+    batches.push(batch);
+  }
+  return batches;
 };
 
-const deleteInBatches = (idsToDelete, batchSize, attemptCounts, res) => {
-  const batch = idsToDelete.splice(0, batchSize);
-  batch.forEach(id => {
-    attemptCounts[id] = (attemptCounts[id] || 0) + 1;
+const fetchDocs = ids => {
+  if (ids.length === 0) {
+    return Promise.resolve([]);
+  }
+  return db.medic.allDocs({ keys: ids, include_docs: true })
+    .then(extractDocs);
+};
+
+const incrementAttemptCounts = (docs, attemptCounts) => {
+  docs.forEach(doc => {
+    attemptCounts[doc._id] = (attemptCounts[doc._id] || 0) + 1;
   });
-  let docsToDelete;
-  let deletionResponse;
-  return db.medic.allDocs({ keys: batch, include_docs: true })
-    .then(result => {
-      docsToDelete = markAsDeleted(result);
-      return db.medic.bulkDocs(docsToDelete);
+};
+
+const deleteDocs = (docsToDelete, deletionAttemptCounts, updateAttemptCounts, cumulativeResult = []) => {
+  const parentMap = {};
+  let docsToUpdate;
+  let docsToModify;
+  docsToDelete.forEach(doc => doc._deleted = true);
+  incrementAttemptCounts(docsToDelete, deletionAttemptCounts);
+  return utils.updateParentContacts(docsToDelete, parentMap)
+    .then(updatedParents => {
+      docsToUpdate = updatedParents;
+      incrementAttemptCounts(docsToUpdate, updateAttemptCounts);
+      docsToModify = docsToDelete.concat(docsToUpdate);
+      return db.medic.bulkDocs(docsToModify);
     })
     .then(result => {
-      deletionResponse = result;
-      const errorIds = deletionResponse
-        .map((docUpdate, index) => docUpdate.error && docUpdate.status !== 404 && (docUpdate.id || docsToDelete[index]._id))
+      result = result.filter(docUpdate => docUpdate.status !== 404);
+      const deletionFailures = [];
+      const updateFailures = [];
+      const deletionIds = docsToDelete.map(doc => doc._id);
+      const updateIds = docsToUpdate.map(doc => doc._id);
+      const errorIds = result
+        .map((docUpdate, index) => docUpdate.error && (docUpdate.id || docsToModify[index]._id))
         .filter(id => id);
       errorIds.forEach(id => {
-        if (attemptCounts[id] < 4) {
-          idsToDelete.push(id);
-          deletionResponse = deletionResponse.filter(docUpdate => docUpdate.id !== id);
+        if (deletionIds.includes(id) && deletionAttemptCounts[id] < 4) {
+          deletionFailures.push(id);
+          result = result.filter(docUpdate => docUpdate.id !== id);
+        } else if (updateIds.includes(id) && updateAttemptCounts[id] < 4) {
+          updateFailures.push(id);
+          result = result.filter(docUpdate => docUpdate.id !== id);
         }
       });
-      const successfullyDeletedDocs = docsToDelete.filter(doc => !errorIds.includes(doc._id));
-      const updateAttemptCounts = {};
-      return updateParentContacts(successfullyDeletedDocs, batchSize, updateAttemptCounts);
-    })
-    .then(updateResponse => {
-      let resString = JSON.stringify(deletionResponse.concat(updateResponse));
-      if (idsToDelete.length > 0) {
-        resString += ',';
-        res.write(resString);
-        return deleteInBatches(idsToDelete, batchSize, attemptCounts, res);
+
+      cumulativeResult = cumulativeResult.concat(result);
+      if (deletionFailures.length > 0 || updateFailures.length > 0) {
+        return fetchDocs(deletionFailures)
+          .then(docsToDelete => {
+            const updatesToRetry = updateFailures.map(id => parentMap[id]);
+            return deleteDocs(docsToDelete.concat(updatesToRetry), deletionAttemptCounts, updateAttemptCounts, cumulativeResult);
+          });
       }
-      res.write(resString);
+      return cumulativeResult;
     });
 };
 
@@ -98,11 +90,24 @@ module.exports = {
   bulkDelete: (docs, res, { batchSize = 100 } = {}) => {
     checkForDuplicates(docs);
     const ids = docs.map(doc => doc._id);
-    const attemptCounts = {};
+    const batches = generateBatches(ids, batchSize);
+    const deletionAttemptCounts = {};
+    const updateAttemptCounts = {};
     res.type('application/json');
     res.setHeader('X-Content-Type-Options', 'nosniff');
     res.write('[');
-    return deleteInBatches(ids, batchSize, attemptCounts, res)
+    return batches.reduce((promise, batch, index) => {
+      return promise
+        .then(() => fetchDocs(batch))
+        .then(docsToDelete => deleteDocs(docsToDelete, deletionAttemptCounts, updateAttemptCounts))
+        .then(result => {
+          let resString = JSON.stringify(result);
+          if (index !== batches.length - 1) {
+            resString += ',';
+          }
+          res.write(resString);
+        });
+    }, Promise.resolve())
       .then(() => {
         res.write(']');
         res.end();

--- a/api/services/bulk-docs.js
+++ b/api/services/bulk-docs.js
@@ -97,7 +97,9 @@ const deleteDocs = (docsToDelete, deletionAttemptCounts = {}, updateAttemptCount
         return fetchDocs(deletionFailures)
           .then(docsToDelete => {
             // Retry updates by resending through the child doc (ensuring the update is still necessary in case of conflict)
-            const updatesToRetryThroughDocDeletions = updateFailures.map(id => documentByParentId[id]);
+            const updatesToRetryThroughDocDeletions = updateFailures
+              .map(id => documentByParentId[id])
+              .filter(doc => !deletionFailures.includes(doc._id));
             return deleteDocs(docsToDelete.concat(updatesToRetryThroughDocDeletions), deletionAttemptCounts, updateAttemptCounts, finalUpdateStatuses);
           });
       }

--- a/api/services/bulk-docs.js
+++ b/api/services/bulk-docs.js
@@ -1,5 +1,4 @@
 const db = require('../db-pouch');
-
 const utils = require('bulk-docs-utils')({
   Promise: Promise,
   DB: db.medic
@@ -35,35 +34,68 @@ const generateBatches = (docs, batchSize) => {
   return batches;
 };
 
-const generateBatchPromise = (batch, res, { isFinal } = {}) => {
-  return db.medic.bulkDocs(batch).then(result => {
-    let resString = JSON.stringify(result);
-    resString += isFinal ? '' : ',';
-    res.write(resString);
-  });
+const getDocsToModify = ids => {
+  let docsToDelete;
+  let allDocs;
+  return db.medic.allDocs({ keys: ids, include_docs: true })
+    .then(result => {
+      docsToDelete = markAsDeleted(result);
+      return utils.updateParentContacts(docsToDelete);
+    })
+    .then(docsToUpdate => {
+      allDocs = docsToDelete.concat(docsToUpdate);
+      checkForDuplicates(allDocs);
+      return allDocs;
+    });
+};
+
+const deleteBatches = (batches, res, docsToRetry, attemptNumber) => {
+  return batches.reduce((promise, batch, index) => {
+    const isFinal = index === batches.length - 1;
+    let docsToModify;
+    return promise
+      .then(() => {
+        return getDocsToModify(batch);
+      })
+      .then(allDocs => {
+        docsToModify = allDocs;
+        return db.medic.bulkDocs(docsToModify);
+      })
+      .then(result => {
+        const errors = result.map(docUpdate => docUpdate.error);
+        const errorIds = docsToModify
+          .filter((doc, index) => errors[index])
+          .map(doc => doc._id);
+        errorIds.forEach(id => docsToRetry.push(id));
+
+        let resString = JSON.stringify(result);
+        if ((!isFinal || docsToRetry.length) && attemptNumber !== 3) {
+          resString += ',';
+        }
+        res.write(resString);
+      });
+  }, Promise.resolve());
 };
 
 module.exports = {
   bulkDelete: (docs, res, { batchSize = 100 } = {}) => {
-    let docsToDelete;
-    const keys = docs.map(doc => doc._id);
-    return db.medic.allDocs({ keys, include_docs: true })
-      .then(result => {
-        docsToDelete = markAsDeleted(result);
-        return utils.updateParentContacts(docsToDelete);
-      })
-      .then(docsToUpdate => {
-        const allDocs = docsToDelete.concat(docsToUpdate);
-        checkForDuplicates(allDocs);
-        const batches = generateBatches(allDocs, batchSize);
-
-        res.type('application/json');
-        res.setHeader('X-Content-Type-Options', 'nosniff');
-        res.write('[');
-
-        return batches.reduce((promise, batch, index) => {
-          return promise.then(() => generateBatchPromise(batch, res, { isFinal: index === batches.length - 1 }));
-        }, Promise.resolve([]));
+    const ids = docs.map(doc => doc._id);
+    const batches = generateBatches(ids, batchSize);
+    let docsToRetry = [];
+    res.type('application/json');
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.write('[');
+    return deleteBatches(batches, res, docsToRetry, 0)
+      .then(() => {
+        // Retry any failures a maximum of 3 times
+        return [1, 2, 3].reduce((promise, attemptNumber) => {
+          if (docsToRetry.length === 0) {
+            return promise;
+          }
+          const batches = generateBatches(docsToRetry, batchSize);
+          docsToRetry.length = 0;
+          return promise.then(() => deleteBatches(batches, res, docsToRetry, attemptNumber));
+        }, Promise.resolve());
       })
       .then(() => {
         res.write(']');

--- a/api/services/bulk-docs.js
+++ b/api/services/bulk-docs.js
@@ -36,14 +36,13 @@ const generateBatches = (docs, batchSize) => {
 
 const getDocsToModify = ids => {
   let docsToDelete;
-  let allDocs;
   return db.medic.allDocs({ keys: ids, include_docs: true })
     .then(result => {
       docsToDelete = markAsDeleted(result);
       return utils.updateParentContacts(docsToDelete);
     })
     .then(docsToUpdate => {
-      allDocs = docsToDelete.concat(docsToUpdate);
+      const allDocs = docsToDelete.concat(docsToUpdate);
       checkForDuplicates(allDocs);
       return allDocs;
     });

--- a/api/services/bulk-docs.js
+++ b/api/services/bulk-docs.js
@@ -43,6 +43,7 @@ const incrementAttemptCounts = (docs, attemptCounts) => {
 };
 
 const deleteDocs = (docsToDelete, deletionAttemptCounts, updateAttemptCounts, cumulativeResult = []) => {
+  const finishedModifications = cumulativeResult.map(docUpdate => docUpdate.id);
   const parentMap = {};
   let docsToUpdate;
   let docsToModify;
@@ -52,7 +53,7 @@ const deleteDocs = (docsToDelete, deletionAttemptCounts, updateAttemptCounts, cu
     .then(updatedParents => {
       docsToUpdate = updatedParents;
       incrementAttemptCounts(docsToUpdate, updateAttemptCounts);
-      docsToModify = docsToDelete.concat(docsToUpdate);
+      docsToModify = docsToDelete.concat(docsToUpdate).filter(doc => !finishedModifications.includes(doc._id));
       return db.medic.bulkDocs(docsToModify);
     })
     .then(result => {

--- a/api/services/bulk-docs.js
+++ b/api/services/bulk-docs.js
@@ -65,14 +65,14 @@ const getFailuresToRetry = (updateStatuses, docsToDelete, docsToUpdate, deletion
 const deleteDocs = (docsToDelete, deletionAttemptCounts = {}, updateAttemptCounts = {}, finalUpdateStatuses = []) => {
   let docsToUpdate;
   let docsToModify;
-  let parentMap;
+  let documentByParentId;
 
   docsToDelete.forEach(doc => doc._deleted = true);
   incrementAttemptCounts(docsToDelete, deletionAttemptCounts);
 
   return utils.updateParentContacts(docsToDelete)
     .then(updatedParents => {
-      parentMap = updatedParents.parentMap;
+      documentByParentId = updatedParents.documentByParentId;
 
       const deletionIds = docsToDelete.map(doc => doc._id);
       // Don't update any parents that are already marked for deletion
@@ -97,7 +97,7 @@ const deleteDocs = (docsToDelete, deletionAttemptCounts = {}, updateAttemptCount
         return fetchDocs(deletionFailures)
           .then(docsToDelete => {
             // Retry updates by resending through the child doc (ensuring the update is still necessary in case of conflict)
-            const updatesToRetryThroughDocDeletions = updateFailures.map(id => parentMap[id]);
+            const updatesToRetryThroughDocDeletions = updateFailures.map(id => documentByParentId[id]);
             return deleteDocs(docsToDelete.concat(updatesToRetryThroughDocDeletions), deletionAttemptCounts, updateAttemptCounts, finalUpdateStatuses);
           });
       }

--- a/api/services/bulk-docs.js
+++ b/api/services/bulk-docs.js
@@ -62,7 +62,7 @@ const getFailuresToRetry = (updateStatuses, docsToDelete, docsToUpdate, deletion
   return { deletionFailures, updateFailures };
 };
 
-const deleteDocs = (docsToDelete, deletionAttemptCounts, updateAttemptCounts, finalUpdateStatuses = []) => {
+const deleteDocs = (docsToDelete, deletionAttemptCounts = {}, updateAttemptCounts = {}, finalUpdateStatuses = []) => {
   let docsToUpdate;
   let docsToModify;
   let parentMap;
@@ -116,11 +116,7 @@ module.exports = {
     return batches.reduce((promise, batch, index) => {
       return promise
         .then(() => fetchDocs(batch))
-        .then(docsToDelete => {
-          const deletionAttemptCounts = {};
-          const updateAttemptCounts = {};
-          return deleteDocs(docsToDelete, deletionAttemptCounts, updateAttemptCounts);
-        })
+        .then(deleteDocs)
         .then(result => {
           let resString = JSON.stringify(result);
           if (index !== batches.length - 1) {

--- a/api/services/bulk-docs.js
+++ b/api/services/bulk-docs.js
@@ -91,7 +91,7 @@ module.exports = {
         return [1, 2, 3].reduce((promise, attemptNumber) => {
           return promise.then(() => {
             if (docsToRetry.length === 0) {
-              return promise;
+              return Promise.resolve();
             }
             const batches = generateBatches(docsToRetry, batchSize);
             docsToRetry.length = 0;

--- a/api/tests/mocha/services/bulk-docs.js
+++ b/api/tests/mocha/services/bulk-docs.js
@@ -149,9 +149,9 @@ describe('Bulk Docs Service', function () {
           allDocs.callCount.should.equal(2);
           bulkDocs.callCount.should.equal(5);
           bulkDocs.getCall(0).args[0].should.deep.equal([expectedA, expectedB, expectedParent]);
-          bulkDocs.getCall(1).args[0].should.deep.equal([expectedA, expectedParent]);
-          bulkDocs.getCall(2).args[0].should.deep.equal([expectedA, expectedParent]);
-          bulkDocs.getCall(3).args[0].should.deep.equal([expectedA, expectedParent]);
+          bulkDocs.getCall(1).args[0].should.deep.equal([expectedParent]);
+          bulkDocs.getCall(2).args[0].should.deep.equal([expectedParent]);
+          bulkDocs.getCall(3).args[0].should.deep.equal([expectedParent]);
           bulkDocs.getCall(4).args[0].should.deep.equal([expectedC]);
           testRes.write.callCount.should.equal(4);
           testRes.write.getCall(0).args[0].should.equal('[');

--- a/api/tests/mocha/services/bulk-docs.js
+++ b/api/tests/mocha/services/bulk-docs.js
@@ -129,11 +129,12 @@ describe('Bulk Docs Service', function () {
 
       const allDocs = sinon.stub(db.medic, 'allDocs');
       allDocs.onCall(0).resolves({ rows: [{ doc: docA }, { doc: docB }] });
-      allDocs.onCall(1).resolves({ rows: [{ doc: docC }] });
+      allDocs.onCall(1).resolves({ rows: [{ doc: docA }] });
+      allDocs.onCall(2).resolves({ rows: [{ doc: docC }] });
 
       const bulkDocs = sinon.stub(db.medic, 'bulkDocs');
-      bulkDocs.onCall(0).resolves([{ id: docA._id, ok: true }, { id: docB._id, ok: true }, { id: parent._id, error: true }]);
-      bulkDocs.onCall(1).resolves([{ id: parent._id, error: true }]);
+      bulkDocs.onCall(0).resolves([{ id: docA._id, error: true }, { id: docB._id, ok: true }, { id: parent._id, error: true }]);
+      bulkDocs.onCall(1).resolves([{ id: docA._id, ok: true }, { id: parent._id, error: true }]);
       bulkDocs.onCall(2).resolves([{ id: parent._id, error: true }]);
       bulkDocs.onCall(3).resolves([{ id: parent._id, error: true }]);
       bulkDocs.onCall(4).resolves([{ id: docC._id, ok: true }]);
@@ -146,16 +147,16 @@ describe('Bulk Docs Service', function () {
 
       return service.bulkDelete(testDocs, testRes, { batchSize: 2 })
         .then(() => {
-          allDocs.callCount.should.equal(2);
+          allDocs.callCount.should.equal(3);
           bulkDocs.callCount.should.equal(5);
           bulkDocs.getCall(0).args[0].should.deep.equal([expectedA, expectedB, expectedParent]);
-          bulkDocs.getCall(1).args[0].should.deep.equal([expectedParent]);
+          bulkDocs.getCall(1).args[0].should.deep.equal([expectedA, expectedParent]);
           bulkDocs.getCall(2).args[0].should.deep.equal([expectedParent]);
           bulkDocs.getCall(3).args[0].should.deep.equal([expectedParent]);
           bulkDocs.getCall(4).args[0].should.deep.equal([expectedC]);
           testRes.write.callCount.should.equal(4);
           testRes.write.getCall(0).args[0].should.equal('[');
-          testRes.write.getCall(1).args[0].should.equal('[{"id":"a","ok":true},{"id":"b","ok":true},{"id":"parent","error":true}],');
+          testRes.write.getCall(1).args[0].should.equal('[{"id":"b","ok":true},{"id":"a","ok":true},{"id":"parent","error":true}],');
           testRes.write.getCall(2).args[0].should.equal('[{"id":"c","ok":true}]');
           testRes.write.getCall(3).args[0].should.equal(']');
           testRes.end.callCount.should.equal(1);

--- a/api/tests/mocha/services/bulk-docs.js
+++ b/api/tests/mocha/services/bulk-docs.js
@@ -72,35 +72,38 @@ describe('Bulk Docs Service', function () {
       const docC = { _id: 'c', _rev: '1' };
       const expectedA = Object.assign({}, docA, { _deleted: true });
       const expectedB = Object.assign({}, docB, { _deleted: true });
+      const expectedC = Object.assign({}, docC, { _deleted: true });
       const allDocs = sinon.stub(db.medic, 'allDocs');
       allDocs.onCall(0).resolves({ rows: [{ doc: docA }, { doc: docB }] });
-      allDocs.onCall(1).resolves({ rows: [{ doc: docC }] });
-      allDocs.onCall(2).resolves({ rows: [{ doc: docA }, { doc: docB }] });
+      allDocs.onCall(1).resolves({ rows: [{ doc: docC }, { doc: docA }] });
+      allDocs.onCall(2).resolves({ rows: [{ doc: docB }] });
       allDocs.onCall(3).resolves({ rows: [{ doc: docB }] });
       allDocs.onCall(4).resolves({ rows: [{ doc: docB }] });
 
       const bulkDocs = sinon.stub(db.medic, 'bulkDocs');
       bulkDocs.onCall(0).resolves([{ error: true }, { error: true }]);
-      bulkDocs.onCall(1).resolves([{ ok: true }]);
-      bulkDocs.onCall(2).resolves([{ ok: true }, { error: true }]);
+      bulkDocs.onCall(1).resolves([{ ok: true }, { ok: true }]);
+      bulkDocs.onCall(2).resolves([{ error: true }]);
       bulkDocs.onCall(3).resolves([{ error: true }]);
       bulkDocs.onCall(4).resolves([{ error: true }]);
 
       return service.bulkDelete(testDocs, testRes, { batchSize: 2 })
         .then(() => {
           allDocs.callCount.should.equal(5);
-          allDocs.getCall(2).args[0].should.deep.equal({ keys: [docA._id, docB._id], include_docs: true });
+          allDocs.getCall(1).args[0].should.deep.equal({ keys: [docC._id, docA._id], include_docs: true });
+          allDocs.getCall(2).args[0].should.deep.equal({ keys: [docB._id], include_docs: true });
           allDocs.getCall(3).args[0].should.deep.equal({ keys: [docB._id], include_docs: true });
           allDocs.getCall(4).args[0].should.deep.equal({ keys: [docB._id], include_docs: true });
           bulkDocs.callCount.should.equal(5);
-          bulkDocs.getCall(2).args[0].should.deep.equal([expectedA, expectedB]);
+          bulkDocs.getCall(1).args[0].should.deep.equal([expectedC, expectedA]);
+          bulkDocs.getCall(2).args[0].should.deep.equal([expectedB]);
           bulkDocs.getCall(3).args[0].should.deep.equal([expectedB]);
           bulkDocs.getCall(4).args[0].should.deep.equal([expectedB]);
           testRes.write.callCount.should.equal(7);
           testRes.write.getCall(0).args[0].should.equal('[');
           testRes.write.getCall(1).args[0].should.equal('[{"error":true},{"error":true}],');
-          testRes.write.getCall(2).args[0].should.equal('[{"ok":true}],');
-          testRes.write.getCall(3).args[0].should.equal('[{"ok":true},{"error":true}],');
+          testRes.write.getCall(2).args[0].should.equal('[{"ok":true},{"ok":true}],');
+          testRes.write.getCall(3).args[0].should.equal('[{"error":true}],');
           testRes.write.getCall(4).args[0].should.equal('[{"error":true}],');
           testRes.write.getCall(5).args[0].should.equal('[{"error":true}]');
           testRes.write.getCall(6).args[0].should.equal(']');

--- a/api/tests/mocha/services/bulk-docs.js
+++ b/api/tests/mocha/services/bulk-docs.js
@@ -49,9 +49,8 @@ describe('Bulk Docs Service', function () {
       allDocs.onCall(1).resolves({ rows: [{ doc: docC }] });
 
       const bulkDocs = sinon.stub(db.medic, 'bulkDocs');
-      bulkDocs.onCall(0).resolves([{ id: docA._id, ok: true }, { id: docB._id, ok: true }]);
-      bulkDocs.onCall(1).resolves([{ id: parent._id, ok: true }]);
-      bulkDocs.onCall(2).resolves([{ id: docC._id, ok: true }]);
+      bulkDocs.onCall(0).resolves([{ id: docA._id, ok: true }, { id: docB._id, ok: true }, { id: parent._id, ok: true }]);
+      bulkDocs.onCall(1).resolves([{ id: docC._id, ok: true }]);
 
       sinon.stub(db.medic, 'get').resolves(parent);
 
@@ -60,10 +59,9 @@ describe('Bulk Docs Service', function () {
           allDocs.callCount.should.equal(2);
           allDocs.getCall(0).args[0].should.deep.equal({ keys: [docA._id, docB._id], include_docs: true });
           allDocs.getCall(1).args[0].should.deep.equal({ keys: [docC._id], include_docs: true });
-          bulkDocs.callCount.should.equal(3);
-          bulkDocs.getCall(0).args[0].should.deep.equal([expectedA, expectedB]);
-          bulkDocs.getCall(1).args[0].should.deep.equal([expectedParent]);
-          bulkDocs.getCall(2).args[0].should.deep.equal([expectedC]);
+          bulkDocs.callCount.should.equal(2);
+          bulkDocs.getCall(0).args[0].should.deep.equal([expectedA, expectedB, expectedParent]);
+          bulkDocs.getCall(1).args[0].should.deep.equal([expectedC]);
           testRes.write.callCount.should.equal(4);
           testRes.write.getCall(0).args[0].should.equal('[');
           testRes.write.getCall(1).args[0].should.equal('[{"id":"a","ok":true},{"id":"b","ok":true},{"id":"parent","ok":true}],');
@@ -83,38 +81,37 @@ describe('Bulk Docs Service', function () {
 
       const allDocs = sinon.stub(db.medic, 'allDocs');
       allDocs.onCall(0).resolves({ rows: [{ doc: docA }, { doc: docB }] });
-      allDocs.onCall(1).resolves({ rows: [{ doc: docC }, { doc: docA }] });
+      allDocs.onCall(1).resolves({ rows: [{ doc: docA }, { doc: docB }] });
       allDocs.onCall(2).resolves({ rows: [{ doc: docB }] });
       allDocs.onCall(3).resolves({ rows: [{ doc: docB }] });
-      allDocs.onCall(4).resolves({ rows: [{ doc: docB }] });
+      allDocs.onCall(4).resolves({ rows: [{ doc: docC }] });
 
       const bulkDocs = sinon.stub(db.medic, 'bulkDocs');
       bulkDocs.onCall(0).resolves([{ id: docA._id, error: true }, { id: docB._id, error: true }]);
-      bulkDocs.onCall(1).resolves([{ id: docC._id, ok: true }, { id: docA._id, ok: true }]);
+      bulkDocs.onCall(1).resolves([{ id: docA._id, ok: true }, { id: docB._id, error: true }]);
       bulkDocs.onCall(2).resolves([{ id: docB._id, error: true }]);
       bulkDocs.onCall(3).resolves([{ id: docB._id, error: true }]);
-      bulkDocs.onCall(4).resolves([{ id: docB._id, error: true }]);
+      bulkDocs.onCall(4).resolves([{ id: docC._id, ok: true }]);
 
       return service.bulkDelete(testDocs, testRes, { batchSize: 2 })
         .then(() => {
           allDocs.callCount.should.equal(5);
-          allDocs.getCall(1).args[0].should.deep.equal({ keys: [docC._id, docA._id], include_docs: true });
+          allDocs.getCall(0).args[0].should.deep.equal({ keys: [docA._id, docB._id], include_docs: true });
+          allDocs.getCall(1).args[0].should.deep.equal({ keys: [docA._id, docB._id], include_docs: true });
           allDocs.getCall(2).args[0].should.deep.equal({ keys: [docB._id], include_docs: true });
           allDocs.getCall(3).args[0].should.deep.equal({ keys: [docB._id], include_docs: true });
-          allDocs.getCall(4).args[0].should.deep.equal({ keys: [docB._id], include_docs: true });
+          allDocs.getCall(4).args[0].should.deep.equal({ keys: [docC._id], include_docs: true });
           bulkDocs.callCount.should.equal(5);
-          bulkDocs.getCall(1).args[0].should.deep.equal([expectedC, expectedA]);
+          bulkDocs.getCall(0).args[0].should.deep.equal([expectedA, expectedB]);
+          bulkDocs.getCall(1).args[0].should.deep.equal([expectedA, expectedB]);
           bulkDocs.getCall(2).args[0].should.deep.equal([expectedB]);
           bulkDocs.getCall(3).args[0].should.deep.equal([expectedB]);
-          bulkDocs.getCall(4).args[0].should.deep.equal([expectedB]);
-          testRes.write.callCount.should.equal(7);
+          bulkDocs.getCall(4).args[0].should.deep.equal([expectedC]);
+          testRes.write.callCount.should.equal(4);
           testRes.write.getCall(0).args[0].should.equal('[');
-          testRes.write.getCall(1).args[0].should.equal('[],');
-          testRes.write.getCall(2).args[0].should.equal('[{"id":"c","ok":true},{"id":"a","ok":true}],');
-          testRes.write.getCall(3).args[0].should.equal('[],');
-          testRes.write.getCall(4).args[0].should.equal('[],');
-          testRes.write.getCall(5).args[0].should.equal('[{"id":"b","error":true}]');
-          testRes.write.getCall(6).args[0].should.equal(']');
+          testRes.write.getCall(1).args[0].should.equal('[{"id":"a","ok":true},{"id":"b","error":true}],');
+          testRes.write.getCall(2).args[0].should.equal('[{"id":"c","ok":true}]');
+          testRes.write.getCall(3).args[0].should.equal(']');
           testRes.end.callCount.should.equal(1);
         });
     });
@@ -125,19 +122,21 @@ describe('Bulk Docs Service', function () {
       const parent = generateParentDoc();
       const docB = { _id: 'b', _rev: '1' };
       const docC = { _id: 'c', _rev: '1' };
+      const expectedA = Object.assign({}, docA, { _deleted: true });
       const expectedParent = Object.assign({}, parent, { contact: null });
+      const expectedB = Object.assign({}, docB, { _deleted: true });
+      const expectedC = Object.assign({}, docC, { _deleted: true });
 
       const allDocs = sinon.stub(db.medic, 'allDocs');
       allDocs.onCall(0).resolves({ rows: [{ doc: docA }, { doc: docB }] });
       allDocs.onCall(1).resolves({ rows: [{ doc: docC }] });
 
       const bulkDocs = sinon.stub(db.medic, 'bulkDocs');
-      bulkDocs.onCall(0).resolves([{ id: docA._id, ok: true }, { id: docB._id, ok: true }]);
+      bulkDocs.onCall(0).resolves([{ id: docA._id, ok: true }, { id: docB._id, ok: true }, { id: parent._id, error: true }]);
       bulkDocs.onCall(1).resolves([{ id: parent._id, error: true }]);
       bulkDocs.onCall(2).resolves([{ id: parent._id, error: true }]);
       bulkDocs.onCall(3).resolves([{ id: parent._id, error: true }]);
-      bulkDocs.onCall(4).resolves([{ id: parent._id, error: true }]);
-      bulkDocs.onCall(5).resolves([{ id: docC._id, ok: true }]);
+      bulkDocs.onCall(4).resolves([{ id: docC._id, ok: true }]);
 
       const get = sinon.stub(db.medic, 'get');
       get.onCall(0).resolves(generateParentDoc());
@@ -148,11 +147,12 @@ describe('Bulk Docs Service', function () {
       return service.bulkDelete(testDocs, testRes, { batchSize: 2 })
         .then(() => {
           allDocs.callCount.should.equal(2);
-          bulkDocs.callCount.should.equal(6);
-          bulkDocs.getCall(1).args[0].should.deep.equal([expectedParent]);
-          bulkDocs.getCall(2).args[0].should.deep.equal([expectedParent]);
-          bulkDocs.getCall(3).args[0].should.deep.equal([expectedParent]);
-          bulkDocs.getCall(4).args[0].should.deep.equal([expectedParent]);
+          bulkDocs.callCount.should.equal(5);
+          bulkDocs.getCall(0).args[0].should.deep.equal([expectedA, expectedB, expectedParent]);
+          bulkDocs.getCall(1).args[0].should.deep.equal([expectedA, expectedParent]);
+          bulkDocs.getCall(2).args[0].should.deep.equal([expectedA, expectedParent]);
+          bulkDocs.getCall(3).args[0].should.deep.equal([expectedA, expectedParent]);
+          bulkDocs.getCall(4).args[0].should.deep.equal([expectedC]);
           testRes.write.callCount.should.equal(4);
           testRes.write.getCall(0).args[0].should.equal('[');
           testRes.write.getCall(1).args[0].should.equal('[{"id":"a","ok":true},{"id":"b","ok":true},{"id":"parent","error":true}],');

--- a/api/tests/mocha/services/bulk-docs.js
+++ b/api/tests/mocha/services/bulk-docs.js
@@ -35,44 +35,52 @@ describe('Bulk Docs Service', function () {
     });
 
     it('writes chunked response', function () {
-      const docA = { _id: 'a', _rev: '1' };
+      const docA = { _id: 'a', _rev: '1', type: 'person', parent: { _id: 'parent' } };
+      const parent = { _id: 'parent', _rev: '1', contact: { _id: 'a' } };
       const docB = { _id: 'b', _rev: '1' };
       const docC = { _id: 'c', _rev: '1' };
       const expectedA = Object.assign({}, docA, { _deleted: true });
+      const expectedParent = Object.assign({}, parent, { contact: null });
       const expectedB = Object.assign({}, docB, { _deleted: true });
       const expectedC = Object.assign({}, docC, { _deleted: true });
+
       const allDocs = sinon.stub(db.medic, 'allDocs');
       allDocs.onCall(0).resolves({ rows: [{ doc: docA }, { doc: docB }] });
       allDocs.onCall(1).resolves({ rows: [{ doc: docC }] });
 
       const bulkDocs = sinon.stub(db.medic, 'bulkDocs');
-      bulkDocs.onCall(0).resolves([{ ok: true }, { ok: true }]);
-      bulkDocs.onCall(1).resolves([{ ok: true }]);
+      bulkDocs.onCall(0).resolves([{ id: docA._id, ok: true }, { id: docB._id, ok: true }]);
+      bulkDocs.onCall(1).resolves([{ id: parent._id, ok: true }]);
+      bulkDocs.onCall(2).resolves([{ id: docC._id, ok: true }]);
+
+      sinon.stub(db.medic, 'get').resolves(parent);
 
       return service.bulkDelete(testDocs, testRes, { batchSize: 2 })
         .then(() => {
           allDocs.callCount.should.equal(2);
-          allDocs.firstCall.args[0].should.deep.equal({ keys: [docA._id, docB._id], include_docs: true });
-          allDocs.secondCall.args[0].should.deep.equal({ keys: [docC._id], include_docs: true });
-          bulkDocs.callCount.should.equal(2);
-          bulkDocs.firstCall.args[0].should.deep.equal([expectedA, expectedB]);
-          bulkDocs.secondCall.args[0].should.deep.equal([expectedC]);
+          allDocs.getCall(0).args[0].should.deep.equal({ keys: [docA._id, docB._id], include_docs: true });
+          allDocs.getCall(1).args[0].should.deep.equal({ keys: [docC._id], include_docs: true });
+          bulkDocs.callCount.should.equal(3);
+          bulkDocs.getCall(0).args[0].should.deep.equal([expectedA, expectedB]);
+          bulkDocs.getCall(1).args[0].should.deep.equal([expectedParent]);
+          bulkDocs.getCall(2).args[0].should.deep.equal([expectedC]);
           testRes.write.callCount.should.equal(4);
           testRes.write.getCall(0).args[0].should.equal('[');
-          testRes.write.getCall(1).args[0].should.equal('[{"ok":true},{"ok":true}],');
-          testRes.write.getCall(2).args[0].should.equal('[{"ok":true}]');
+          testRes.write.getCall(1).args[0].should.equal('[{"id":"a","ok":true},{"id":"b","ok":true},{"id":"parent","ok":true}],');
+          testRes.write.getCall(2).args[0].should.equal('[{"id":"c","ok":true}]');
           testRes.write.getCall(3).args[0].should.equal(']');
           testRes.end.callCount.should.equal(1);
         });
     });
 
-    it('retries failures up to 3 times', function () {
+    it('retries deletion failures up to 3 times', function () {
       const docA = { _id: 'a', _rev: '1' };
       const docB = { _id: 'b', _rev: '1' };
       const docC = { _id: 'c', _rev: '1' };
       const expectedA = Object.assign({}, docA, { _deleted: true });
       const expectedB = Object.assign({}, docB, { _deleted: true });
       const expectedC = Object.assign({}, docC, { _deleted: true });
+
       const allDocs = sinon.stub(db.medic, 'allDocs');
       allDocs.onCall(0).resolves({ rows: [{ doc: docA }, { doc: docB }] });
       allDocs.onCall(1).resolves({ rows: [{ doc: docC }, { doc: docA }] });
@@ -81,11 +89,11 @@ describe('Bulk Docs Service', function () {
       allDocs.onCall(4).resolves({ rows: [{ doc: docB }] });
 
       const bulkDocs = sinon.stub(db.medic, 'bulkDocs');
-      bulkDocs.onCall(0).resolves([{ error: true }, { error: true }]);
-      bulkDocs.onCall(1).resolves([{ ok: true }, { ok: true }]);
-      bulkDocs.onCall(2).resolves([{ error: true }]);
-      bulkDocs.onCall(3).resolves([{ error: true }]);
-      bulkDocs.onCall(4).resolves([{ error: true }]);
+      bulkDocs.onCall(0).resolves([{ id: docA._id, error: true }, { id: docB._id, error: true }]);
+      bulkDocs.onCall(1).resolves([{ id: docC._id, ok: true }, { id: docA._id, ok: true }]);
+      bulkDocs.onCall(2).resolves([{ id: docB._id, error: true }]);
+      bulkDocs.onCall(3).resolves([{ id: docB._id, error: true }]);
+      bulkDocs.onCall(4).resolves([{ id: docB._id, error: true }]);
 
       return service.bulkDelete(testDocs, testRes, { batchSize: 2 })
         .then(() => {
@@ -101,12 +109,55 @@ describe('Bulk Docs Service', function () {
           bulkDocs.getCall(4).args[0].should.deep.equal([expectedB]);
           testRes.write.callCount.should.equal(7);
           testRes.write.getCall(0).args[0].should.equal('[');
-          testRes.write.getCall(1).args[0].should.equal('[{"error":true},{"error":true}],');
-          testRes.write.getCall(2).args[0].should.equal('[{"ok":true},{"ok":true}],');
-          testRes.write.getCall(3).args[0].should.equal('[{"error":true}],');
-          testRes.write.getCall(4).args[0].should.equal('[{"error":true}],');
-          testRes.write.getCall(5).args[0].should.equal('[{"error":true}]');
+          testRes.write.getCall(1).args[0].should.equal('[],');
+          testRes.write.getCall(2).args[0].should.equal('[{"id":"c","ok":true},{"id":"a","ok":true}],');
+          testRes.write.getCall(3).args[0].should.equal('[],');
+          testRes.write.getCall(4).args[0].should.equal('[],');
+          testRes.write.getCall(5).args[0].should.equal('[{"id":"b","error":true}]');
           testRes.write.getCall(6).args[0].should.equal(']');
+          testRes.end.callCount.should.equal(1);
+        });
+    });
+
+    it('retries update failures up to 3 times', function () {
+      const generateParentDoc = () => ({ _id: 'parent', _rev: '1', contact: { _id: 'a' } });
+      const docA = { _id: 'a', _rev: '1', type: 'person', parent: { _id: 'parent' } };
+      const parent = generateParentDoc();
+      const docB = { _id: 'b', _rev: '1' };
+      const docC = { _id: 'c', _rev: '1' };
+      const expectedParent = Object.assign({}, parent, { contact: null });
+
+      const allDocs = sinon.stub(db.medic, 'allDocs');
+      allDocs.onCall(0).resolves({ rows: [{ doc: docA }, { doc: docB }] });
+      allDocs.onCall(1).resolves({ rows: [{ doc: docC }] });
+
+      const bulkDocs = sinon.stub(db.medic, 'bulkDocs');
+      bulkDocs.onCall(0).resolves([{ id: docA._id, ok: true }, { id: docB._id, ok: true }]);
+      bulkDocs.onCall(1).resolves([{ id: parent._id, error: true }]);
+      bulkDocs.onCall(2).resolves([{ id: parent._id, error: true }]);
+      bulkDocs.onCall(3).resolves([{ id: parent._id, error: true }]);
+      bulkDocs.onCall(4).resolves([{ id: parent._id, error: true }]);
+      bulkDocs.onCall(5).resolves([{ id: docC._id, ok: true }]);
+
+      const get = sinon.stub(db.medic, 'get');
+      get.onCall(0).resolves(generateParentDoc());
+      get.onCall(1).resolves(generateParentDoc());
+      get.onCall(2).resolves(generateParentDoc());
+      get.onCall(3).resolves(generateParentDoc());
+
+      return service.bulkDelete(testDocs, testRes, { batchSize: 2 })
+        .then(() => {
+          allDocs.callCount.should.equal(2);
+          bulkDocs.callCount.should.equal(6);
+          bulkDocs.getCall(1).args[0].should.deep.equal([expectedParent]);
+          bulkDocs.getCall(2).args[0].should.deep.equal([expectedParent]);
+          bulkDocs.getCall(3).args[0].should.deep.equal([expectedParent]);
+          bulkDocs.getCall(4).args[0].should.deep.equal([expectedParent]);
+          testRes.write.callCount.should.equal(4);
+          testRes.write.getCall(0).args[0].should.equal('[');
+          testRes.write.getCall(1).args[0].should.equal('[{"id":"a","ok":true},{"id":"b","ok":true},{"id":"parent","error":true}],');
+          testRes.write.getCall(2).args[0].should.equal('[{"id":"c","ok":true}]');
+          testRes.write.getCall(3).args[0].should.equal(']');
           testRes.end.callCount.should.equal(1);
         });
     });

--- a/api/tests/mocha/services/bulk-docs.js
+++ b/api/tests/mocha/services/bulk-docs.js
@@ -38,9 +38,12 @@ describe('Bulk Docs Service', function () {
       const docA = { _id: 'a', _rev: '1' };
       const docB = { _id: 'b', _rev: '1' };
       const docC = { _id: 'c', _rev: '1' };
-      const allDocs = sinon.stub(db.medic, 'allDocs').resolves({
-        rows: [{ doc: docA }, { doc: docB }, { doc: docC }]
-      });
+      const expectedA = Object.assign({}, docA, { _deleted: true });
+      const expectedB = Object.assign({}, docB, { _deleted: true });
+      const expectedC = Object.assign({}, docC, { _deleted: true });
+      const allDocs = sinon.stub(db.medic, 'allDocs');
+      allDocs.onCall(0).resolves({ rows: [{ doc: docA }, { doc: docB }] });
+      allDocs.onCall(1).resolves({ rows: [{ doc: docC }] });
 
       const bulkDocs = sinon.stub(db.medic, 'bulkDocs');
       bulkDocs.onCall(0).resolves([{ ok: true }, { ok: true }]);
@@ -48,15 +51,59 @@ describe('Bulk Docs Service', function () {
 
       return service.bulkDelete(testDocs, testRes, { batchSize: 2 })
         .then(() => {
-          allDocs.callCount.should.equal(1);
+          allDocs.callCount.should.equal(2);
+          allDocs.firstCall.args[0].should.deep.equal({ keys: [docA._id, docB._id], include_docs: true });
+          allDocs.secondCall.args[0].should.deep.equal({ keys: [docC._id], include_docs: true });
           bulkDocs.callCount.should.equal(2);
-          bulkDocs.firstCall.args[0].should.deep.equal([docA, docB]);
-          bulkDocs.secondCall.args[0].should.deep.equal([docC]);
+          bulkDocs.firstCall.args[0].should.deep.equal([expectedA, expectedB]);
+          bulkDocs.secondCall.args[0].should.deep.equal([expectedC]);
           testRes.write.callCount.should.equal(4);
           testRes.write.getCall(0).args[0].should.equal('[');
           testRes.write.getCall(1).args[0].should.equal('[{"ok":true},{"ok":true}],');
           testRes.write.getCall(2).args[0].should.equal('[{"ok":true}]');
           testRes.write.getCall(3).args[0].should.equal(']');
+          testRes.end.callCount.should.equal(1);
+        });
+    });
+
+    it('retries failures up to 3 times', function () {
+      const docA = { _id: 'a', _rev: '1' };
+      const docB = { _id: 'b', _rev: '1' };
+      const docC = { _id: 'c', _rev: '1' };
+      const expectedA = Object.assign({}, docA, { _deleted: true });
+      const expectedB = Object.assign({}, docB, { _deleted: true });
+      const allDocs = sinon.stub(db.medic, 'allDocs');
+      allDocs.onCall(0).resolves({ rows: [{ doc: docA }, { doc: docB }] });
+      allDocs.onCall(1).resolves({ rows: [{ doc: docC }] });
+      allDocs.onCall(2).resolves({ rows: [{ doc: docA }, { doc: docB }] });
+      allDocs.onCall(3).resolves({ rows: [{ doc: docB }] });
+      allDocs.onCall(4).resolves({ rows: [{ doc: docB }] });
+
+      const bulkDocs = sinon.stub(db.medic, 'bulkDocs');
+      bulkDocs.onCall(0).resolves([{ error: true }, { error: true }]);
+      bulkDocs.onCall(1).resolves([{ ok: true }]);
+      bulkDocs.onCall(2).resolves([{ ok: true }, { error: true }]);
+      bulkDocs.onCall(3).resolves([{ error: true }]);
+      bulkDocs.onCall(4).resolves([{ error: true }]);
+
+      return service.bulkDelete(testDocs, testRes, { batchSize: 2 })
+        .then(() => {
+          allDocs.callCount.should.equal(5);
+          allDocs.getCall(2).args[0].should.deep.equal({ keys: [docA._id, docB._id], include_docs: true });
+          allDocs.getCall(3).args[0].should.deep.equal({ keys: [docB._id], include_docs: true });
+          allDocs.getCall(4).args[0].should.deep.equal({ keys: [docB._id], include_docs: true });
+          bulkDocs.callCount.should.equal(5);
+          bulkDocs.getCall(2).args[0].should.deep.equal([expectedA, expectedB]);
+          bulkDocs.getCall(3).args[0].should.deep.equal([expectedB]);
+          bulkDocs.getCall(4).args[0].should.deep.equal([expectedB]);
+          testRes.write.callCount.should.equal(7);
+          testRes.write.getCall(0).args[0].should.equal('[');
+          testRes.write.getCall(1).args[0].should.equal('[{"error":true},{"error":true}],');
+          testRes.write.getCall(2).args[0].should.equal('[{"ok":true}],');
+          testRes.write.getCall(3).args[0].should.equal('[{"ok":true},{"error":true}],');
+          testRes.write.getCall(4).args[0].should.equal('[{"error":true}],');
+          testRes.write.getCall(5).args[0].should.equal('[{"error":true}]');
+          testRes.write.getCall(6).args[0].should.equal(']');
           testRes.end.callCount.should.equal(1);
         });
     });

--- a/shared-libs/bulk-docs-utils/src/bulk-docs-utils.js
+++ b/shared-libs/bulk-docs-utils/src/bulk-docs-utils.js
@@ -5,7 +5,13 @@ module.exports = function(dependencies) {
 
   function getParent(doc) {
     if (doc.type === 'person' && doc.parent && doc.parent._id) {
-      return DB.get(doc.parent._id);
+      return DB.get(doc.parent._id)
+        .catch(function(err) {
+          if (err.status === 404) {
+            return;
+          }
+          throw err;
+        });
     }
     return Promise.resolve();
   }

--- a/shared-libs/bulk-docs-utils/src/bulk-docs-utils.js
+++ b/shared-libs/bulk-docs-utils/src/bulk-docs-utils.js
@@ -11,13 +11,16 @@ module.exports = function(dependencies) {
   }
 
   return {
-    updateParentContacts: function(docs) {
+    updateParentContacts: function(docs, parentMap) {
       return Promise.all(docs.map(function(doc) {
         return getParent(doc)
           .then(function(parent) {
             var shouldUpdateParentContact = parent && parent.contact && parent.contact._id && parent.contact._id === doc._id;
             if (shouldUpdateParentContact) {
               parent.contact = null;
+              if (parentMap) {
+                parentMap[parent._id] = doc;
+              }
               return parent;
             }
           });

--- a/shared-libs/bulk-docs-utils/src/bulk-docs-utils.js
+++ b/shared-libs/bulk-docs-utils/src/bulk-docs-utils.js
@@ -11,24 +11,27 @@ module.exports = function(dependencies) {
   }
 
   return {
-    updateParentContacts: function(docs, parentMap) {
+    updateParentContacts: function(docs) {
+      var parentMap = {};
       return Promise.all(docs.map(function(doc) {
         return getParent(doc)
           .then(function(parent) {
             var shouldUpdateParentContact = parent && parent.contact && parent.contact._id && parent.contact._id === doc._id;
             if (shouldUpdateParentContact) {
               parent.contact = null;
-              if (parentMap) {
-                parentMap[parent._id] = doc;
-              }
+              parentMap[parent._id] = doc;
               return parent;
             }
           });
         }))
         .then(function(parents) {
-          return parents.filter(function(parent) {
+          var docs = parents.filter(function(parent) {
             return parent;
           });
+          return {
+            docs: docs,
+            parentMap: parentMap
+          };
         });
     },
 

--- a/shared-libs/bulk-docs-utils/src/bulk-docs-utils.js
+++ b/shared-libs/bulk-docs-utils/src/bulk-docs-utils.js
@@ -18,14 +18,14 @@ module.exports = function(dependencies) {
 
   return {
     updateParentContacts: function(docs) {
-      var parentMap = {};
+      var documentByParentId = {};
       return Promise.all(docs.map(function(doc) {
         return getParent(doc)
           .then(function(parent) {
             var shouldUpdateParentContact = parent && parent.contact && parent.contact._id && parent.contact._id === doc._id;
             if (shouldUpdateParentContact) {
               parent.contact = null;
-              parentMap[parent._id] = doc;
+              documentByParentId[parent._id] = doc;
               return parent;
             }
           });
@@ -36,7 +36,7 @@ module.exports = function(dependencies) {
           });
           return {
             docs: docs,
-            parentMap: parentMap
+            documentByParentId: documentByParentId
           };
         });
     },

--- a/static/js/services/delete-docs.js
+++ b/static/js/services/delete-docs.js
@@ -51,10 +51,10 @@ var utilsFactory = require('bulk-docs-utils');
           docsToDelete.forEach(function(doc) {
             doc._deleted = true;
           });
+          checkForDuplicates(docsToDelete);
           return utils.updateParentContacts(docsToDelete)
             .then(function(updatedParents) {
-              var allDocs = docsToDelete.concat(updatedParents);
-              checkForDuplicates(allDocs);
+              var allDocs = docsToDelete.concat(updatedParents.docs);
               minifyLineage(allDocs);
               return DB().bulkDocs(allDocs);
             });

--- a/static/js/services/delete-docs.js
+++ b/static/js/services/delete-docs.js
@@ -76,7 +76,7 @@ var utilsFactory = require('bulk-docs-utils');
           if (xhr.responseText) {
             var currentResponse = partialParse(xhr.responseText);
             var successfulDeletions = _.flatten(currentResponse).filter(function(doc) {
-              return doc.ok;
+              return !doc.error;
             });
             var totalDocsDeleted = successfulDeletions.length;
             if (eventListeners.progress && Array.isArray(currentResponse)) {

--- a/static/js/services/delete-docs.js
+++ b/static/js/services/delete-docs.js
@@ -75,7 +75,10 @@ var utilsFactory = require('bulk-docs-utils');
         xhr.onprogress = function() {
           if (xhr.responseText) {
             var currentResponse = partialParse(xhr.responseText);
-            var totalDocsDeleted = _.flatten(currentResponse).length;
+            var successfulDeletions = _.flatten(currentResponse).filter(function(doc) {
+              return doc.ok;
+            });
+            var totalDocsDeleted = successfulDeletions.length;
             if (eventListeners.progress && Array.isArray(currentResponse)) {
               eventListeners.progress(totalDocsDeleted);
             }


### PR DESCRIPTION
# Description

We want to force deletion of documents and retry any failures a set number of times before giving up. This should force deletion in case of conflict, an alternative would be to use the `new_edits` flag but that doesn't seem to be its intended purpose...

medic/medic-webapp#4469

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.