### PR TITLE
Flag potentially incompatible releases

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -348,6 +348,7 @@ module.exports = function(grunt) {
           mkdir -p webapp/dist/ddocs/medic/build_info;
           cd webapp/dist/ddocs/medic/build_info;
           echo "${releaseName}" > version;
+          echo "${require('./package.json').version}" > base_version;
           echo "${new Date().toISOString()}" > time;
           echo "grunt on \`whoami\`" > author;`
       },

--- a/admin/src/js/controllers/upgrade.js
+++ b/admin/src/js/controllers/upgrade.js
@@ -113,6 +113,20 @@ angular.module('controllers').controller('UpgradeCtrl',
         $scope.loading = false;
       });
 
+    $scope.potentiallyIncompatible = function(release) {
+      // Old builds may not have a base version, which means unless their version
+      // is in the form 1.2.3[-maybe.4] (ie it's a branch) we can't tell and will
+      // just presume maybe it's bad
+      if (!release.base_version && !Version.parse(release.version)) {
+        return true;
+      }
+
+      var currentVersion = Version.parse($scope.currentDeploy.base_version);
+      var releaseVersion = Version.parse(release.base_version || release.version);
+
+      return Version.compare(currentVersion, releaseVersion) > 0;
+    };
+
     $scope.upgrade = function(version, action) {
       Modal({
         templateUrl: 'templates/upgrade_confirm.html',

--- a/admin/src/js/directives/release.js
+++ b/admin/src/js/directives/release.js
@@ -1,0 +1,6 @@
+angular.module('directives').directive('release', function() {
+  'use strict';
+  return {
+    templateUrl: 'templates/release.html',
+  };
+});

--- a/admin/src/js/directives/release.js
+++ b/admin/src/js/directives/release.js
@@ -1,6 +1,14 @@
 angular.module('directives').directive('release', function() {
   'use strict';
+
   return {
+    restrict: 'E',
     templateUrl: 'templates/release.html',
+    scope: {
+      dateFormat: '@',
+      release: '=',
+      potentiallyIncompatible: '=',
+      upgrade: '=',
+    }
   };
 });

--- a/admin/src/js/filters/build-version.js
+++ b/admin/src/js/filters/build-version.js
@@ -1,0 +1,15 @@
+angular.module('filters').filter('buildVersion',
+  function(
+  ) {
+    'use strict';
+    'ngInject';
+
+    return function(buildInfo) {
+      if (buildInfo.version === buildInfo.base_version || !buildInfo.base_version) {
+        return buildInfo.version;
+      } else {
+        return buildInfo.version + ' (~' + buildInfo.base_version + ')';
+      }
+    };
+  }
+);

--- a/admin/src/js/filters/build-version.js
+++ b/admin/src/js/filters/build-version.js
@@ -5,10 +5,12 @@ angular.module('filters').filter('buildVersion',
     'ngInject';
 
     return function(buildInfo) {
-      if (buildInfo.version === buildInfo.base_version || !buildInfo.base_version) {
-        return buildInfo.version;
-      } else {
-        return buildInfo.version + ' (~' + buildInfo.base_version + ')';
+      if (buildInfo) {
+        if (buildInfo.version === buildInfo.base_version || !buildInfo.base_version) {
+          return buildInfo.version;
+        } else {
+          return buildInfo.version + ' (~' + buildInfo.base_version + ')';
+        }
       }
     };
   }

--- a/admin/src/js/main.js
+++ b/admin/src/js/main.js
@@ -48,6 +48,7 @@ require('./directives/modal');
 angular.module('filters', ['ngSanitize']);
 require('./filters/resource-icon');
 require('./filters/translate-from');
+require('./filters/build-version');
 
 angular.module('services', []);
 require('./services/blob');

--- a/admin/src/js/main.js
+++ b/admin/src/js/main.js
@@ -44,6 +44,7 @@ require('./controllers/users');
 
 angular.module('directives', ['ngSanitize']);
 require('./directives/modal');
+require('./directives/release');
 
 angular.module('filters', ['ngSanitize']);
 require('./filters/resource-icon');

--- a/admin/src/js/services/version.js
+++ b/admin/src/js/services/version.js
@@ -35,7 +35,10 @@ angular.module('services').factory('Version',
     };
 
     var compare = function(version1, version2) {
-      for (var part of ['major', 'minor', 'patch']) {
+      var parts = ['major', 'minor', 'patch'];
+      for (var i = 0; i < parts.length; i++) {
+        var part = parts[i];
+
         if (version1[part] !== version2[part]) {
           return version1[part] - version2[part];
         }

--- a/admin/src/js/services/version.js
+++ b/admin/src/js/services/version.js
@@ -4,7 +4,7 @@ angular.module('services').factory('Version',
     'use strict';
 
     var minimumNextRelease = function(version) {
-      var minVersion = versionInformation(version);
+      var minVersion = versionInformation(version) || {};
 
       if (minVersion.beta !== undefined) {
         ++minVersion.beta;
@@ -31,12 +31,36 @@ angular.module('services').factory('Version',
         }
 
         return version;
-      } else {
-        return {};
       }
     };
 
+    var compare = function(version1, version2) {
+      for (var part of ['major', 'minor', 'patch']) {
+        if (version1[part] !== version2[part]) {
+          return version1[part] - version2[part];
+        }
+      }
+
+      // Because beta is optional, chucking it in the array above means this
+      // function could return NaN sometimes, which is weird
+      if (version1.beta === undefined && version2.beta === undefined) {
+        return 0;
+      }
+
+      if (version1.beta === undefined && version2.beta !== undefined) {
+        return -1;
+      }
+
+      if (version1.beta !== undefined && version2.beta === undefined) {
+        return 1;
+      }
+
+      return version1.beta - version2.beta;
+    };
+
     return {
-      minimumNextRelease: minimumNextRelease
+      minimumNextRelease: minimumNextRelease,
+      parse: versionInformation,
+      compare: compare
     };
   });

--- a/admin/src/templates/release.html
+++ b/admin/src/templates/release.html
@@ -1,5 +1,6 @@
 <div class="col-xs-5"><span class="label label-info">{{release | buildVersion}}</span></div>
-<div class="col-xs-4" ng-bind-html="release.time | date"></div>
+<div class="col-xs-4" ng-if="!dateFormat" ng-bind-html="release.time | date"></div>
+<div class="col-xs-4" ng-if="dateFormat === 'medium'" ng-bind-html="release.time | date:'medium'"></div>
 <div class="col-xs-1">
   <i ng-if="potentiallyIncompatible(release)" class="fa fa-exclamation-triangle" translate translate-attr-title="instance.upgrade.potentiallyIncompatible"></i>
 </div>

--- a/admin/src/templates/release.html
+++ b/admin/src/templates/release.html
@@ -1,0 +1,4 @@
+<div class="col-xs-5"><span class="label label-info">{{release | buildVersion}}</span></div>
+<div class="col-xs-5" ng-bind-html="release.time | date"></div>
+<div class="col-xs-1"><button ng-click="upgrade(release.version, 'stage')" class="btn btn-secondary" translate>instance.upgrade.stage</button></div>
+<div class="col-xs-1"><button ng-click="upgrade(release.version)" class="btn btn-primary" translate>instance.upgrade.install</button></div>

--- a/admin/src/templates/release.html
+++ b/admin/src/templates/release.html
@@ -1,4 +1,7 @@
 <div class="col-xs-5"><span class="label label-info">{{release | buildVersion}}</span></div>
-<div class="col-xs-5" ng-bind-html="release.time | date"></div>
+<div class="col-xs-4" ng-bind-html="release.time | date"></div>
+<div class="col-xs-1">
+  <i ng-if="potentiallyIncompatible(release)" class="fa fa-exclamation-triangle" translate translate-attr-title="instance.upgrade.potentiallyIncompatible"></i>
+</div>
 <div class="col-xs-1"><button ng-click="upgrade(release.version, 'stage')" class="btn btn-secondary" translate>instance.upgrade.stage</button></div>
 <div class="col-xs-1"><button ng-click="upgrade(release.version)" class="btn btn-primary" translate>instance.upgrade.install</button></div>

--- a/admin/src/templates/upgrade.html
+++ b/admin/src/templates/upgrade.html
@@ -64,7 +64,7 @@
       <p ng-hide="versions.releases.length" translate>instance.upgrade.no_new_releases</p>
       <ul ng-show="versions.releases.length" class="table table-striped">
         <li ng-repeat="release in versions.releases" class="row">
-          <release />
+          <release release="release" potentially-incompatible="potentiallyIncompatible" upgrade="upgrade"/>
         </li>
       </ul>
     </div>
@@ -75,7 +75,7 @@
         <p ng-hide="versions.betas.length" translate>instance.upgrade.no_betas</p>
         <ul ng-show="versions.betas.length" class="table table-striped">
           <li ng-repeat="release in versions.betas" class="row">
-            <release />
+            <release release="release" potentially-incompatible="potentiallyIncompatible" upgrade="upgrade"/>
           </li>
         </ul>
       </div>
@@ -87,14 +87,14 @@
         <p ng-hide="versions.branches.length" translate>instance.upgrade.no_branches</p>
         <ul ng-show="versions.branches.length" class="table table-striped">
           <li ng-repeat="release in versions.branches" class="row">
-            <release />
+            <release release="release" potentially-incompatible="potentiallyIncompatible" upgrade="upgrade" date-format="medium" />
           </li>
         </ul>
       </div>
     </div>
   </div>
 
-  <div class="col-sm-12" ng-show="loading || (deployDoc && !deployDoc._deleted && (deployDoc.action !== 'stage' || !deployDoc.staging_complete))    ">
+  <div class="col-sm-12" ng-show="loading || (deployDoc && !deployDoc._deleted && (deployDoc.action !== 'stage' || !deployDoc.staging_complete))">
     <div class="loader"></div>
   </div>
 </div>

--- a/admin/src/templates/upgrade.html
+++ b/admin/src/templates/upgrade.html
@@ -51,7 +51,7 @@
       <p ng-hide="currentDeploy" translate>instance.upgrade.no_details</p>
       <dl ng-show="currentDeploy" class="horizontal">
         <dt translate>instance.upgrade.version</dt>
-        <dd>{{currentDeploy.version}}</dd>
+        <dd>{{currentDeploy | buildVersion}}</dd>
         <dt translate>instance.upgrade.deployed_by</dt>
         <dd>{{currentDeploy.user}}</dd>
         <dt translate>instance.upgrade.at</dt>
@@ -64,10 +64,10 @@
       <p ng-hide="versions.releases.length" translate>instance.upgrade.no_new_releases</p>
       <ul ng-show="versions.releases.length" class="table table-striped">
         <li ng-repeat="release in versions.releases" class="row">
-          <div class="col-xs-5"><span class="label label-info">{{release.id}}</span></div>
-          <div class="col-xs-5" ng-bind-html="release.value.time | date"></div>
-          <div class="col-xs-1"><button ng-click="upgrade(release.id, 'stage')" class="btn btn-secondary" translate>instance.upgrade.stage</button></div>
-          <div class="col-xs-1"><button ng-click="upgrade(release.id)" class="btn btn-primary" translate>instance.upgrade.install</button></div>
+          <div class="col-xs-5"><span class="label label-info">{{release | buildVersion}}</span></div>
+          <div class="col-xs-5" ng-bind-html="release.time | date"></div>
+          <div class="col-xs-1"><button ng-click="upgrade(release.version, 'stage')" class="btn btn-secondary" translate>instance.upgrade.stage</button></div>
+          <div class="col-xs-1"><button ng-click="upgrade(release.version)" class="btn btn-primary" translate>instance.upgrade.install</button></div>
         </li>
       </ul>
     </div>
@@ -78,10 +78,10 @@
         <p ng-hide="versions.betas.length" translate>instance.upgrade.no_betas</p>
         <ul ng-show="versions.betas.length" class="table table-striped">
           <li ng-repeat="release in versions.betas" class="row">
-            <div class="col-xs-5"><span class="label label-info">{{release.id}}</span></div>
-            <div class="col-xs-5" ng-bind-html="release.value.time | date"></div>
-            <div class="col-xs-1"><button ng-click="upgrade(release.id, 'stage')" class="btn btn-secondary" translate>instance.upgrade.stage</button></div>
-            <div class="col-xs-1"><button ng-click="upgrade(release.id)" class="btn btn-primary" translate>instance.upgrade.install</button></div>
+            <div class="col-xs-5"><span class="label label-info">{{release | buildVersion}}</span></div>
+            <div class="col-xs-5" ng-bind-html="release.time | date"></div>
+            <div class="col-xs-1"><button ng-click="upgrade(release.version, 'stage')" class="btn btn-secondary" translate>instance.upgrade.stage</button></div>
+            <div class="col-xs-1"><button ng-click="upgrade(release.version)" class="btn btn-primary" translate>instance.upgrade.install</button></div>
           </li>
         </ul>
       </div>
@@ -93,10 +93,10 @@
         <p ng-hide="versions.branches.length" translate>instance.upgrade.no_branches</p>
         <ul ng-show="versions.branches.length" class="table table-striped">
           <li ng-repeat="release in versions.branches" class="row">
-            <div class="col-xs-5"><span class="label label-info">{{release.id}}</span></div>
-            <div class="col-xs-5">{{release.value.time | date:'medium'}}</div>
-            <div class="col-xs-1"><button ng-click="upgrade(release.id, 'stage')" class="btn btn-secondary" translate>instance.upgrade.stage</button></div>
-            <div class="col-xs-1"><button ng-click="upgrade(release.id)" class="btn btn-primary" translate>instance.upgrade.install</button></div>
+            <div class="col-xs-5"><span class="label label-info">{{release | buildVersion}}</span></div>
+            <div class="col-xs-5">{{release.time | date:'medium'}}</div>
+            <div class="col-xs-1"><button ng-click="upgrade(release.version, 'stage')" class="btn btn-secondary" translate>instance.upgrade.stage</button></div>
+            <div class="col-xs-1"><button ng-click="upgrade(release.version)" class="btn btn-primary" translate>instance.upgrade.install</button></div>
           </li>
         </ul>
       </div>

--- a/admin/src/templates/upgrade.html
+++ b/admin/src/templates/upgrade.html
@@ -64,10 +64,7 @@
       <p ng-hide="versions.releases.length" translate>instance.upgrade.no_new_releases</p>
       <ul ng-show="versions.releases.length" class="table table-striped">
         <li ng-repeat="release in versions.releases" class="row">
-          <div class="col-xs-5"><span class="label label-info">{{release | buildVersion}}</span></div>
-          <div class="col-xs-5" ng-bind-html="release.time | date"></div>
-          <div class="col-xs-1"><button ng-click="upgrade(release.version, 'stage')" class="btn btn-secondary" translate>instance.upgrade.stage</button></div>
-          <div class="col-xs-1"><button ng-click="upgrade(release.version)" class="btn btn-primary" translate>instance.upgrade.install</button></div>
+          <release />
         </li>
       </ul>
     </div>
@@ -78,10 +75,7 @@
         <p ng-hide="versions.betas.length" translate>instance.upgrade.no_betas</p>
         <ul ng-show="versions.betas.length" class="table table-striped">
           <li ng-repeat="release in versions.betas" class="row">
-            <div class="col-xs-5"><span class="label label-info">{{release | buildVersion}}</span></div>
-            <div class="col-xs-5" ng-bind-html="release.time | date"></div>
-            <div class="col-xs-1"><button ng-click="upgrade(release.version, 'stage')" class="btn btn-secondary" translate>instance.upgrade.stage</button></div>
-            <div class="col-xs-1"><button ng-click="upgrade(release.version)" class="btn btn-primary" translate>instance.upgrade.install</button></div>
+            <release />
           </li>
         </ul>
       </div>
@@ -93,10 +87,7 @@
         <p ng-hide="versions.branches.length" translate>instance.upgrade.no_branches</p>
         <ul ng-show="versions.branches.length" class="table table-striped">
           <li ng-repeat="release in versions.branches" class="row">
-            <div class="col-xs-5"><span class="label label-info">{{release | buildVersion}}</span></div>
-            <div class="col-xs-5">{{release.time | date:'medium'}}</div>
-            <div class="col-xs-1"><button ng-click="upgrade(release.version, 'stage')" class="btn btn-secondary" translate>instance.upgrade.stage</button></div>
-            <div class="col-xs-1"><button ng-click="upgrade(release.version)" class="btn btn-primary" translate>instance.upgrade.install</button></div>
+            <release />
           </li>
         </ul>
       </div>

--- a/admin/tests/unit/services/version.js
+++ b/admin/tests/unit/services/version.js
@@ -23,36 +23,26 @@ describe('version', () => {
     });
 
     it('A beta returns the beta incremented by one', () => {
-      chai.expect(service.minimumNextRelease('1.2.3-beta.0')).to.deep.equal(
-        v(1,2,3,1));
-      chai.expect(service.minimumNextRelease('1.2.3-beta.1')).to.deep.equal(
-        v(1,2,3,2));
-      chai.expect(service.minimumNextRelease('1.2.3-beta.9')).to.deep.equal(
-        v(1,2,3,10));
-      chai.expect(service.minimumNextRelease('1.2.3-beta.10')).to.deep.equal(
-        v(1,2,3,11));
+      chai.expect(service.minimumNextRelease('1.2.3-beta.0')).to.deep.equal(v(1,2,3,1));
+      chai.expect(service.minimumNextRelease('1.2.3-beta.1')).to.deep.equal(v(1,2,3,2));
+      chai.expect(service.minimumNextRelease('1.2.3-beta.9')).to.deep.equal(v(1,2,3,10));
+      chai.expect(service.minimumNextRelease('1.2.3-beta.10')).to.deep.equal(v(1,2,3,11));
     });
 
     it('A release returns the patch incremented by one', () => {
-      chai.expect(service.minimumNextRelease('1.2.0')).to.deep.equal(
-        v(1,2,1));
-      chai.expect(service.minimumNextRelease('1.2.1')).to.deep.equal(
-        v(1,2,2));
-      chai.expect(service.minimumNextRelease('1.2.9')).to.deep.equal(
-        v(1,2,10));
-      chai.expect(service.minimumNextRelease('1.2.10')).to.deep.equal(
-        v(1,2,11));
+      chai.expect(service.minimumNextRelease('1.2.0')).to.deep.equal(v(1,2,1));
+      chai.expect(service.minimumNextRelease('1.2.1')).to.deep.equal(v(1,2,2));
+      chai.expect(service.minimumNextRelease('1.2.9')).to.deep.equal(v(1,2,10));
+      chai.expect(service.minimumNextRelease('1.2.10')).to.deep.equal(v(1,2,11));
     });
   });
 
   describe('Parse', () => {
     it('Parses a standard version', () => {
-      chai.expect(service.parse('1.2.3')).to.deep.equal(
-        v(1,2,3));
+      chai.expect(service.parse('1.2.3')).to.deep.equal(v(1,2,3));
     });
     it('Parses versions with beta information', () => {
-      chai.expect(service.parse('1.2.3-beta.4')).to.deep.equal(
-        v(1,2,3,4));
+      chai.expect(service.parse('1.2.3-beta.4')).to.deep.equal(v(1,2,3,4));
     });
     it('Returns undefined if it cannot parse the version', () => {
       chai.expect(service.parse('master')).to.equal(undefined);

--- a/admin/tests/unit/services/version.js
+++ b/admin/tests/unit/services/version.js
@@ -1,3 +1,13 @@
+const v = (ma, mi, pa, be) => {
+  const version = {major: ma, minor: mi, patch: pa};
+
+  if (be !== undefined) {
+    version.beta = be;
+  }
+
+  return version;
+};
+
 describe('version', () => {
   let service;
 
@@ -13,53 +23,59 @@ describe('version', () => {
     });
 
     it('A beta returns the beta incremented by one', () => {
-      chai.expect(service.minimumNextRelease('1.2.3-beta.0')).to.deep.equal({
-        major: 1,
-        minor: 2,
-        patch: 3,
-        beta: 1
-      });
-      chai.expect(service.minimumNextRelease('1.2.3-beta.1')).to.deep.equal({
-        major: 1,
-        minor: 2,
-        patch: 3,
-        beta: 2
-      });
-      chai.expect(service.minimumNextRelease('1.2.3-beta.9')).to.deep.equal({
-        major: 1,
-        minor: 2,
-        patch: 3,
-        beta: 10
-      });
-      chai.expect(service.minimumNextRelease('1.2.3-beta.10')).to.deep.equal({
-        major: 1,
-        minor: 2,
-        patch: 3,
-        beta: 11
-      });
+      chai.expect(service.minimumNextRelease('1.2.3-beta.0')).to.deep.equal(
+        v(1,2,3,1));
+      chai.expect(service.minimumNextRelease('1.2.3-beta.1')).to.deep.equal(
+        v(1,2,3,2));
+      chai.expect(service.minimumNextRelease('1.2.3-beta.9')).to.deep.equal(
+        v(1,2,3,10));
+      chai.expect(service.minimumNextRelease('1.2.3-beta.10')).to.deep.equal(
+        v(1,2,3,11));
     });
 
     it('A release returns the patch incremented by one', () => {
-      chai.expect(service.minimumNextRelease('1.2.0')).to.deep.equal({
-        major: 1,
-        minor: 2,
-        patch: 1
-      });
-      chai.expect(service.minimumNextRelease('1.2.1')).to.deep.equal({
-        major: 1,
-        minor: 2,
-        patch: 2
-      });
-      chai.expect(service.minimumNextRelease('1.2.9')).to.deep.equal({
-        major: 1,
-        minor: 2,
-        patch: 10
-      });
-      chai.expect(service.minimumNextRelease('1.2.10')).to.deep.equal({
-        major: 1,
-        minor: 2,
-        patch: 11
-      });
+      chai.expect(service.minimumNextRelease('1.2.0')).to.deep.equal(
+        v(1,2,1));
+      chai.expect(service.minimumNextRelease('1.2.1')).to.deep.equal(
+        v(1,2,2));
+      chai.expect(service.minimumNextRelease('1.2.9')).to.deep.equal(
+        v(1,2,10));
+      chai.expect(service.minimumNextRelease('1.2.10')).to.deep.equal(
+        v(1,2,11));
+    });
+  });
+
+  describe('Parse', () => {
+    it('Parses a standard version', () => {
+      chai.expect(service.parse('1.2.3')).to.deep.equal(
+        v(1,2,3));
+    });
+    it('Parses versions with beta information', () => {
+      chai.expect(service.parse('1.2.3-beta.4')).to.deep.equal(
+        v(1,2,3,4));
+    });
+    it('Returns undefined if it cannot parse the version', () => {
+      chai.expect(service.parse('master')).to.equal(undefined);
+      chai.expect(service.parse('1.2.3.4.5')).to.equal(undefined);
+      chai.expect(service.parse('1.2.3-unsupported_type.4')).to.equal(undefined);
+    });
+  });
+
+  describe('Compare', () => {
+    it('Correctly compares different standard versions', () => {
+      chai.expect(service.compare(v(1,2,3), v(3,2,1))).to.be.below(0);
+      chai.expect(service.compare(v(3,2,1), v(1,2,3))).to.be.above(0);
+      chai.expect(service.compare(v(3,0,0), v(3,0,0))).to.equal(0);
+    });
+    it('Correctly compares versions with beta information', () => {
+      chai.expect(service.compare(v(1,0,0,5), v(1,0,0,5))).to.equal(0);
+      chai.expect(service.compare(v(1,0,0,5), v(1,0,0,4))).to.be.above(0);
+      chai.expect(service.compare(v(1,0,0,5), v(1,0,0,6))).to.be.below(0);
+
+      chai.expect(service.compare(v(2,0,0,5), v(1,0,0,4))).to.be.above(0);
+
+      chai.expect(service.compare(v(2,0,0), v(2,0,0,1))).to.be.below(0);
+      chai.expect(service.compare(v(2,0,0,1), v(2,0,0))).to.be.above(0);
     });
   });
 });

--- a/webapp/src/ddocs/medic/_attachments/translations/messages-en.properties
+++ b/webapp/src/ddocs/medic/_attachments/translations/messages-en.properties
@@ -982,6 +982,7 @@ contact.deceased.view = View deceased ({{count}})
 user.password.current = Current password
 password.incorrect = Password is not correct.
 error.loading.form.no_contact = Error loading form. Your user does not have an associated contact, or does not have access to the associated contact. Talk to your administrator to correct this.
+instance.upgrade.potentiallyIncompatible = This release may be incompatible with your current release
 instance.upgrade.install = Install
 instance.upgrade.stage = Stage
 online.action.title = Please make sure that you are online.


### PR DESCRIPTION
Adds a warning flag to releases that may be incompatible because the base version of the release is older than your current base version.

medic/medic-webapp#4580

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.