### PR TITLE
Fixes message recipient resolution

### DIFF
--- a/shared-libs/message-utils/src/index.js
+++ b/shared-libs/message-utils/src/index.js
@@ -117,15 +117,12 @@ var getLocale = function(config, doc) {
 };
 
 var extractTemplateContext = function(doc) {
-  var clinic = getClinic(doc);
-  var healthCenter = getHealthCenter(doc);
-  var district = getDistrict(doc);
   var internal = {
-    clinic: clinic,
-    parent: healthCenter,
-    health_center: healthCenter,
-    grandparent: district,
-    district: district
+    parent: doc && doc.parent,
+    grandparent: doc && doc.parent && doc.parent.parent,
+    clinic: getClinic(doc),
+    health_center: getHealthCenter(doc),
+    district: getDistrict(doc)
   };
   return _.defaults(internal, doc.fields, doc);
 };
@@ -145,6 +142,8 @@ var extendedTemplateContext = function(doc, extras) {
     templateContext.patient_name = templateContext.patient_name || extras.patient.name;
   }
 
+  _.defaults(templateContext, extractTemplateContext(doc));
+
   if (extras.registrations && extras.registrations.length) {
     _.defaults(templateContext, extractTemplateContext(extras.registrations[0]));
   }
@@ -155,8 +154,6 @@ var extendedTemplateContext = function(doc, extras) {
     // "registered" through the UI, only creating a patient and no registration report
     throw Error('Cannot provide registrations to template context without a patient');
   }
-
-  _.defaults(templateContext, extractTemplateContext(doc));
 
   return templateContext;
 };
@@ -264,3 +261,4 @@ exports.template = function(config, translate, doc, content, extraContext) {
 };
 
 exports._getRecipient = getRecipient;
+exports._extendedTemplateContext = extendedTemplateContext;

--- a/shared-libs/message-utils/test/index.js
+++ b/shared-libs/message-utils/test/index.js
@@ -85,6 +85,26 @@ describe('messageUtils', () => {
         utils._getRecipient(doc, 'grandparent')
           .should.equal(grandparentPhone);
       });
+      it('resolves clinic based on patient if given', () => {
+        const context = {
+          patient: {
+            parent: {
+              type: 'clinic',
+              contact: {
+                phone: '111'
+              }
+            }
+          },
+          parent: {
+            type: 'clinic',
+            contact: {
+              phone: '222'
+            }
+          }
+        };
+        utils._getRecipient(context, 'clinic')
+          .should.equal('111');
+      });
     });
     it('tries to resolve the value from the fields property', () => {
       utils._getRecipient({fields: {foo: 'bar'}}, 'foo')
@@ -105,33 +125,6 @@ describe('messageUtils', () => {
   });
 
   describe('extendedTemplateContext', () => {
-
-    it('calculates parent correctly', () => {
-      const doc = {
-        from: 'foo',
-        contact: {
-          parent: {
-            type: 'health_center',
-            contact: { phone: '111' }
-          }
-        }
-      };
-      const extraContext = {
-        patient: {
-          parent: {
-            type: 'clinic',
-            contact: { phone: '222' },
-            parent: {
-              type: 'health_center',
-              contact: { phone: '111' }
-            }
-          }
-        }
-      };
-      const actual = utils._extendedTemplateContext(doc, extraContext);
-      actual.parent.type.should.equal('clinic');
-      actual.grandparent.type.should.equal('health_center');
-    });
 
     it('picks patient data first', () => {
       const doc = { name: 'alice', fields: { name: 'bob' } };

--- a/shared-libs/message-utils/test/index.js
+++ b/shared-libs/message-utils/test/index.js
@@ -104,6 +104,76 @@ describe('messageUtils', () => {
     });
   });
 
+  describe('extendedTemplateContext', () => {
+
+    it('calculates parent correctly', () => {
+      const doc = {
+        from: 'foo',
+        contact: {
+          parent: {
+            type: 'health_center',
+            contact: { phone: '111' }
+          }
+        }
+      };
+      const extraContext = {
+        patient: {
+          parent: {
+            type: 'clinic',
+            contact: { phone: '222' },
+            parent: {
+              type: 'health_center',
+              contact: { phone: '111' }
+            }
+          }
+        }
+      };
+      const actual = utils._extendedTemplateContext(doc, extraContext);
+      actual.parent.type.should.equal('clinic');
+      actual.grandparent.type.should.equal('health_center');
+    });
+
+    it('picks patient data first', () => {
+      const doc = { name: 'alice', fields: { name: 'bob' } };
+      const patient = { name: 'charles' };
+      const registrations = [{ name: 'doug', fields: { name: 'elisa' } }];
+      const actual = utils._extendedTemplateContext(doc, { patient: patient, registrations: registrations });
+      actual.name.should.equal('charles');
+    });
+
+    it('picks doc.fields properties second', () => {
+      const doc = { name: 'alice', fields: { name: 'bob' } };
+      const patient = { };
+      const registrations = [{ name: 'doug', fields: { name: 'elisa' } }];
+      const actual = utils._extendedTemplateContext(doc, { patient: patient, registrations: registrations });
+      actual.name.should.equal('bob');
+    });
+
+    it('picks doc properties third', () => {
+      const doc = { name: 'alice' };
+      const patient = { };
+      const registrations = [{ name: 'doug', fields: { name: 'elisa' } }];
+      const actual = utils._extendedTemplateContext(doc, { patient: patient, registrations: registrations });
+      actual.name.should.equal('alice');
+    });
+
+    it('picks registration[0].fields properties fourth', () => {
+      const doc = { };
+      const patient = { };
+      const registrations = [{ name: 'doug', fields: { name: 'elisa' } }];
+      const actual = utils._extendedTemplateContext(doc, { patient: patient, registrations: registrations });
+      actual.name.should.equal('elisa');
+    });
+
+    it('picks registration[0].fields properties fifth', () => {
+      const doc = { };
+      const patient = { };
+      const registrations = [{ name: 'doug' }];
+      const actual = utils._extendedTemplateContext(doc, { patient: patient, registrations: registrations });
+      actual.name.should.equal('doug');
+    });
+  });
+
   describe('generate', () => {
 
     it('adds uuid', () => {


### PR DESCRIPTION
# Description

This fixes two bugs;

Firstly, the "parent" and "grandparent" properties were based on having
clinic centric reports and were off by one in a patient centric world.
This meant when resolving the phone number iterating up the "parent" to
find the closest place of a certain type often started at the wrong level.

Secondly, when making the template context the current doc properties
should take precedence over the previous registrations.

medic/medic-webapp#4512

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.