### PR TITLE
Emit NODE_OPTIONS during API startup

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -22,6 +22,7 @@ const nodeVersionCheck = () => {
   if (major < MIN_MAJOR) {
     throw new Error(`Node version ${major}.${minor}.${patch} is not supported, minimum is ${MIN_MAJOR}.0.0`);
   }
+  console.log(`Node Environment Options: '${process.env.NODE_OPTIONS}'`);
   console.log(`Node Version: ${major}.${minor}.${patch} in ${process.env.NODE_ENV || 'development'} mode`);
 };
 


### PR DESCRIPTION
Toward #4676

# Description

Emit NODE_OPTIONS during API startup. Doing this proved useful for diagnostic purposes while troubleshooting an OOM issue in production, and it seems fairly harmless. Useful for observing things like `--max_old_space_size`. Always a string.

medic/medic-webapp#4676

# Review checklist

- [x] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [x] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.