### PR TITLE
Allows replication of specific reports to supervisors

### DIFF
--- a/shared-libs/view-map-utils/src/view-map-utils.js
+++ b/shared-libs/view-map-utils/src/view-map-utils.js
@@ -30,18 +30,16 @@ module.exports = {
     var viewNames = argumentsToArray.apply({ skip: 1 }, arguments);
     viewNames.forEach(function(view) {
       viewMapStrings[ddocId][view] = ddoc.views && ddoc.views[view] && ddoc.views[view].map || false;
-      viewMapFns[ddocId][view] = {};
     });
   },
 
-  getViewMapFn: function (ddocId, viewName, full) {
+  getViewMapFn: function (ddocId, viewName) {
     var COMMENT_REGEX = /\/\/.*/g,
         SIGNATURE_REGEX = /emit\(/g,
         NEW_LINE_REGEX = /\\n/g;
 
-    full = !!full;
-    if (viewMapFns[ddocId] && viewMapFns[ddocId][viewName] && viewMapFns[ddocId][viewName][full]) {
-      return viewMapFns[ddocId][viewName][full];
+    if (viewMapFns[ddocId] && viewMapFns[ddocId][viewName]) {
+      return viewMapFns[ddocId][viewName];
     }
 
     var fnString = module.exports.getViewMapString(ddocId, viewName);
@@ -64,9 +62,9 @@ module.exports = {
         return emitted.push(argumentsToArray.apply(null, arguments));
       };
       fn.apply({ emit: emit }, arguments);
-      return (full ? emitted : emitted[0]);
+      return emitted;
     };
-    viewMapFns[ddocId][viewName][full] = viewMapFn;
+    viewMapFns[ddocId][viewName] = viewMapFn;
     return viewMapFn;
   },
 

--- a/shared-libs/view-map-utils/test/view-map-utils.js
+++ b/shared-libs/view-map-utils/test/view-map-utils.js
@@ -60,15 +60,15 @@ describe('Replication Helper Views Lib', function() {
       };
       lib.loadViewMaps(ddoc, 'viewName', 'viewName2');
       var fn = lib.getViewMapFn('ddoc', 'viewName');
-      fn(2, 3, '+').should.deep.equal([5]);
-      fn(5, 2, '-').should.deep.equal([3]);
-      fn(4, 2, '*').should.deep.equal([8]);
-      fn(16, 4, '/').should.deep.equal([4]);
+      fn(2, 3, '+').should.deep.equal([[5]]);
+      fn(5, 2, '-').should.deep.equal([[3]]);
+      fn(4, 2, '*').should.deep.equal([[8]]);
+      fn(16, 4, '/').should.deep.equal([[4]]);
 
       var fn2 = lib.getViewMapFn('ddoc', 'viewName2');
-      fn2(0).should.deep.equal([2]);
-      fn2(2).should.deep.equal([4]);
-      fn2(-2).should.deep.equal([0]);
+      fn2(0).should.deep.equal([[2]]);
+      fn2(2).should.deep.equal([[4]]);
+      fn2(-2).should.deep.equal([[0]]);
     });
 
     it('supports multiple emits', function() {
@@ -80,26 +80,9 @@ describe('Replication Helper Views Lib', function() {
         }
       };
       lib.loadViewMaps(ddoc, 'viewName');
-      var fn = lib.getViewMapFn('ddoc', 'viewName', true);
+      var fn = lib.getViewMapFn('ddoc', 'viewName');
       fn(1).should.deep.equal([[2], [3], [4]]);
       fn(2).should.deep.equal([[3], [4], [5]]);
-    });
-
-    it('supports multiple and single emits for the same view', function() {
-      var fnString = 'function(a) { emit(a + 1); emit(a + 2); emit(a + 3); }';
-      var ddoc = {
-        _id: '_design/ddoc',
-        views: {
-          viewName: { map: fnString }
-        }
-      };
-      lib.loadViewMaps(ddoc, 'viewName');
-      var fnMultiple = lib.getViewMapFn('ddoc', 'viewName', true);
-      var fnSingle = lib.getViewMapFn('ddoc', 'viewName', false);
-      fnMultiple(1).should.deep.equal([[2], [3], [4]]);
-      fnMultiple(2).should.deep.equal([[3], [4], [5]]);
-      fnSingle(1).should.deep.equal([2]);
-      fnSingle(2).should.deep.equal([3]);
     });
 
     it('throws error when requested a view that does not exist ', function() {
@@ -124,21 +107,14 @@ describe('Replication Helper Views Lib', function() {
         }
       };
       lib.loadViewMaps(ddoc, 'viewName');
-      var fnMultiple = lib.getViewMapFn('ddoc', 'viewName', true);
-      fnMultiple = lib.getViewMapFn('ddoc', 'viewName', true);
-      fnMultiple = lib.getViewMapFn('ddoc', 'viewName', true);
-      fnMultiple = lib.getViewMapFn('ddoc', 'viewName', true);
-      var fnSingle = lib.getViewMapFn('ddoc', 'viewName', false);
-      fnSingle = lib.getViewMapFn('ddoc', 'viewName', false);
-      fnSingle = lib.getViewMapFn('ddoc', 'viewName', false);
-      fnSingle = lib.getViewMapFn('ddoc', 'viewName', false);
-      fnMultiple(1).should.deep.equal([[2], [3], [4]]);
-      fnMultiple(2).should.deep.equal([[3], [4], [5]]);
-      fnSingle(1).should.deep.equal([2]);
-      fnSingle(2).should.deep.equal([3]);
-      lib.getViewMapString.callCount.should.equal(2);
+      var fn = lib.getViewMapFn('ddoc', 'viewName');
+      fn = lib.getViewMapFn('ddoc', 'viewName');
+      fn = lib.getViewMapFn('ddoc', 'viewName');
+      fn = lib.getViewMapFn('ddoc', 'viewName');
+      fn(1).should.deep.equal([[2], [3], [4]]);
+      fn(2).should.deep.equal([[3], [4], [5]]);
+      lib.getViewMapString.callCount.should.equal(1);
       lib.getViewMapString.args[0].should.deep.equal(['ddoc', 'viewName']);
-      lib.getViewMapString.args[1].should.deep.equal(['ddoc', 'viewName']);
     });
   });
 
@@ -168,8 +144,8 @@ describe('Replication Helper Views Lib', function() {
       };
       lib.loadViewMaps(ddoc, 'view1');
 
-      lib.getViewMapFn('ddoc', 'view1')(1).should.deep.equal([1]);
-      lib.getViewMapFn('ddoc', 'view1')('I am a happy hippo').should.deep.equal(['I am a happy hippo']);
+      lib.getViewMapFn('ddoc', 'view1')(1).should.deep.equal([[1]]);
+      lib.getViewMapFn('ddoc', 'view1')('I am a happy hippo').should.deep.equal([['I am a happy hippo']]);
 
       fnStringView1 = 'function(a) { return emit(4); }';
       ddoc = {
@@ -179,8 +155,8 @@ describe('Replication Helper Views Lib', function() {
         }
       };
       lib.loadViewMaps(ddoc, 'view1');
-      lib.getViewMapFn('ddoc', 'view1')(1).should.deep.equal([4]);
-      lib.getViewMapFn('ddoc', 'view1')('I am a happy hippo').should.deep.equal([4]);
+      lib.getViewMapFn('ddoc', 'view1')(1).should.deep.equal([[4]]);
+      lib.getViewMapFn('ddoc', 'view1')('I am a happy hippo').should.deep.equal([[4]]);
 
       fnStringView1 = 'function(a) { return emit(4); }';
       ddoc = {
@@ -212,10 +188,10 @@ describe('Replication Helper Views Lib', function() {
       };
       lib.loadViewMaps(ddoc2, 'view');
 
-      lib.getViewMapFn('ddoc1', 'view')(1).should.deep.equal([1]);
-      lib.getViewMapFn('ddoc1', 'view')('I am a happy hippo').should.deep.equal(['I am a happy hippo']);
-      lib.getViewMapFn('ddoc2', 'view')(1).should.deep.equal([3]);
-      lib.getViewMapFn('ddoc2', 'view')(33).should.deep.equal([35]);
+      lib.getViewMapFn('ddoc1', 'view')(1).should.deep.equal([[1]]);
+      lib.getViewMapFn('ddoc1', 'view')('I am a happy hippo').should.deep.equal([['I am a happy hippo']]);
+      lib.getViewMapFn('ddoc2', 'view')(1).should.deep.equal([[3]]);
+      lib.getViewMapFn('ddoc2', 'view')(33).should.deep.equal([[35]]);
 
       fnStringView1 = 'function(a) { return emit(1024); }';
       ddoc1 = {
@@ -226,10 +202,10 @@ describe('Replication Helper Views Lib', function() {
       };
       lib.loadViewMaps(ddoc1, 'view');
 
-      lib.getViewMapFn('ddoc1', 'view')(1).should.deep.equal([1024]);
-      lib.getViewMapFn('ddoc1', 'view')('I am a happy hippo').should.deep.equal([1024]);
-      lib.getViewMapFn('ddoc2', 'view')(1).should.deep.equal([3]);
-      lib.getViewMapFn('ddoc2', 'view')(33).should.deep.equal([35]);
+      lib.getViewMapFn('ddoc1', 'view')(1).should.deep.equal([[1024]]);
+      lib.getViewMapFn('ddoc1', 'view')('I am a happy hippo').should.deep.equal([[1024]]);
+      lib.getViewMapFn('ddoc2', 'view')(1).should.deep.equal([[3]]);
+      lib.getViewMapFn('ddoc2', 'view')(33).should.deep.equal([[35]]);
 
       fnStringView2 = 'function(a) { return emit(\'Medic Mobile\'); }';
       ddoc2 = {
@@ -240,10 +216,10 @@ describe('Replication Helper Views Lib', function() {
       };
       lib.loadViewMaps(ddoc2, 'view');
 
-      lib.getViewMapFn('ddoc1', 'view')(1).should.deep.equal([1024]);
-      lib.getViewMapFn('ddoc1', 'view')('I am a happy hippo').should.deep.equal([1024]);
-      lib.getViewMapFn('ddoc2', 'view')(1).should.deep.equal(['Medic Mobile']);
-      lib.getViewMapFn('ddoc2', 'view')(33).should.deep.equal(['Medic Mobile']);
+      lib.getViewMapFn('ddoc1', 'view')(1).should.deep.equal([[1024]]);
+      lib.getViewMapFn('ddoc1', 'view')('I am a happy hippo').should.deep.equal([[1024]]);
+      lib.getViewMapFn('ddoc2', 'view')(1).should.deep.equal([['Medic Mobile']]);
+      lib.getViewMapFn('ddoc2', 'view')(33).should.deep.equal([['Medic Mobile']]);
     });
   });
 });

--- a/webapp/src/ddocs/medic/views/docs_by_replication_key/map.js
+++ b/webapp/src/ddocs/medic/views/docs_by_replication_key/map.js
@@ -48,7 +48,16 @@ function (doc) {
       if (doc.form && doc.contact) {
         value.submitter = doc.contact._id;
       }
-      return emit(subject, value);
+      emit(subject, value);
+      if (doc.fields &&
+          doc.fields.needs_signoff &&
+          doc.contact &&
+          doc.contact._id &&
+          doc.contact._id !== subject
+      ) {
+        emit(doc.contact._id, value);
+      }
+      return;
     case 'clinic':
     case 'district_hospital':
     case 'health_center':


### PR DESCRIPTION
# Description

If the report has a field named "needs_signoff" then the submitter
is also considered a subject which means any supervisor who can see
the submitter can also see their report. This allows specific
reports to be replicated to supervisors for review.

medic/medic-webapp#4591

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.