### PR TITLE
Resolving sms_message phone to existing contact

### DIFF
--- a/api/src/controllers/records.js
+++ b/api/src/controllers/records.js
@@ -1,7 +1,8 @@
 const db = require('../db-pouch'),
       auth = require('../auth'),
       serverUtils = require('../server-utils'),
-      recordUtils = require('./record-utils');
+      recordUtils = require('./record-utils'),
+      lineage = require('lineage')(Promise, db.medic);
 
 const generate = (req, options) => {
   if (req.is('urlencoded')) {
@@ -13,9 +14,27 @@ const generate = (req, options) => {
   throw new Error('Content type not supported.');
 };
 
+const resolvePhoneToExistingContact = doc => {
+  if(doc.sms_message && doc.sms_message.type === 'sms_message') {
+    return db.medic.query('medic-client/contacts_by_phone', {
+      key: doc.sms_message.from,
+      include_docs: true
+    }).then((result) => {
+      const contact = result && result.rows && result.rows.length && result.rows[0].doc;
+      if(contact) {
+        doc.contact = lineage.minifyLineage(contact);
+      }
+      return doc;
+    });
+  } else {
+    return doc;
+  }
+};
+
 const process = (req, res, options) => {
   return auth.check(req, 'can_create_records')
     .then(() => generate(req, options))
+    .then(doc => resolvePhoneToExistingContact(doc))
     .then(doc => db.medic.post(doc))
     .then(result => res.json({ success: true, id: result.id }))
     .catch(err => serverUtils.error(err, req, res));


### PR DESCRIPTION
# Description

Resolves sms phone (from) to existing contact.

medic/medic-webapp#4284

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.