### PR TITLE
Process CouchDB tombstone-stubs correctly in LiveList and TombstoneUtils

### DIFF
--- a/shared-libs/tombstone-utils/src/tombstone-utils.js
+++ b/shared-libs/tombstone-utils/src/tombstone-utils.js
@@ -60,7 +60,13 @@ var getDoc = function(Promise, DB, change) {
 
 // CouchDB `DELETE`d docs are stubs { _id, _rev, _deleted: true }
 var isCouchDbTombstone = function(doc) {
-  if (!_.difference(Object.keys(doc), COUCHDB_TOMBSTONE_PROPERTIES).length && doc._deleted) {
+  var arrayIncludes = function(array1, array2) {
+    return array2.every(function(elem) {
+      return array1.indexOf(elem) !== -1;
+    });
+  };
+
+  if (arrayIncludes(COUCHDB_TOMBSTONE_PROPERTIES, Object.keys(doc)) && doc._deleted) {
     return true;
   }
 

--- a/webapp/src/js/controllers/contacts.js
+++ b/webapp/src/js/controllers/contacts.js
@@ -354,7 +354,8 @@ var _ = require('underscore'),
           _query({ limit: limit, silent: true });
         },
         filter: function(change) {
-          return ContactSchema.getTypes().indexOf(change.doc.type) !== -1;
+          return ContactSchema.getTypes().indexOf(change.doc.type) !== -1 ||
+                 liveList.isContainedTombstone(change.doc);
         }
       });
 

--- a/webapp/src/js/controllers/reports.js
+++ b/webapp/src/js/controllers/reports.js
@@ -476,7 +476,7 @@ angular.module('inboxControllers').controller('ReportsCtrl',
         }
       },
       filter: function(change) {
-        return change.doc.form;
+        return change.doc.form || liveList.isContainedTombstone(change.doc);
       }
     });
 

--- a/webapp/src/js/services/live-list.js
+++ b/webapp/src/js/services/live-list.js
@@ -466,6 +466,16 @@ angular.module('inboxServices').factory('LiveList',
       delete idx.selected;
     }
 
+    function _isContainedTombstone(listName, doc) {
+      // When a document is deleted via DELETE call, CouchDB doesn't save the whole body of the doc in the tombstone,
+      // just the _id, _rev, and _deleted flag.
+      if (Object.keys(doc).length === 3 && doc._deleted) {
+        return _contains(listName, doc);
+      }
+
+      return false;
+    }
+
     function refreshAll() {
       var i, now = new Date();
 
@@ -521,6 +531,7 @@ angular.module('inboxServices').factory('LiveList',
         initialised: _.partial(_initialised, name),
         setSelected: _.partial(_setSelected, name),
         clearSelected: _.partial(_clearSelected, name),
+        isContainedTombstone: _.partial(_isContainedTombstone, name)
       };
 
       return api[name];

--- a/webapp/src/js/services/live-list.js
+++ b/webapp/src/js/services/live-list.js
@@ -469,7 +469,9 @@ angular.module('inboxServices').factory('LiveList',
     function _isContainedTombstone(listName, doc) {
       // When a document is deleted via DELETE call, CouchDB doesn't save the whole body of the doc in the tombstone,
       // just the _id, _rev, and _deleted flag.
-      if (Object.keys(doc).length === 3 && doc._deleted) {
+      // _conflicts, _attachments can be part of the _changes request result
+      var tombstoneProperties = [ '_id', '_rev', '_deleted', '_conflicts', '_attachments' ];
+      if (!_.difference(Object.keys(doc), tombstoneProperties).length && doc._deleted) {
         return _contains(listName, doc);
       }
 

--- a/webapp/src/js/services/live-list.js
+++ b/webapp/src/js/services/live-list.js
@@ -467,11 +467,16 @@ angular.module('inboxServices').factory('LiveList',
     }
 
     function _isContainedTombstone(listName, doc) {
+      var arrayIncludes = function(array1, array2) {
+        return array2.every(function(elem) {
+          return array1.indexOf(elem) !== -1;
+        });
+      };
       // When a document is deleted via DELETE call, CouchDB doesn't save the whole body of the doc in the tombstone,
       // just the _id, _rev, and _deleted flag.
       // _conflicts, _attachments can be part of the _changes request result
       var tombstoneProperties = [ '_id', '_rev', '_deleted', '_conflicts', '_attachments' ];
-      if (!_.difference(Object.keys(doc), tombstoneProperties).length && doc._deleted) {
+      if (arrayIncludes(tombstoneProperties, Object.keys(doc)) && doc._deleted) {
         return _contains(listName, doc);
       }
 

--- a/webapp/tests/karma/unit/controllers/contacts.js
+++ b/webapp/tests/karma/unit/controllers/contacts.js
@@ -53,7 +53,8 @@ describe('Contacts controller', () => {
           return elements.pop();
         }
         return false;
-      }
+      },
+      isContainedTombstone: sinon.stub()
     };
   };
 
@@ -525,6 +526,7 @@ describe('Contacts controller', () => {
         assert.equal(changesFilter({ doc: { type: 'clinic' } }), true);
         assert.equal(changesFilter({ doc: { type: 'health_center' } }), true);
         assert.equal(changesFilter({ doc: { type: 'district_hospital' } }), true);
+        assert.equal(contactsLiveList.isContainedTombstone.callCount, 0);
       });
     });
 
@@ -533,6 +535,7 @@ describe('Contacts controller', () => {
         assert.isNotOk(changesFilter({ doc: { } }));
         assert.isNotOk(changesFilter({ doc: { type: 'data_record' } }));
         assert.isNotOk(changesFilter({ doc: { type: '' } }));
+        assert.equal(contactsLiveList.isContainedTombstone.callCount, 3);
       });
     });
 
@@ -567,6 +570,15 @@ describe('Contacts controller', () => {
           changesCallback({ deleted: true });
           assert.equal(searchService.args[1][2].limit, 30);
         });
+    });
+
+    it('filtering returns true for contained tombstones', () => {
+      contactsLiveList.isContainedTombstone.returns(true);
+      return createController()
+        .getSetupPromiseForTesting()
+        .then(() => {
+          assert.equal(changesFilter({ doc: { } }), true);
+      });
     });
   });
 });

--- a/webapp/tests/karma/unit/services/live-list.js
+++ b/webapp/tests/karma/unit/services/live-list.js
@@ -133,6 +133,7 @@ describe('LiveListSrv', function() {
       'initialised',
       'setSelected',
       'clearSelected',
+      'isContainedTombstone'
     ]);
   });
 
@@ -505,4 +506,40 @@ describe('LiveListSrv', function() {
       ]);
     });
   });
+
+  describe('isContainedTombstone', () => {
+    beforeEach(function() {
+      var config = {
+        listItem: SIMPLE_LIST_ITEM,
+        orderBy: SIMPLE_ORDER_FUNCTION,
+        selector: '#list',
+      };
+      service.$listFor('testing', config);
+    });
+
+    it('returns false for non-tombstone, not deleted docs', () => {
+      const doc = { _id: 'a', _rev: 'b', name: 'something' };
+      assert.equal(service.testing.isContainedTombstone(doc), false);
+
+      const doc2 = { _id: 'a', _rev: 'b', name: 'something', lastname: 'else' };
+      assert.equal(service.testing.isContainedTombstone(doc2), false);
+    });
+
+    it('returns false for non-tombstone, deleted docs', () => {
+      const doc = { _id: 'a', _rev: 'b', name: 'something', reported: 'now', _deleted: true };
+      assert.equal(service.testing.isContainedTombstone(doc), false);
+    });
+
+    it('returns false for tombstone deleted not-contained docs', () => {
+      const doc = { _id: 'a', _rev: 'b', _deleted: true };
+      assert.equal(service.testing.isContainedTombstone(doc), false);
+    });
+
+    it('returns true for tombstone deleted docs', () => {
+      const doc = { _id: 'a', _rev: 'b', _deleted: true };
+      service.testing.set([{ _id: 'a' }]);
+      assert.equal(service.testing.isContainedTombstone(doc), true);
+    });
+  });
+
 });


### PR DESCRIPTION
# Description

When a doc is deleted via a `DELETE` call, CouchDB only saves a stubbed version of the doc (containing just `_id`, `_rev` and `_deleted: true` flag).

When such a change was received by `webapp`'s listeners, it was not filtered as relevant, since the attached `doc` didn't have the required properties, so the `LiveList` was not updated. This modifies the `webapp` changes listeners to check for delete stubs which exist in the `LiveList`.

Updates `tombstone-utils` shared library so it will try save the previous revision of delete-stubs as the `tombstone`, so offline users will replicate the `DELETE`s. 

medic/medic-webapp#4754

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.