### PR TITLE
Fix proxy headers on errors

### DIFF
--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -569,9 +569,16 @@ proxyForChanges.on('proxyReq', (proxyReq, req) => {
 
 // because these are longpolls, we need to manually flush the CouchDB heartbeats through compression
 proxyForChanges.on('proxyRes', (proxyRes, req, res) => {
-  if (!res.headersSent) {
-    res.writeHead(proxyRes.statusCode, proxyRes.headers);
+  res.statusCode = proxyRes.statusCode;
+  if(proxyRes.statusMessage) {
+    res.statusMessage = proxyRes.statusMessage;
   }
+
+  _.each(proxyRes.headers, (value, key) => {
+    if (value !== undefined) {
+      res.setHeader(String(key).trim(), value);
+    }
+  });
 
   proxyRes.pipe(res);
   proxyRes.on('data', () => res.flush());

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -530,6 +530,21 @@ const writeParsedBody = (proxyReq, req) => {
   }
 };
 
+const copyProxyHeaders = (proxyRes, res) => {
+  if (!res.headersSent) {
+    res.statusCode = proxyRes.statusCode;
+    if (proxyRes.statusMessage) {
+      res.statusMessage = proxyRes.statusMessage;
+    }
+
+    _.each(proxyRes.headers, (value, key) => {
+      if (value !== undefined) {
+        res.setHeader(String(key).trim(), value);
+      }
+    });
+  }
+};
+
 /**
  * Set cache control on static resources. Must be hacked in to
  * ensure we set the value first.
@@ -569,16 +584,7 @@ proxyForChanges.on('proxyReq', (proxyReq, req) => {
 
 // because these are longpolls, we need to manually flush the CouchDB heartbeats through compression
 proxyForChanges.on('proxyRes', (proxyRes, req, res) => {
-  res.statusCode = proxyRes.statusCode;
-  if(proxyRes.statusMessage) {
-    res.statusMessage = proxyRes.statusMessage;
-  }
-
-  _.each(proxyRes.headers, (value, key) => {
-    if (value !== undefined) {
-      res.setHeader(String(key).trim(), value);
-    }
-  });
+  copyProxyHeaders(proxyRes, res);
 
   proxyRes.pipe(res);
   proxyRes.on('data', () => res.flush());

--- a/api/src/server-utils.js
+++ b/api/src/server-utils.js
@@ -21,9 +21,11 @@ var respond = function(req, res, code, message, details) {
   if (wantsJSON(req)) {
     return writeJSON(res, code, message, details);
   }
-  res.writeHead(code, {
-    'Content-Type': 'text/plain'
-  });
+  if (!res.headersSent) {
+    res.writeHead(code, {
+      'Content-Type': 'text/plain'
+    });
+  }
   if (details) {
     message += ': ' + JSON.stringify(details);
   }

--- a/tests/e2e/api/controllers/changes.js
+++ b/tests/e2e/api/controllers/changes.js
@@ -251,6 +251,30 @@ describe('changes handler', () => {
         });
     });
 
+    it('should copy proxied response headers', () => {
+      const options = {
+        hostname: constants.API_HOST,
+        port: constants.API_PORT,
+        auth: auth.user + ':' + auth.pass,
+        path: `/${constants.DB_NAME}/_changes?limit=1`
+      };
+
+      return new Promise((resolve, reject) => {
+          const req = http.request(options, res => {
+            res.on('data', () => {});
+            res.on('end', () => resolve(res.headers));
+          });
+
+          req.on('error', e => reject(e));
+          req.end();
+        })
+        .then(headers => {
+          expect(headers).toBeTruthy();
+          expect(headers['content-type']).toEqual('application/json');
+          expect(headers.server).toBeTruthy();
+        });
+    });
+
     it('should send heartbeats at specified intervals for all types of _changes requests', () => {
       const heartRateMonitor = options => {
         options = options || {};


### PR DESCRIPTION
# Description

If proxies throw errors, don't try to send headers twice.

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.