### PR TITLE
Fixes everywhere that relied on national_admin

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1247,8 +1247,7 @@ Bulk delete endpoint for deleting large numbers of documents. Docs will be batch
 
 ### Permissions
 
-Available to users with role `_admin` or `national_admin`.
-
+Only available to online users.
 
 ### Parameters
 

--- a/api/auth.js
+++ b/api/auth.js
@@ -2,7 +2,8 @@ var request = require('request'),
     url = require('url'),
     _ = require('underscore'),
     db = require('./db'),
-    config = require('./config');
+    config = require('./config'),
+    ONLINE_ROLE = 'mm-online';
 
 var get = function(path, headers, callback) {
   var fullUrl = url.format({
@@ -67,9 +68,10 @@ module.exports = {
     });
   },
 
-  isAdmin: function(userCtx) {
+  isOnlineOnly: function(userCtx) {
     return hasRole(userCtx, '_admin') ||
-           hasRole(userCtx, 'national_admin');
+           hasRole(userCtx, 'national_admin') || // kept for backwards compatibility
+           hasRole(userCtx, ONLINE_ROLE);
   },
 
   hasAllPermissions: function(userCtx, permissions) {

--- a/api/controllers/bulk-docs.js
+++ b/api/controllers/bulk-docs.js
@@ -5,7 +5,7 @@ module.exports = {
   bulkDelete: (req, res, next) => {
     return auth.getUserCtx(req)
       .then(userCtx => {
-        if (!auth.isAdmin(userCtx)) {
+        if (!auth.isOnlineOnly(userCtx)) {
           throw {
             code: 401,
             message: 'User is not an admin'

--- a/api/controllers/export-data.js
+++ b/api/controllers/export-data.js
@@ -124,7 +124,7 @@ module.exports = {
     return auth.getUserCtx(req)
       .then(userCtx => {
         if (!auth.isOnlineOnly(userCtx)) {
-          throw new Error({ code: 403, message: 'Insufficient privileges' });
+          throw { code: 403, message: 'Insufficient privileges' };
         }
       })
       .then(() => auth.check(req, getExportPermission(req.params.type)))

--- a/api/controllers/export-data.js
+++ b/api/controllers/export-data.js
@@ -121,7 +121,7 @@ module.exports = {
     //    by the following auth check in ctx.district (maybe?)
     //  - Still don't let offline users use this API, and instead refactor the
     //    export logic so it can be used in webapp, and have exports works offline
-    return auth.getUserCtx()
+    return auth.getUserCtx(req)
       .then(userCtx => {
         if (!auth.isOnlineOnly(userCtx)) {
           throw new Error({ code: 403, message: 'Insufficient privileges' });

--- a/api/controllers/export-data.js
+++ b/api/controllers/export-data.js
@@ -121,7 +121,13 @@ module.exports = {
     //    by the following auth check in ctx.district (maybe?)
     //  - Still don't let offline users use this API, and instead refactor the
     //    export logic so it can be used in webapp, and have exports works offline
-    return auth.check(req, ['national_admin', getExportPermission(req.params.type)])
+    return auth.getUserCtx()
+      .then(userCtx => {
+        if (!auth.isOnlineOnly(userCtx)) {
+          throw new Error({ code: 403, message: 'Insufficient privileges' });
+        }
+      })
+      .then(() => auth.check(req, getExportPermission(req.params.type)))
       .then(() => {
         writeExportHeaders(res, req.params.type, formats.csv);
 

--- a/api/handlers/changes.js
+++ b/api/handlers/changes.js
@@ -514,7 +514,7 @@ module.exports = {
         res.setHeader('X-Accel-Buffering', 'no');
       }
 
-      if (auth.isAdmin(userCtx)) {
+      if (auth.isOnlineOnly(userCtx)) {
         proxy.web(req, res);
       } else {
         const feed = {

--- a/api/tests/mocha/controllers/bulk-docs.js
+++ b/api/tests/mocha/controllers/bulk-docs.js
@@ -13,7 +13,7 @@ const testRes = {};
 describe('Bulk Docs controller', () => {
   beforeEach(() => {
     sinon.stub(auth, 'getUserCtx');
-    sinon.stub(auth, 'isAdmin');
+    sinon.stub(auth, 'isOnlineOnly');
   });
 
   afterEach(() => {
@@ -23,12 +23,12 @@ describe('Bulk Docs controller', () => {
   it('checks that user is an admin', () => {
     const userCtx = {};
     auth.getUserCtx.resolves(userCtx);
-    auth.isAdmin.withArgs(userCtx).returns(false);
+    auth.isOnlineOnly.withArgs(userCtx).returns(false);
     const next = sinon.stub();
     return controller.bulkDelete(testReq, testRes, next)
       .then(() => {
         auth.getUserCtx.callCount.should.equal(1);
-        auth.isAdmin.callCount.should.equal(1);
+        auth.isOnlineOnly.callCount.should.equal(1);
         next.callCount.should.equal(1);
         next.getCall(0).args[0].code.should.equal(401);
       });

--- a/api/tests/mocha/controllers/export-data.js
+++ b/api/tests/mocha/controllers/export-data.js
@@ -13,6 +13,8 @@ describe('Export Data controller', () => {
   beforeEach(() => {
     sinon.stub(serverUtils, 'error');
     sinon.stub(auth, 'check');
+    sinon.stub(auth, 'getUserCtx');
+    sinon.stub(auth, 'isOnlineOnly');
     sinon.stub(exportDataV2, 'export');
 
     set = sinon.stub().returns({ set });
@@ -30,10 +32,11 @@ describe('Export Data controller', () => {
     });
     it('Checks permissions', () => {
       auth.check.returns(Promise.reject({message: 'Bad permissions'}));
+      auth.getUserCtx.returns(Promise.resolve({}));
+      auth.isOnlineOnly.returns(true);
       return controller.routeV2({req: true, params: {type: 'reports'}}, {res: true})
         .then(() => {
           auth.check.callCount.should.equal(1);
-          auth.check.args[0][1].should.contain('national_admin');
           serverUtils.error.callCount.should.equal(1);
           serverUtils.error.args[0][0].message.should.contain('Bad permissions');
           serverUtils.error.args[0][1].req.should.equal(true);
@@ -55,6 +58,8 @@ describe('Export Data controller', () => {
         }
       };
       auth.check.resolves();
+      auth.getUserCtx.returns(Promise.resolve({}));
+      auth.isOnlineOnly.returns(true);
       return controller.routeV2(req, { set: set, flushHeaders: sinon.stub() }).then(() => {
         exportDataV2.export.callCount.should.equal(1);
         exportDataV2.export.args[0].should.deep.equal([

--- a/api/tests/unit/auth.js
+++ b/api/tests/unit/auth.js
@@ -191,10 +191,11 @@ exports['checkUrl requests the given url and returns status'] = function(test) {
   });
 };
 
-exports['isAdmin checks for "admin" and "national_admin" roles'] = function(test) {
-  test.expect(3);
-  test.equal(auth.isAdmin({ roles: ['_admin'] }), true);
-  test.equal(auth.isAdmin({ roles: ['national_admin'] }), true);
-  test.equal(auth.isAdmin({ roles: ['district_admin'] }), false);
+exports['isOnlineOnly checks for "admin" and "national_admin" roles'] = function(test) {
+  test.expect(4);
+  test.equal(auth.isOnlineOnly({ roles: ['_admin'] }), true);
+  test.equal(auth.isOnlineOnly({ roles: ['national_admin'] }), true);
+  test.equal(auth.isOnlineOnly({ roles: ['mm-online'] }), true);
+  test.equal(auth.isOnlineOnly({ roles: ['district_admin'] }), false);
   test.done();
 };

--- a/api/tests/unit/handlers/changes.js
+++ b/api/tests/unit/handlers/changes.js
@@ -17,7 +17,7 @@ exports.tearDown = function (callback) {
   callback();
 };
 
-exports['allows "admin" and "national_admin" users direct access'] = function(test) {
+exports['allows online users direct access'] = function(test) {
   test.expect(2);
 
   var testReq = { query:{} };
@@ -25,7 +25,7 @@ exports['allows "admin" and "national_admin" users direct access'] = function(te
 
   var userCtx = 'fake userCtx';
   sinon.stub(auth, 'getUserCtx').callsArgWith(1, null, userCtx);
-  sinon.stub(auth, 'isAdmin').returns(true);
+  sinon.stub(auth, 'isOnlineOnly').returns(true);
 
   var proxy = {web: function(req, res) {
     test.equals(req, testReq);
@@ -58,7 +58,7 @@ exports['filters the changes to relevant ones'] = function(test) {
   };
 
   sinon.stub(auth, 'getUserCtx').callsArgWith(1, null, userCtx);
-  sinon.stub(auth, 'isAdmin').returns(false);
+  sinon.stub(auth, 'isOnlineOnly').returns(false);
   sinon.stub(auth, 'hasAllPermissions').returns(false);
   sinon.stub(auth, 'getFacilityId').callsArgWith(2, null, 'facilityId');
   sinon.stub(auth, 'getContactId').callsArgWith(1, null, 'contactId');
@@ -166,7 +166,7 @@ exports['allows unallocated access when it is configured and the user has permis
   var subjectId = 'zyx';
 
   sinon.stub(auth, 'getUserCtx').callsArgWith(1, null, userCtx);
-  sinon.stub(auth, 'isAdmin').returns(false);
+  sinon.stub(auth, 'isOnlineOnly').returns(false);
   sinon.stub(auth, 'hasAllPermissions').returns(true);
   sinon.stub(auth, 'getFacilityId').callsArgWith(2, null, 'facilityId');
   sinon.stub(auth, 'getContactId').callsArgWith(1, null, 'contactId');
@@ -252,7 +252,7 @@ exports['respects replication depth when it is configured and the user has permi
   var subjectId = 'zyx';
 
   sinon.stub(auth, 'getUserCtx').callsArgWith(1, null, userCtx);
-  sinon.stub(auth, 'isAdmin').returns(false);
+  sinon.stub(auth, 'isOnlineOnly').returns(false);
   sinon.stub(auth, 'getFacilityId').callsArgWith(2, null, 'facilityId');
   sinon.stub(auth, 'getContactId').callsArgWith(1, null, 'contactId');
   var get = sinon.stub(config, 'get');
@@ -335,7 +335,7 @@ exports['correctly handles depth of 0'] = function(test) {
   var subjectId = 'zyx';
 
   sinon.stub(auth, 'getUserCtx').callsArgWith(1, null, userCtx);
-  sinon.stub(auth, 'isAdmin').returns(false);
+  sinon.stub(auth, 'isOnlineOnly').returns(false);
   sinon.stub(auth, 'getFacilityId').callsArgWith(2, null, 'facilityId');
   sinon.stub(auth, 'getContactId').callsArgWith(1, null, 'contactId');
   var get = sinon.stub(config, 'get');
@@ -414,7 +414,7 @@ exports['no configured depth defaults to Ininite depth'] = function(test) {
   var subjectId = 'zyx';
 
   sinon.stub(auth, 'getUserCtx').callsArgWith(1, null, userCtx);
-  sinon.stub(auth, 'isAdmin').returns(false);
+  sinon.stub(auth, 'isOnlineOnly').returns(false);
   sinon.stub(auth, 'getFacilityId').callsArgWith(2, null, 'facilityId');
   sinon.stub(auth, 'getContactId').callsArgWith(1, null, 'contactId');
   var get = sinon.stub(config, 'get');
@@ -493,7 +493,7 @@ exports['no roles (eg: admin) defaults to Ininite depth'] = function(test) {
   var subjectId = 'zyx';
 
   sinon.stub(auth, 'getUserCtx').callsArgWith(1, null, userCtx);
-  sinon.stub(auth, 'isAdmin').returns(false);
+  sinon.stub(auth, 'isOnlineOnly').returns(false);
   sinon.stub(auth, 'getFacilityId').callsArgWith(2, null, 'facilityId');
   sinon.stub(auth, 'getContactId').callsArgWith(1, null, 'contactId');
   var get = sinon.stub(config, 'get');
@@ -571,7 +571,7 @@ exports['does not return reports about you or your place by someone above you in
   var contactId = 'wsa';
 
   sinon.stub(auth, 'getUserCtx').callsArgWith(1, null, userCtx);
-  sinon.stub(auth, 'isAdmin').returns(false);
+  sinon.stub(auth, 'isOnlineOnly').returns(false);
   sinon.stub(auth, 'getFacilityId').callsArgWith(2, null, facilityId);
   sinon.stub(auth, 'getContactId').callsArgWith(1, null, contactId);
   var get = sinon.stub(config, 'get');
@@ -665,7 +665,7 @@ exports['filters out undeleted docs they are not allowed to see'] = function(tes
   };
 
   sinon.stub(auth, 'getUserCtx').callsArgWith(1, null, userCtx);
-  sinon.stub(auth, 'isAdmin').returns(false);
+  sinon.stub(auth, 'isOnlineOnly').returns(false);
   sinon.stub(auth, 'hasAllPermissions').returns(false);
   sinon.stub(auth, 'getFacilityId').callsArgWith(2, null, 'facilityId');
   sinon.stub(auth, 'getContactId').callsArgWith(1, null, 'contactId');
@@ -732,7 +732,7 @@ exports['updates the feed when the doc is updated'] = function(test) {
   };
 
   sinon.stub(auth, 'getUserCtx').callsArgWith(1, null, userCtx);
-  sinon.stub(auth, 'isAdmin').returns(false);
+  sinon.stub(auth, 'isOnlineOnly').returns(false);
   sinon.stub(auth, 'hasAllPermissions').returns(false);
   sinon.stub(auth, 'getFacilityId').callsArgWith(2, null, 'facilityId');
   sinon.stub(auth, 'getContactId').callsArgWith(1, null, 'contactId');
@@ -839,7 +839,7 @@ exports['do not respond with new lastSeq unless sure we have all relevant change
   };
 
   sinon.stub(auth, 'getUserCtx').onCall(0).callsArgWith(1, null, userCtx);
-  sinon.stub(auth, 'isAdmin').returns(false);
+  sinon.stub(auth, 'isOnlineOnly').returns(false);
   sinon.stub(auth, 'hasAllPermissions').returns(false);
   const getFacilityId = sinon.stub(auth, 'getFacilityId');
   getFacilityId.callsArgWith(2, null, 'a');
@@ -964,7 +964,7 @@ exports['replicates new docs to relevant feeds'] = function(test) {
     .onCall(0).callsArgWith(1, null, userCtx1)
     .onCall(1).callsArgWith(1, null, userCtx2)
     .onCall(2).callsArgWith(1, null, userCtx2);
-  sinon.stub(auth, 'isAdmin').returns(false);
+  sinon.stub(auth, 'isOnlineOnly').returns(false);
   sinon.stub(auth, 'hasAllPermissions').returns(false);
   var getFacilityId = sinon.stub(auth, 'getFacilityId');
   getFacilityId.onCall(0).callsArgWith(2, null, 'a');
@@ -1124,7 +1124,7 @@ exports['cleans up when the client connection is closed - #2476'] = function(tes
   };
 
   sinon.stub(auth, 'getUserCtx').callsArgWith(1, null, userCtx);
-  sinon.stub(auth, 'isAdmin').returns(false);
+  sinon.stub(auth, 'isOnlineOnly').returns(false);
   sinon.stub(auth, 'hasAllPermissions').returns(false);
   sinon.stub(auth, 'getFacilityId').callsArgWith(2, null, 'facilityId');
   sinon.stub(auth, 'getContactId').callsArgWith(1, null, 'contactId');
@@ -1183,7 +1183,7 @@ exports['makes multiple requests when you can see more than 100 docs - #3508'] =
   };
 
   sinon.stub(auth, 'getUserCtx').callsArgWith(1, null, userCtx);
-  sinon.stub(auth, 'isAdmin').returns(false);
+  sinon.stub(auth, 'isOnlineOnly').returns(false);
   sinon.stub(auth, 'hasAllPermissions').returns(false);
   sinon.stub(auth, 'getFacilityId').callsArgWith(2, null, 'facilityId');
   sinon.stub(auth, 'getContactId').callsArgWith(1, null, 'contactId');
@@ -1281,7 +1281,7 @@ exports['test sorting by couchdb 2 sequence style'] = test => {
   };
 
   sinon.stub(auth, 'getUserCtx').callsArgWith(1, null, userCtx);
-  sinon.stub(auth, 'isAdmin').returns(false);
+  sinon.stub(auth, 'isOnlineOnly').returns(false);
   sinon.stub(auth, 'hasAllPermissions').returns(false);
   sinon.stub(auth, 'getFacilityId').callsArgWith(2, null, 'facilityId');
   sinon.stub(auth, 'getContactId').callsArgWith(1, null, 'contactId');

--- a/static/js/bootstrapper.js
+++ b/static/js/bootstrapper.js
@@ -2,6 +2,8 @@
 
   'use strict';
 
+  var ONLINE_ROLE = 'mm-online';
+
   var getUserCtx = function() {
     var userCtx;
     document.cookie.split(';').forEach(function(c) {
@@ -95,7 +97,8 @@
 
   var hasFullDataAccess = function(userCtx) {
     return hasRole(userCtx, '_admin') ||
-           hasRole(userCtx, 'national_admin');
+           hasRole(userCtx, 'national_admin') || // kept for backwards compatibility
+           hasRole(userCtx, ONLINE_ROLE);
   };
 
   module.exports = function(POUCHDB_OPTIONS, callback) {

--- a/static/js/services/session.js
+++ b/static/js/services/session.js
@@ -102,6 +102,7 @@ var COOKIE_NAME = 'userCtx',
         isOnlineOnly: function(userCtx) {
           userCtx = userCtx || getUserCtx();
           return hasRole(userCtx, '_admin') ||
+                 hasRole(userCtx, 'national_admin') || // kept for backwards compatibility
                  hasRole(userCtx, ONLINE_ROLE);
         }
       };


### PR DESCRIPTION
# Description

national_admin is no longer the only way to designate a user as
online only. This checks for the mm-online role in addition
everywhere we were checking for national_admin.

medic/medic-webapp#4525

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.