### PR TITLE
Enable i18n for dates in tasks and scheduled messages.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -112,6 +112,7 @@ module.exports = function(grunt) {
             '../../js/dropdown.jquery': './webapp/node_modules/bootstrap/js/dropdown', // enketo currently duplicates bootstrap's dropdown code.  working to resolve this upstream https://github.com/enketo/enketo-core/issues/454
             'angular-translate-interpolation-messageformat': './webapp/node_modules/angular-translate/dist/angular-translate-interpolation-messageformat/angular-translate-interpolation-messageformat',
             'angular-translate-handler-log':  './webapp/node_modules/angular-translate/dist/angular-translate-handler-log/angular-translate-handler-log',
+            'moment': './webapp/node_modules/moment/moment'
           },
         }
       },

--- a/shared-libs/message-utils/src/index.js
+++ b/shared-libs/message-utils/src/index.js
@@ -176,6 +176,7 @@ var formatDate = function(config, text, view, formatString, locale) {
   if (!isNaN(date)) {
     date = parseInt(date, 10);
   }
+  locale = locale || moment().locale();
   return moment(date).locale(locale).format(formatString);
 };
 
@@ -183,7 +184,7 @@ var render = function(config, template, view, locale) {
   return mustache.render(template, _.extend(view, {
     bikram_sambat_date: function() {
       return function(text) {
-        return toBikramSambatLetters(formatDate(config, text, view, 'YYYY-MM-DD', 'en'));
+        return toBikramSambatLetters(formatDate(config, text, view, 'YYYY-MM-DD'));
       };
     },
     date: function() {

--- a/shared-libs/message-utils/src/index.js
+++ b/shared-libs/message-utils/src/index.js
@@ -171,29 +171,29 @@ mustache.escape = function(value) {
   return value;
 };
 
-var formatDate = function(config, text, view, formatString) {
+var formatDate = function(config, text, view, formatString, locale) {
   var date = render(config, text, view);
   if (!isNaN(date)) {
     date = parseInt(date, 10);
   }
-  return moment(date).format(formatString);
+  return moment(date).locale(locale).format(formatString);
 };
 
-var render = function(config, template, view) {
+var render = function(config, template, view, locale) {
   return mustache.render(template, _.extend(view, {
     bikram_sambat_date: function() {
       return function(text) {
-        return toBikramSambatLetters(formatDate(config, text, view, 'YYYY-MM-DD'));
+        return toBikramSambatLetters(formatDate(config, text, view, 'YYYY-MM-DD', 'en'));
       };
     },
     date: function() {
       return function(text) {
-        return formatDate(config, text, view, config.date_format);
+        return formatDate(config, text, view, config.date_format, locale);
       };
     },
     datetime: function() {
       return function(text) {
-        return formatDate(config, text, view, config.reported_date_format);
+        return formatDate(config, text, view, config.reported_date_format, locale);
       };
     }
   }));
@@ -266,7 +266,7 @@ exports.template = function(config, translate, doc, content, extraContext) {
     return '';
   }
   var context = extendedTemplateContext(doc, extraContext);
-  return render(config, template, context);
+  return render(config, template, context, locale);
 };
 
 exports._getRecipient = getRecipient;

--- a/shared-libs/message-utils/test/index.js
+++ b/shared-libs/message-utils/test/index.js
@@ -449,6 +449,16 @@ describe('messageUtils', () => {
         expect(actual).to.equal(moment(date).format(config.reported_date_format));
       });
 
+      it('i18n', () => {
+        const date = 1457235941000;
+        const input = '{{#datetime}}Date({{reported_date}}){{/datetime}}';
+        const doc = { reported_date: date, locale: 'sw' };
+        const config = { reported_date_format: 'DD-MMMM-YYYY HH:mm:ss' };
+        const actual = utils.template(config, null, doc, { message: input });
+        expect(actual).to.equal(moment(date).locale('sw').format(config.reported_date_format));
+        expect(actual).to.not.equal(moment(date).format(config.reported_date_format));
+      });
+
     });
 
     describe('bikram sambat', () => {
@@ -468,6 +478,16 @@ describe('messageUtils', () => {
         const expected = '२३ फाल्गुन २०७२';
         const input = '{{#bikram_sambat_date}}Date({{reported_date}}){{/bikram_sambat_date}}';
         const doc = { reported_date: date };
+        const config = { reported_date_format: 'DD-MMMM-YYYY HH:mm:ss' };
+        const actual = utils.template(config, null, doc, { message: input });
+        expect(actual).to.equal(expected);
+      });
+
+      it('i18n', () => {
+        const date = 1457235941000;
+        const expected = '२३ फाल्गुन २०७२';
+        const input = '{{#bikram_sambat_date}}Date({{reported_date}}){{/bikram_sambat_date}}';
+        const doc = { reported_date: date, locale: 'sw' };
         const config = { reported_date_format: 'DD-MMMM-YYYY HH:mm:ss' };
         const actual = utils.template(config, null, doc, { message: input });
         expect(actual).to.equal(expected);

--- a/shared-libs/message-utils/test/index.js
+++ b/shared-libs/message-utils/test/index.js
@@ -459,6 +459,26 @@ describe('messageUtils', () => {
         expect(actual).to.not.equal(moment(date).format(config.reported_date_format));
       });
 
+      it('i18n with inexistent locale falls back to en', () => {
+        const date = 1457235941000;
+        const input = '{{#datetime}}Date({{reported_date}}){{/datetime}}';
+        const doc = { reported_date: date, locale: 'this-locale-doesnt-exist' };
+        const config = { reported_date_format: 'DD-MMMM-YYYY HH:mm:ss' };
+        const actual = utils.template(config, null, doc, { message: input });
+        expect(actual).to.equal(moment(date).locale('en').format(config.reported_date_format));
+        expect(actual).to.equal(moment(date).format(config.reported_date_format));
+      });
+
+      it('i18n with undefined locale falls back to en', () => {
+        const date = 1457235941000;
+        const input = '{{#datetime}}Date({{reported_date}}){{/datetime}}';
+        const doc = { reported_date: date, locale: false };
+        const config = { reported_date_format: 'DD-MMMM-YYYY HH:mm:ss' };
+        const actual = utils.template(config, null, doc, { message: input });
+        expect(actual).to.equal(moment(date).locale('en').format(config.reported_date_format));
+        expect(actual).to.equal(moment(date).format(config.reported_date_format));
+      });
+
     });
 
     describe('bikram sambat', () => {
@@ -483,7 +503,7 @@ describe('messageUtils', () => {
         expect(actual).to.equal(expected);
       });
 
-      it('i18n', () => {
+      it('i18n has no influence', () => {
         const date = 1457235941000;
         const expected = '२३ फाल्गुन २०७२';
         const input = '{{#bikram_sambat_date}}Date({{reported_date}}){{/bikram_sambat_date}}';

--- a/shared-libs/message-utils/test/index.js
+++ b/shared-libs/message-utils/test/index.js
@@ -453,7 +453,7 @@ describe('messageUtils', () => {
         const date = 1457235941000;
         const input = '{{#datetime}}Date({{reported_date}}){{/datetime}}';
         const doc = { reported_date: date, locale: 'sw' };
-        const config = { reported_date_format: 'DD-MMMM-YYYY HH:mm:ss' };
+        const config = { reported_date_format: 'ddd, MMM Do, YYYY' };
         const actual = utils.template(config, null, doc, { message: input });
         expect(actual).to.equal(moment(date).locale('sw').format(config.reported_date_format));
         expect(actual).to.not.equal(moment(date).format(config.reported_date_format));
@@ -463,7 +463,7 @@ describe('messageUtils', () => {
         const date = 1457235941000;
         const input = '{{#datetime}}Date({{reported_date}}){{/datetime}}';
         const doc = { reported_date: date, locale: 'this-locale-doesnt-exist' };
-        const config = { reported_date_format: 'DD-MMMM-YYYY HH:mm:ss' };
+        const config = { reported_date_format: 'ddd, MMM Do, YYYY' };
         const actual = utils.template(config, null, doc, { message: input });
         expect(actual).to.equal(moment(date).locale('en').format(config.reported_date_format));
         expect(actual).to.equal(moment(date).format(config.reported_date_format));
@@ -473,7 +473,7 @@ describe('messageUtils', () => {
         const date = 1457235941000;
         const input = '{{#datetime}}Date({{reported_date}}){{/datetime}}';
         const doc = { reported_date: date, locale: false };
-        const config = { reported_date_format: 'DD-MMMM-YYYY HH:mm:ss' };
+        const config = { reported_date_format: 'ddd, MMM Do, YYYY' };
         const actual = utils.template(config, null, doc, { message: input });
         expect(actual).to.equal(moment(date).locale('en').format(config.reported_date_format));
         expect(actual).to.equal(moment(date).format(config.reported_date_format));
@@ -508,7 +508,7 @@ describe('messageUtils', () => {
         const expected = '२३ फाल्गुन २०७२';
         const input = '{{#bikram_sambat_date}}Date({{reported_date}}){{/bikram_sambat_date}}';
         const doc = { reported_date: date, locale: 'sw' };
-        const config = { reported_date_format: 'DD-MMMM-YYYY HH:mm:ss' };
+        const config = { reported_date_format: 'ddd, MMM Do, YYYY' };
         const actual = utils.template(config, null, doc, { message: input });
         expect(actual).to.equal(expected);
       });

--- a/tests/e2e/registration-by-sms.js
+++ b/tests/e2e/registration-by-sms.js
@@ -1,6 +1,7 @@
 const utils = require('../utils'),
       commonElements = require('../page-objects/common/common.po.js'),
-      helper = require('../helper');
+      helper = require('../helper'),
+      moment = require('moment');
 
 describe('registration transition', () => {
 
@@ -149,7 +150,14 @@ describe('registration transition', () => {
           locale: 'en'
         }],
         recipient: 'reporting_unit'
-      }]
+      },
+        {
+          message: [{
+            content: 'LMP {{#date}}{{expected_date}}{{/date}}',
+            locale: 'en'
+          }],
+          recipient: 'reporting_unit'
+        }]
     }],
     schedules: [{
       name: 'ANC Reminders LMP',
@@ -180,7 +188,9 @@ describe('registration transition', () => {
           recipient: 'reporting_unit'
         }
       ]
-    }]
+    }],
+    date_format: 'ddd, MMM Do, YYYY',
+    locale_outgoing: 'sw'
   };
 
   const submit = body => {
@@ -239,9 +249,17 @@ describe('registration transition', () => {
 
     const checkAutoResponse = () => {
       const taskElement = element(by.css('#reports-content .details > ul'));
-      expect(taskElement.element(by.css('.task-list > li > ul > li')).getText()).toBe('Thank you '+ CAROL.name +' for registering Siobhan');
-      expect(taskElement.element(by.css('.task-list .task-state .state.pending')).isDisplayed()).toBeTruthy();
-      expect(taskElement.element(by.css('.task-list .task-state .recipient')).getText()).toBe(' to +64271234567');
+      expect(taskElement.element(by.css('.task-list > li:nth-child(1) > ul > li')).getText()).toBe('Thank you '+ CAROL.name +' for registering Siobhan');
+      expect(taskElement.element(by.css('.task-list > li:nth-child(1) .task-state .state.pending')).isDisplayed()).toBeTruthy();
+      expect(taskElement.element(by.css('.task-list > li:nth-child(1) .task-state .recipient')).getText()).toBe(' to +64271234567');
+
+      const start = moment().startOf('day');
+      start.subtract(12, 'weeks');
+      const expected_date = start.clone().add(40, 'weeks');
+
+      expect(taskElement.element(by.css('.task-list > li:nth-child(2) > ul > li')).getText()).toBe('LMP ' + expected_date.locale('sw').format('ddd, MMM Do, YYYY'));
+      expect(taskElement.element(by.css('.task-list > li:nth-child(2) .task-state .state.pending')).isDisplayed()).toBeTruthy();
+      expect(taskElement.element(by.css('.task-list > li:nth-child(2) .task-state .recipient')).getText()).toBe(' to +64271234567');
     };
 
     const checkScheduledTask = (childIndex, title, message) => {


### PR DESCRIPTION
# Description

Also adds `browserify` alias for `moment` library, to fix bug where `moment` library would be loaded twice in `webapp` (once by `webapp` and once by `@shared-libs/message-utils`).

medic/medic-webapp#4681

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.