### PR TITLE
Fixes bug where dbdoc-att route would not match slashed att names

### DIFF
--- a/api/src/controllers/db-doc.js
+++ b/api/src/controllers/db-doc.js
@@ -7,7 +7,8 @@ const RESERVED_ENDPOINTS = [
   '_all_docs',
   '_bulk_docs',
   '_bulk_get',
-  '_changes'
+  '_changes',
+  '_design'
 ];
 
 const isValidRequest = (method, docId, body) => {
@@ -58,6 +59,15 @@ module.exports = {
         next();
       })
       .catch(err => serverUtils.serverError(err, req, res));
+  },
+
+  requestDdoc: (appDdoc, req, res, next) => {
+    if (req.params.ddocId === appDdoc) {
+      return next('route');
+    }
+
+    req.params.docId = `_design/${req.params.ddocId}`;
+    return module.exports.request(req, res, next);
   }
 };
 

--- a/api/src/controllers/db-doc.js
+++ b/api/src/controllers/db-doc.js
@@ -62,6 +62,7 @@ module.exports = {
   },
 
   requestDdoc: (appDdoc, req, res, next) => {
+    // offline users are allowed to access app _rewrites, which are authorized by another route
     if (req.params.ddocId === appDdoc) {
       return next('route');
     }

--- a/api/src/middleware/authorization.js
+++ b/api/src/middleware/authorization.js
@@ -12,7 +12,8 @@ const getUserSettings = (req) => {
     .getUserSettings(req.userCtx)
     .then(userCtx => {
       req.userCtx = userCtx;
-    });
+    })
+    .catch(err => err);
 };
 
 module.exports = {

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -503,22 +503,30 @@ app.post(
 
 // filter db-doc and attachment requests for offline users
 // these are audited endpoints: online and allowed offline requests will pass through to the audit route
-const dbDocHandler = require('./controllers/db-doc').request,
+const dbDocHandler = require('./controllers/db-doc'),
       docPath = routePrefix + ':docId/{0,}',
-      attachmentPath = routePrefix + ':docId/+:attachmentId*';
+      attachmentPath = routePrefix + ':docId/+:attachmentId*',
+      ddocPath = routePrefix + '_design/+:ddocId*';
+
+app.get(
+  ddocPath,
+  authorization.checkAuth,
+  onlineUserProxy,
+  _.partial(dbDocHandler.requestDdoc, db.settings.ddoc)
+);
 
 app.get(
   docPath,
   authorization.checkAuth,
   onlineUserProxy, // online user GET requests are proxied directly to CouchDB
-  dbDocHandler
+  dbDocHandler.request
 );
 app.post(
   routePrefix,
   authorization.checkAuth,
   authorization.onlineUserPassThrough, // online user requests pass through to the next route
   jsonParser, // request body must be json
-  dbDocHandler,
+  dbDocHandler.request,
   authorization.setAuthorized // adds the `authorized` flag to the `req` object, so it passes the firewall
 );
 app.put(
@@ -526,21 +534,21 @@ app.put(
   authorization.checkAuth,
   authorization.onlineUserPassThrough, // online user requests pass through to the next route,
   jsonParser,
-  dbDocHandler,
+  dbDocHandler.request,
   authorization.setAuthorized // adds the `authorized` flag to the `req` object, so it passes the firewall
 );
 app.delete(
   docPath,
   authorization.checkAuth,
   authorization.onlineUserPassThrough, // online user requests pass through to the next route,
-  dbDocHandler,
+  dbDocHandler.request,
   authorization.setAuthorized // adds the `authorized` flag to the `req` object, so it passes the firewall
 );
 app.all(
   attachmentPath,
   authorization.checkAuth,
   authorization.onlineUserPassThrough,  // online user requests pass through to the next route
-  dbDocHandler,
+  dbDocHandler.request,
   authorization.setAuthorized // adds the `authorized` flag to the `req` object, so it passes the firewall
 );
 

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -505,7 +505,7 @@ app.post(
 // these are audited endpoints: online and allowed offline requests will pass through to the audit route
 const dbDocHandler = require('./controllers/db-doc').request,
       docPath = routePrefix + ':docId/{0,}',
-      attachmentPath = routePrefix + ':docId/+:attachmentId';
+      attachmentPath = routePrefix + ':docId/+:attachmentId*';
 
 app.get(
   docPath,

--- a/tests/e2e/api/controllers/db-doc.spec.js
+++ b/tests/e2e/api/controllers/db-doc.spec.js
@@ -669,4 +669,74 @@ describe('db-doc handler', () => {
         expect(result.content).toEqual('content');
       });
   });
+
+  it('allows GETting _design/medic-client', () => {
+    const request = {
+      path: '/_design/medic-client'
+    };
+
+    return utils
+      .requestOnTestDb(_.defaults(request, offlineRequestOptions), false)
+      .then(result => {
+        expect(result._id).toEqual('_design/medic-client');
+      });
+  });
+
+  it('blocks PUTting _design/medic-client', () => {
+    const request = {
+      path: '/_design/medic-client',
+      method: 'PUT',
+      body: JSON.stringify({ _id: '_design/medic-client', some: 'data' }),
+      headers: { 'Content-Type': 'application/json' },
+    };
+
+    return utils
+      .requestOnTestDb(_.defaults(request, offlineRequestOptions), false)
+      .catch(result => {
+        expect(result.statusCode).toEqual(403);
+        expect(result.responseBody.error).toEqual('forbidden');
+      });
+  });
+
+  it('blocks GETing _design/medic', () => {
+    const request = {
+      path: '/_design/medic'
+    };
+
+    return utils
+      .requestOnTestDb(_.defaults(request, offlineRequestOptions), false, true)
+      .catch(result => {
+        expect(result.statusCode).toEqual(403);
+        expect(result.responseBody.error).toEqual('forbidden');
+      });
+  });
+
+  it('blocks PUTting _design/medic', () => {
+    const request = {
+      path: '/_design/medic',
+      method: 'PUT',
+      body: JSON.stringify({ _id: '_design/medic', some: 'data' }),
+      headers: { 'Content-Type': 'application/json' },
+    };
+
+    return utils
+      .requestOnTestDb(_.defaults(request, offlineRequestOptions), false, true)
+      .catch(result => {
+        expect(result.statusCode).toEqual(403);
+        expect(result.responseBody.error).toEqual('forbidden');
+      });
+  });
+
+  it('blocks GETing inexistent ddoc', () => {
+    const request = {
+      path: '/_design/something'
+    };
+
+    return utils
+      .requestOnTestDb(_.defaults(request, offlineRequestOptions), false, true)
+      .catch(result => {
+        expect(result.statusCode).toEqual(403);
+        expect(result.responseBody.error).toEqual('forbidden');
+      });
+  });
 });

--- a/tests/e2e/api/controllers/db-doc.spec.js
+++ b/tests/e2e/api/controllers/db-doc.spec.js
@@ -474,6 +474,80 @@ describe('db-doc handler', () => {
         });
     });
 
+    it('GET attachment with name containing slashes', () => {
+      const revs = {
+        'allowed_attach_1': [],
+        'denied_attach_1': []
+      };
+
+      return utils
+        .saveDocs([
+          { _id: 'allowed_attach_1', type: 'clinic', parent: { _id: 'fixture:offline' }, name: 'allowed attach'},
+          { _id: 'denied_attach_1', type: 'clinic', parent: { _id: 'fixture:online' }, name: 'denied attach'},
+        ])
+        .then(results => Promise.all(results.map(result => {
+          revs[result.id].push(result.rev);
+          return utils.requestOnTestDb({
+            path: `/${result.id}/att_name/1/2/3/etc?rev=${result.rev}`,
+            method: 'PUT',
+            body: 'my attachment content',
+            headers: { 'Content-Type': 'text/plain' }
+          });
+        })))
+        .then(results => {
+          results.forEach(result => revs[result.id].push(result.rev));
+          return Promise.all([
+            utils
+              .requestOnTestDb(_.extend({ path: '/allowed_attach_1/att_name/1/2/3/etc' }, offlineRequestOptions), false, true),
+            utils
+              .requestOnTestDb(_.extend({ path: '/denied_attach_1/att_name/1/2/3/etc' }, offlineRequestOptions))
+              .catch(err => err)
+          ]);
+        })
+        .then(results => {
+          expect(results[0]).toEqual('my attachment content');
+          expect(results[1].statusCode).toEqual(403);
+          expect(results[1].responseBody).toEqual({ error: 'forbidden', reason: 'Insufficient privileges' });
+
+          return Promise.all([
+            utils.getDoc('allowed_attach_1'),
+            utils.getDoc('denied_attach_1')
+          ]);
+        })
+        .then(results => {
+          return utils.saveDocs([
+            _.extend(results[0], {  parent: { _id: 'fixture:online' } }),
+            _.extend(results[1], {  parent: { _id: 'fixture:offline' } }),
+          ]);
+        })
+        .then(results => {
+          results.forEach(result => revs[result.id].push(result.rev));
+
+          return Promise.all(_.flatten(_.map(revs, (revisions, id) => {
+            return revisions.map(rev =>
+              utils
+                .requestOnTestDb(_.extend({ path: `/${id}/att_name/1/2/3/etc?rev=${rev}` }, offlineRequestOptions), false, true)
+                .catch(err => err)
+            );
+          })));
+        })
+        .then(results => {
+          // allowed_attach is allowed, but missing attachment
+          expect(JSON.parse(results[0])).toEqual({ error: 'not_found', reason: 'Document is missing attachment' });
+          // allowed_attach is allowed and has attachment
+          expect(results[1]).toEqual('my attachment content');
+          // allowed_attach is not allowed and has attachment
+          expect(JSON.parse(results[2]).error).toEqual('forbidden');
+
+          // denied_attach is not allowed, but missing attachment
+          expect(JSON.parse(results[3]).error).toEqual('forbidden');
+          // denied_attach is not allowed and has attachment
+          expect(JSON.parse(results[4]).error).toEqual('forbidden');
+          // denied_attach is allowed and has attachment
+          expect(results[5]).toEqual('my attachment content');
+        });
+    });
+
     it('PUT attachment', () => {
       _.extend(offlineRequestOptions, {
         method: 'PUT',

--- a/tests/e2e/api/routing.js
+++ b/tests/e2e/api/routing.js
@@ -483,6 +483,30 @@ describe('routing', () => {
         });
     });
 
+    it('allows access to the app - redirect cause of no trailing slash', () => {
+      const request = {
+        path: '/_design/medic/_rewrite'
+      };
+
+      return utils
+        .requestOnTestDb(_.defaults(request, offlineRequestOptions), false, true)
+        .then(result => {
+          expect(result).toEqual(`Found. Redirecting to /${constants.DB_NAME}/_design/medic/_rewrite/`);
+        });
+    });
+
+    it('allows access to the app', () => {
+      const request = {
+        path: '/_design/medic/_rewrite/'
+      };
+
+      return utils
+        .requestOnTestDb(_.defaults(request, offlineRequestOptions), false, true)
+        .then(result => {
+          expect(result.includes('DOCTYPE html')).toBe(true);
+        });
+    });
+
     it('blocks direct access to CouchDB and to fauxton', () => {
       return Promise
         .all([

--- a/tests/e2e/api/routing.js
+++ b/tests/e2e/api/routing.js
@@ -483,27 +483,17 @@ describe('routing', () => {
         });
     });
 
-    it('allows access to the app - redirect cause of no trailing slash', () => {
-      const request = {
-        path: '/_design/medic/_rewrite'
-      };
-
-      return utils
-        .requestOnTestDb(_.defaults(request, offlineRequestOptions), false, true)
-        .then(result => {
-          expect(result).toEqual(`Found. Redirecting to /${constants.DB_NAME}/_design/medic/_rewrite/`);
-        });
-    });
-
     it('allows access to the app', () => {
-      const request = {
-        path: '/_design/medic/_rewrite/'
-      };
-
-      return utils
-        .requestOnTestDb(_.defaults(request, offlineRequestOptions), false, true)
-        .then(result => {
-          expect(result.includes('DOCTYPE html')).toBe(true);
+      return Promise
+        .all([
+          utils.requestOnTestDb(_.defaults({ path: '/_design/medic/_rewrite' }, offlineRequestOptions), false, true),
+          utils.requestOnTestDb(_.defaults({ path: '/_design/medic/_rewrite/' }, offlineRequestOptions), false, true),
+          utils.requestOnTestDb(_.defaults({ path: '/_design/medic/_rewrite/css/inbox.css' }, offlineRequestOptions), false, true)
+        ])
+        .then(results => {
+          expect(results[0].includes('Found. Redirecting to')).toBe(true);
+          expect(results[1].includes('DOCTYPE html')).toBe(true);
+          expect(results[2].includes('html')).toBe(true);
         });
     });
 


### PR DESCRIPTION
# Description

* Adds support for db-doc attachments with names containing slashes
* Adds `ddoc` specific `GET` route which forwards main `ddoc` requests (_rewrites are authorized by another route). Db-doc controller forwards all other `ddoc` requests without authorizing them.  
* Catch `auth.getUserSettings` errors in `authorization` middleware
* Adds e2e tests which prove interactions with ddocs
* Adds e2e tests to check for access to main ddoc rewrites

medic/medic-webapp#2734

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.