### PR TITLE
Saves docs only if the task state has updated

### DIFF
--- a/api/controllers/messages.js
+++ b/api/controllers/messages.js
@@ -145,6 +145,11 @@ module.exports = {
         const stateChangesByDocId = applyTaskStateChangesToDocs(taskStateChanges, docs);
         docs = docs.filter(doc => stateChangesByDocId[doc._id] && stateChangesByDocId[doc._id].length);
 
+        if (!docs.length) {
+          // nothing to update
+          return callback(null, {success: true});
+        }
+
         db.medic.bulk({docs: docs}, (err, results) => {
           if (err) {
             return callback(err);


### PR DESCRIPTION
# Description

Improves performance by not making db updates where nothing changed but the _rev.

medic/medic-webapp#4688

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.