### PR TITLE
Adds the MRDT enketo widget and android integration

### DIFF
--- a/ddocs/medic/_attachments/translations/messages-en.properties
+++ b/ddocs/medic/_attachments/translations/messages-en.properties
@@ -1031,3 +1031,5 @@ contacts.results.sort = Sort results
 contacts.results.sort.title = Sort this list
 contacts.results.sort.alpha = Alphabetically
 contacts.results.sort.date.last.visited = By date last visited
+mrdt.disabled = The MRDT app is not available on this device
+mrdt.verify = Take photo

--- a/demo-forms/mrdt-demo.xml
+++ b/demo-forms/mrdt-demo.xml
@@ -4,25 +4,25 @@
     <h:title>MRDT Demo</h:title>
     <model>
       <instance>
-        <data delimiter="#" id="mrdt_demo">
+        <mrdt delimiter="#" id="mrdt_demo">
           <name/>
-          <mrdt_image_data/>
+          <mrdt_image_data type="binary"/>
           <meta>
             <instanceID/>
           </meta>
-        </data>
+        </mrdt>
       </instance>
-      <bind nodeset="/data/name" type="string"/>
-      <bind nodeset="/data/mrdt_image_data" type="string"/>
+      <bind nodeset="/mrdt/name" type="string"/>
+      <bind nodeset="/mrdt/mrdt_image_data" type="string"/>
     </model>
   </h:head>
   <h:body class="pages">
-    <group appearance="field-list" ref="/data">
+    <group appearance="field-list" ref="/mrdt">
       <label>Submit a photo of an MRDT test result</label>
-      <input ref="/data/name">
+      <input ref="/mrdt/name">
         <label>Patient name</label>
       </input>
-      <input ref="/data/mrdt_image_data" appearance="mrdt-verify">
+      <input ref="/mrdt/mrdt_image_data" appearance="mrdt-verify">
         <label>MRDT image</label>
       </input>
     </group>

--- a/demo-forms/mrdt-demo.xml
+++ b/demo-forms/mrdt-demo.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <h:head>
+    <h:title>MRDT Demo</h:title>
+    <model>
+      <instance>
+        <data delimiter="#" id="mrdt_demo">
+          <name/>
+          <mrdt_image_data/>
+          <meta>
+            <instanceID/>
+          </meta>
+        </data>
+      </instance>
+      <bind nodeset="/data/name" type="string"/>
+      <bind nodeset="/data/mrdt_image_data" type="string"/>
+    </model>
+  </h:head>
+  <h:body class="pages">
+    <group appearance="field-list" ref="/data">
+      <label>Submit a photo of an MRDT test result</label>
+      <input ref="/data/name">
+        <label>Patient name</label>
+      </input>
+      <input ref="/data/mrdt_image_data" appearance="mrdt-verify">
+        <label>MRDT image</label>
+      </input>
+    </group>
+  </h:body>
+</h:html>

--- a/webapp/src/css/enketo/medic.less
+++ b/webapp/src/css/enketo/medic.less
@@ -208,6 +208,16 @@
     max-width: 320px;
     display: block;
   }
+  .or-appearance-mrdt-verify {
+    .mrdt-verify,
+    .mrdt-preview {
+      margin: 8px 0;
+    }
+    input,
+    textarea {
+      display: none;
+    }
+  }
   .option-wrapper > label:not(.filler) {
     padding-top: 8px;
     padding-bottom: 8px;

--- a/webapp/src/js/enketo/widgets.js
+++ b/webapp/src/js/enketo/widgets.js
@@ -27,6 +27,7 @@ define( function( require, exports, module ) {
         require( './widgets/android-datepicker' ),
         require( './widgets/bikram-sambat-datepicker' ),
         require( './widgets/simprints' ),
+        require( './widgets/mrdt' ),
     ];
 
     module.exports = widgets;

--- a/webapp/src/js/enketo/widgets/mrdt.js
+++ b/webapp/src/js/enketo/widgets/mrdt.js
@@ -1,0 +1,84 @@
+if ( typeof exports === 'object' && typeof exports.nodeName !== 'string' && typeof define !== 'function' ) {
+    var define = function( factory ) {
+        factory( require, exports, module );
+    };
+}
+
+define( function( require, exports, module ) {
+    'use strict';
+    var Widget = require('enketo-core/src/js/Widget');
+    var $ = require( 'jquery' );
+    require('enketo-core/src/js/plugins');
+
+    var pluginName = 'mrdtwidget';
+
+    /**
+     * @constructor
+     * @param {Element} element [description]
+     * @param {(boolean|{touch: boolean, repeat: boolean})} options options
+     * @param {*=} e     event
+     */
+    function Mrdtwidget( element, options ) {
+        this.namespace = pluginName;
+        Widget.call( this, element, options );
+        this._init();
+    }
+
+    //copy the prototype functions from the Widget super class
+    Mrdtwidget.prototype = Object.create( Widget.prototype );
+
+    //ensure the constructor is the new one
+    Mrdtwidget.prototype.constructor = Mrdtwidget;
+
+    Mrdtwidget.prototype._init = function() {
+        var $el = $( this.element );
+        var $input = $el.find( 'input' );
+        $input.attr( 'disabled', true );
+        var angularServices = angular.element( document.body ).injector();
+        var $translate = angularServices.get( '$translate' );
+        var service = angularServices.get( 'Mrdt' );
+
+        if ( !service.enabled() ) {
+            $translate( 'mrdt.disabled' ).then(function( label ) {
+                $el.append( '<p>' + label + '</p>' );
+            });
+            return;
+        }
+
+        $el.on( 'click', '.btn.mrdt-verify', function() {
+            service.verify().then( function(mrdtId) {
+                $input.val( mrdtId ).trigger( 'change' );
+            } );
+        } );
+
+/* TODO translate!        $translate( 'mrdt.verify' ).then( function( label ) { */
+            var label = 'take photo';
+            $el.append( '<div><img class="mrdt-preview"/></div><div><a class="btn btn-default mrdt-verify">' + label + '</a></div>' );
+/*        } ); */
+    };
+
+    Mrdtwidget.prototype.destroy = function( element ) {
+        /* jshint unused:false */
+    };
+
+    $.fn[ pluginName ] = function( options, event ) {
+        return this.each( function() {
+            var $this = $( this ),
+                data = $this.data( pluginName );
+
+            options = options || {};
+
+            if ( !data && typeof options === 'object' ) {
+                $this.data( pluginName, ( data = new Mrdtwidget( this, options, event ) ) );
+            } else if ( data && typeof options === 'string' ) {
+                data[ options ]( this );
+            }
+        } );
+    };
+
+    module.exports = {
+        'name': pluginName,
+        'selector': '.or-appearance-mrdt-verify',
+    };
+} );
+

--- a/webapp/src/js/services/add-attachment.js
+++ b/webapp/src/js/services/add-attachment.js
@@ -6,13 +6,23 @@ angular.module('inboxServices').factory('AddAttachment',
     'ngInject';
     'use strict';
 
-    return function(doc, name, content, contentType) {
+    /**
+     * doc: The doc to add the attachment to
+     * name: The name of the attachment
+     * content: The data to include in the attachment
+     * contentType: The mime type of data, eg: 'application/xml'
+     * alreadyEncoded: (optional, defaults to false) If true, assumes
+     *   the content is already base64 encoded and doesn't do it again
+     */
+    return function(doc, name, content, contentType, alreadyEncoded) {
       if (!doc._attachments) {
         doc._attachments = {};
       }
-      var blob = new Blob([ content ], { type: contentType });
+      if (!alreadyEncoded) {
+        content = new Blob([ content ], { type: contentType });
+      }
       doc._attachments[name] = {
-        data: blob,
+        data: content,
         content_type: contentType
       };
     };

--- a/webapp/src/js/services/android-api.js
+++ b/webapp/src/js/services/android-api.js
@@ -9,6 +9,7 @@ angular.module('inboxServices').factory('AndroidApi',
     $log,
     $rootScope,
     $state,
+    MRDT,
     Session,
     Simprints
   ) {
@@ -148,14 +149,8 @@ angular.module('inboxServices').factory('AndroidApi',
          * @param response The stringified JSON response from the MRDT app.
          */
         mrdtResponse: function(response) {
-          //$log.error('mrdtResponse()', 'response =', response);
           try {
-            response = JSON.parse(response);
-
-            var $mrdtField = $('.or-appearance-mrdt-verify input');
-            $mrdtField.val(response).trigger('change');
-
-            $('img.mrdt-preview').attr('src', 'data:image/png;base64, ' + response);
+            MRDT.respond(JSON.parse(response));
           } catch(e) {
             return $log.error(new Error('Unable to parse JSON response from android app: "' + response + '"'));
           }

--- a/webapp/src/js/services/android-api.js
+++ b/webapp/src/js/services/android-api.js
@@ -144,6 +144,24 @@ angular.module('inboxServices').factory('AndroidApi',
         },
 
         /**
+         * Handle the response from the MRDT app
+         * @param response The stringified JSON response from the MRDT app.
+         */
+        mrdtResponse: function(response) {
+          //$log.error('mrdtResponse()', 'response =', response);
+          try {
+            response = JSON.parse(response);
+
+            var $mrdtField = $('.or-appearance-mrdt-verify input');
+            $mrdtField.val(response).trigger('change');
+
+            $('img.mrdt-preview').attr('src', 'data:image/png;base64, ' + response);
+          } catch(e) {
+            return $log.error(new Error('Unable to parse JSON response from android app: "' + response + '"'));
+          }
+        },
+
+        /**
          * Handle the response from the simprints device
          *
          * @param requestType Indicates the response handler to call. Either 'identify' or 'register'.

--- a/webapp/src/js/services/enketo-translation.js
+++ b/webapp/src/js/services/enketo-translation.js
@@ -263,12 +263,16 @@ angular.module('inboxServices').service('EnketoTranslation', [
             return;
           }
 
+          var typeAttribute = n.attributes.getNamedItem('type');
           var updatedPath = path + '/' + n.nodeName;
           var value;
 
           var hasChildren = withElements(n.childNodes).size().value();
           if(hasChildren) {
             value = nodesToJs(n.childNodes, repeatPaths, updatedPath);
+          } else if (typeAttribute && typeAttribute.value === 'binary') {
+            // this is attached to the doc instead of inlined
+            value = '';
           } else {
             value = n.textContent;
           }

--- a/webapp/src/js/services/enketo.js
+++ b/webapp/src/js/services/enketo.js
@@ -426,14 +426,23 @@ angular.module('inboxServices').service('Enketo',
       doc._id = getId('/*');
       doc.hidden_fields = EnketoTranslation.getHiddenFieldList(record);
 
+      var attach = function(elem, file, type, alreadyEncoded) {
+        var filename = 'user-file' + xpathPath(elem);
+        AddAttachment(doc, filename, file, type, alreadyEncoded);
+      };
+
       $record.find('[type=file]').each(function() {
-        var xpath = xpathPath(this);
-        var path = 'user-file' + xpath;
-        var $input = $('input[type=file][name="' + xpath + '"]');
-        var file = $input[0].files[0];
+        var file = $(this).files[0];
         if (file) {
-          AddAttachment(doc, path, file, file.type);
-        } // else file set previously, but not changed during this edit
+          attach(this, file, file.type);
+        }
+      });
+
+      $record.find('[type=binary]').each(function() {
+        var file = $(this).text();
+        if (file) {
+          attach(this, file, 'image/png', true);
+        }
       });
 
       docsToStore.unshift(doc);

--- a/webapp/src/js/services/index.js
+++ b/webapp/src/js/services/index.js
@@ -57,6 +57,7 @@
   require('./message-state');
   require('./modal');
   require('./moment-locale-data');
+  require('./mrdt');
   require('./place-hierarchy');
   require('./recurring-process-manager');
   require('./relative-date');

--- a/webapp/src/js/services/mrdt.js
+++ b/webapp/src/js/services/mrdt.js
@@ -1,4 +1,4 @@
-angular.module('inboxServices').service('Mrdt',
+angular.module('inboxServices').service('MRDT',
   function(
     $log,
     $q,
@@ -6,6 +6,8 @@ angular.module('inboxServices').service('Mrdt',
   ) {
     'use strict';
     'ngInject';
+
+    var current;
 
     return {
       enabled: function() {
@@ -21,9 +23,15 @@ angular.module('inboxServices').service('Mrdt',
         }
       },
       verify: function() {
-        return $window.medicmobile_android.mrdt_verify();
+        current = $q.defer();
+        $window.medicmobile_android.mrdt_verify();
+        return current.promise;
+      },
+      respond: function(image) {
+        if (current) {
+          current.resolve(image);
+        }
       },
     };
   }
 );
-

--- a/webapp/src/js/services/mrdt.js
+++ b/webapp/src/js/services/mrdt.js
@@ -1,0 +1,29 @@
+angular.module('inboxServices').service('Mrdt',
+  function(
+    $log,
+    $q,
+    $window
+  ) {
+    'use strict';
+    'ngInject';
+
+    return {
+      enabled: function() {
+        try {
+          return !!(
+            $window.medicmobile_android &&
+            typeof $window.medicmobile_android.mrdt_available === 'function' &&
+            $window.medicmobile_android.mrdt_available()
+          );
+        } catch (err) {
+          $log.error(err);
+          return false;
+        }
+      },
+      verify: function() {
+        return $window.medicmobile_android.mrdt_verify();
+      },
+    };
+  }
+);
+

--- a/webapp/src/js/services/report-view-model-generator.js
+++ b/webapp/src/js/services/report-view-model-generator.js
@@ -48,8 +48,7 @@ angular.module('inboxServices').factory('ReportViewModelGenerator',
               doc._attachments &&
               doc._attachments[filePath] &&
               doc._attachments[filePath].content_type &&
-              doc._attachments[filePath].content_type.startsWith('image/') &&
-                true) {
+              doc._attachments[filePath].content_type.startsWith('image/')) {
             result.imagePath = filePath;
           }
 


### PR DESCRIPTION
# Description

This adds a new widget for MRDT verification which launches a third party app which
returns a photo of the MRDT result which gets attached to the report and displayed in
the report view.

Attaching binary content to the report is done generically so other widgets can use the
same pattern.

medic/medic-webapp#4743
medic/medic-webapp#4745
medic/medic-webapp#4742

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.