### PR TITLE
Sets response headers to increase security

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -15,6 +15,8 @@
     "toc": "doctoc --github --maxlevel 2 README.md"
   },
   "dependencies": {
+    "@shared-libs/tombstone-utils": "file:../shared-libs/tombstone-utils",
+    "@shared-libs/view-map-utils": "file:../shared-libs/view-map-utils",
     "async": "^2.6.0",
     "body-parser": "^1.18.2",
     "buffer-shims": "^1.0.0",
@@ -23,6 +25,7 @@
     "express": "^4.16.3",
     "fast-csv": "^2.4.1",
     "google-libphonenumber": "^3.1.3",
+    "helmet": "^3.12.1",
     "http-proxy": "^1.16.2",
     "lineage": "file:../shared-libs/lineage",
     "moment": "^2.22.0",
@@ -39,8 +42,6 @@
     "request": "^2.85.0",
     "search": "file:../shared-libs/search",
     "simple-password-tester": "^1.0.0",
-    "@shared-libs/tombstone-utils": "file:../shared-libs/tombstone-utils",
-    "@shared-libs/view-map-utils": "file:../shared-libs/view-map-utils",
     "task-utils": "file:../shared-libs/task-utils",
     "underscore": "^1.8.3",
     "url": "^0.11.0",

--- a/api/package.json
+++ b/api/package.json
@@ -52,6 +52,8 @@
     "doctoc": "^1.3.1"
   },
   "bundledDependencies": [
+    "@shared-libs/tombstone-utils",
+    "@shared-libs/view-map-utils",
     "async",
     "body-parser",
     "buffer-shims",
@@ -60,6 +62,7 @@
     "express",
     "fast-csv",
     "google-libphonenumber",
+    "helmet",
     "http-proxy",
     "lineage",
     "moment",
@@ -76,8 +79,6 @@
     "request",
     "search",
     "simple-password-tester",
-    "@shared-libs/tombstone-utils",
-    "@shared-libs/view-map-utils",
     "task-utils",
     "underscore",
     "url",

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -76,7 +76,7 @@ app.use(morgan('combined', {
 
 app.use(helmet({
   // runs with a bunch of defaults: https://github.com/helmetjs/helmet
-  hpkp: false, // explicitely block dangerous header
+  hpkp: false, // explicitly block dangerous header
   contentSecurityPolicy: {
     directives: {
       frameSrc: ['\'self\'']

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -32,8 +32,6 @@ const _ = require('underscore'),
       appcacheManifest = /\/manifest\.appcache$/,
       app = express();
 
-app.use(helmet());
-
 // requires content-type application/json header
 var jsonParser = bodyParser.json({limit: '32mb'});
 
@@ -75,6 +73,8 @@ if(process.argv.slice(2).includes('--allow-cors')) {
 app.use(morgan('combined', {
   immediate: true
 }));
+
+app.use(helmet());
 
 app.use(function(req, res, next) {
   var domain = createDomain();

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -75,6 +75,8 @@ app.use(morgan('combined', {
 }));
 
 app.use(helmet({
+  // runs with a bunch of defaults: https://github.com/helmetjs/helmet
+  hpkp: false, // explicitely block dangerous header
   contentSecurityPolicy: {
     directives: {
       frameSrc: ['\'self\'']

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -74,7 +74,13 @@ app.use(morgan('combined', {
   immediate: true
 }));
 
-app.use(helmet());
+app.use(helmet({
+  contentSecurityPolicy: {
+    directives: {
+      frameSrc: ['\'self\'']
+    }
+  }
+}));
 
 app.use(function(req, res, next) {
   var domain = createDomain();

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -2,6 +2,7 @@ const _ = require('underscore'),
       bodyParser = require('body-parser'),
       express = require('express'),
       morgan = require('morgan'),
+      helmet = require('helmet'),
       db = require('./db-nano'),
       path = require('path'),
       auth = require('./auth'),
@@ -30,6 +31,8 @@ const _ = require('underscore'),
       serverUtils = require('./server-utils'),
       appcacheManifest = /\/manifest\.appcache$/,
       app = express();
+
+app.use(helmet());
 
 // requires content-type application/json header
 var jsonParser = bodyParser.json({limit: '32mb'});

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -163,6 +163,10 @@ cached-constructors-x@^1.0.0, cached-constructors-x@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cached-constructors-x/-/cached-constructors-x-1.0.2.tgz#d8a7b79b43fdcf13fd861bb763f38b627b0ccf91"
 
+camelize@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
+
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
@@ -226,6 +230,10 @@ content-disposition@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
 
+content-security-policy-builder@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/content-security-policy-builder/-/content-security-policy-builder-2.0.0.tgz#8749a1d542fcbe82237281ea9f716ce68b394dd2"
+
 content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
@@ -259,6 +267,10 @@ dashdash@^1.12.0:
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   dependencies:
     assert-plus "^1.0.0"
+
+dasherize@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dasherize/-/dasherize-2.0.0.tgz#6d809c9cd0cf7bb8952d80fc84fa13d47ddb1308"
 
 date-extended@~0.0.3:
   version "0.0.6"
@@ -300,6 +312,10 @@ destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
 
+dns-prefetch-control@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/dns-prefetch-control/-/dns-prefetch-control-0.1.0.tgz#60ddb457774e178f1f9415f0cabb0e85b0b300b2"
+
 doctoc@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/doctoc/-/doctoc-1.3.1.tgz#f012e3603e3156254c2ef22ac88c7190f55426ba"
@@ -339,6 +355,10 @@ domutils@^1.5.1:
     dom-serializer "0"
     domelementtype "1"
 
+dont-sniff-mimetype@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/dont-sniff-mimetype/-/dont-sniff-mimetype-1.0.0.tgz#5932890dc9f4e2f19e5eb02a20026e5e5efc8f58"
+
 ecc-jsbn@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
@@ -376,6 +396,10 @@ etag@~1.8.1:
 eventemitter3@1.x.x:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.2.0.tgz#1c86991d816ad1e504750e73874224ecf3bec508"
+
+expect-ct@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/expect-ct/-/expect-ct-0.1.1.tgz#de84476a2dbcb85000d5903737e9bc8a5ba7b897"
 
 express@^4.16.3:
   version "4.16.3"
@@ -481,6 +505,10 @@ forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
 
+frameguard@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/frameguard/-/frameguard-3.0.0.tgz#7bcad469ee7b96e91d12ceb3959c78235a9272e9"
+
 fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
@@ -543,9 +571,48 @@ hawk@~6.0.2:
     hoek "4.x.x"
     sntp "2.x.x"
 
+helmet-csp@2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/helmet-csp/-/helmet-csp-2.7.0.tgz#7934094617d1feb7bb2dc43bb7d9e8830f774716"
+  dependencies:
+    camelize "1.0.0"
+    content-security-policy-builder "2.0.0"
+    dasherize "2.0.0"
+    lodash.reduce "4.6.0"
+    platform "1.3.5"
+
+helmet@^3.12.1:
+  version "3.12.1"
+  resolved "https://registry.yarnpkg.com/helmet/-/helmet-3.12.1.tgz#8b05bbd60f3966d70f13dad0de2c1d6c1a8303f1"
+  dependencies:
+    dns-prefetch-control "0.1.0"
+    dont-sniff-mimetype "1.0.0"
+    expect-ct "0.1.1"
+    frameguard "3.0.0"
+    helmet-csp "2.7.0"
+    hide-powered-by "1.0.0"
+    hpkp "2.0.0"
+    hsts "2.1.0"
+    ienoopen "1.0.0"
+    nocache "2.0.0"
+    referrer-policy "1.1.0"
+    x-xss-protection "1.1.0"
+
+hide-powered-by@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/hide-powered-by/-/hide-powered-by-1.0.0.tgz#4a85ad65881f62857fc70af7174a1184dccce32b"
+
 hoek@4.x.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
+
+hpkp@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/hpkp/-/hpkp-2.0.0.tgz#10e142264e76215a5d30c44ec43de64dee6d1672"
+
+hsts@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/hsts/-/hsts-2.1.0.tgz#cbd6c918a2385fee1dd5680bfb2b3a194c0121cc"
 
 htmlparser2@~3.9.2:
   version "3.9.2"
@@ -594,6 +661,10 @@ http-signature@~1.2.0:
 iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
+
+ienoopen@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ienoopen/-/ienoopen-1.0.0.tgz#346a428f474aac8f50cf3784ea2d0f16f62bda6b"
 
 immediate@3.0.6, immediate@~3.0.5:
   version "3.0.6"
@@ -770,6 +841,10 @@ lodash.isnull@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash.isnull/-/lodash.isnull-3.0.0.tgz#fafbe59ea1dca27eed786534039dd84c2e07c56e"
 
+lodash.reduce@4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.reduce/-/lodash.reduce-4.6.0.tgz#f1ab6b839299ad48f784abbf476596f03b914d3b"
+
 lodash@^3.5.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
@@ -882,6 +957,10 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
+nocache@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/nocache/-/nocache-2.0.0.tgz#202b48021a0c4cbde2df80de15a17443c8b43980"
+
 normalize-space-x@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-space-x/-/normalize-space-x-3.0.0.tgz#17907d6c7c724a4f9567471cbb319553bc0f8882"
@@ -988,6 +1067,10 @@ performance-now@^2.1.0:
 
 "phone-number@file:../shared-libs/phone-number":
   version "1.0.0"
+
+platform@1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.5.tgz#fb6958c696e07e2918d2eeda0f0bc9448d733444"
 
 pouchdb-abstract-mapreduce@6.4.3:
   version "6.4.3"
@@ -1187,6 +1270,10 @@ readable-stream@^2.0.2, readable-stream@^2.2.2:
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
+
+referrer-policy@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/referrer-policy/-/referrer-policy-1.1.0.tgz#35774eb735bf50fb6c078e83334b472350207d79"
 
 remark-parse@^1.1.0:
   version "1.1.0"
@@ -1676,6 +1763,10 @@ white-space-x@^3.0.0:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+
+x-xss-protection@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/x-xss-protection/-/x-xss-protection-1.1.0.tgz#4f1898c332deb1e7f2be1280efb3e2c53d69c1a7"
 
 xmlbuilder@^2.6.2:
   version "2.6.5"


### PR DESCRIPTION
# Description

Uses the helmet library with default settings to set/unset response
headers to protect against common attacks.

medic/medic-webapp#1140

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.