### PR TITLE
Supports new registration fields to define age in months or years

### DIFF
--- a/sentinel/src/transitions/registration.js
+++ b/sentinel/src/transitions/registration.js
@@ -137,6 +137,14 @@ module.exports = {
       return '';
     }
     const today = moment(date.getDate()).startOf('day');
+    const years = parseInt(module.exports.getYearsSinceDOB(doc), 10);
+    if (!isNaN(years)) {
+      return today.subtract(years, 'years');
+    }
+    const months = parseInt(module.exports.getMonthsSinceDOB(doc), 10);
+    if (!isNaN(months)) {
+      return today.subtract(months, 'months');
+    }
     const weeks = parseInt(module.exports.getWeeksSinceDOB(doc), 10);
     if (!isNaN(weeks)) {
       return today.subtract(weeks, 'weeks');
@@ -147,6 +155,14 @@ module.exports = {
     }
     // no given date of birth - return today as it's the best we can do
     return today;
+  },
+  getYearsSinceDOB: doc => {
+    const fields = [ 'years_since_dob', 'years_since_birth', 'age_in_years' ];
+    return findFirstDefinedValue(doc, fields);
+  },
+  getMonthsSinceDOB: doc => {
+    const fields = [ 'months_since_dob', 'months_since_birth', 'age_in_months' ];
+    return findFirstDefinedValue(doc, fields);
   },
   getWeeksSinceDOB: doc => {
     const fields = [ 'weeks_since_dob', 'dob', 'weeks_since_birth', 'age_in_weeks' ];

--- a/sentinel/tests/unit/patient_registration.js
+++ b/sentinel/tests/unit/patient_registration.js
@@ -104,6 +104,18 @@ describe('patient registration', () => {
     assert.equal(transition.getWeeksSinceLMP({ fields: { last_menstrual_period: '12' } }), 12);
   });
 
+  it('getYearsSinceDOB supports three property names', () => {
+    assert.equal(transition.getYearsSinceDOB({ fields: { years_since_dob: '12' } }), 12);
+    assert.equal(transition.getYearsSinceDOB({ fields: { years_since_birth: '12' } }), 12);
+    assert.equal(transition.getYearsSinceDOB({ fields: { age_in_years: '12' } }), 12);
+  });
+
+  it('getMonthsSinceDOB supports three property names', () => {
+    assert.equal(transition.getMonthsSinceDOB({ fields: { months_since_dob: '12' } }), 12);
+    assert.equal(transition.getMonthsSinceDOB({ fields: { months_since_birth: '12' } }), 12);
+    assert.equal(transition.getMonthsSinceDOB({ fields: { age_in_months: '12' } }), 12);
+  });
+
   it('getWeeksSinceDOB supports four property names', () => {
     assert.equal(transition.getWeeksSinceDOB({ fields: { dob: '12' } }), 12);
     assert.equal(transition.getWeeksSinceDOB({ fields: { weeks_since_dob: '12' } }), 12);


### PR DESCRIPTION
# Description

Adds support for the following fields:
months_since_dob, months_since_birth, age_in_months,
years_since_dob, years_since_birth, age_in_years

medic/medic-webapp#4597

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.