### PR TITLE
Fixes call to config in sentinel schedules.

### DIFF
--- a/sentinel/src/lib/schedules.js
+++ b/sentinel/src/lib/schedules.js
@@ -132,7 +132,7 @@ module.exports = {
                     };
                     if (!msg.translation_key) {
                         // no translation_key so generate now
-                        task.messages = messageUtils.generate(config, utils.translate, doc, msg, msg.recipient, {
+                        task.messages = messageUtils.generate(config.getAll(), utils.translate, doc, msg, msg.recipient, {
                             registrations: registrations,
                             patient: patient
                         });

--- a/sentinel/src/lib/schedules.js
+++ b/sentinel/src/lib/schedules.js
@@ -132,10 +132,16 @@ module.exports = {
                     };
                     if (!msg.translation_key) {
                         // no translation_key so generate now
-                        task.messages = messageUtils.generate(config.getAll(), utils.translate, doc, msg, msg.recipient, {
+                        task.messages = messageUtils.generate(
+                          config.getAll(),
+                          utils.translate,
+                          doc,
+                          msg,
+                          msg.recipient,
+                          {
                             registrations: registrations,
                             patient: patient
-                        });
+                          });
                     }
                     const state = messages.isOutgoingAllowed(doc.from) ? 'scheduled' : 'denied';
                     utils.setTaskState(task, state);

--- a/sentinel/tests/unit/schedules.js
+++ b/sentinel/tests/unit/schedules.js
@@ -1,8 +1,11 @@
 var moment = require('moment'),
     assert = require('chai').assert,
-    schedules = require('../../src/lib/schedules');
+    schedules = require('../../src/lib/schedules'),
+    config = require('../../src/config'),
+    sinon = require('sinon');
 
 describe('schedules', () => {
+  afterEach(() => sinon.restore());
 
   it('getOffset returns false for bad syntax', () => {
     assert.equal(schedules.getOffset('x'), false);
@@ -367,5 +370,43 @@ describe('schedules', () => {
               }
           ]
       }, 'x'), true);
+  });
+
+  it('assignSchedule sends correct config to messageUtils', () => {
+    const doc = {
+      form: 'x',
+      serial_number: 'abc',
+      reported_date: moment().valueOf(),
+      fields: {
+        some_date: moment().add(10, 'days').valueOf(),
+      }
+    };
+
+    const configuration = {
+      locale_outgoing: 'sw',
+      date_format: 'dddd, Do MMMM YYYY'
+    };
+    sinon.stub(config, 'getAll').returns(configuration);
+
+    schedules.assignSchedule(doc, {
+      name: 'duckland',
+      start_from: 'reported_date',
+      messages: [
+        {
+          group: 1,
+          offset: '1 week',
+          message: [{
+            content: '{{#date}}{{some_date}}{{/date}}',
+            locale: 'en'
+          }]
+        }
+      ]
+    });
+
+    assert.equal(
+      doc.scheduled_tasks[0].messages[0].message,
+      moment(doc.fields.some_date).locale('sw').format('dddd, Do MMMM YYYY')
+    );
+    assert.equal(config.getAll.callCount, 1);
   });
 });

--- a/tests/e2e/registration-by-sms.js
+++ b/tests/e2e/registration-by-sms.js
@@ -186,6 +186,17 @@ describe('registration transition', () => {
           send_day: 'monday',
           send_time: '09:00',
           recipient: 'reporting_unit'
+        },
+        {
+          message: [{
+            content: 'LMP {{#date}}{{expected_date}}{{/date}}',
+            locale: 'en'
+          }],
+          group: 3,
+          offset: '20 weeks',
+          send_day: 'monday',
+          send_time: '09:00',
+          recipient: 'reporting_unit'
         }
       ]
     }],
@@ -237,6 +248,10 @@ describe('registration transition', () => {
       jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
     });
 
+    const start = moment().startOf('day');
+    start.subtract(12, 'weeks');
+    const expected_date = start.clone().add(40, 'weeks');
+
     const checkItemSummary = () => {
       const summaryElement = element(by.css('#reports-content .item-summary'));
       expect(summaryElement.element(by.css('.sender .name')).getText()).toMatch(`Sent by ${CAROL.name}`);
@@ -252,10 +267,6 @@ describe('registration transition', () => {
       expect(taskElement.element(by.css('.task-list > li:nth-child(1) > ul > li')).getText()).toBe('Thank you '+ CAROL.name +' for registering Siobhan');
       expect(taskElement.element(by.css('.task-list > li:nth-child(1) .task-state .state.pending')).isDisplayed()).toBeTruthy();
       expect(taskElement.element(by.css('.task-list > li:nth-child(1) .task-state .recipient')).getText()).toBe(' to +64271234567');
-
-      const start = moment().startOf('day');
-      start.subtract(12, 'weeks');
-      const expected_date = start.clone().add(40, 'weeks');
 
       expect(taskElement.element(by.css('.task-list > li:nth-child(2) > ul > li')).getText()).toBe('LMP ' + expected_date.locale('sw').format('ddd, MMM Do, YYYY'));
       expect(taskElement.element(by.css('.task-list > li:nth-child(2) .task-state .state.pending')).isDisplayed()).toBeTruthy();
@@ -285,6 +296,7 @@ describe('registration transition', () => {
       checkAutoResponse();
       checkScheduledTask(1, 'ANC Reminders LMP:1', 'Visit 1 reminder for Siobhan');
       checkScheduledTask(2, 'ANC Reminders LMP:2', 'Visit 2 reminder for Siobhan');
+      checkScheduledTask(3, 'ANC Reminders LMP:3', 'LMP ' + expected_date.locale('sw').format('ddd, MMM Do, YYYY'));
     });
 
   });


### PR DESCRIPTION
# Description

Instead of sending the `config` module, send the actual configs. 

medic/medic-webapp#4735

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.