### PR TITLE
Only request _session once!

### DIFF
--- a/api/src/auth.js
+++ b/api/src/auth.js
@@ -83,15 +83,27 @@ module.exports = {
   },
 
   getUserCtx: req => {
+    if (req.userCtx) {
+      return Promise.resolve(req.userCtx);
+    }
+
+    if (req.authErr) {
+      return Promise.reject(req.authErr);
+    }
+
     return get('/_session', req.headers)
       .catch(err => {
-        throw { code: 401, message: 'Not logged in', err: err };
+        req.authErr = { code: 401, message: 'Not logged in', err: err };
+        throw req.authErr;
       })
       .then(auth => {
         if (auth && auth.userCtx && auth.userCtx.name) {
-          return auth.userCtx;
+          req.userCtx = auth.userCtx;
+          return req.userCtx;
         }
-        throw { code: 401, message: 'Not logged in' };
+
+        req.authErr = { code: 401, message: 'Not logged in' };
+        throw req.authErr;
       });
   },
 

--- a/api/src/middleware/authorization.js
+++ b/api/src/middleware/authorization.js
@@ -20,13 +20,9 @@ module.exports = {
   getUserCtx: (req, res, next) => {
     return auth
       .getUserCtx(req)
-      .then(userCtx => {
-        req.userCtx = userCtx;
-      })
-      .catch(err => {
-        req.authErr = err;
-      })
-      .then(next);
+      // catch not-logged-in errors - not all endpoints require authenticated users
+      .catch(() => {})
+      .then(() => next());
   },
 
   // blocks unauthenticated requests from passing through

--- a/api/tests/mocha/middleware/authorization.spec.js
+++ b/api/tests/mocha/middleware/authorization.spec.js
@@ -32,21 +32,21 @@ describe('Authorization middleware', () => {
         .getUserCtx(testReq, testRes, next)
         .then(() => {
           next.callCount.should.equal(1);
-          (!!testReq.userCtx).should.equal(false);
-          testReq.authErr.should.deep.equal({ some: 'error' });
+          auth.getUserCtx.callCount.should.equal(1);
+          auth.getUserCtx.args[0].should.deep.equal([ testReq ]);
           serverUtils.notLoggedIn.callCount.should.equal(0);
         });
     });
 
-    it('saves CouchDB session as `userCtx` in the `req` object', () => {
+    it('calls auth.getUserCtx', () => {
       auth.getUserCtx.resolves({ name: 'user' });
       return middleware
         .getUserCtx(testReq, testRes, next)
         .then(() => {
           serverUtils.notLoggedIn.callCount.should.equal(0);
           next.callCount.should.equal(1);
-          testReq.userCtx.should.deep.equal({ name: 'user' });
-          (!!testReq.authErr).should.equal(false);
+          auth.getUserCtx.callCount.should.equal(1);
+          auth.getUserCtx.args[0].should.deep.equal([ testReq ]);
         });
     });
   });


### PR DESCRIPTION
# Description

Refactors API auth.getUserCtx to save _session result/error in the
request object and resolve/reject with those values on following calls.

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.