### PR TITLE
Fixes a race condition in deleting read docs

### DIFF
--- a/sentinel/src/db-nano.js
+++ b/sentinel/src/db-nano.js
@@ -46,6 +46,9 @@ if (couchUrl) {
             insert: function() {},
             fetch: function() {}
         },
+        db: {
+            list: function() {}
+        },
         settings: {}
     };
 } else {

--- a/sentinel/src/transitions/index.js
+++ b/sentinel/src/transitions/index.js
@@ -119,21 +119,6 @@ const processChange = (change, callback) => {
     });
 };
 
-const getAdminNames = callback => {
-  db.medic.view('medic', 'online_user_settings_by_id', {}, (err, results) => {
-    if (err) {
-      return callback(err);
-    }
-    const admins = results.rows
-      .map(row => {
-        const parts = row.id.split(':');
-        return parts.length > 1 && parts[1];
-      })
-      .filter(name => !!name);
-    callback(null, admins);
-  });
-};
-
 const deleteReadDocs = (change, callback) => {
 
   // we don't know if the deleted doc was a report or a message so
@@ -141,34 +126,33 @@ const deleteReadDocs = (change, callback) => {
   const possibleReadDocIds = [ 'report', 'message' ]
     .map(type => `read:${type}:${change.id}`);
 
-  getAdminNames((err, admins) => {
+  db.db.list((err, dbs) => {
     if (err) {
       return callback(err);
     }
 
+    const userDbs = dbs.filter(db => db.indexOf('medic-user-') === 0);
+
     async.each(
-      admins,
-      (admin, callback) => {
-        const metaDb = db.use(`medic-user-${admin}-meta`);
-        metaDb.info(err => {
+      userDbs,
+      (userDb, callback) => {
+        const metaDb = db.use(userDb);
+        metaDb.fetch({ keys: possibleReadDocIds }, (err, results) => {
           if (err) {
-            if (err.statusCode === 404) {
-              // no meta data db exists for this user - ignore
-              return callback();
-            }
             return callback(err);
           }
-          metaDb.fetch({ keys: possibleReadDocIds }, (err, results) => {
-            if (err) {
+          // find which of the possible ids was the right one
+          const row = results.rows.find(row => !!row.doc);
+          if (!row) {
+            return callback();
+          }
+          row.doc._deleted = true;
+          metaDb.insert(row.doc, err => {
+            // ignore 404s or 409s - the doc was probably deleted client side already
+            if (err && err.statusCode !== 404 && err.statusCode !== 409) {
               return callback(err);
             }
-            // find which of the possible ids was the right one
-            const row = results.rows.find(row => !!row.doc);
-            if (!row) {
-              return callback();
-            }
-            row.doc._deleted = true;
-            metaDb.insert(row.doc, callback);
+            callback();
           });
         });
       },
@@ -181,7 +165,6 @@ const deleteReadDocs = (change, callback) => {
  * Load transitions using `require` based on what is in AVAILABLE_TRANSITIONS
  * constant and what is enabled in the `transitions` property in the settings
  * data.  Log warnings on failure.
- *
  */
 const loadTransitions = () => {
 

--- a/webapp/src/ddocs/medic/views/online_user_settings_by_id/map.js
+++ b/webapp/src/ddocs/medic/views/online_user_settings_by_id/map.js
@@ -1,8 +1,0 @@
-function(doc) {
-  if (doc.type === 'user-settings' &&
-      doc.roles &&
-      (doc.roles.indexOf('_admin') !== -1 ||
-      doc.roles.indexOf('national_admin') !== -1)) {
-    emit(doc._id);
-  }
-}


### PR DESCRIPTION
# Description

Deletes all read docs, not just admin ones, so there is no change a
user will still have a read doc with no corresponding doc.

Removes an obsolete view which doesn't work now we have configurable
roles.

medic/medic-webapp#3960

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.