### PR TITLE
Adding phone validation types

### DIFF
--- a/shared-libs/phone-number/src/phone-number.js
+++ b/shared-libs/phone-number/src/phone-number.js
@@ -9,6 +9,17 @@ var _init = function(settings, phone) {
   var countryCode = settings && settings.default_country_code;
   var regionCode = instance.getRegionCodeForCountryCode(countryCode);
   var parsed = instance.parseAndKeepRawInput(phone, regionCode);
+  var validationType = ((settings && settings.phone_validation) || '').toLowerCase();
+
+  function validPhone(){
+    if (validationType === 'partial') {
+      return instance.isPossibleNumber(parsed);
+    }
+    if(validationType === 'none') {
+      return true;
+    }
+    return instance.isValidNumber(parsed);
+  }
 
   return {
     format: function(scheme) {
@@ -25,7 +36,7 @@ var _init = function(settings, phone) {
       return instance.format(parsed, scheme).toString();
     },
     validate: function() {
-      return instance.isValidNumber(parsed) &&
+      return validPhone() &&
         // Disallow alpha numbers which libphonenumber considers valid,
         // e.g. 1-800-MICROSOFT.
         !phone.match(CHARACTER_REGEX);

--- a/shared-libs/phone-number/test/libphonenumber.spec.js
+++ b/shared-libs/phone-number/test/libphonenumber.spec.js
@@ -73,7 +73,7 @@ describe('libphonenumber', () => {
     assert.isFalse(actual);
   });
 
-  // Correct for libphonenumber weirdness : 
+  // Correct for libphonenumber weirdness :
   // For some reason, '<validnumber>a' or '<validnumber>aa' is valid for libphonenumber.
   // Issue : https://github.com/googlei18n/libphonenumber/issues/328
   it('normalize returns false for invalid number - two extra letters - trailing', () => {
@@ -112,6 +112,19 @@ describe('libphonenumber', () => {
     assert.equal(actual, expected);
   });
 
+  it('validation types', () => {
+    var xsettings = {default_country_code: COUNTRY_CODES.new_zealand};
+    // Default validation (full)
+    assert.isFalse(phonenumber.validate(xsettings, '123'));
+    xsettings.phone_validation = 'partial';
+    assert.isFalse(phonenumber.validate(xsettings, '123456'));
+    assert.isTrue(phonenumber.validate(xsettings, '1234567'));
+    xsettings.phone_validation = 'none';
+    assert.isTrue(phonenumber.validate(xsettings, '123'));
+    xsettings.phone_validation = 'whatever';
+    assert.isFalse(phonenumber.validate(xsettings, '123'));
+  });
+
   it('validate returns false for empty number', () => {
     var actual = phonenumber.validate(settings, '');
     assert.isFalse(actual);
@@ -144,7 +157,7 @@ describe('libphonenumber', () => {
     assert.isFalse(actual);
   });
 
-  // Correct for libphonenumber weirdness : 
+  // Correct for libphonenumber weirdness :
   // For some reason, '<validnumber>a' or '<validnumber>aa' is valid for libphonenumber.
   // Issue : https://github.com/googlei18n/libphonenumber/issues/328
   it('validate returns false for invalid number - two extra letters - trailing', () => {


### PR DESCRIPTION
# Description

Adding support for phone validation partial and none.

medic/medic-webapp#4127

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.