### PR TITLE
Switch back to _users.user from medic.user.

### DIFF
--- a/api/src/auth.js
+++ b/api/src/auth.js
@@ -185,5 +185,15 @@ module.exports = {
     });
   },
 
-  getUserSettings: userCtx => db.medic.get('org.couchdb.user:' + userCtx.name)
+  getUserSettings: userCtx => {
+    return Promise
+      .all([
+        db.users.get('org.couchdb.user:' + userCtx.name),
+        db.medic.get('org.couchdb.user:' + userCtx.name)
+      ])
+      .then(([ user, medicUser ]) => {
+        medicUser.facility_id = user.facility_id;
+        return medicUser;
+      });
+  }
 };

--- a/api/src/db-pouch.js
+++ b/api/src/db-pouch.js
@@ -20,6 +20,16 @@ if(UNIT_TEST_ENV) {
     getAttachment: stubMe('getAttachment'),
     changes: stubMe('changes')
   };
+
+  module.exports.users = {
+    allDocs: stubMe('allDocs'),
+    bulkDocs: stubMe('bulkDocs'),
+    put: stubMe('put'),
+    post: stubMe('post'),
+    query: stubMe('query'),
+    get: stubMe('get'),
+    changes: stubMe('changes')
+  };
 } else if(COUCH_URL) {
   // strip trailing slash from to prevent bugs in path matching
   const couchUrl = COUCH_URL.replace(/\/$/, '');

--- a/api/src/services/authorization.js
+++ b/api/src/services/authorization.js
@@ -10,10 +10,10 @@ const ALL_KEY = '_all', // key in the docs_by_replication_key view for records e
 
 // fake view map, to store only relevant information about user changes
 const couchDbUser = (doc) => {
-  if (doc.type === 'user-settings') {
-    return _.pick(doc, 'contact_id', 'facility_id');
+  if (doc.type !== 'user-settings') {
+    return false;
   }
-  return false;
+  return true;
 };
 
 const getDepth = (userCtx) => {
@@ -183,13 +183,7 @@ const isAuthChange = (docId, userCtx, { couchDbUser }) => {
   if (docId !== 'org.couchdb.user:' + userCtx.name || !couchDbUser) {
     return false;
   }
-
-  if (userCtx.contact_id !== couchDbUser.contact_id ||
-      userCtx.facility_id !== couchDbUser.facility_id) {
-    return true;
-  }
-
-  return false;
+  return true;
 };
 
 module.exports = {

--- a/api/tests/mocha/services/authorization.js
+++ b/api/tests/mocha/services/authorization.js
@@ -228,7 +228,7 @@ describe('Authorization service', () => {
       });
     });
 
-    it('extracts correct information for user-settings docs', () => {
+    it('sets couchDBUser view value as true for user-settings docs', () => {
       const doc = {
         id: 'user',
         type: 'user-settings',
@@ -236,7 +236,7 @@ describe('Authorization service', () => {
         facility_id: 'facility-id'
       };
       const result = service.getViewResults(doc);
-      result.couchDbUser.should.deep.equal({ contact_id: 'contact-id', facility_id: 'facility-id' });
+      result.couchDbUser.should.deep.equal(true);
     });
   });
 
@@ -493,19 +493,16 @@ describe('Authorization service', () => {
     });
 
     describe('isAuthChange', () => {
-      it('returns true if change affects user contact or facility, false otherwise', () => {
+      it('returns true if doc is own user Settings doc, false otherwise', () => {
         const userCtx = { name: 'user', facility_id: 'facility_id', contact_id: 'contact_id' };
-        let viewResults = { couchDbUser: { facility_id: 'new_facility_id', contact_id: 'contact_id' }};
+        let viewResults = { couchDbUser: true };
         service.isAuthChange('org.couchdb.user:user', userCtx, viewResults).should.equal(true);
 
-        viewResults = { couchDbUser: { facility_id: 'new_facility_id', contact_id: 'new_contact_id' }};
-        service.isAuthChange('org.couchdb.user:user', userCtx, viewResults).should.equal(true);
-
-        viewResults = { couchDbUser: { facility_id: 'facility_id', contact_id: 'contact_id' }};
-        service.isAuthChange('org.couchdb.user:user', userCtx, viewResults).should.equal(false);
+        viewResults = { couchDbUser: true };
+        service.isAuthChange('org.couchdb.user:otheruser', userCtx, viewResults).should.equal(false);
 
         viewResults = { couchDbUser: false };
-        service.isAuthChange('someId', userCtx, viewResults).should.equal(false);
+        service.isAuthChange('org.couchdb.user:user', userCtx, viewResults).should.equal(false);
       });
     });
   });


### PR DESCRIPTION
# Description

Reverts to reading user `facility_id` from `_users` doc instead of `medic.user-settings` doc when building authorization context for offline users. 

medic/medic-webapp#4774

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.