### PR TITLE
Fixes a race condition in deleting read docs

### DIFF
--- a/lib/views.js
+++ b/lib/views.js
@@ -340,17 +340,6 @@ exports.places_by_contact = {
   }
 };
 
-exports.online_user_settings_by_id = {
-  map: function(doc) {
-    if (doc.type === 'user-settings' &&
-        doc.roles &&
-        (doc.roles.indexOf('_admin') !== -1 ||
-        doc.roles.indexOf('national_admin') !== -1)) {
-      emit(doc._id);
-    }
-  }
-};
-
 exports.sms_messages = {
   map: function(doc) {
     if (doc.type === 'data_record' && doc.sms_message && doc.sms_message.gateway_ref) {

--- a/sentinel/db.js
+++ b/sentinel/db.js
@@ -40,6 +40,9 @@ if (couchUrl) {
             insert: function() {},
             fetch: function() {}
         },
+        db: {
+            list: function() {}
+        },
         settings: {}
     };
 } else {


### PR DESCRIPTION
# Description

Deletes all read docs, not just admin ones, so there is no change a
user will still have a read doc with no corresponding doc.

Removes an obsolete view which doesn't work now we have configurable
roles.

medic/medic-webapp#3960

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.