### PR TITLE
Shows patient name if submitted

### DIFF
--- a/ddocs/medic-client/views/doc_summaries_by_id/map.js
+++ b/ddocs/medic-client/views/doc_summaries_by_id/map.js
@@ -25,11 +25,14 @@ function(doc) {
   };
 
   var getSubject = function(doc) {
+    var subject = {};
     var reference = doc.patient_id ||
                     (doc.fields && doc.fields.patient_id) ||
                     doc.place_id;
     var patientName = doc.fields && doc.fields.patient_name;
-    var subject = { name: patientName };
+    if (patientName) {
+      subject.name = patientName;
+    }
 
     if (reference) {
       subject.value = reference;

--- a/ddocs/medic-client/views/doc_summaries_by_id/map.js
+++ b/ddocs/medic-client/views/doc_summaries_by_id/map.js
@@ -25,16 +25,20 @@ function(doc) {
   };
 
   var getSubject = function(doc) {
-    var subject = {};
+    var reference = doc.patient_id ||
+                    (doc.fields && doc.fields.patient_id) ||
+                    doc.place_id;
+    var patientName = doc.fields && doc.fields.patient_name;
+    var subject = { name: patientName };
 
-    if (doc.patient_id || (doc.fields && doc.fields.patient_id) || doc.place_id) {
-      subject.value = doc.patient_id || (doc.fields && doc.fields.patient_id) || doc.place_id;
+    if (reference) {
+      subject.value = reference;
       subject.type = 'reference';
     } else if (doc.fields && doc.fields.place_id) {
       subject.value = doc.fields.place_id;
       subject.type = 'id';
-    } else if (doc.fields && doc.fields.patient_name) {
-      subject.value = doc.fields.patient_name;
+    } else if (patientName) {
+      subject.value = patientName;
       subject.type = 'name';
     } else if (doc.errors) {
       doc.errors.forEach(function(error) {

--- a/static/js/services/get-summaries.js
+++ b/static/js/services/get-summaries.js
@@ -44,11 +44,14 @@ angular.module('inboxServices').factory('GetSummaries',
       };
 
       var getSubject = function(doc) {
+        var subject = {};
         var reference = doc.patient_id ||
                         (doc.fields && doc.fields.patient_id) ||
                         doc.place_id;
         var patientName = doc.fields && doc.fields.patient_name;
-        var subject = { name: patientName };
+        if (patientName) {
+          subject.name = patientName;
+        }
 
         if (reference) {
           subject.value = reference;

--- a/static/js/services/get-summaries.js
+++ b/static/js/services/get-summaries.js
@@ -44,16 +44,20 @@ angular.module('inboxServices').factory('GetSummaries',
       };
 
       var getSubject = function(doc) {
-        var subject = {};
+        var reference = doc.patient_id ||
+                        (doc.fields && doc.fields.patient_id) ||
+                        doc.place_id;
+        var patientName = doc.fields && doc.fields.patient_name;
+        var subject = { name: patientName };
 
-        if (doc.patient_id || (doc.fields && doc.fields.patient_id) || doc.place_id) {
-          subject.value = doc.patient_id || (doc.fields && doc.fields.patient_id) || doc.place_id;
+        if (reference) {
+          subject.value = reference;
           subject.type = 'reference';
         } else if (doc.fields && doc.fields.place_id) {
           subject.value = doc.fields.place_id;
           subject.type = 'id';
-        } else if (doc.fields && doc.fields.patient_name) {
-          subject.value = doc.fields.patient_name;
+        } else if (patientName) {
+          subject.value = patientName;
           subject.type = 'name';
         } else if (doc.errors) {
           doc.errors.forEach(function(error) {

--- a/static/js/services/live-list.js
+++ b/static/js/services/live-list.js
@@ -102,6 +102,16 @@ angular.module('inboxServices').factory('LiveListConfig',
         listItem: contacts_config.listItem,
       });
 
+      var getHeading = function(report) {
+        if (report.validSubject) {
+          return report.subject.value;
+        }
+        if (report.subject.name) {
+          return report.subject.name;
+        }
+        return $translate.instant('report.subject.unknown');
+      };
+
       var reports_config = {
         orderBy: function(r1, r2) {
           var lhs = r1 && r1.reported_date,
@@ -123,8 +133,7 @@ angular.module('inboxServices').factory('LiveListConfig',
           var form = _.findWhere($scope.forms, { code: report.form });
           scope.route = 'reports';
           scope.icon = form && form.icon;
-          scope.heading =
-            report.validSubject ? report.subject.value : $translate.instant('report.subject.unknown');
+          scope.heading = getHeading(report);
           scope.date = report.reported_date;
           scope.summary = form ? form.title : report.form;
           scope.showStatus = true;

--- a/templates/partials/reports_content.html
+++ b/templates/partials/reports_content.html
@@ -36,7 +36,7 @@
 
           <div ng-if="summary.subject.type" class="subject">
             <span class="name"
-                  ng-bind="(summary.subject.type === 'name' && summary.subject.value) || ('report.subject.unknown' | translate)"></span>
+                  ng-bind="(summary.subject.type === 'name' && summary.subject.value) || summary.subject.name || ('report.subject.unknown' | translate)"></span>
           </div>
           <mm-sender ng-if="!summary.subject.type" message="selection" hide-lineage="true"></mm-sender>
           <div>{{summary | title:forms}}</div>

--- a/tests/mocha/unit/views/doc_summaries_by_id.spec.js
+++ b/tests/mocha/unit/views/doc_summaries_by_id.spec.js
@@ -345,6 +345,7 @@ describe('doc_summaries_by_id view', () => {
         contact: 'df28f38e-cd3c-475f-96b5-48080d863e34',
         lineage: ['1a1aac55-04d6-40dc-aae2-e67a75a1496d'],
         subject: {
+          name: 'mother',
           type: 'reference',
           value: 'a29c933c-90cb-4cb0-9e25-36403499aee4'
         }
@@ -365,6 +366,7 @@ describe('doc_summaries_by_id view', () => {
         contact: 'df28f38e-cd3c-475f-96b5-48080d863e34',
         lineage: ['1a1aac55-04d6-40dc-aae2-e67a75a1496d'],
         subject: {
+          name: 'mother',
           type: 'name',
           value: 'mother'
         }
@@ -385,6 +387,7 @@ describe('doc_summaries_by_id view', () => {
         contact: undefined,
         lineage: [],
         subject: {
+          name: 'test',
           type: 'name',
           value: 'test'
         }


### PR DESCRIPTION
# Description

If the patient with the patient_id isn't found but the form has a
patient_name field then show that value. Otherwise display
"unknown subject" as before.

This is useful for supervisors who don't have access to the patient
doc.

medic/medic-webapp#4591

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.