### PR TITLE
Block from booting until API is ready

### DIFF
--- a/api/src/migrations/convert-bad-dob-format.js
+++ b/api/src/migrations/convert-bad-dob-format.js
@@ -52,7 +52,7 @@ module.exports = {
         });
       } else {
         db.request({
-          db: 'medic',
+          db: db.settings.db,
           method: 'POST',
           path: '_find',
           body: {

--- a/api/src/migrations/convert-bad-dob-format.js
+++ b/api/src/migrations/convert-bad-dob-format.js
@@ -32,7 +32,7 @@ module.exports = {
 
       if (version.major === '1') {
         db.request({
-          db: 'medic',
+          db: db.settings.db,
           method: 'POST',
           path: '_temp_view',
           body: temporaryView,

--- a/api/src/migrations/remove-empty-parents.js
+++ b/api/src/migrations/remove-empty-parents.js
@@ -51,7 +51,7 @@ module.exports = {
         });
       } else {
         db.request({
-          db: 'medic',
+          db: db.settings.db,
           method: 'POST',
           path: '_find',
           body: {

--- a/api/src/migrations/remove-empty-parents.js
+++ b/api/src/migrations/remove-empty-parents.js
@@ -31,7 +31,7 @@ module.exports = {
 
       if (version.major === '1') {
         db.request({
-          db: 'medic',
+          db: db.settings.db,
           method: 'POST',
           path: '_temp_view',
           body: { map: emptyParentsView.toString() },

--- a/sentinel/package.json
+++ b/sentinel/package.json
@@ -27,6 +27,7 @@
     "pouchdb-adapter-http": "^7.0.0",
     "pouchdb-core": "^7.0.0",
     "pouchdb-mapreduce": "^7.0.0",
+    "request": "^2.87.0",
     "task-utils": "file:../shared-libs/task-utils",
     "underscore": "^1.8.3",
     "uuid": "^3.2.1",

--- a/sentinel/server.js
+++ b/sentinel/server.js
@@ -20,7 +20,7 @@ process.on('unhandledRejection', reason => {
   console.error(reason);
 });
 
-const waitForApi = () => new Promise((resolve, reject) => {
+const waitForApi = () => new Promise(resolve => {
   //
   // This waits forever, with no escape hatch, becayse there is no way currently
   // to know what API is doing, and migrations could legitimately take days

--- a/sentinel/server.js
+++ b/sentinel/server.js
@@ -27,7 +27,7 @@ const waitForApi = () => new Promise(resolve => {
   //
   //
   const waitLoop = () => {
-    request('http://localhost:5988/setup/poll', (err, response, body) => {
+    request(`http://localhost:${process.env.API_PORT || 5988}/setup/poll`, (err, response, body) => {
       if (err) {
         logger.info('Waiting for API to be ready...');
         return setTimeout(() => waitLoop(), 10 * 1000);

--- a/sentinel/server.js
+++ b/sentinel/server.js
@@ -50,7 +50,7 @@ serverChecks.check(db.serverUrl)
     return config.init()
       .then(() => {
         if (!loglevel) {
-          logger.transports.Console.level = require('./src/config').get('loglevel');
+          logger.transports.Console.level = config.get('loglevel');
           logger.debug('loglevel is %s.', logger.transports.Console.level);
         }
         require('./src/schedule').checkSchedule();

--- a/sentinel/server.js
+++ b/sentinel/server.js
@@ -55,7 +55,7 @@ serverChecks.check(db.serverUrl)
         }
         require('./src/schedule').checkSchedule();
         logger.info('startup complete.');
-      })
+      });
   })
   .catch(err => {
     console.error('Fatal error intialising medic-sentinel');

--- a/sentinel/yarn.lock
+++ b/sentinel/yarn.lock
@@ -498,7 +498,7 @@ rc4@~0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/rc4/-/rc4-0.1.5.tgz#08c6e04a0168f6eb621c22ab6cb1151bd9f4a64d"
 
-request@^2.83.0, request@^2.85.0:
+request@^2.83.0, request@^2.85.0, request@^2.87.0:
   version "2.87.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
   dependencies:


### PR DESCRIPTION
When installing or upgrading, there may be changes (migrations) that API
has to run before sentinel has a valid environment to work with.

To avoid spamming errors, sentinel now blocks until API has booted.