### PR TITLE
Fixes everywhere that relied on national_admin

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -994,8 +994,7 @@ Bulk delete endpoint for deleting large numbers of documents. Docs will be batch
 
 ### Permissions
 
-Available to users with role `_admin` or `national_admin`.
-
+Only available to online users.
 
 ### Parameters
 

--- a/api/src/auth.js
+++ b/api/src/auth.js
@@ -2,7 +2,8 @@ var request = require('request'),
     url = require('url'),
     _ = require('underscore'),
     db = require('./db-nano'),
-    config = require('./config');
+    config = require('./config'),
+    ONLINE_ROLE = 'mm-online';
 
 var get = function(path, headers, callback) {
   var fullUrl = url.format({
@@ -67,9 +68,10 @@ module.exports = {
     });
   },
 
-  isAdmin: function(userCtx) {
+  isOnlineOnly: function(userCtx) {
     return hasRole(userCtx, '_admin') ||
-           hasRole(userCtx, 'national_admin');
+           hasRole(userCtx, 'national_admin') || // kept for backwards compatibility
+           hasRole(userCtx, ONLINE_ROLE);
   },
 
   hasAllPermissions: function(userCtx, permissions) {

--- a/api/src/controllers/bulk-docs.js
+++ b/api/src/controllers/bulk-docs.js
@@ -5,7 +5,7 @@ module.exports = {
   bulkDelete: (req, res, next) => {
     return auth.getUserCtx(req)
       .then(userCtx => {
-        if (!auth.isAdmin(userCtx)) {
+        if (!auth.isOnlineOnly(userCtx)) {
           throw {
             code: 401,
             message: 'User is not an admin'

--- a/api/src/controllers/changes.js
+++ b/api/src/controllers/changes.js
@@ -395,7 +395,7 @@ const request = (proxy, req, res) => {
           res.setHeader('X-Accel-Buffering', 'no');
         }
 
-        if (auth.isAdmin(userCtx)) {
+        if (auth.isOnlineOnly(userCtx)) {
           return proxy.web(req, res);
         }
         res.type('json');

--- a/api/src/controllers/export-data.js
+++ b/api/src/controllers/export-data.js
@@ -114,7 +114,13 @@ module.exports = {
     //    by the following auth check in ctx.district (maybe?)
     //  - Still don't let offline users use this API, and instead refactor the
     //    export logic so it can be used in webapp, and have exports works offline
-    return auth.check(req, ['national_admin', getExportPermission(req.params.type)])
+    return auth.getUserCtx(req)
+      .then(userCtx => {
+        if (!auth.isOnlineOnly(userCtx)) {
+          throw { code: 403, message: 'Insufficient privileges' };
+        }
+      })
+      .then(() => auth.check(req, getExportPermission(req.params.type)))
       .then(() => {
         writeExportHeaders(res, req.params.type, formats.csv);
 

--- a/api/src/controllers/settings.js
+++ b/api/src/controllers/settings.js
@@ -33,10 +33,10 @@ module.exports = {
   put: (req, res) => {
     auth.getUserCtx(req)
       .then(userCtx => {
-        if (!auth.isAdmin(userCtx)) {
+        if (!auth.hasAllPermissions(userCtx, 'can_configure')) {
           throw {
-            code: 401,
-            message: 'User is not an admin'
+            code: 403,
+            message: 'Insufficient permissions'
           };
         }
       })

--- a/api/tests/mocha/auth.spec.js
+++ b/api/tests/mocha/auth.spec.js
@@ -182,10 +182,11 @@ describe('Auth', () => {
     });
   });
 
-  it('isAdmin checks for "admin" and "national_admin" roles', done => {
-    chai.expect(auth.isAdmin({ roles: ['_admin'] })).to.equal(true);
-    chai.expect(auth.isAdmin({ roles: ['national_admin'] })).to.equal(true);
-    chai.expect(auth.isAdmin({ roles: ['district_admin'] })).to.equal(false);
+  it('isOnlineOnly checks for "admin" and "national_admin" roles', done => {
+    chai.expect(auth.isOnlineOnly({ roles: ['_admin'] })).to.equal(true);
+    chai.expect(auth.isOnlineOnly({ roles: ['national_admin'] })).to.equal(true);
+    chai.expect(auth.isOnlineOnly({ roles: ['mm-online'] })).to.equal(true);
+    chai.expect(auth.isOnlineOnly({ roles: ['district_admin'] })).to.equal(false);
     done();
   });
 

--- a/api/tests/mocha/controllers/bulk-docs.js
+++ b/api/tests/mocha/controllers/bulk-docs.js
@@ -13,7 +13,7 @@ const testRes = {};
 describe('Bulk Docs controller', () => {
   beforeEach(() => {
     sinon.stub(auth, 'getUserCtx');
-    sinon.stub(auth, 'isAdmin');
+    sinon.stub(auth, 'isOnlineOnly');
   });
 
   afterEach(() => {
@@ -23,12 +23,12 @@ describe('Bulk Docs controller', () => {
   it('checks that user is an admin', () => {
     const userCtx = {};
     auth.getUserCtx.resolves(userCtx);
-    auth.isAdmin.withArgs(userCtx).returns(false);
+    auth.isOnlineOnly.withArgs(userCtx).returns(false);
     const next = sinon.stub();
     return controller.bulkDelete(testReq, testRes, next)
       .then(() => {
         auth.getUserCtx.callCount.should.equal(1);
-        auth.isAdmin.callCount.should.equal(1);
+        auth.isOnlineOnly.callCount.should.equal(1);
         next.callCount.should.equal(1);
         next.getCall(0).args[0].code.should.equal(401);
       });

--- a/api/tests/mocha/controllers/changes.js
+++ b/api/tests/mocha/controllers/changes.js
@@ -52,7 +52,7 @@ describe('Changes controller', () => {
     changesCancelSpy = sinon.spy();
 
     sinon.stub(auth, 'getUserCtx').resolves({ name: 'user' });
-    sinon.stub(auth, 'isAdmin').returns(false);
+    sinon.stub(auth, 'isOnlineOnly').returns(false);
     sinon.stub(auth, 'getUserSettings').resolves(userCtx);
 
     sinon.stub(authorization, 'getViewResults').returns({});
@@ -177,7 +177,7 @@ describe('Changes controller', () => {
 
   describe('request', () => {
     it('initializes the continuous changes feed', () => {
-      auth.isAdmin.returns(true);
+      auth.isOnlineOnly.returns(true);
       return controller
         .request(proxy, testReq, testRes)
         .then(() => {
@@ -186,7 +186,7 @@ describe('Changes controller', () => {
     });
 
     it('only initializes on first call', () => {
-      auth.isAdmin.returns(true);
+      auth.isOnlineOnly.returns(true);
       return controller
         .request(proxy, testReq, testRes)
         .then(() => controller.request(proxy, testReq, testRes))
@@ -198,7 +198,7 @@ describe('Changes controller', () => {
     });
 
     it('sends admin requests through the proxy', () => {
-      auth.isAdmin.returns(true);
+      auth.isOnlineOnly.returns(true);
       return controller
         .request(proxy, testReq, testRes)
         .then(() => {
@@ -228,7 +228,7 @@ describe('Changes controller', () => {
     });
 
     it('sets correct headers when longpoll requests are received', () => {
-      auth.isAdmin.returns(true);
+      auth.isOnlineOnly.returns(true);
       testReq.query = { feed: 'longpoll' };
       return controller._init().then(() => {
         return controller

--- a/api/tests/mocha/controllers/export-data.js
+++ b/api/tests/mocha/controllers/export-data.js
@@ -13,6 +13,8 @@ describe('Export Data controller', () => {
   beforeEach(() => {
     sinon.stub(serverUtils, 'error');
     sinon.stub(auth, 'check');
+    sinon.stub(auth, 'getUserCtx');
+    sinon.stub(auth, 'isOnlineOnly');
     sinon.stub(exportDataV2, 'export');
 
     set = sinon.stub().returns({ set });
@@ -30,10 +32,11 @@ describe('Export Data controller', () => {
     });
     it('Checks permissions', () => {
       auth.check.returns(Promise.reject({message: 'Bad permissions'}));
+      auth.getUserCtx.returns(Promise.resolve({}));
+      auth.isOnlineOnly.returns(true);
       return controller.routeV2({req: true, params: {type: 'reports'}}, {res: true})
         .then(() => {
           auth.check.callCount.should.equal(1);
-          auth.check.args[0][1].should.contain('national_admin');
           serverUtils.error.callCount.should.equal(1);
           serverUtils.error.args[0][0].message.should.contain('Bad permissions');
           serverUtils.error.args[0][1].req.should.equal(true);
@@ -55,6 +58,8 @@ describe('Export Data controller', () => {
         }
       };
       auth.check.resolves();
+      auth.getUserCtx.returns(Promise.resolve({}));
+      auth.isOnlineOnly.returns(true);
       return controller.routeV2(req, { set: set, flushHeaders: sinon.stub() }).then(() => {
         exportDataV2.export.callCount.should.equal(1);
         exportDataV2.export.args[0].should.deep.equal([

--- a/webapp/src/js/bootstrapper.js
+++ b/webapp/src/js/bootstrapper.js
@@ -2,6 +2,8 @@
 
   'use strict';
 
+  var ONLINE_ROLE = 'mm-online';
+
   var getUserCtx = function() {
     var userCtx;
     document.cookie.split(';').forEach(function(c) {
@@ -94,7 +96,8 @@
 
   var hasFullDataAccess = function(userCtx) {
     return hasRole(userCtx, '_admin') ||
-           hasRole(userCtx, 'national_admin');
+           hasRole(userCtx, 'national_admin') || // kept for backwards compatibility
+           hasRole(userCtx, ONLINE_ROLE);
   };
 
   module.exports = function(POUCHDB_OPTIONS, callback) {

--- a/webapp/src/js/services/session.js
+++ b/webapp/src/js/services/session.js
@@ -89,6 +89,12 @@ var COOKIE_NAME = 'userCtx',
         return _.contains(userCtx && userCtx.roles, role);
       };
 
+      var isAdmin = function(userCtx) {
+        userCtx = userCtx || getUserCtx();
+        return hasRole(userCtx, '_admin') ||
+               hasRole(userCtx, 'national_admin'); // deprecated: kept for backwards compatibility: #4525
+      };
+
       return {
         logout: logout,
 
@@ -106,18 +112,14 @@ var COOKIE_NAME = 'userCtx',
          * Returns true if the logged in user has the db or national admin role.
          * @param {userCtx} (optional) Will get the current userCtx if not provided.
          */
-        isAdmin: function(userCtx) {
-          userCtx = userCtx || getUserCtx();
-          return hasRole(userCtx, '_admin') ||
-                 hasRole(userCtx, 'national_admin'); // deprecated: kept for backwards compatibility: #4525
-        },
+        isAdmin: isAdmin,
 
         /**
          * Returns true if the logged in user is online only
          */
         isOnlineOnly: function(userCtx) {
           userCtx = userCtx || getUserCtx();
-          return hasRole(userCtx, '_admin') ||
+          return isAdmin(userCtx) ||
                  hasRole(userCtx, ONLINE_ROLE);
         }
       };


### PR DESCRIPTION
# Description

national_admin is no longer the only way to designate a user as
online only. This checks for the mm-online role in addition
everywhere we were checking for national_admin.

medic/medic-webapp#4525

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.