### PR TITLE
Offline user rev-less invalid attachment requests return a 404

### DIFF
--- a/api/src/controllers/db-doc.js
+++ b/api/src/controllers/db-doc.js
@@ -37,15 +37,14 @@ const isValidAttachmentRequest = (params, query) => {
   return true;
 };
 
-const requestError = (res, status) => {
-  if (status === 404) {
-    res.status(404);
-    res.json({ error: 'bad_request', reason: 'Invalid rev format' });
-    return;
-  }
-
+const permissionsError = res => {
   res.status(403);
   res.json({ error: 'forbidden', reason: 'Insufficient privileges' });
+};
+
+const notFoundError = res => {
+  res.status(404);
+  res.json({ error: 'bad_request', reason: 'Invalid rev format' });
 };
 
 module.exports = {
@@ -55,7 +54,7 @@ module.exports = {
     }
 
     if (!isValidRequest(req.method, req.params.docId, req.body)) {
-      return requestError(res);
+      return permissionsError(res);
     }
 
     return dbDoc
@@ -65,10 +64,10 @@ module.exports = {
           // if this is an attachment request without `rev` parameter that is not valid,
           // send a `404` so PouchDB will retry with a `rev` parameter.
           if (!isValidAttachmentRequest(req.params, req.query)) {
-            return requestError(res, 404);
+            return notFoundError(res);
           }
 
-          return requestError(res);
+          return permissionsError(res);
         }
 
         if (_.isObject(result)) {

--- a/api/src/controllers/db-doc.js
+++ b/api/src/controllers/db-doc.js
@@ -54,11 +54,6 @@ module.exports = {
       return next('route');
     }
 
-    // don't support attachment requests without `rev` parameter
-    if (!isValidAttachmentRequest(req.params, req.query)) {
-      return requestError(res, 404);
-    }
-
     if (!isValidRequest(req.method, req.params.docId, req.body)) {
       return requestError(res);
     }
@@ -67,6 +62,12 @@ module.exports = {
       .filterOfflineRequest(req.userCtx, req.params, req.method, req.query, req.body)
       .then(result => {
         if (!result) {
+          // if this is an attachment request without `rev` parameter that is not valid,
+          // send a `404` so PouchDB will retry with a `rev` parameter.
+          if (!isValidAttachmentRequest(req.params, req.query)) {
+            return requestError(res, 404);
+          }
+
           return requestError(res);
         }
 

--- a/api/src/services/bulk-get.js
+++ b/api/src/services/bulk-get.js
@@ -24,8 +24,8 @@ module.exports = {
       .getAuthorizationContext(userCtx)
       .then(context => {
         authorizationContext = context;
-        // actually execute the _bulk_get request as-is and filter the response
-        return db.medic.bulkGet(_.defaults({ docs: docs }, query));
+        // actually execute the _bulk_get request as-is, excluding `latest` param, and filter the response
+        return db.medic.bulkGet(_.defaults({ docs: docs }, _.omit(query, 'latest')));
       })
       .then(result => {
         result.results = filterResults(authorizationContext, result);

--- a/api/tests/mocha/controllers/db-doc.spec.js
+++ b/api/tests/mocha/controllers/db-doc.spec.js
@@ -50,6 +50,24 @@ describe('db-doc controller', () => {
       });
     });
 
+    describe('isValidAttachmentRequest', () => {
+      it('returns true for non-attachment requests', () => {
+        controller._isValidAttachmentRequest({}, {}).should.equal(true);
+        controller._isValidAttachmentRequest({ something: true }, {}).should.equal(true);
+        controller._isValidAttachmentRequest({ attachmentId: false }, {}).should.equal(true);
+      });
+
+      it('returns true for attachment requests with rev parameter', () => {
+        controller._isValidAttachmentRequest({ attachmentId: 'attId' }, { rev: 'something' }).should.equal(true);
+      });
+
+      it('returns false for attachment requests without rev parameter', () => {
+        controller._isValidAttachmentRequest({ attachmentId: 'attId' }, {}).should.equal(false);
+        controller._isValidAttachmentRequest({ attachmentId: 'attId' }, { something: true }).should.equal(false);
+        controller._isValidAttachmentRequest({ attachmentId: 'attId' }, { rev: false }).should.equal(false);
+      });
+    });
+
     it('forwards to next route when docID is a couchDB endpoint or a _design document', () => {
       testReq.params.docId = '_bulk_docs';
       controller.request(testReq, testRes, next);
@@ -129,6 +147,19 @@ describe('db-doc controller', () => {
           testRes.json.callCount.should.deep.equal(1);
           testRes.json.args[0].should.deep.equal([{ error: 'forbidden', reason: 'Insufficient privileges' }]);
         });
+    });
+
+    it('sends error when request is not a valid attachment request', () => {
+      testReq.query = {};
+      testReq.params.attachmentId = 'something';
+      controller.request(testReq, testRes, next);
+
+      next.callCount.should.equal(0);
+      testRes.status.callCount.should.equal(1);
+      testRes.status.args[0].should.deep.equal([404]);
+      testRes.json.callCount.should.deep.equal(1);
+      testRes.json.args[0].should.deep.equal([{ error: 'bad_request', reason: 'Invalid rev format' }]);
+      service.filterOfflineRequest.callCount.should.equal(0);
     });
 
     it('catches service errors', () => {

--- a/api/tests/mocha/services/bulk-get.spec.js
+++ b/api/tests/mocha/services/bulk-get.spec.js
@@ -44,9 +44,9 @@ describe('Bulk Get service', () => {
         });
     });
 
-    it('passes request query parameters to the db call', () => {
+    it('passes request query parameters to the db call, except latest param', () => {
       docs = [{ id: 'a', rev: '1-a' }, { id: 'b' }];
-      query = { revs: 'yes', attachments: 'no', some: 'param' };
+      query = { revs: 'yes', attachments: 'no', some: 'param', latest: true };
 
       return service.filterOfflineRequest(userCtx, query, docs).then(() => {
         authorization.getAuthorizationContext.callCount.should.equal(1);

--- a/tests/e2e/api/controllers/bulk-get.spec.js
+++ b/tests/e2e/api/controllers/bulk-get.spec.js
@@ -209,6 +209,7 @@ describe('bulk-docs handler', () => {
             { id: 'd2', rev: revs.d2[1] } // allowed
           ]
         });
+        offlineRequestOptions.path = '/_bulk_get?latest=true';
 
         return utils.requestOnTestDb(offlineRequestOptions);
       })

--- a/tests/e2e/api/controllers/db-doc.spec.js
+++ b/tests/e2e/api/controllers/db-doc.spec.js
@@ -424,16 +424,29 @@ describe('db-doc handler', () => {
           results.forEach(result => revs[result.id].push(result.rev));
           return Promise.all([
             utils
-              .requestOnTestDb(_.extend({ path: '/allowed_attach/att_name' }, offlineRequestOptions), false, true),
+              .requestOnTestDb(_.extend({ path: `/allowed_attach/att_name?rev=${results[0].rev}` }, offlineRequestOptions), false, true),
             utils
-              .requestOnTestDb(_.extend({ path: '/denied_attach/att_name' }, offlineRequestOptions))
-              .catch(err => err)
+              .requestOnTestDb(_.extend({ path: `/denied_attach/att_name?rev=${results[1].rev}` }, offlineRequestOptions))
+              .catch(err => err),
+            utils
+              .requestOnTestDb(_.extend({ path: `/allowed_attach/att_name` }, offlineRequestOptions))
+              .catch(err => err),
+            utils
+              .requestOnTestDb(_.extend({ path: `/denied_attach/att_name` }, offlineRequestOptions))
+              .catch(err => err),
           ]);
         })
         .then(results => {
           expect(results[0]).toEqual('my attachment content');
+
           expect(results[1].statusCode).toEqual(403);
           expect(results[1].responseBody).toEqual({ error: 'forbidden', reason: 'Insufficient privileges' });
+
+          expect(results[2].statusCode).toEqual(404);
+          expect(results[2].responseBody).toEqual({ error: 'bad_request', reason: 'Invalid rev format' });
+
+          expect(results[3].statusCode).toEqual(404);
+          expect(results[3].responseBody).toEqual({ error: 'bad_request', reason: 'Invalid rev format' });
 
           return Promise.all([
             utils.getDoc('allowed_attach'),
@@ -498,16 +511,29 @@ describe('db-doc handler', () => {
           results.forEach(result => revs[result.id].push(result.rev));
           return Promise.all([
             utils
-              .requestOnTestDb(_.extend({ path: '/allowed_attach_1/att_name/1/2/3/etc' }, offlineRequestOptions), false, true),
+              .requestOnTestDb(_.extend({ path: `/allowed_attach_1/att_name/1/2/3/etc?rev=${results[0].rev}` }, offlineRequestOptions), false, true),
             utils
-              .requestOnTestDb(_.extend({ path: '/denied_attach_1/att_name/1/2/3/etc' }, offlineRequestOptions))
-              .catch(err => err)
+              .requestOnTestDb(_.extend({ path: `/denied_attach_1/att_name/1/2/3/etc?rev=${results[1].rev}` }, offlineRequestOptions))
+              .catch(err => err),
+            utils
+              .requestOnTestDb(_.extend({ path: `/allowed_attach_1/att_name/1/2/3/etc` }, offlineRequestOptions))
+              .catch(err => err),
+            utils
+              .requestOnTestDb(_.extend({ path: `/denied_attach_1/att_name/1/2/3/etc` }, offlineRequestOptions))
+              .catch(err => err),
           ]);
         })
         .then(results => {
           expect(results[0]).toEqual('my attachment content');
+
           expect(results[1].statusCode).toEqual(403);
           expect(results[1].responseBody).toEqual({ error: 'forbidden', reason: 'Insufficient privileges' });
+
+          expect(results[2].statusCode).toEqual(404);
+          expect(results[2].responseBody).toEqual({ error: 'bad_request', reason: 'Invalid rev format' });
+
+          expect(results[3].statusCode).toEqual(404);
+          expect(results[3].responseBody).toEqual({ error: 'bad_request', reason: 'Invalid rev format' });
 
           return Promise.all([
             utils.getDoc('allowed_attach_1'),
@@ -571,10 +597,10 @@ describe('db-doc handler', () => {
           expect(results[1].responseBody).toEqual({ error: 'forbidden', reason: 'Insufficient privileges' });
 
           return Promise.all([
-            utils.requestOnTestDb({ path: '/a_with_attachments' }),
-            utils.requestOnTestDb({ path: '/a_with_attachments/new_attachment' }, false, true),
-            utils.requestOnTestDb({ path: '/d_with_attachments' }),
-            utils.requestOnTestDb({ path: '/d_with_attachments/new_attachment' }).catch(err => err)
+            utils.requestOnTestDb({ path: `/a_with_attachments` }),
+            utils.requestOnTestDb({ path: `/a_with_attachments/new_attachment` }, false, true),
+            utils.requestOnTestDb({ path: `/d_with_attachments` }),
+            utils.requestOnTestDb({ path: `/d_with_attachments/new_attachment` }).catch(err => err)
           ]);
         })
         .then(results => {
@@ -617,7 +643,7 @@ describe('db-doc handler', () => {
           .catch(err => err)
       ]))
       .then(results => {
-        expect(results.every(result => result.statusCode === 403)).toBe(true);
+        expect(results.every(result => result.statusCode === 403 || result.statusCode === 404)).toBe(true);
       });
   });
 

--- a/tests/e2e/api/controllers/db-doc.spec.js
+++ b/tests/e2e/api/controllers/db-doc.spec.js
@@ -797,4 +797,5 @@ describe('db-doc handler', () => {
         });
     });
   });
+
 });


### PR DESCRIPTION
# Description

When replicating an existent `doc`, PouchDB attachment requests would not include `rev` param. When the `doc` had been deleted (or the latest `rev` would not be allowed), they would receive a `403`,  which would abort the replication process. 
As a fix, offline attachment `rev`-less denied requests will now respond with a `404`, which will cause PouchDB to retry retrieving the attachment including the `rev` param.

Omits `latest` param for offline `_bulk_get` requests.

medic/medic-webapp#2734

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.