### PR TITLE
Fixes bug where docs_by_id_lineage emits for empty parent

### DIFF
--- a/webapp/src/ddocs/medic-client/views/docs_by_id_lineage/map.js
+++ b/webapp/src/ddocs/medic-client/views/docs_by_id_lineage/map.js
@@ -1,7 +1,7 @@
 function(doc) {
 
   var emitLineage = function(contact, depth) {
-    while (contact) {
+    while (contact && contact._id) {
       emit([ doc._id, depth++ ], { _id: contact._id });
       contact = contact.parent;
     }

--- a/webapp/tests/mocha/unit/views/doc_summaries_by_id.spec.js
+++ b/webapp/tests/mocha/unit/views/doc_summaries_by_id.spec.js
@@ -1,32 +1,5 @@
 const assert = require('chai').assert;
-const fs = require('fs');
-const path = require('path');
-const vm = require('vm');
-const MAP_ARG_NAME = 'doc';
-
-var loadMedicClientViewValues = (viewName) => {
-  const mapString = fs.readFileSync(path.join(
-    __dirname,
-    '../../../../src/ddocs/medic-client/views/',
-    viewName,
-    '/map.js'), 'utf8');
-
-  const mapScript = new vm.Script('(' + mapString + ')(' + MAP_ARG_NAME + ');');
-
-  let emitted = [];
-  const context = new vm.createContext({
-    emitted: emitted,
-    emit: function(key, value) {
-      emitted.push({ key: key, value: value });
-    }
-  });
-
-  return (doc) => {
-    context[MAP_ARG_NAME] = doc;
-    mapScript.runInContext(context);
-    return context.emitted;
-  };
-};
+const utils = require('./utils');
 
 const person = {
   _id: '2bba279f-8ad9-4823-be69-a8eb09879402',
@@ -237,7 +210,7 @@ const jsonHouseholdBis = Object.assign({}, jsonHousehold, {
 
 describe('doc_summaries_by_id view', () => {
   it('indexes name, phone, type, contact, lineage, simprints, dod for non-data-records', () => {
-    const map = loadMedicClientViewValues('doc_summaries_by_id');
+    const map = utils.loadView('medic-client', 'doc_summaries_by_id', true);
 
     const emitted = map(person) && map(personBis);
     assert.deepEqual(emitted[0], {
@@ -269,7 +242,7 @@ describe('doc_summaries_by_id view', () => {
   });
 
   it('indexes data-records summary and subject', () => {
-    const map = loadMedicClientViewValues('doc_summaries_by_id');
+    const map = utils.loadView('medic-client', 'doc_summaries_by_id', true);
 
     const reportsList = [
       householdVisit,

--- a/webapp/tests/mocha/unit/views/docs_by_id_lineage.spec.js
+++ b/webapp/tests/mocha/unit/views/docs_by_id_lineage.spec.js
@@ -1,0 +1,182 @@
+const expect = require('chai').expect,
+      utils = require('./utils'),
+      map = utils.loadView('medic-client', 'docs_by_id_lineage', true, true);
+
+describe('docs_by_id_lineage view', () => {
+  describe('data_record lineage', () => {
+    it('does not emit if doc is not a report', () => {
+      const doc = {
+        _id: 'messsage',
+        type: 'data_record',
+        sms_message: { }
+      };
+
+      const result = map(doc);
+      expect(result.length).to.equal(0);
+    });
+    it('emits report document for depth 0', () => {
+      const doc = {
+        _id: 'report',
+        type: 'data_record',
+        form: 'form',
+      };
+
+      const result = map(doc);
+      console.log(result);
+      expect(result.length).to.equal(1);
+      expect(result[0]).to.deep.equal({ key: [ 'report', 0 ], value: undefined });
+    });
+
+    it('emits contact lineage for depth 1+', () => {
+      const doc = {
+        _id: 'report',
+        type: 'data_record',
+        form: 'form',
+        contact: {
+          _id: 'contact1',
+          parent: {
+            _id: 'contact2',
+            parent: {
+              _id: 'contact3'
+            }
+          }
+        }
+      };
+      const result = map(doc);
+      expect(result.length).to.equal(4);
+      expect(result[0]).to.deep.equal({ key: [ 'report', 0 ], value: undefined });
+      expect(result[1]).to.deep.equal({ key: [ 'report', 1 ], value: { _id: 'contact1' }});
+      expect(result[2]).to.deep.equal({ key: [ 'report', 2 ], value: { _id: 'contact2' }});
+      expect(result[3]).to.deep.equal({ key: [ 'report', 3 ], value: { _id: 'contact3' }});
+    });
+
+    it('does not emit lineage for empty contact parents', () => {
+      const doc1 = {
+        _id: 'report1',
+        type: 'data_record',
+        form: 'form',
+        contact: {}
+      };
+      const result1 = map(doc1);
+      expect(result1.length).to.equal(1);
+      expect(result1[0]).to.deep.equal({ key: [ 'report1', 0 ], value: undefined });
+
+      const doc2 = {
+        _id: 'report2',
+        type: 'data_record',
+        form: 'form',
+        contact: {
+          _id: 'contact1',
+          parent: {}
+        }
+      };
+      const result2 = map(doc2);
+      expect(result2.length).to.equal(2);
+      expect(result2[0]).to.deep.equal({ key: [ 'report2', 0 ], value: undefined });
+      expect(result2[1]).to.deep.equal({ key: [ 'report2', 1 ], value: { _id: 'contact1' }});
+
+      const doc3 = {
+        _id: 'report3',
+        type: 'data_record',
+        form: 'form',
+        contact: {
+          _id: 'contact1',
+          parent: {
+            _id: 'contact2',
+            parent: {}
+          }
+        }
+      };
+      const result3 = map(doc3);
+      expect(result3.length).to.equal(3);
+      expect(result3[0]).to.deep.equal({ key: [ 'report3', 0 ], value: undefined });
+      expect(result3[1]).to.deep.equal({ key: [ 'report3', 1 ], value: { _id: 'contact1' }});
+      expect(result3[2]).to.deep.equal({ key: [ 'report3', 2 ], value: { _id: 'contact2' }});
+    });
+  });
+
+  describe('contacts lineage', () => {
+    it('emits lineage for type `person`, `clinic`, `health_center` and `district_hospital`', () => {
+      const person = { _id: 'person', type: 'person' };
+      const result = map(person);
+      expect(result.length).to.equal(1);
+      expect(result[0]).to.deep.equal({ key: [ 'person', 0 ], value: { _id: 'person' }});
+
+      const clinic = { _id: 'clinic', type: 'clinic' };
+      const resultClinic = map(clinic);
+      expect(resultClinic.length).to.equal(1);
+      expect(resultClinic[0]).to.deep.equal({ key: [ 'clinic', 0 ], value: { _id: 'clinic' }});
+
+      const healthCenter = { _id: 'healthCenter', type: 'health_center' };
+      const resultHealthCenter = map(healthCenter);
+      expect(resultHealthCenter.length).to.equal(1);
+      expect(resultHealthCenter[0]).to.deep.equal({ key: [ 'healthCenter', 0 ], value: { _id: 'healthCenter' }});
+
+      const districtHospital = { _id: 'districtHospital', type: 'district_hospital' };
+      const resultdistrictHospital = map(districtHospital);
+      expect(resultdistrictHospital.length).to.equal(1);
+      expect(resultdistrictHospital[0]).to.deep.equal({ key: [ 'districtHospital', 0 ], value: { _id: 'districtHospital' }});
+    });
+
+    it('emits full lineage', () => {
+      const depth = Math.floor(Math.random() * 10),
+            doc = { _id: 'person', type: 'person', parent: {} };
+      let currentParent = doc.parent;
+      for (let i = 0; i < depth; i++) {
+        currentParent._id = `parent${i}`;
+        currentParent.parent = {};
+        currentParent = currentParent.parent;
+      }
+
+      const results = map(doc);
+      expect(results.length).to.equal(depth + 1);
+      expect(results[0]).to.deep.equal({ key: [ 'person', 0 ], value: { _id: 'person' }});
+      results.forEach((result, key) => {
+        if (key > 0) {
+          expect(result).to.deep.equal({ key: [ 'person', key ], value: { _id: `parent${key-1}` }});
+        }
+      });
+    });
+
+    it('does not emit lineage for empty parents', () => {
+      const doc1 = {
+        _id: 'contact1',
+        type: 'person',
+        parent: {}
+      };
+      const result1 = map(doc1);
+      expect(result1.length).to.equal(1);
+      expect(result1[0]).to.deep.equal({ key: [ 'contact1', 0 ], value: { _id: 'contact1'} });
+
+      const doc2 = {
+        _id: 'contact2',
+        type: 'person',
+        parent: {
+          _id: 'contact3',
+          parent: {}
+        }
+      };
+      const result2 = map(doc2);
+      expect(result2.length).to.equal(2);
+      expect(result2[0]).to.deep.equal({ key: [ 'contact2', 0 ], value: { _id: 'contact2' }});
+      expect(result2[1]).to.deep.equal({ key: [ 'contact2', 1 ], value: { _id: 'contact3' }});
+
+      const doc3 = {
+        _id: 'contact3',
+        type: 'person',
+        parent: {
+          _id: 'contact4',
+          parent: {
+            _id: 'contact5',
+            parent: {}
+          }
+        }
+      };
+      const result3 = map(doc3);
+      expect(result3.length).to.equal(3);
+      expect(result3[0]).to.deep.equal({ key: [ 'contact3', 0 ], value: { _id: 'contact3' }});
+      expect(result3[1]).to.deep.equal({ key: [ 'contact3', 1 ], value: { _id: 'contact4' }});
+      expect(result3[2]).to.deep.equal({ key: [ 'contact3', 2 ], value: { _id: 'contact5' }});
+    });
+  });
+});

--- a/webapp/tests/mocha/unit/views/utils.js
+++ b/webapp/tests/mocha/unit/views/utils.js
@@ -5,7 +5,7 @@ const vm = require('vm');
 
 const MAP_ARG_NAME = 'doc';
 
-module.exports.loadView = (ddocName, viewName) => {
+module.exports.loadView = (ddocName, viewName, saveValues = false, reset = false) => {
   const mapString = fs.readFileSync(path.join(
     __dirname,
     '../../../../src/ddocs',
@@ -19,12 +19,18 @@ module.exports.loadView = (ddocName, viewName) => {
   const emitted = [];
   const context = new vm.createContext({
     emitted: emitted,
-    emit: function(e) {
-      emitted.push(e);
+    emit: function(key, value) {
+      if (!saveValues) {
+        return emitted.push(key);
+      }
+      emitted.push({ key: key, value: value });
     }
   });
 
   return (doc) => {
+    if (reset) {
+      emitted.splice(0, emitted.length);
+    }
     context[MAP_ARG_NAME] = doc;
     mapScript.runInContext(context);
     return context.emitted;


### PR DESCRIPTION
# Description

When a document's lineage would end with an empty parent (a truthy value but lacking `_id` property), `docs_by_id_lineage` would emit. This caused queries for such docs to return the original document twice (as first and last row), causing `lineage` library to create an extra level of `parent`, containing the ID of the document itself. 
In case a sentinel transition had updated the document, this form of would be saved. 

medic/medic-webapp#4487

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.