### PR TITLE
Configures PouchDB not to batch changes requests

### DIFF
--- a/api/src/controllers/changes.js
+++ b/api/src/controllers/changes.js
@@ -202,7 +202,9 @@ const restartNormalFeed = feed => {
 const getChanges = feed => {
   const options = {
     since: feed.req.query && feed.req.query.since || 0,
-    batch_size: MAX_DOC_IDS + 1 // PouchDB batch size
+    // PouchDB batches requests using this value as a limit and keeps issuing requests until the result
+    // set length is lower than the limit.
+    batch_size: MAX_DOC_IDS + 1
   };
   _.extend(options, _.pick(feed.req.query, 'style', 'conflicts', 'seq_interval'));
 

--- a/api/src/controllers/changes.js
+++ b/api/src/controllers/changes.js
@@ -375,7 +375,8 @@ const getCouchDbConfig = () => {
       return DEFAULT_MAX_DOC_IDS;
     })
     .then(value => {
-      MAX_DOC_IDS = value;
+      value = parseInt(value);
+      MAX_DOC_IDS = (!isNaN(value) && value) ? value : DEFAULT_MAX_DOC_IDS;
     });
 };
 

--- a/api/src/controllers/changes.js
+++ b/api/src/controllers/changes.js
@@ -376,7 +376,8 @@ const getCouchDbConfig = () => {
     })
     .then(value => {
       value = parseInt(value);
-      MAX_DOC_IDS = (!isNaN(value) && value) ? value : DEFAULT_MAX_DOC_IDS;
+      const isValidValue = (!isNaN(value) && value > 0);
+      MAX_DOC_IDS = isValidValue ? value : DEFAULT_MAX_DOC_IDS;
     });
 };
 

--- a/api/src/controllers/changes.js
+++ b/api/src/controllers/changes.js
@@ -201,7 +201,8 @@ const restartNormalFeed = feed => {
 
 const getChanges = feed => {
   const options = {
-    since: feed.req.query && feed.req.query.since || 0
+    since: feed.req.query && feed.req.query.since || 0,
+    batch_size: MAX_DOC_IDS // PouchDB batch size
   };
   _.extend(options, _.pick(feed.req.query, 'style', 'conflicts', 'seq_interval'));
 

--- a/api/src/controllers/changes.js
+++ b/api/src/controllers/changes.js
@@ -202,7 +202,7 @@ const restartNormalFeed = feed => {
 const getChanges = feed => {
   const options = {
     since: feed.req.query && feed.req.query.since || 0,
-    batch_size: MAX_DOC_IDS // PouchDB batch size
+    batch_size: MAX_DOC_IDS + 1 // PouchDB batch size
   };
   _.extend(options, _.pick(feed.req.query, 'style', 'conflicts', 'seq_interval'));
 

--- a/api/src/controllers/changes.js
+++ b/api/src/controllers/changes.js
@@ -257,7 +257,7 @@ const getChanges = feed => {
 
 const initFeed = (req, res, userCtx) => {
   const feed = {
-    id: req.uniqId || uuid(),
+    id: req.id || uuid(),
     req: req,
     res: res,
     userCtx: userCtx,

--- a/api/src/services/db-config.js
+++ b/api/src/services/db-config.js
@@ -9,8 +9,8 @@ module.exports = {
       const fullPath = path.join('_node', COUCH_NODE_NAME, '_config', section, key);
       const fullUrl = `${db.serverUrl}/${fullPath}`;
       request.get({ url: fullUrl, json: true }, (err, res, body) => {
-        if (err) {
-          reject(err);
+        if (err || res.statusCode !== 200) {
+          reject(err || body);
         } else {
           resolve(body);
         }

--- a/api/tests/mocha/controllers/changes.js
+++ b/api/tests/mocha/controllers/changes.js
@@ -327,7 +327,7 @@ describe('Changes controller', () => {
           changesSpy.callCount.should.equal(2);
           changesSpy.args[1][0].should.deep.equal({
             since: 0,
-            batch_size: 40,
+            batch_size: 41,
             doc_ids: ['d1', 'd2', 'd3']
           });
         });
@@ -344,7 +344,7 @@ describe('Changes controller', () => {
           changesSpy.callCount.should.equal(2);
           changesSpy.args[1][0].should.deep.equal({
             since: '22',
-            batch_size: 40,
+            batch_size: 41,
             doc_ids: ['d1', 'd2', 'd3'],
             conflicts: true,
             seq_interval: false
@@ -1306,7 +1306,7 @@ describe('Changes controller', () => {
         .then(() => {
           changesSpy.callCount.should.equal(2);
           changesSpy.args[1][0].should.deep.equal({
-            batch_size: 2,
+            batch_size: 3,
             doc_ids: ['a', 'b'],
             since: 'seq'
           });
@@ -1347,12 +1347,12 @@ describe('Changes controller', () => {
 
           changesSpy.callCount.should.equal(4);
           changesSpy.args[2][0].should.deep.equal({
-            batch_size: 2,
+            batch_size: 3,
             doc_ids: ['a', 'b'],
             since: 'seq'
           });
           changesSpy.args[3][0].should.deep.equal({
-            batch_size: 2,
+            batch_size: 3,
             doc_ids: ['c', 'd'],
             since: 'seq'
           });

--- a/api/tests/mocha/controllers/changes.js
+++ b/api/tests/mocha/controllers/changes.js
@@ -534,7 +534,7 @@ describe('Changes controller', () => {
     it('when no normal results are received for a longpoll request, push to longpollFeeds', () => {
       authorization.getAllowedDocIds.resolves([1, 2]);
       testReq.query = { feed: 'longpoll' };
-      testReq.uniqId = 'myUniqueId';
+      testReq.id = 'myUniqueId';
       return controller
         .request(proxy, testReq, testRes)
         .then(nextTick)
@@ -576,7 +576,7 @@ describe('Changes controller', () => {
       authorization.getAllowedDocIds.onCall(1).resolves([42]);
       auth.getUserSettings.onCall(1).resolves({ name: 'user', facility_id: 'facility_id' });
 
-      testReq.uniqId = 'myFeed';
+      testReq.id = 'myFeed';
       const userChange = {
         id: 'org.couchdb.user:' + userCtx.name,
         doc: {
@@ -812,8 +812,8 @@ describe('Changes controller', () => {
         .withArgs(sinon.match(/^[0-9]+$/), sinon.match({ id: 'two' })).returns({ newSubjects: 0 });
 
       testReq.query = { feed: 'longpoll' };
-      testReq.uniqId = 'one';
-      const testReq2 = { on: sinon.stub(), uniqId: 'two', query: { feed: 'longpoll' } };
+      testReq.id = 'one';
+      const testReq2 = { on: sinon.stub(), id: 'two', query: { feed: 'longpoll' } };
       const testRes2 = {
         type: sinon.stub(),
         write: sinon.stub(),
@@ -821,7 +821,7 @@ describe('Changes controller', () => {
         setHeader: sinon.stub(),
         flush: sinon.stub()
       };
-      const testReq3 = { on: sinon.stub(), uniqId: 'three', query: { feed: 'longpoll' } };
+      const testReq3 = { on: sinon.stub(), id: 'three', query: { feed: 'longpoll' } };
       const testRes3 = {
         type: sinon.stub(),
         write: sinon.stub(),
@@ -888,7 +888,7 @@ describe('Changes controller', () => {
 
     it('resets the feed when a breaking authorization change is received', () => {
       testReq.query = { feed: 'longpoll' };
-      testReq.uniqId = 'myFeed';
+      testReq.id = 'myFeed';
       authorization.getAllowedDocIds.resolves([1, 2, 3]);
       authorization.getAllowedDocIds.onCall(1).resolves([ 'a', 'b', 'c' ]);
       const authChange = { id: 'org.couchdb.user:name' };
@@ -1291,7 +1291,7 @@ describe('Changes controller', () => {
       sinon.stub(dbConfig, 'get').resolves(2);
       defaultSettings.reiterate_changes = false;
       testReq.query = { feed: 'longpoll', since: 'seq' };
-      testReq.uniqId = 'myFeed';
+      testReq.id = 'myFeed';
       authorization.getUserAuthorizationData.resolves({ subjectIds: ['a', 'b'], contactsByDepthKeys: []});
       authorization.getAllowedDocIds.onCall(0).resolves([ 'a', 'b' ]);
       authorization.getAllowedDocIds.onCall(1).resolves([ 'a', 'b', 'c', 'd' ]);
@@ -1359,7 +1359,7 @@ describe('Changes controller', () => {
 
           controller._getLongpollFeeds().length.should.equal(0);
           const feed = controller._getNormalFeeds()[0];
-          feed.id.should.equal(testReq.uniqId);
+          feed.id.should.equal(testReq.id);
           feed.upstreamRequests.length.should.equal(2);
           feed.chunkedAllowedDocIds.should.deep.equal([[ 'a', 'b' ],[ 'c', 'd' ]]);
 

--- a/api/tests/mocha/controllers/changes.js
+++ b/api/tests/mocha/controllers/changes.js
@@ -161,10 +161,17 @@ describe('Changes controller', () => {
       });
     });
 
-    it('uses default values when CouchDB config request returns 0', () => {
-      sinon.stub(dbConfig, 'get').resolves('0');
+    it('uses default values when CouchDB config request returns lower than 0 value', () => {
+      sinon.stub(dbConfig, 'get').resolves('-100');
       return controller._init().then(() => {
         controller._getMaxDocIds().should.equal(100);
+      });
+    });
+
+    it('uses config value when it is valid', () => {
+      sinon.stub(dbConfig, 'get').resolves('400');
+      return controller._init().then(() => {
+        controller._getMaxDocIds().should.equal(400);
       });
     });
 

--- a/api/tests/mocha/controllers/changes.js
+++ b/api/tests/mocha/controllers/changes.js
@@ -327,6 +327,7 @@ describe('Changes controller', () => {
           changesSpy.callCount.should.equal(2);
           changesSpy.args[1][0].should.deep.equal({
             since: 0,
+            batch_size: 40,
             doc_ids: ['d1', 'd2', 'd3']
           });
         });
@@ -343,6 +344,7 @@ describe('Changes controller', () => {
           changesSpy.callCount.should.equal(2);
           changesSpy.args[1][0].should.deep.equal({
             since: '22',
+            batch_size: 40,
             doc_ids: ['d1', 'd2', 'd3'],
             conflicts: true,
             seq_interval: false
@@ -1304,6 +1306,7 @@ describe('Changes controller', () => {
         .then(() => {
           changesSpy.callCount.should.equal(2);
           changesSpy.args[1][0].should.deep.equal({
+            batch_size: 2,
             doc_ids: ['a', 'b'],
             since: 'seq'
           });
@@ -1344,10 +1347,12 @@ describe('Changes controller', () => {
 
           changesSpy.callCount.should.equal(4);
           changesSpy.args[2][0].should.deep.equal({
+            batch_size: 2,
             doc_ids: ['a', 'b'],
             since: 'seq'
           });
           changesSpy.args[3][0].should.deep.equal({
+            batch_size: 2,
             doc_ids: ['c', 'd'],
             since: 'seq'
           });

--- a/api/tests/mocha/controllers/changes.js
+++ b/api/tests/mocha/controllers/changes.js
@@ -154,6 +154,20 @@ describe('Changes controller', () => {
       });
     });
 
+    it('uses default values when CouchDB config request returns non-numeric values', () => {
+      sinon.stub(dbConfig, 'get').resolves({ some: 'object' });
+      return controller._init().then(() => {
+        controller._getMaxDocIds().should.equal(100);
+      });
+    });
+
+    it('uses default values when CouchDB config request returns 0', () => {
+      sinon.stub(dbConfig, 'get').resolves('0');
+      return controller._init().then(() => {
+        controller._getMaxDocIds().should.equal(100);
+      });
+    });
+
     it('sends changes to be analyzed and updates current seq when changes come in', () => {
       tombstoneUtils.isTombstoneId.withArgs('change').returns(false);
       return controller._init().then(() => {

--- a/api/tests/mocha/services/db-config.spec.js
+++ b/api/tests/mocha/services/db-config.spec.js
@@ -20,7 +20,7 @@ describe('db config service', () => {
   afterEach(() => sinon.restore());
 
   describe('get', () => {
-    
+
     it('returns errors', () => {
       sinon.stub(request, 'get').callsArgWith(1, 'boom');
       return service.get().catch(actual => {
@@ -28,9 +28,16 @@ describe('db config service', () => {
       });
     });
 
+    it('rejects when response status is not 200', () => {
+      sinon.stub(request, 'get').callsArgWith(1, null, { statusCode: 404 }, { error: 'not_found' });
+      return service.get().catch(actual => {
+        chai.expect(actual).to.deep.equal({ error: 'not_found' });
+      });
+    });
+
     it('gets the whole config when no params', () => {
       const expected = { some_val: true, other_val: 'untrue' };
-      const requestGet = sinon.stub(request, 'get').callsArgWith(1, null, null, expected);
+      const requestGet = sinon.stub(request, 'get').callsArgWith(1, null, { statusCode: 200 }, expected);
       return service.get().then(actual => {
         chai.expect(actual).to.deep.equal(expected);
         chai.expect(requestGet.callCount).to.equal(1);
@@ -41,7 +48,7 @@ describe('db config service', () => {
 
     it('gets the whole config when section only', () => {
       const expected = { some_val: true, other_val: 'untrue' };
-      const requestGet = sinon.stub(request, 'get').callsArgWith(1, null, null, expected);
+      const requestGet = sinon.stub(request, 'get').callsArgWith(1, null, { statusCode: 200 }, expected);
       return service.get('my-section').then(actual => {
         chai.expect(actual).to.deep.equal(expected);
         chai.expect(requestGet.callCount).to.equal(1);
@@ -52,7 +59,7 @@ describe('db config service', () => {
 
     it('gets the whole config when section and key', () => {
       const expected = 500;
-      const requestGet = sinon.stub(request, 'get').callsArgWith(1, null, null, expected);
+      const requestGet = sinon.stub(request, 'get').callsArgWith(1, null, { statusCode: 200 }, expected);
       return service.get('my-section', 'my-key').then(actual => {
         chai.expect(actual).to.equal(expected);
         chai.expect(requestGet.callCount).to.equal(1);


### PR DESCRIPTION
# Description

By default, PouchDB http adapter batches changes requests with a batch size of 25. 
Because we're already creating our own batches by splitting `_doc_ids`, forcing PouchDB not to batch brings a slight performance improvement and also fixes missed changes bug due to CouchDB not calculating sequences reliably. 
Updates `feeds` to use new `req.id` property. 
Adds `statusCode` check in `db-config` service to reject responses with `404` and `412` statuses.
Adds `changes_doc_ids_optimization_threshold` value validation. 

medic/medic-webapp#4185

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.