### PR TITLE
Makes recipient resolution patient centric

### DIFF
--- a/sentinel/lib/message-utils.js
+++ b/sentinel/lib/message-utils.js
@@ -10,7 +10,7 @@ var _ = require('underscore'),
     SMS_TRUNCATION_SUFFIX = '...';
 
 var getParent = function(doc, type) {
-  var facility = doc.contact || doc;
+  var facility = doc.parent ? doc : doc.contact;
   while (facility && facility.type !== type) {
     facility = facility.parent;
   }
@@ -133,7 +133,7 @@ var extractTemplateContext = function(doc) {
 };
 
 var extendedTemplateContext = function(doc, extras) {
-  var templateContext = extractTemplateContext(doc);
+  var templateContext = {};
 
   if (extras.templateContext) {
     _.defaults(templateContext, extras.templateContext);
@@ -157,6 +157,8 @@ var extendedTemplateContext = function(doc, extras) {
     // "registered" through the UI, only creating a patient and no registration report
     throw Error('Cannot provide registrations to template context without a patient');
   }
+
+  _.defaults(templateContext, extractTemplateContext(doc));
 
   return templateContext;
 };

--- a/sentinel/test/mocha/lib/message-utils.js
+++ b/sentinel/test/mocha/lib/message-utils.js
@@ -121,6 +121,66 @@ describe('messageUtils', () => {
       expect(message.uuid).to.equal('some-uuid');
     });
 
+    it('calculates recipient from contact if no patient', () => {
+      const config = {};
+      const translate = null;
+      const doc = {
+        from: '+111',
+        contact: {
+          type: 'person',
+          parent: {
+            type: 'clinic',
+            contact: {
+              type: 'person',
+              phone: '+222'
+            }
+          }
+        }
+      };
+      const content = { message: 'xxx' };
+      const recipient = 'clinic';
+      const context = {};
+      const messages = utils.generate(config, translate, doc, content, recipient, context);
+      expect(messages.length).to.equal(1);
+      const message = messages[0];
+      expect(message.to).to.equal('+222');
+    });
+
+    it('calculates recipient from patient', () => {
+      const config = {};
+      const translate = null;
+      const doc = {
+        from: '+111',
+        contact: {
+          type: 'person',
+          parent: {
+            type: 'clinic',
+            contact: {
+              type: 'person',
+              phone: '+222'
+            }
+          }
+        }
+      };
+      const content = { message: 'xxx' };
+      const recipient = 'clinic';
+      const context = {
+        patient: {
+          parent: {
+            type: 'clinic',
+            contact: {
+              type: 'person',
+              phone: '+333'
+            }
+          }
+        }
+      };
+      const messages = utils.generate(config, translate, doc, content, recipient, context);
+      expect(messages.length).to.equal(1);
+      const message = messages[0];
+      expect(message.to).to.equal('+333');
+    });
+
     describe('truncation', () => {
 
       it('does not truncate short sms', () => {

--- a/static/js/modules/message-utils.js
+++ b/static/js/modules/message-utils.js
@@ -10,7 +10,7 @@ var _ = require('underscore'),
     SMS_TRUNCATION_SUFFIX = '...';
 
 var getParent = function(doc, type) {
-  var facility = doc.contact || doc;
+  var facility = doc.parent ? doc : doc.contact;
   while (facility && facility.type !== type) {
     facility = facility.parent;
   }
@@ -133,7 +133,7 @@ var extractTemplateContext = function(doc) {
 };
 
 var extendedTemplateContext = function(doc, extras) {
-  var templateContext = extractTemplateContext(doc);
+  var templateContext = {};
 
   if (extras.templateContext) {
     _.defaults(templateContext, extras.templateContext);
@@ -157,6 +157,8 @@ var extendedTemplateContext = function(doc, extras) {
     // "registered" through the UI, only creating a patient and no registration report
     throw Error('Cannot provide registrations to template context without a patient');
   }
+
+   _.defaults(templateContext, extractTemplateContext(doc));
 
   return templateContext;
 };


### PR DESCRIPTION
# Description

This means if you ask for "clinic" it'll attempt to resolve the
clinic of the patient, not the sender. This allows for reports to be
submitted by anyone about a patient which generate scheduled tasks
for the patient's CHP.

medic/medic-webapp#4512

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.