### PR TITLE
 Process CouchDB delete-stubs correctly in LiveList and TombstoneUtils

### DIFF
--- a/api/src/services/authorization.js
+++ b/api/src/services/authorization.js
@@ -263,5 +263,6 @@ module.exports = {
   convertTombstoneIds: convertTombstoneIds,
   alwaysAllowCreate: alwaysAllowCreate,
   updateContext: updateContext,
-  filterAllowedDocs: filterAllowedDocs
+  filterAllowedDocs: filterAllowedDocs,
+  isDeleteStub: tombstoneUtils._isDeleteStub
 };

--- a/api/src/services/bulk-get.js
+++ b/api/src/services/bulk-get.js
@@ -9,7 +9,8 @@ const filterResults = (authorizationContext, result) => {
       if (!doc.ok) {
         return false;
       }
-      return authorization.allowedDoc(resultDocs.id, authorizationContext, authorization.getViewResults(doc.ok));
+      return authorization.allowedDoc(resultDocs.id, authorizationContext, authorization.getViewResults(doc.ok)) ||
+             authorization.isDeleteStub(doc.ok);
     });
     return resultDocs.docs.length;
   });

--- a/api/src/services/db-doc.js
+++ b/api/src/services/db-doc.js
@@ -13,6 +13,9 @@ const getStoredDoc = (params, method, query, isAttachment) => {
   // `db-doc` PUT and DELETE requests will require latest `rev` to be allowed
   if ((method === 'GET' || isAttachment) && query) {
     options = query;
+    if (options.open_revs) {
+      options.open_revs = JSON.parse(options.open_revs);
+    }
   }
 
   return db.medic
@@ -57,9 +60,12 @@ module.exports = {
           return false;
         }
 
+        console.log(requestDoc, storedDoc);
+
         // user must be allowed to see existent document
         if (storedDoc &&
-            !authorization.allowedDoc(storedDoc._id, authorizationContext, authorization.getViewResults(storedDoc))) {
+            !authorization.allowedDoc(storedDoc._id, authorizationContext, authorization.getViewResults(storedDoc)) &&
+            !authorization.isDeleteStub(storedDoc)) {
           return false;
         }
 

--- a/api/src/services/db-doc.js
+++ b/api/src/services/db-doc.js
@@ -13,9 +13,6 @@ const getStoredDoc = (params, method, query, isAttachment) => {
   // `db-doc` PUT and DELETE requests will require latest `rev` to be allowed
   if ((method === 'GET' || isAttachment) && query) {
     options = query;
-    if (options.open_revs) {
-      options.open_revs = JSON.parse(options.open_revs);
-    }
   }
 
   return db.medic

--- a/api/src/services/db-doc.js
+++ b/api/src/services/db-doc.js
@@ -57,8 +57,6 @@ module.exports = {
           return false;
         }
 
-        console.log(requestDoc, storedDoc);
-
         // user must be allowed to see existent document
         if (storedDoc &&
             !authorization.allowedDoc(storedDoc._id, authorizationContext, authorization.getViewResults(storedDoc)) &&

--- a/api/tests/mocha/services/bulk-get.spec.js
+++ b/api/tests/mocha/services/bulk-get.spec.js
@@ -16,6 +16,7 @@ describe('Bulk Get service', () => {
     sinon.stub(authorization, 'getAuthorizationContext').resolves({});
     sinon.stub(authorization, 'allowedDoc').returns(true);
     sinon.stub(authorization, 'getViewResults').callsFake(doc => ({ view: doc }));
+    sinon.stub(authorization, 'isDeleteStub').returns(false);
     sinon.stub(db.medic, 'bulkGet').resolves({ results: [] });
   });
 
@@ -57,9 +58,9 @@ describe('Bulk Get service', () => {
     });
 
     it('filters request docs, excluding error and not allowed docs', () => {
-      docs = [{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }, { id: 'e' }, { id: 'f' }];
+      docs = [{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }, { id: 'e' }, { id: 'f' }, { id: 'g' }];
       db.medic.bulkGet
-        .withArgs({ docs: [{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }, { id: 'e' }, { id: 'f' }] })
+        .withArgs({ docs: [{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }, { id: 'e' }, { id: 'f' }, { id: 'g' }] })
         .resolves({ results:
             [
               { id: 'a', docs: [ { ok: { id: 'a', rev: 1 } }, { error: { id: 'a', rev: 2 } }, { ok: { id: 'a', rev: 3 } } ] },
@@ -68,6 +69,7 @@ describe('Bulk Get service', () => {
               { id: 'd', docs: [ { ok: { id: 'd' } } ] },
               { id: 'e', docs: [ { ok: { id: 'e' } } ] },
               { id: 'f', docs: [ { error: { id: 'f' } } ] },
+              { id: 'g', docs: [ { ok: { id: 'g' } } ] },
             ]});
 
       authorization.getAuthorizationContext.withArgs({ name: 'user' }).resolves({ });
@@ -78,22 +80,33 @@ describe('Bulk Get service', () => {
         .withArgs('b', sinon.match.any, { view: { id: 'b', rev: 2 }}).returns(true)
         .withArgs('b', sinon.match.any, { view: { id: 'b', rev: 3 }}).returns(false)
         .withArgs('d').returns(true)
-        .withArgs('e').returns(false);
+        .withArgs('e').returns(false)
+        .withArgs('g').returns(false);
+
+      authorization.isDeleteStub.withArgs({ id: 'g' }).returns(true);
 
       return service
         .filterOfflineRequest(userCtx, query, docs)
         .then(result => {
           authorization.getAuthorizationContext.callCount.should.equal(1);
-          authorization.allowedDoc.callCount.should.equal(7);
+          authorization.allowedDoc.callCount.should.equal(8);
+          authorization.isDeleteStub.callCount.should.equal(5);
+          authorization.isDeleteStub.args.should.deep.equal([
+            [{ id: 'a', rev: 1 }], [{ id: 'a', rev: 3 }],
+            [{ id: 'b', rev: 3 }],
+            [{ id: 'e' }],
+            [{ id: 'g' }]
+          ]);
 
           db.medic.bulkGet.callCount.should.equal(1);
           db.medic.bulkGet.args[0][0].should.deep.equal(
-            { docs: [{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }, { id: 'e' }, { id: 'f' }]});
+            { docs: [{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }, { id: 'e' }, { id: 'f' }, { id: 'g' }]});
 
           result.should.deep.equal({
             results: [
               { id: 'b', docs: [ { ok: { id: 'b', rev: 1 } }, { ok: { id: 'b', rev: 2 } } ] },
-              { id: 'd', docs: [ { ok: { id: 'd' } } ] }
+              { id: 'd', docs: [ { ok: { id: 'd' } } ] },
+              { id: 'g', docs: [ { ok: { id: 'g' } } ] }
             ]
           });
         });

--- a/shared-libs/tombstone-utils/test/tombstone-utils.js
+++ b/shared-libs/tombstone-utils/test/tombstone-utils.js
@@ -1,6 +1,7 @@
 var sinon = require('sinon'),
     lib = require('../src/tombstone-utils'),
     expect = require('chai').expect,
+    _ = require('underscore'),
     DB;
 
 describe('Tombstone Utils Lib', function() {
@@ -46,11 +47,11 @@ describe('Tombstone Utils Lib', function() {
       var healthCenter = { _id: 'healthCenterId', _rev: 'healthCenterRev', type: 'health_center' };
       var report = { _id: 'reportId', _rev: 'reportRev', type: 'data_record' };
 
-      DB.get.withArgs(person._id).resolves(person);
-      DB.get.withArgs(clinic._id).resolves(clinic);
-      DB.get.withArgs(districtHospital._id).resolves(districtHospital);
-      DB.get.withArgs(healthCenter._id).resolves(healthCenter);
-      DB.get.withArgs(report._id).resolves(report);
+      DB.get.withArgs(person._id).resolves(_.extend({ _revisions: 'something' }, person));
+      DB.get.withArgs(clinic._id).resolves(_.extend({ _revisions: 'something' }, clinic));
+      DB.get.withArgs(districtHospital._id).resolves(_.extend({ _revisions: 'something' }, districtHospital));
+      DB.get.withArgs(healthCenter._id).resolves(_.extend({ _revisions: 'something' }, healthCenter));
+      DB.get.withArgs(report._id).resolves(_.extend({ _revisions: 'something' }, report));
 
       DB.put.resolves();
       var personChange = { id: 'personId', deleted: true, changes: [{ rev: 'personRev' }] };
@@ -69,11 +70,11 @@ describe('Tombstone Utils Lib', function() {
         ])
         .then(function() {
           expect(DB.get.callCount).to.equal(5);
-          expect(DB.get.args[0]).to.deep.equal([ 'personId', { rev: 'personRev' } ]);
-          expect(DB.get.args[1]).to.deep.equal([ 'clinicId', { rev: 'clinicRev' } ]);
-          expect(DB.get.args[2]).to.deep.equal([ 'districtHospitalId', { rev: 'districtHospitalRev' } ]);
-          expect(DB.get.args[3]).to.deep.equal([ 'healthCenterId', { rev: 'healthCenterRev' } ]);
-          expect(DB.get.args[4]).to.deep.equal([ 'reportId', { rev: 'reportRev' } ]);
+          expect(DB.get.args[0]).to.deep.equal([ 'personId', { rev: 'personRev', revs: true } ]);
+          expect(DB.get.args[1]).to.deep.equal([ 'clinicId', { rev: 'clinicRev', revs: true } ]);
+          expect(DB.get.args[2]).to.deep.equal([ 'districtHospitalId', { rev: 'districtHospitalRev', revs: true } ]);
+          expect(DB.get.args[3]).to.deep.equal([ 'healthCenterId', { rev: 'healthCenterRev', revs: true } ]);
+          expect(DB.get.args[4]).to.deep.equal([ 'reportId', { rev: 'reportRev', revs: true } ]);
 
           expect(DB.put.callCount).to.equal(5);
           expect(DB.put.args[0]).to.deep.equal([{
@@ -112,12 +113,12 @@ describe('Tombstone Utils Lib', function() {
       var tombstone = {_id: 'tombstone', _rev: 'tombstoneRev', type: 'tombstone'};
       var translation = {_id: 'translation', _rev: 'translationRev', type: 'translations'};
 
-      DB.get.withArgs(notype._id).resolves(notype);
-      DB.get.withArgs(form._id).resolves(form);
-      DB.get.withArgs(feedback._id).resolves(feedback);
-      DB.get.withArgs(info._id).resolves(info);
-      DB.get.withArgs(tombstone._id).resolves(tombstone);
-      DB.get.withArgs(translation._id).resolves(translation);
+      DB.get.withArgs(notype._id).resolves(_.extend({ _revisions: 'something' }, notype));
+      DB.get.withArgs(form._id).resolves(_.extend({ _revisions: 'something' }, form));
+      DB.get.withArgs(feedback._id).resolves(_.extend({ _revisions: 'something' }, feedback));
+      DB.get.withArgs(info._id).resolves(_.extend({ _revisions: 'something' }, info));
+      DB.get.withArgs(tombstone._id).resolves(_.extend({ _revisions: 'something' }, tombstone));
+      DB.get.withArgs(translation._id).resolves(_.extend({ _revisions: 'something' }, translation));
 
       DB.put.resolves();
       var notypeChange = {id: 'doc1', deleted: true, changes: [{rev: 'doc1Rev'}]};
@@ -138,12 +139,12 @@ describe('Tombstone Utils Lib', function() {
         ])
         .then(function () {
           expect(DB.get.callCount).to.equal(6);
-          expect(DB.get.args[0]).to.deep.equal(['doc1', {rev: 'doc1Rev'}]);
-          expect(DB.get.args[1]).to.deep.equal(['form', {rev: 'formRev'}]);
-          expect(DB.get.args[2]).to.deep.equal(['feedback', {rev: 'feedbackRev'}]);
-          expect(DB.get.args[3]).to.deep.equal(['info', {rev: 'infoRev'}]);
-          expect(DB.get.args[4]).to.deep.equal(['tombstone', {rev: 'tombstoneRev'}]);
-          expect(DB.get.args[5]).to.deep.equal(['translation', {rev: 'translationRev'}]);
+          expect(DB.get.args[0]).to.deep.equal(['doc1', {rev: 'doc1Rev', revs: true}]);
+          expect(DB.get.args[1]).to.deep.equal(['form', {rev: 'formRev', revs: true}]);
+          expect(DB.get.args[2]).to.deep.equal(['feedback', {rev: 'feedbackRev', revs: true}]);
+          expect(DB.get.args[3]).to.deep.equal(['info', {rev: 'infoRev', revs: true}]);
+          expect(DB.get.args[4]).to.deep.equal(['tombstone', {rev: 'tombstoneRev', revs: true}]);
+          expect(DB.get.args[5]).to.deep.equal(['translation', {rev: 'translationRev', revs: true}]);
 
           expect(DB.put.callCount).to.equal(5);
           expect(DB.put.args[0]).to.deep.equal([{
@@ -216,6 +217,104 @@ describe('Tombstone Utils Lib', function() {
           expect(err.name).to.equal('some other error');
         });
     });
+
+    it('saves change.doc if provided', function() {
+      var change = {
+        id: 'id',
+        deleted: true,
+        changes: [{ rev: '2' }], doc: { _id: 'id', _rev: '2', some: 'thing', _deleted: true }
+      };
+      DB.put.resolves();
+
+      return lib
+        .processChange(Promise, DB, change)
+        .then(function() {
+          expect(DB.get.callCount).to.equal(0);
+          expect(DB.put.callCount).to.equal(1);
+          expect(DB.put.args[0]).to.deep.equal([{
+            _id: 'id____2____tombstone',
+            type: 'tombstone',
+            tombstone: { _id: 'id', _rev: '2', some: 'thing' }
+          }]);
+        });
+    });
+
+    describe('for CouchDB tombstone stubs', function() {
+      it('saves previous version of doc content for CouchDB generated tombstones', function() {
+        var doc = [ { _id: 'id', _rev: '5-rev', _deleted: true }, { _id: 'id', _rev: '4-prev', 'some': 'thing' } ],
+            revisions = { start: 5, ids: ['rev', 'prev', '1', '2', '3'] },
+            change = { id: 'id', deleted: true, changes: [{ rev: '5-rev' }, { rev: '3-1' }] };
+
+        DB.put.resolves();
+        DB.get
+          .withArgs('id', { rev: '5-rev', revs: true })
+          .resolves(_.extend({ _revisions: revisions }, doc[0]));
+        DB.get
+          .withArgs('id', { rev: '4-prev' })
+          .resolves(doc[1]);
+        return lib
+          .processChange(Promise, DB, change)
+          .then(function() {
+            expect(DB.get.callCount).to.equal(2);
+            expect(DB.get.args[0]).to.deep.equal([ 'id', { rev: '5-rev', revs: true } ]);
+            expect(DB.get.args[1]).to.deep.equal([ 'id', { rev: '4-prev' } ]);
+            expect(DB.put.callCount).to.equal(1);
+            expect(DB.put.args[0]).to.deep.equal([{
+              _id: 'id____5-rev____tombstone',
+              type: 'tombstone',
+              tombstone: { _id: 'id', _rev: '4-prev', 'some': 'thing' }
+            }]);
+          });
+      });
+
+      it('saves original version when no previous revisions are available for some reason', function() {
+        var change = { id: 'id', deleted: true, changes: [{ rev: '2-rev' }] };
+        DB.get
+          .withArgs('id', { rev: '2-rev', revs: true })
+          .resolves({ _id: 'id', _rev: '2-rev', _deleted: true, _revisions: false });
+        DB.put.resolves();
+
+        return lib
+          .processChange(Promise, DB, change)
+          .then(function() {
+            expect(DB.get.callCount).to.equal(1);
+            expect(DB.get.args[0]).to.deep.equal([ 'id', { rev: '2-rev', revs: true } ]);
+            expect(DB.put.callCount).to.equal(1);
+            expect(DB.put.args[0]).to.deep.equal([{
+              _id: 'id____2-rev____tombstone',
+              type: 'tombstone',
+              tombstone: { _id: 'id', _rev: '2-rev' }
+            }]);
+          });
+      });
+
+      it('saves previous version of doc when change doc is a couchdb tombstone', function() {
+        var doc = [ { _id: 'id', _rev: '5-rev', _deleted: true }, { _id: 'id', _rev: '4-prev', 'some': 'thing' } ],
+            revisions = { start: 5, ids: ['rev', 'prev', '1', '2', '3'] },
+            change = { id: 'id', deleted: true, changes: [{ rev: '5-rev' }, { rev: '3-1' }], doc: doc[0] };
+
+        DB.put.resolves();
+        DB.get
+          .withArgs('id', { rev: '5-rev', revs: true })
+          .resolves(_.extend({ _revisions: revisions }, doc[0]));
+        DB.get
+          .withArgs('id', { rev: '4-prev' })
+          .resolves(doc[1]);
+        return lib
+          .processChange(Promise, DB, change)
+          .then(function() {
+            expect(DB.get.callCount).to.equal(2);
+            expect(DB.get.args[0]).to.deep.equal([ 'id', { rev: '5-rev', revs: true } ]);
+            expect(DB.get.args[1]).to.deep.equal([ 'id', { rev: '4-prev' } ]);
+            expect(DB.put.callCount).to.equal(1);
+            expect(DB.put.args[0]).to.deep.equal([{
+              _id: 'id____5-rev____tombstone',
+              type: 'tombstone',
+              tombstone: { _id: 'id', _rev: '4-prev', 'some': 'thing' }
+            }]);
+          });
+      });
+    });
   });
 
   describe('generateChangeFromTombstone', function() {
@@ -242,5 +341,57 @@ describe('Tombstone Utils Lib', function() {
       expect(lib.generateChangeFromTombstone(changeWithDoc, true))
         .to.deep.equal({ id: 'id', changes:[{ rev: 'rev' }], deleted: true, seq: undefined, doc: { _id: 'id', _rev: 'rev' }});
     });
+  });
+
+  describe('isDeleteStub', function() {
+    it('returns false for docs that have properties', function() {
+      expect(lib._isDeleteStub({ _id: 'a', some: 'thing' })).to.equal(false);
+      expect(lib._isDeleteStub({ _id: 'a', some: 'thing', _rev: '1' })).to.equal(false);
+    });
+
+    it('returns false for docs that are not deleted', function() {
+      expect(lib._isDeleteStub({ _id: 'a', _rev: 'thing' })).to.equal(false);
+      expect(lib._isDeleteStub({ _id: 'a', _rev: 'thing', _deleted: false })).to.equal(false);
+    });
+
+    it('returns true for couchDB tombstones', function() {
+      var doc = {
+        _id: 'id',
+        _rev: 'rev',
+        _revisions: 'a',
+        _attachments: 'b',
+        _conflicts: 'c',
+        _deleted: true
+      };
+
+      expect(lib._isDeleteStub(doc)).to.equal(true);
+      doc._deleted = false;
+      expect(lib._isDeleteStub(doc)).to.equal(false);
+      doc._deleted = true;
+      doc.a = 'something';
+      expect(lib._isDeleteStub(doc)).to.equal(false);
+    });
+  });
+
+  describe('getPreviousRev', function() {
+    it('returns false when rev is missing', function() {
+      expect(lib._getPreviousRev(false)).to.equal(false);
+      expect(lib._getPreviousRev(undefined)).to.equal(false);
+      expect(lib._getPreviousRev({})).to.equal(false);
+      expect(lib._getPreviousRev({ start: 1 })).to.equal(false);
+      expect(lib._getPreviousRev({ start: 2 })).to.equal(false);
+      expect(lib._getPreviousRev({ start: 2, ids: [] })).to.equal(false);
+      expect(lib._getPreviousRev({ start: 2, ids: ['a'] })).to.equal(false);
+      expect(lib._getPreviousRev({ start: 1, ids: ['a', 'b', 'c'] })).to.equal(false);
+    });
+
+    it('returns previous rev', function() {
+      expect(lib._getPreviousRev({ start: 2, ids: ['a', 'b'] })).to.equal('1-b');
+      expect(lib._getPreviousRev({ start: 720, ids: ['a', 'b', 'c', 'd', 'e', 'f'] })).to.equal('719-b');
+      expect(lib._getPreviousRev({ start: 10, ids: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] })).to.equal('9-2');
+      expect(lib._getPreviousRev({ start: 500, ids: [500, 499, 498, 497, 496, 495, 494, 493] })).to.equal('499-499');
+    });
+
+
   });
 });

--- a/webapp/src/js/controllers/contacts.js
+++ b/webapp/src/js/controllers/contacts.js
@@ -354,7 +354,8 @@ var _ = require('underscore'),
           _query({ limit: limit, silent: true });
         },
         filter: function(change) {
-          return ContactSchema.getTypes().indexOf(change.doc.type) !== -1;
+          return ContactSchema.getTypes().indexOf(change.doc.type) !== -1 ||
+                 liveList.containsDeleteStub(change.doc);
         }
       });
 

--- a/webapp/src/js/controllers/reports.js
+++ b/webapp/src/js/controllers/reports.js
@@ -476,7 +476,8 @@ angular.module('inboxControllers').controller('ReportsCtrl',
         }
       },
       filter: function(change) {
-        return change.doc.form;
+        return change.doc.form ||
+               liveList.containsDeleteStub(change.doc);
       }
     });
 

--- a/webapp/src/js/services/live-list.js
+++ b/webapp/src/js/services/live-list.js
@@ -466,6 +466,21 @@ angular.module('inboxServices').factory('LiveList',
       delete idx.selected;
     }
 
+    function _containsDeleteStub(listName, doc) {
+      // determines if array2 is included in array1
+      var arrayIncludes = function(array1, array2) {
+        return array2.every(function(elem) {
+          return array1.indexOf(elem) !== -1;
+        });
+      };
+      // CouchDB/Fauxton deletes don't include doc fields in the deleted revision
+      // _conflicts, _attachments can be part of the _changes request result
+      var stubProps = [ '_id', '_rev', '_deleted', '_conflicts', '_attachments' ];
+      return arrayIncludes(stubProps, Object.keys(doc)) &&
+             !!doc._deleted &&
+             _contains(listName, doc);
+    }
+
     function refreshAll() {
       var i, now = new Date();
 
@@ -521,6 +536,7 @@ angular.module('inboxServices').factory('LiveList',
         initialised: _.partial(_initialised, name),
         setSelected: _.partial(_setSelected, name),
         clearSelected: _.partial(_clearSelected, name),
+        containsDeleteStub: _.partial(_containsDeleteStub, name)
       };
 
       return api[name];

--- a/webapp/tests/karma/unit/controllers/contacts.js
+++ b/webapp/tests/karma/unit/controllers/contacts.js
@@ -53,7 +53,8 @@ describe('Contacts controller', () => {
           return elements.pop();
         }
         return false;
-      }
+      },
+      containsDeleteStub: sinon.stub()
     };
   };
 
@@ -525,6 +526,7 @@ describe('Contacts controller', () => {
         assert.equal(changesFilter({ doc: { type: 'clinic' } }), true);
         assert.equal(changesFilter({ doc: { type: 'health_center' } }), true);
         assert.equal(changesFilter({ doc: { type: 'district_hospital' } }), true);
+        assert.equal(contactsLiveList.containsDeleteStub.callCount, 0);
       });
     });
 
@@ -533,6 +535,7 @@ describe('Contacts controller', () => {
         assert.isNotOk(changesFilter({ doc: { } }));
         assert.isNotOk(changesFilter({ doc: { type: 'data_record' } }));
         assert.isNotOk(changesFilter({ doc: { type: '' } }));
+        assert.equal(contactsLiveList.containsDeleteStub.callCount, 3);
       });
     });
 
@@ -567,6 +570,15 @@ describe('Contacts controller', () => {
           changesCallback({ deleted: true });
           assert.equal(searchService.args[1][2].limit, 30);
         });
+    });
+
+    it('filtering returns true for contained tombstones', () => {
+      contactsLiveList.containsDeleteStub.returns(true);
+      return createController()
+        .getSetupPromiseForTesting()
+        .then(() => {
+          assert.equal(changesFilter({ doc: { } }), true);
+      });
     });
   });
 });

--- a/webapp/tests/karma/unit/controllers/reports.js
+++ b/webapp/tests/karma/unit/controllers/reports.js
@@ -13,7 +13,8 @@ describe('ReportsCtrl controller', () => {
       Search,
       Changes,
       FormatDataRecord,
-      changesCallback;
+      changesCallback,
+      changesFilter;
 
   beforeEach(module('inboxApp'));
 
@@ -40,7 +41,10 @@ describe('ReportsCtrl controller', () => {
     };
     LiveList = { reports: {
       initialised: () => true,
-      setSelected: sinon.stub()
+      setSelected: sinon.stub(),
+      containsDeleteStub: sinon.stub(),
+      remove: sinon.stub(),
+      count: sinon.stub()
     }};
     MarkRead = () => {};
     FormatDataRecord = data => {
@@ -54,16 +58,16 @@ describe('ReportsCtrl controller', () => {
       };
     };
 
-    Search = (type, filters, options, callback) => {
-      callback(null, { });
-    };
+    Search = sinon.stub().resolves();
 
-    Changes = options => {
+    Changes = sinon.stub().callsFake(options => {
       changesCallback = options.callback;
+      changesFilter = options.filter;
       return { unsubscribe: () => {} };
-    };
+    });
 
     changesCallback = undefined;
+    changesFilter = undefined;
 
     createController = () => {
       return $controller('ReportsCtrl', {
@@ -257,6 +261,67 @@ describe('ReportsCtrl controller', () => {
           name: 'hello',
           verified: undefined
         }]);
+      });
+    });
+  });
+
+  describe('Changes listener', () => {
+    it('subscribes to changes', () => {
+      createController();
+      return Promise.resolve().then(() => {
+        chai.expect(Changes.callCount).to.equal(1);
+      });
+    });
+
+    it('filters reports', () => {
+      createController();
+
+      return Promise.resolve().then(() => {
+        const change = { doc: { form: 'something' } };
+        chai.expect(!!changesFilter(change)).to.equal(true);
+        chai.expect(LiveList.reports.containsDeleteStub.callCount).to.equal(0);
+      });
+    });
+
+    it('filters contained tombstones', () => {
+      createController();
+
+      return Promise.resolve().then(() => {
+        const change = { doc: { type: 'this is not a form' } };
+        LiveList.reports.containsDeleteStub.returns(true);
+        chai.expect(!!changesFilter(change)).to.equal(true);
+        chai.expect(LiveList.reports.containsDeleteStub.callCount).to.equal(1);
+        chai.expect(LiveList.reports.containsDeleteStub.args[0]).to.deep.equal([ change.doc ]);
+      });
+    });
+
+    it('filters everything else', () => {
+      createController();
+      LiveList.reports.containsDeleteStub.returns(false);
+
+      return Promise.resolve().then(() => {
+        chai.expect(!!changesFilter({ doc: { some: 'thing' } })).to.equal(false);
+      });
+    });
+
+    it('removes deleted reports from the list', () => {
+      createController();
+
+      return Promise.resolve().then(() => {
+        changesCallback({ deleted: true, doc: { _id: 'id' } });
+        chai.expect(LiveList.reports.remove.callCount).to.equal(1);
+        chai.expect(LiveList.reports.remove.args[0]).to.deep.equal([ { _id: 'id' } ]);
+        chai.expect(Search.callCount).to.equal(0);
+      });
+    });
+
+    it('refreshes list', () => {
+      createController();
+
+      return Promise.resolve().then(() => {
+        changesCallback({ doc: { _id: 'id' } });
+        chai.expect(LiveList.reports.remove.callCount).to.equal(0);
+        chai.expect(Search.callCount).to.equal(1);
       });
     });
   });

--- a/webapp/tests/karma/unit/services/live-list.js
+++ b/webapp/tests/karma/unit/services/live-list.js
@@ -133,6 +133,7 @@ describe('LiveListSrv', function() {
       'initialised',
       'setSelected',
       'clearSelected',
+      'containsDeleteStub'
     ]);
   });
 
@@ -505,4 +506,40 @@ describe('LiveListSrv', function() {
       ]);
     });
   });
+
+  describe('containsDeleteStub', () => {
+    beforeEach(function() {
+      var config = {
+        listItem: SIMPLE_LIST_ITEM,
+        orderBy: SIMPLE_ORDER_FUNCTION,
+        selector: '#list',
+      };
+      service.$listFor('testing', config);
+    });
+
+    it('returns false for non-tombstone, not deleted docs', () => {
+      const doc = { _id: 'a', _rev: 'b', name: 'something' };
+      assert.equal(service.testing.containsDeleteStub(doc), false);
+
+      const doc2 = { _id: 'a', _rev: 'b', name: 'something', lastname: 'else' };
+      assert.equal(service.testing.containsDeleteStub(doc2), false);
+    });
+
+    it('returns false for non-tombstone, deleted docs', () => {
+      const doc = { _id: 'a', _rev: 'b', name: 'something', reported: 'now', _deleted: true };
+      assert.equal(service.testing.containsDeleteStub(doc), false);
+    });
+
+    it('returns false for tombstone deleted not-contained docs', () => {
+      const doc = { _id: 'a', _rev: 'b', _deleted: true };
+      assert.equal(service.testing.containsDeleteStub(doc), false);
+    });
+
+    it('returns true for tombstone deleted docs', () => {
+      const doc = { _id: 'a', _rev: 'b', _deleted: true };
+      service.testing.set([{ _id: 'a' }]);
+      assert.equal(service.testing.containsDeleteStub(doc), true);
+    });
+  });
+
 });


### PR DESCRIPTION
# Description


Process CouchDB delete-stubs correctly in LiveList and TombstoneUtils  …
When a doc is deleted via a DELETE call (or from Fauxton UI), CouchDB
only saves a stubbed version of the doc (containing just _id, _rev and
_deleted: true flag).

When such a change was received by webapp's listeners, it was not
filtered as relevant, since the attached doc didn't have the required
properties, so the LiveList was not updated. This modifies the webapp
changes listeners to filter delete stubs of docs that exist in the
LiveList.

Updates tombstone-utils shared library so it will try to save the
previous revision of delete-stubs as the tombstone, so offline users
will replicate the DELETEs.

Additionally, support restricted offline users, namely:
Offline users db-doc `GET` and `_bulk_get` requests always allow delete stubs. 

medic/medic-webapp#4754

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.