### PR TITLE
Allows configuration of date of death field

### DIFF
--- a/sentinel/test/mocha/transitions/death_reporting.js
+++ b/sentinel/test/mocha/transitions/death_reporting.js
@@ -27,7 +27,8 @@ describe('death_reporting', () => {
       };
       sinon.stub(config, 'get').returns({
         mark_deceased_forms: ['death-confirm'],
-        undo_deceased_forms: ['death-undo']
+        undo_deceased_forms: ['death-undo'],
+        date_field: 'death.date'
       });
       const getPatientContact = sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, patient);
       const saveDoc = sinon.stub(db.audit, 'saveDoc').callsArg(1);
@@ -56,7 +57,8 @@ describe('death_reporting', () => {
       };
       sinon.stub(config, 'get').returns({
         mark_deceased_forms: ['death-confirm'],
-        undo_deceased_forms: ['death-undo']
+        undo_deceased_forms: ['death-undo'],
+        date_field: 'death.date'
       });
       const getPatientContact = sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, patient);
       const saveDoc = sinon.stub(db.audit, 'saveDoc').callsArg(1);
@@ -69,6 +71,35 @@ describe('death_reporting', () => {
         saveDoc.callCount.should.equal(1);
         saveDoc.args[0][0].should.deep.equal({ name: 'greg', date_of_death: dateOfDeath });
         done();
+      });
+    });
+
+    it('uses the configured field for the date', () => {
+      const patientId = 'some-uuid';
+      const dateOfDeath = 1529285369317;
+      const patient = { name: 'greg' };
+      const change = {
+        doc: {
+          reported_date: 15612321,
+          form: 'death-confirm',
+          fields: {
+            patient_id: patientId,
+            death: { date: dateOfDeath }
+          }
+        }
+      };
+      sinon.stub(config, 'get').returns({
+        mark_deceased_forms: ['death-confirm'],
+        undo_deceased_forms: ['death-undo'],
+        date_field: 'fields.death.date'
+      });
+      sinon.stub(utils, 'getPatientContact').callsArgWith(2, null, patient);
+      const saveDoc = sinon.stub(db.audit, 'saveDoc').callsArg(1);
+      sinon.stub(db.medic, 'get').callsArgWith(1, null, patient);
+      return transition.onMatch(change).then(changed => {
+        changed.should.equal(true);
+        saveDoc.callCount.should.equal(1);
+        saveDoc.args[0][0].should.deep.equal({ name: 'greg', date_of_death: dateOfDeath });
       });
     });
 


### PR DESCRIPTION
# Description

The old configuration used the reporting_date of the confirmation
as the date_of_death of the patient. This enables the transition
to be configured to use any other property in the report so users
can provide the actual date of death.

medic/medic-webapp#4636

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.