### PR TITLE
Uses allDocs to handle 404s gracefully

### DIFF
--- a/webapp/src/js/services/z-score.js
+++ b/webapp/src/js/services/z-score.js
@@ -70,15 +70,10 @@ angular.module('inboxServices').factory('ZScore',
     };
 
     var init = function() {
-      return DB().get(CONFIGURATION_DOC_ID)
-        .then(function(doc) {
-          tables = doc.charts;
-        })
-        .catch(function(err) {
-          if (err.status === 404) {
-            return;
-          }
-          throw err;
+      // use allDocs instead of get so a 404 doesn't report an error
+      return DB().allDocs({ key: CONFIGURATION_DOC_ID, include_docs: true })
+        .then(function(result) {
+          tables = result.rows.length && result.rows[0].doc.charts;
         });
     };
 

--- a/webapp/tests/karma/unit/services/z-score.js
+++ b/webapp/tests/karma/unit/services/z-score.js
@@ -36,6 +36,14 @@ describe('ZScore service', () => {
       }]
     };
 
+    it('returns undefined when no z-score doc', () => {
+      allDocs.resolves({ rows: [ ] });
+      return service().then(util => {
+        const actual = util('weight-for-age', 'male', 10, 150);
+        chai.expect(actual).to.equal(undefined);
+      });
+    });
+
     it('returns undefined for unconfigured chart', () => {
       mockAllDocs({ charts: [] });
       return service().then(util => {


### PR DESCRIPTION
# Description

Chrome reports request 404s in the console which can look alarming.
Using allDocs instead means we can handle the valid case of the
zscore doc being missing without an error being logged.

medic/medic-webapp#4548

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.