### PR TITLE
Adds specific routing for canceling contacts-edit forms

### DIFF
--- a/tests/page-objects/contacts/contacts.po.js
+++ b/tests/page-objects/contacts/contacts.po.js
@@ -3,7 +3,7 @@ const helper = require('../../helper');
 const searchBox = element(by.css('#freetext')),
       seachButton = element(by.css('#search')),
       refreshButton = element(by.css('.fa fa-undo')),
-      newDistrictButton = element(by.css('a[href="#/contacts//add/district_hospital/true"]')),
+      newDistrictButton = element(by.css('a[href="#/contacts//add/district_hospital?fromList=true"]')),
       newPlaceName = element(by.css('[name="/data/district_hospital/name"]')),
       newPersonButton = element(by.css('a.btn.btn-link.add-new')),
       nextButton = element(by.css('button.btn.btn-primary.next-page.ng-scope')),

--- a/tests/page-objects/contacts/contacts.po.js
+++ b/tests/page-objects/contacts/contacts.po.js
@@ -3,7 +3,7 @@ const helper = require('../../helper');
 const searchBox = element(by.css('#freetext')),
       seachButton = element(by.css('#search')),
       refreshButton = element(by.css('.fa fa-undo')),
-      newDistrictButton = element(by.css('a[href="#/contacts//add/district_hospital"]')),
+      newDistrictButton = element(by.css('a[href="#/contacts//add/district_hospital/true"]')),
       newPlaceName = element(by.css('[name="/data/district_hospital/name"]')),
       newPersonButton = element(by.css('a.btn.btn-link.add-new')),
       nextButton = element(by.css('button.btn.btn-primary.next-page.ng-scope')),
@@ -16,7 +16,7 @@ const searchBox = element(by.css('#freetext')),
       submitButton = element(by.css('.btn.submit.btn-primary.ng-scope'));
 
 module.exports = {
-  
+
   getSubmitButton: () => {
     return submitButton;
   },

--- a/tests/page-objects/contacts/contacts.po.js
+++ b/tests/page-objects/contacts/contacts.po.js
@@ -3,7 +3,7 @@ const helper = require('../../helper');
 const searchBox = element(by.css('#freetext')),
       seachButton = element(by.css('#search')),
       refreshButton = element(by.css('.fa fa-undo')),
-      newDistrictButton = element(by.css('a[href="#/contacts//add/district_hospital?fromList=true"]')),
+      newDistrictButton = element(by.css('a[href="#/contacts//add/district_hospital?from=list"]')),
       newPlaceName = element(by.css('[name="/data/district_hospital/name"]')),
       newPersonButton = element(by.css('a.btn.btn-link.add-new')),
       nextButton = element(by.css('button.btn.btn-primary.next-page.ng-scope')),

--- a/webapp/src/js/controllers/contacts-edit.js
+++ b/webapp/src/js/controllers/contacts-edit.js
@@ -20,7 +20,11 @@ angular.module('inboxControllers').controller('ContactsEditCtrl',
     $scope.loadingContent = true;
     $scope.setShowContent(true);
     $scope.setCancelTarget(function() {
-      $state.go('contacts.detail', { id: $state.params.id || $state.params.parent_id });
+      if ($state.params.redirectToList) {
+        $state.go('contacts.detail', { id: null });
+      } else {
+        $state.go('contacts.detail', { id: $state.params.id || $state.params.parent_id });
+      }
     });
 
     var setTitle = function() {

--- a/webapp/src/js/controllers/contacts-edit.js
+++ b/webapp/src/js/controllers/contacts-edit.js
@@ -20,7 +20,7 @@ angular.module('inboxControllers').controller('ContactsEditCtrl',
     $scope.loadingContent = true;
     $scope.setShowContent(true);
     $scope.setCancelTarget(function() {
-      if ($state.params.fromList) {
+      if ($state.params.from === 'list') {
         $state.go('contacts.detail', { id: null });
       } else {
         $state.go('contacts.detail', { id: $state.params.id || $state.params.parent_id });

--- a/webapp/src/js/controllers/contacts-edit.js
+++ b/webapp/src/js/controllers/contacts-edit.js
@@ -20,7 +20,7 @@ angular.module('inboxControllers').controller('ContactsEditCtrl',
     $scope.loadingContent = true;
     $scope.setShowContent(true);
     $scope.setCancelTarget(function() {
-      if ($state.params.redirectToList) {
+      if ($state.params.fromList) {
         $state.go('contacts.detail', { id: null });
       } else {
         $state.go('contacts.detail', { id: $state.params.id || $state.params.parent_id });

--- a/webapp/src/js/router.js
+++ b/webapp/src/js/router.js
@@ -146,7 +146,7 @@
         }
       })
       .state('contacts.addChild', {
-        url: '/:parent_id/add/:type',
+        url: '/:parent_id/add/:type/:redirectToList?',
         views: {
           content: {
             controller: 'ContactsEditCtrl',

--- a/webapp/src/js/router.js
+++ b/webapp/src/js/router.js
@@ -146,7 +146,7 @@
         }
       })
       .state('contacts.addChild', {
-        url: '/:parent_id/add/:type?fromList',
+        url: '/:parent_id/add/:type?from',
         views: {
           content: {
             controller: 'ContactsEditCtrl',

--- a/webapp/src/js/router.js
+++ b/webapp/src/js/router.js
@@ -146,11 +146,17 @@
         }
       })
       .state('contacts.addChild', {
-        url: '/:parent_id/add/:type/:redirectToList?',
+        url: '/:parent_id/add/:type/:redirectToList',
         views: {
           content: {
             controller: 'ContactsEditCtrl',
             templateUrl: 'templates/partials/contacts_edit.html'
+          }
+        },
+        params: {
+          redirectToList: {
+            value: null,
+            squash: true
           }
         }
       })

--- a/webapp/src/js/router.js
+++ b/webapp/src/js/router.js
@@ -146,17 +146,11 @@
         }
       })
       .state('contacts.addChild', {
-        url: '/:parent_id/add/:type/:fromList',
+        url: '/:parent_id/add/:type?fromList',
         views: {
           content: {
             controller: 'ContactsEditCtrl',
             templateUrl: 'templates/partials/contacts_edit.html'
-          }
-        },
-        params: {
-          fromList: {
-            value: null,
-            squash: true
           }
         }
       })

--- a/webapp/src/js/router.js
+++ b/webapp/src/js/router.js
@@ -146,7 +146,7 @@
         }
       })
       .state('contacts.addChild', {
-        url: '/:parent_id/add/:type/:redirectToList',
+        url: '/:parent_id/add/:type/:fromList',
         views: {
           content: {
             controller: 'ContactsEditCtrl',
@@ -154,7 +154,7 @@
           }
         },
         params: {
-          redirectToList: {
+          fromList: {
             value: null,
             squash: true
           }

--- a/webapp/src/templates/partials/actionbar.html
+++ b/webapp/src/templates/partials/actionbar.html
@@ -50,7 +50,7 @@
 
       <div class="col-sm-4 general-actions left-pane" ng-show="currentTab === 'contacts'">
         <div class="actions dropup" mm-auth mm-auth-any="[ isAdmin, actionBar.left.userChildPlace.type && 'can_create_places' ]">
-          <a class="mm-icon mm-icon-inverse mm-icon-caption" ng-show="actionBar.left.userChildPlace.type" ui-sref="contacts.addChild({ type: actionBar.left.userChildPlace.type, parent_id: actionBar.left.userFacilityId, redirectToList: true })" mm-auth="can_create_places">
+          <a class="mm-icon mm-icon-inverse mm-icon-caption" ng-show="actionBar.left.userChildPlace.type" ui-sref="contacts.addChild({ type: actionBar.left.userChildPlace.type, parent_id: actionBar.left.userFacilityId, fromList: true })" mm-auth="can_create_places">
             <span class="fa-stack">
               <i ng-bind-html="actionBar.left.userChildPlace.icon | resourceIcon"></i>
               <i class="fa fa-plus fa-stack-1x"></i>

--- a/webapp/src/templates/partials/actionbar.html
+++ b/webapp/src/templates/partials/actionbar.html
@@ -50,7 +50,7 @@
 
       <div class="col-sm-4 general-actions left-pane" ng-show="currentTab === 'contacts'">
         <div class="actions dropup" mm-auth mm-auth-any="[ isAdmin, actionBar.left.userChildPlace.type && 'can_create_places' ]">
-          <a class="mm-icon mm-icon-inverse mm-icon-caption" ng-show="actionBar.left.userChildPlace.type" ui-sref="contacts.addChild({ type: actionBar.left.userChildPlace.type, parent_id: actionBar.left.userFacilityId })" mm-auth="can_create_places">
+          <a class="mm-icon mm-icon-inverse mm-icon-caption" ng-show="actionBar.left.userChildPlace.type" ui-sref="contacts.addChild({ type: actionBar.left.userChildPlace.type, parent_id: actionBar.left.userFacilityId, redirectToList: true })" mm-auth="can_create_places">
             <span class="fa-stack">
               <i ng-bind-html="actionBar.left.userChildPlace.icon | resourceIcon"></i>
               <i class="fa fa-plus fa-stack-1x"></i>

--- a/webapp/src/templates/partials/actionbar.html
+++ b/webapp/src/templates/partials/actionbar.html
@@ -50,7 +50,7 @@
 
       <div class="col-sm-4 general-actions left-pane" ng-show="currentTab === 'contacts'">
         <div class="actions dropup" mm-auth mm-auth-any="[ isAdmin, actionBar.left.userChildPlace.type && 'can_create_places' ]">
-          <a class="mm-icon mm-icon-inverse mm-icon-caption" ng-show="actionBar.left.userChildPlace.type" ui-sref="contacts.addChild({ type: actionBar.left.userChildPlace.type, parent_id: actionBar.left.userFacilityId, fromList: true })" mm-auth="can_create_places">
+          <a class="mm-icon mm-icon-inverse mm-icon-caption" ng-show="actionBar.left.userChildPlace.type" ui-sref="contacts.addChild({ type: actionBar.left.userChildPlace.type, parent_id: actionBar.left.userFacilityId, from: 'list' })" mm-auth="can_create_places">
             <span class="fa-stack">
               <i ng-bind-html="actionBar.left.userChildPlace.icon | resourceIcon"></i>
               <i class="fa fa-plus fa-stack-1x"></i>

--- a/webapp/tests/karma/unit/controllers/contacts-edit.js
+++ b/webapp/tests/karma/unit/controllers/contacts-edit.js
@@ -2,13 +2,9 @@ describe('Contacts Edit controller', () => {
 
   'use strict';
 
-  let buttonLabel,
-      childType,
-      contactSchema,
+  let contactSchema,
       createController,
-      icon,
       scope,
-      typeLabel,
       $rootScope,
       contactForm,
       spyState;
@@ -16,10 +12,6 @@ describe('Contacts Edit controller', () => {
   beforeEach(module('inboxApp'));
 
   beforeEach(inject((_$rootScope_, $controller) => {
-    childType = 'childType';
-    icon = 'fa-la-la-la-la';
-    buttonLabel = 'ClICK ME!!';
-    typeLabel = 'District';
     contactForm = { forEdit: sinon.stub(), forCreate: sinon.stub() };
     $rootScope = _$rootScope_;
     scope = $rootScope.$new();
@@ -27,9 +19,7 @@ describe('Contacts Edit controller', () => {
     scope.clearSelected = sinon.stub();
     scope.setShowContent = sinon.stub();
     scope.setCancelTarget = sinon.stub();
-    contactSchema = {
-      get: sinon.stub().returns({ icon: icon, addButtonLabel : buttonLabel, label: typeLabel, fields: { parent: '' } })
-    };
+    contactSchema = { get: sinon.stub().returns({ fields: { parent: '' }}) };
     var $translate = key => Promise.resolve(key + 'translated');
     $translate.instant = key => key + 'translated';
 
@@ -90,5 +80,4 @@ describe('Contacts Edit controller', () => {
     chai.expect(spyState.go.callCount).to.equal(1);
     chai.expect(spyState.go.args[0]).to.deep.equal([ 'contacts.detail', { 'id': 'id' } ]);
   });
-
 });

--- a/webapp/tests/karma/unit/controllers/contacts-edit.js
+++ b/webapp/tests/karma/unit/controllers/contacts-edit.js
@@ -49,9 +49,9 @@ describe('Contacts Edit controller', () => {
     };
   }));
 
-  it('cancelling redirects to contacts list when route has redirectToList param', () => {
+  it('cancelling redirects to contacts list when query has `from` param equal to `list`', () => {
     let cancelTarget;
-    spyState.params.fromList = true;
+    spyState.params.from = 'list';
     scope.setCancelTarget.callsFake(func => cancelTarget = func);
 
     createController();
@@ -60,7 +60,18 @@ describe('Contacts Edit controller', () => {
     chai.expect(spyState.go.args[0]).to.deep.equal([ 'contacts.detail', { id: null } ]);
   });
 
-  it('cancelling falls back to parent contact if new contact and route does not have redirectToList', () => {
+  it('cancelling falls back to parent contact if new contact and query `from` param is not equal to `list`', () => {
+    let cancelTarget;
+    spyState.params.from = 'something';
+    scope.setCancelTarget.callsFake(func => cancelTarget = func);
+
+    createController();
+    cancelTarget();
+    chai.expect(spyState.go.callCount).to.equal(1);
+    chai.expect(spyState.go.args[0]).to.deep.equal([ 'contacts.detail', { 'id': 'parent_id' } ]);
+  });
+
+  it('cancelling falls back to parent contact if new contact and query does not have `from` param', () => {
     let cancelTarget;
     scope.setCancelTarget.callsFake(func => cancelTarget = func);
 

--- a/webapp/tests/karma/unit/controllers/contacts-edit.js
+++ b/webapp/tests/karma/unit/controllers/contacts-edit.js
@@ -91,4 +91,5 @@ describe('Contacts Edit controller', () => {
     chai.expect(spyState.go.callCount).to.equal(1);
     chai.expect(spyState.go.args[0]).to.deep.equal([ 'contacts.detail', { 'id': 'id' } ]);
   });
+
 });

--- a/webapp/tests/karma/unit/controllers/contacts-edit.js
+++ b/webapp/tests/karma/unit/controllers/contacts-edit.js
@@ -51,7 +51,7 @@ describe('Contacts Edit controller', () => {
 
   it('cancelling redirects to contacts list when route has redirectToList param', () => {
     let cancelTarget;
-    spyState.params.redirectToList = true;
+    spyState.params.fromList = true;
     scope.setCancelTarget.callsFake(func => cancelTarget = func);
 
     createController();

--- a/webapp/tests/karma/unit/controllers/contacts-edit.js
+++ b/webapp/tests/karma/unit/controllers/contacts-edit.js
@@ -1,0 +1,94 @@
+describe('Contacts Edit controller', () => {
+
+  'use strict';
+
+  let buttonLabel,
+      childType,
+      contactSchema,
+      createController,
+      icon,
+      scope,
+      typeLabel,
+      $rootScope,
+      contactForm,
+      spyState;
+
+  beforeEach(module('inboxApp'));
+
+  beforeEach(inject((_$rootScope_, $controller) => {
+    childType = 'childType';
+    icon = 'fa-la-la-la-la';
+    buttonLabel = 'ClICK ME!!';
+    typeLabel = 'District';
+    contactForm = { forEdit: sinon.stub(), forCreate: sinon.stub() };
+    $rootScope = _$rootScope_;
+    scope = $rootScope.$new();
+    scope.setTitle = sinon.stub();
+    scope.clearSelected = sinon.stub();
+    scope.setShowContent = sinon.stub();
+    scope.setCancelTarget = sinon.stub();
+    contactSchema = {
+      get: sinon.stub().returns({ icon: icon, addButtonLabel : buttonLabel, label: typeLabel, fields: { parent: '' } })
+    };
+    var $translate = key => Promise.resolve(key + 'translated');
+    $translate.instant = key => key + 'translated';
+
+    spyState = {
+      go: sinon.spy(),
+      current: { name: 'my.state.is.great' },
+      includes: () => { return true; },
+      params: { parent_id: 'parent_id' }
+    };
+
+    createController = () => {
+      return $controller('ContactsEditCtrl', {
+        '$log': { error: sinon.stub() },
+        '$q': Q,
+        '$scope': scope,
+        '$state': spyState,
+        '$timeout': work => work(),
+        '$translate': $translate,
+        'ContactForm': contactForm,
+        'ContactSave': sinon.stub(),
+        'ContactSchema': contactSchema,
+        'Enketo': sinon.stub(),
+        'LineageModelGenerator': { contact: sinon.stub().resolves() },
+        'Snackbar': sinon.stub(),
+        'SessionStorage': sessionStorage
+      });
+    };
+  }));
+
+  it('cancelling redirects to contacts list when route has redirectToList param', () => {
+    let cancelTarget;
+    spyState.params.redirectToList = true;
+    scope.setCancelTarget.callsFake(func => cancelTarget = func);
+
+    createController();
+    cancelTarget();
+    chai.expect(spyState.go.callCount).to.equal(1);
+    chai.expect(spyState.go.args[0]).to.deep.equal([ 'contacts.detail', { id: null } ]);
+  });
+
+  it('cancelling falls back to parent contact if new contact and route does not have redirectToList', () => {
+    let cancelTarget;
+    scope.setCancelTarget.callsFake(func => cancelTarget = func);
+
+    createController();
+    cancelTarget();
+    chai.expect(spyState.go.callCount).to.equal(1);
+    chai.expect(spyState.go.args[0]).to.deep.equal([ 'contacts.detail', { 'id': 'parent_id' } ]);
+  });
+
+  it('cancelling falls back to contact if edit contact', () => {
+    let cancelTarget;
+    spyState.params.id = 'id';
+    scope.setCancelTarget.callsFake(func => cancelTarget = func);
+
+    createController();
+    cancelTarget();
+    chai.expect(spyState.go.callCount).to.equal(1);
+    chai.expect(spyState.go.args[0]).to.deep.equal([ 'contacts.detail', { 'id': 'id' } ]);
+  });
+
+});


### PR DESCRIPTION
# Description

Adds a new route parameter to `contacts.addChild` to identify actions that originated in the contacts list.
If such a form is canceled, the user is redirected to contacts list instead of parent contact.

medic/medic-webapp#4444

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.