### PR TITLE
Converts all non-string translations to string.

### DIFF
--- a/api/src/translations.js
+++ b/api/src/translations.js
@@ -57,6 +57,8 @@ const merge = (attachments, backups, docs) => {
       const value = attachment.values[knownKey];
       if (_.isUndefined(value) || value === null) {
         attachment.values[knownKey] = knownKey;
+      } else if (typeof value !== 'string') {
+        attachment.values[knownKey] = String(value);
       }
     });
     const backup = _.findWhere(backups, { code: code });


### PR DESCRIPTION
# Description

Because `angular-translate` expects all translations to be strings and `properties` package `cast` prioritises Booleans and Numbers before Strings, all translations must be converted to strings before being saved in CouchDB. 

medic/medic-webapp#4584

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.