### PR TITLE
Translates scheduled messages using the given locale

### DIFF
--- a/webapp/src/js/services/format-data-record.js
+++ b/webapp/src/js/services/format-data-record.js
@@ -240,7 +240,7 @@ angular.module('inboxServices').factory('FormatDataRecord',
         return getMessage(settings, key, locale) || key;
       }
       var interpolation = skipInterpolation ? 'no-interpolation' : null;
-      return $translate.instant(key, ctx, interpolation);
+      return $translate.instant(key, ctx, interpolation, locale);
     };
 
     /*
@@ -433,7 +433,7 @@ angular.module('inboxServices').factory('FormatDataRecord',
           if (!copy.messages) { // backwards compatibility
             copy.messages = messages.generate(
               settings,
-              _.partial(translate, settings, _, null, null, true),
+              _.partial(translate, settings, _, _, null, true),
               doc,
               content,
               t.recipient,


### PR DESCRIPTION
# Description

We were using the webapp user's configured language for displaying
scheduled messages but we decided to change it to use the locale
that the message will be sent using so you can preview how it will
acutally work.

medic/medic-webapp#4514

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.