### PR TITLE
Fixes double escaping of messages

### DIFF
--- a/webapp/src/js/services/format-data-record.js
+++ b/webapp/src/js/services/format-data-record.js
@@ -247,7 +247,11 @@ angular.module('inboxServices').factory('FormatDataRecord',
         return getMessage(settings, key, locale) || key;
       }
       var interpolation = skipInterpolation ? 'no-interpolation' : null;
-      return $translate.instant(key, ctx, interpolation, locale);
+      // NB: The 5th parameter must be explicitely null to disable sanitization.
+      // The result will be sanitized by angular when it's rendered, so using
+      // the default sanitization would result in double encoding.
+      // Issue: medic/medic-webapp#4618
+      return $translate.instant(key, ctx, interpolation, locale, null);
     };
 
     /*


### PR DESCRIPTION
# Description

Passing null as the translation sanitization strategy disables it
which is safe in this case because the string is escaped when
rendered by angular.

medic/medic-webapp#4618

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.