### PR TITLE
Fixes bug detecting configured on/off forms

### DIFF
--- a/sentinel/src/transitions/update_notifications.js
+++ b/sentinel/src/transitions/update_notifications.js
@@ -8,9 +8,11 @@ var async = require('async'),
     transitionUtils = require('./utils'),
     NAME = 'update_notifications';
 
-var getMessage = function(config, eventType) {
-    var msg = _.findWhere(config.messages, { event_type: eventType });
-    return msg && msg.message;
+var isConfigured = function(config, eventType) {
+    return config && config.messages && config.messages.some(message => {
+        return message.event_type === eventType &&
+               (message.message || message.translation_key);
+    });
 };
 
 var getEventType = function(config, doc) {
@@ -27,13 +29,12 @@ var getEventType = function(config, doc) {
         // transition does not apply; return false
         return false;
     }
-    var eventType = mute ? 'on_mute' : 'on_unmute';
-    var msg = getMessage(config, eventType);
+    var msg = isConfigured(config, mute ? 'on_mute' : 'on_unmute');
     if (!msg) {
         // no configured message for the given eventType
         return false;
     }
-    return { mute: mute, type: eventType };
+    return { mute: mute };
 };
 
 module.exports = {


### PR DESCRIPTION
# Description

We can now use either message arrays or translation_key configuration
but prior to this change the transition was only checking for the
former.

medic/medic-webapp#4513

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.