### PR TITLE
Removes the can_access_directly permission

### DIFF
--- a/api/migrations/remove-can-access-directly-permission.js
+++ b/api/migrations/remove-can-access-directly-permission.js
@@ -1,0 +1,17 @@
+var db = require('../db-pouch').medic;
+
+module.exports = {
+  name: 'remove-can-access-directly-permission',
+  created: new Date(2018, 3, 27),
+  run: function(callback) {
+    db.get('_design/medic')
+      .then(ddoc => {
+        if(ddoc.app_settings.permissions) {
+          ddoc.app_settings.permissions = ddoc.app_settings.permissions.filter(p => p.name !== 'can_access_directly');
+          return db.put(ddoc);
+        }
+      })
+      .then(() => callback())
+      .catch(callback);
+  },
+};


### PR DESCRIPTION
# Description

medic/medic-webapp#4144

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.