### PR TITLE
Bypasses initing pouchdb when UNIT_TEST_ENV is set

### DIFF
--- a/sentinel/src/db-pouch.js
+++ b/sentinel/src/db-pouch.js
@@ -2,11 +2,33 @@ const PouchDB = require('pouchdb-core');
 PouchDB.plugin(require('pouchdb-adapter-http'));
 PouchDB.plugin(require('pouchdb-mapreduce'));
 
-const { COUCH_URL } = process.env;
-// strip trailing slash from to prevent bugs in path matching
-const couchUrl = COUCH_URL && COUCH_URL.replace(/\/$/, '');
+const { COUCH_URL, UNIT_TEST_ENV } = process.env;
 
-module.exports.medic = new PouchDB(couchUrl);
-module.exports.audit = new PouchDB(`${couchUrl}-audit`);
-module.exports.sentinel = new PouchDB(`${couchUrl}-sentinel`);
-module.exports._url = couchUrl;
+if(UNIT_TEST_ENV) {
+  const stubMe = functionName => () => {
+    console.error(new Error(`db.${functionName}() not stubbed!  UNIT_TEST_ENV=${UNIT_TEST_ENV}.  Please stub PouchDB functions that will be interacted with in unit tests.`));
+    process.exit(1);
+  };
+
+  module.exports.medic = {
+    allDocs: stubMe('allDocs'),
+    bulkDocs: stubMe('bulkDocs'),
+    put: stubMe('put'),
+    post: stubMe('post'),
+    query: stubMe('query'),
+  };
+} else if(COUCH_URL) {
+  // strip trailing slash from to prevent bugs in path matching
+  const couchUrl = COUCH_URL && COUCH_URL.replace(/\/$/, '');
+
+  module.exports.medic = new PouchDB(couchUrl);
+  module.exports.audit = new PouchDB(`${couchUrl}-audit`);
+  module.exports.sentinel = new PouchDB(`${couchUrl}-sentinel`);
+} else {
+  console.log(
+    'Please define a COUCH_URL in your environment e.g. \n' +
+    'export COUCH_URL=\'http://admin:123qwe@localhost:5984/medic\'\n\n' +
+    'If you are running unit tests use UNIT_TEST_ENV=1 in your environment.\n'
+  );
+  process.exit(1);
+}

--- a/sentinel/src/db-pouch.js
+++ b/sentinel/src/db-pouch.js
@@ -16,6 +16,16 @@ if(UNIT_TEST_ENV) {
     put: stubMe('put'),
     post: stubMe('post'),
     query: stubMe('query'),
+    get: stubMe('get'),
+  };
+
+  module.exports.sentinel = {
+    allDocs: stubMe('allDocs'),
+    bulkDocs: stubMe('bulkDocs'),
+    put: stubMe('put'),
+    post: stubMe('post'),
+    query: stubMe('query'),
+    get: stubMe('get'),
   };
 } else if(COUCH_URL) {
   // strip trailing slash from to prevent bugs in path matching


### PR DESCRIPTION
# Description

Bypasses initing pouchdb when UNIT_TEST_ENV is set

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.