### PR TITLE
LiveList full refresh

### DIFF
--- a/static/js/controllers/contacts.js
+++ b/static/js/controllers/contacts.js
@@ -95,7 +95,14 @@ var _ = require('underscore'),
           extensions.sortByLastVisitedDate = true;
         }
 
-        return Search('contacts', actualFilter, options, extensions).then(function(contacts) {
+        var docIds = [];
+        if (options.sendIds) {
+          docIds = liveList.getList().map(function(item) {
+            return item._id;
+          });
+        }
+
+        return Search('contacts', actualFilter, options, extensions, docIds).then(function(contacts) {
           // If you have a home place make sure its at the top
           if (usersHomePlace) {
             var homeIndex = _.findIndex(contacts, function(contact) {
@@ -379,7 +386,9 @@ var _ = require('underscore'),
           if (change.deleted) {
             liveList.remove(change.doc);
           }
-          _query({ limit: limit, silent: true });
+
+          var sendIds = $scope.sortDirection === 'last_visited_date' && !!isRelevantVisitReport(change.doc);
+          return _query({ limit: limit, silent: true, sendIds: sendIds });
         },
         filter: function(change) {
           return ContactSchema.getTypes().indexOf(change.doc.type) !== -1 ||

--- a/static/js/controllers/contacts.js
+++ b/static/js/controllers/contacts.js
@@ -371,23 +371,26 @@ var _ = require('underscore'),
       });
 
       var isRelevantVisitReport = function(doc) {
+        var isRelevantDelete = doc._deleted && $scope.sortDirection === 'last_visited_date';
         return $scope.lastVisitedDateExtras &&
                doc.type === 'data_record' &&
                doc.form &&
                doc.fields &&
                doc.fields.visited_contact_uuid &&
-               liveList.contains({ _id: doc.fields.visited_contact_uuid });
+               (liveList.contains({ _id: doc.fields.visited_contact_uuid }) || isRelevantDelete);
       };
 
       var changeListener = Changes({
         key: 'contacts-list',
         callback: function(change) {
           var limit = liveList.count();
-          if (change.deleted) {
+          if (change.deleted && change.doc.type !== 'data_record') {
             liveList.remove(change.doc);
           }
 
-          var sendIds = $scope.sortDirection === 'last_visited_date' && !!isRelevantVisitReport(change.doc);
+          var sendIds = $scope.sortDirection === 'last_visited_date' &&
+                        !!isRelevantVisitReport(change.doc) &&
+                        !change.deleted;
           return _query({ limit: limit, silent: true, sendIds: sendIds });
         },
         filter: function(change) {

--- a/static/js/services/live-list.js
+++ b/static/js/services/live-list.js
@@ -46,7 +46,7 @@ angular.module('inboxServices').factory('LiveListConfig',
             return;
           }
           if (c1.sortByLastVisitedDate) {
-            return c1.lastVisitedDate < c2.lastVisitedDate;
+            return c1.lastVisitedDate - c2.lastVisitedDate;
           }
           if (c1.simprints && c2.simprints) {
             return c2.simprints.confidence - c1.simprints.confidence;

--- a/static/js/services/search.js
+++ b/static/js/services/search.js
@@ -86,7 +86,7 @@ var _ = require('underscore'),
         });
       };
 
-      return function(type, filters, options, extensions) {
+      return function(type, filters, options, extensions, docIds) {
         $log.debug('Doing Search', type, filters, options, extensions);
 
         options = options || {};
@@ -102,6 +102,9 @@ var _ = require('underscore'),
 
         return _search(type, filters, options, extensions)
           .then(function(searchResults) {
+            if (docIds && docIds.length) {
+              searchResults = _.union(searchResults, docIds);
+            }
             var dataRecordsPromise = GetDataRecords(searchResults, options);
 
             var result;

--- a/static/js/services/search.js
+++ b/static/js/services/search.js
@@ -104,7 +104,9 @@ var _ = require('underscore'),
           .then(function(searchResults) {
             if (docIds && docIds.length) {
               docIds.forEach(function(docId) {
-                return searchResults.indexOf(docId) === -1 && searchResults.push(docId);
+                if (searchResults.indexOf(docId) === -1) {
+                  searchResults.push(docId);
+                }
               });
             }
             var dataRecordsPromise = GetDataRecords(searchResults, options);

--- a/static/js/services/search.js
+++ b/static/js/services/search.js
@@ -103,7 +103,9 @@ var _ = require('underscore'),
         return _search(type, filters, options, extensions)
           .then(function(searchResults) {
             if (docIds && docIds.length) {
-              searchResults = _.union(searchResults, docIds);
+              docIds.forEach(function(docId) {
+                return searchResults.indexOf(docId) === -1 && searchResults.push(docId);
+              });
             }
             var dataRecordsPromise = GetDataRecords(searchResults, options);
 

--- a/tests/karma/unit/controllers/contacts.js
+++ b/tests/karma/unit/controllers/contacts.js
@@ -567,7 +567,7 @@ describe('Contacts controller', () => {
             { types: { selected: ['childType'] } },
             { limit: 50 },
             {},
-            []
+            undefined
           ]);
 
           scope.sortDirection = 'something';
@@ -598,7 +598,7 @@ describe('Contacts controller', () => {
               displayLastVisitedDate: true,
               visitCountSettings: {}
             },
-            []
+            undefined
           ]);
         });
     });
@@ -634,7 +634,7 @@ describe('Contacts controller', () => {
               displayLastVisitedDate: true,
               visitCountSettings: { monthStartDate: false, visitCountGoal: 1 }
             },
-            []
+            undefined
           ]);
         });
     });
@@ -670,7 +670,7 @@ describe('Contacts controller', () => {
               displayLastVisitedDate: true,
               visitCountSettings: { monthStartDate: false, visitCountGoal: 1 }
             },
-            []
+            undefined
           ]);
 
           scope.sortDirection = 'somethingElse';
@@ -712,7 +712,7 @@ describe('Contacts controller', () => {
               visitCountSettings: { monthStartDate: 25, visitCountGoal: 125 },
               sortByLastVisitedDate: true
             },
-            []
+            undefined
           ]);
 
           scope.sortDirection = 'something';
@@ -811,9 +811,9 @@ describe('Contacts controller', () => {
                     assert.deepEqual(searchService.args[i], [
                       'contacts',
                       { types: { selected: ['childType'] } },
-                      { limit: 5, sendIds: false, silent: true },
+                      { limit: 5, withIds: false, silent: true },
                       { displayLastVisitedDate: true, visitCountSettings: {}, },
-                      []
+                      undefined
                     ]);
                   }
                 });
@@ -839,7 +839,7 @@ describe('Contacts controller', () => {
                   assert.deepEqual(searchService.args[1], [
                     'contacts',
                     { types: { selected: ['childType'] } },
-                    { limit: 5, sendIds: true, silent: true },
+                    { limit: 5, withIds: true, silent: true },
                     { displayLastVisitedDate: true, visitCountSettings: {}, sortByLastVisitedDate: true },
                     ['abcde', 0, 1, 2, 3, 4]
                   ]);
@@ -848,9 +848,9 @@ describe('Contacts controller', () => {
                     assert.deepEqual(searchService.args[i], [
                       'contacts',
                       { types: { selected: ['childType'] } },
-                      { limit: 5, sendIds: false, silent: true },
+                      { limit: 5, withIds: false, silent: true },
                       { displayLastVisitedDate: true, visitCountSettings: {}, sortByLastVisitedDate: true },
-                      []
+                      undefined
                     ]);
                   }
                 });
@@ -883,9 +883,9 @@ describe('Contacts controller', () => {
                     assert.deepEqual(searchService.args[i], [
                       'contacts',
                       { types: { selected: ['childType'] } },
-                      { limit: 5, sendIds: false, silent: true },
+                      { limit: 5, withIds: false, silent: true },
                       { displayLastVisitedDate: true, visitCountSettings: {}, },
-                      []
+                      undefined
                     ]);
                   }
                 });
@@ -910,7 +910,7 @@ describe('Contacts controller', () => {
                   assert.deepEqual(searchService.args[1], [
                     'contacts',
                     { types: { selected: ['childType'] } },
-                    { limit: 5, sendIds: true, silent: true },
+                    { limit: 5, withIds: true, silent: true },
                     { displayLastVisitedDate: true, visitCountSettings: {}, sortByLastVisitedDate: true },
                     ['abcde', 0, 1, 2, 3, 4]
                   ]);
@@ -919,9 +919,9 @@ describe('Contacts controller', () => {
                     assert.deepEqual(searchService.args[i], [
                       'contacts',
                       { types: { selected: ['childType'] } },
-                      { limit: 5, sendIds: false, silent: true },
+                      { limit: 5, withIds: false, silent: true },
                       { displayLastVisitedDate: true, visitCountSettings: {}, sortByLastVisitedDate: true },
-                      []
+                      undefined
                     ]);
                   }
                 });
@@ -956,9 +956,9 @@ describe('Contacts controller', () => {
                     assert.deepEqual(searchService.args[i], [
                       'contacts',
                       { types: { selected: ['childType'] } },
-                      { limit: 5, sendIds: false, silent: true },
+                      { limit: 5, withIds: false, silent: true },
                       {},
-                      []
+                      undefined
                     ]);
                   }
                 });
@@ -991,9 +991,9 @@ describe('Contacts controller', () => {
                     assert.deepEqual(searchService.args[2], [
                       'contacts',
                       { types: { selected: ['childType'] } },
-                      { limit: 5, sendIds: false, silent: true },
+                      { limit: 5, withIds: false, silent: true },
                       {},
-                      []
+                      undefined
                     ]);
                   }
                 });

--- a/tests/karma/unit/services/search.js
+++ b/tests/karma/unit/services/search.js
@@ -394,7 +394,7 @@ describe('Search service', function() {
         { _id: 1 }, { _id: 2 }, { _id: 3 }
       ]);
 
-      return service('reports', {}, {}, {}).then(result => {
+      return service('reports', {}, {}, {}, undefined).then(result => {
         chai.expect(GetDataRecords.callCount).to.equal(1);
         chai.expect(GetDataRecords.args[0][0]).to.deep.equal([1, 2, 3]);
         chai.expect(result).to.deep.equal([

--- a/tests/karma/unit/services/search.js
+++ b/tests/karma/unit/services/search.js
@@ -191,7 +191,6 @@ describe('Search service', function() {
           chai.expect(db.query.args[0])
             .to.deep.equal([ 'medic-client/contacts_by_last_visited', {reduce: false, keys: ['1', '2', '3']} ]);
 
-          console.log(result);
           chai.expect(result).to.deep.equal([
             {
               _id: '1',
@@ -294,4 +293,114 @@ describe('Search service', function() {
     });
   });
 
+  describe('provided docIds', () => {
+    it('merges provided docIds with search results', () => {
+      searchStub.resolves([1, 2, 3, 4]);
+      GetDataRecords.withArgs([1, 2, 3, 4, 5, 6, 7, 8]).resolves([
+        { _id: 1 }, { _id: 2 }, { _id: 3 }, { _id: 4 }, { _id: 5 }, { _id: 6 }, { _id: 7 }, { _id: 8 }
+      ]);
+
+      return service('contacts', {}, {}, {}, [5, 6, 7, 8]).then(result => {
+        chai.expect(GetDataRecords.callCount).to.equal(1);
+        chai.expect(GetDataRecords.args[0][0]).to.deep.equal([1, 2, 3, 4, 5, 6, 7, 8]);
+        chai.expect(result).to.deep.equal([
+          { _id: 1 }, { _id: 2 }, { _id: 3 }, { _id: 4 }, { _id: 5 }, { _id: 6 }, { _id: 7 }, { _id: 8 }
+        ]);
+      });
+    });
+
+    it('merges the lists keeping records unique', () => {
+      searchStub.resolves([1, 2, 3, 4]);
+      GetDataRecords.withArgs([1, 2, 3, 4, 5]).resolves([
+        { _id: 1 }, { _id: 2 }, { _id: 3 }, { _id: 4 }, { _id: 5 }
+      ]);
+
+      return service('contacts', {}, {}, {}, [1, 2, 3, 4, 5]).then(result => {
+        chai.expect(GetDataRecords.callCount).to.equal(1);
+        chai.expect(GetDataRecords.args[0][0]).to.deep.equal([1, 2, 3, 4, 5]);
+        chai.expect(result).to.deep.equal([
+          { _id: 1 }, { _id: 2 }, { _id: 3 }, { _id: 4 }, { _id: 5 }
+        ]);
+      });
+    });
+
+    it('queries for last visited date with the full list of ids', () => {
+      searchStub.resolves(['1', '2']);
+      GetDataRecords.withArgs(['1', '2', '3', '4']).resolves([
+        { _id: '1' }, { _id: '2' }, { _id: '3' }, { _id: '4' }
+      ]);
+      db.query
+        .withArgs('medic-client/contacts_by_last_visited')
+        .resolves({ rows :[
+          { key: '1', value: 1 },
+          { key: '2', value: 2 },
+          { key: '3', value: 3 },
+          { key: '4', value: 4 },
+        ]});
+
+      const extensions = { displayLastVisitedDate: true };
+
+      return service('contacts', {}, {}, extensions, ['3', '4']).then(results => {
+        chai.expect(GetDataRecords.callCount).to.equal(1);
+        chai.expect(GetDataRecords.args[0][0]).to.deep.equal(['1', '2', '3', '4']);
+        chai.expect(db.query.callCount).to.equal(1);
+        chai.expect(db.query.args[0])
+          .to.deep.equal([ 'medic-client/contacts_by_last_visited', { reduce: false, keys: ['1', '2', '3', '4']} ]);
+
+        console.log(results[0]);
+
+        chai.expect(results).to.deep.equal([
+          { _id: '1', lastVisitedDate: 1, visitCount: 0, visitCountGoal: undefined, sortByLastVisitedDate: undefined },
+          { _id: '2', lastVisitedDate: 2, visitCount: 0, visitCountGoal: undefined, sortByLastVisitedDate: undefined },
+          { _id: '3', lastVisitedDate: 3, visitCount: 0, visitCountGoal: undefined, sortByLastVisitedDate: undefined },
+          { _id: '4', lastVisitedDate: 4, visitCount: 0, visitCountGoal: undefined, sortByLastVisitedDate: undefined }
+        ]);
+      });
+    });
+
+    it('works for reports too', () => {
+      searchStub.resolves([1, 2, 3]);
+      GetDataRecords.withArgs([1, 2, 3, 4, 5]).resolves([
+        { _id: 1 }, { _id: 2 }, { _id: 3 }, { _id: 4 }, { _id: 5 }
+      ]);
+
+      return service('reports', {}, {}, {}, [1, 2, 3, 4, 5]).then(result => {
+        chai.expect(GetDataRecords.callCount).to.equal(1);
+        chai.expect(GetDataRecords.args[0][0]).to.deep.equal([1, 2, 3, 4, 5]);
+        chai.expect(result).to.deep.equal([
+          { _id: 1 }, { _id: 2 }, { _id: 3 }, { _id: 4 }, { _id: 5 }
+        ]);
+      });
+    });
+
+    it('has no effect when docIds is empty', () => {
+      searchStub.resolves([1, 2, 3]);
+      GetDataRecords.withArgs([1, 2, 3]).resolves([
+        { _id: 1 }, { _id: 2 }, { _id: 3 }
+      ]);
+
+      return service('reports', {}, {}, {}, []).then(result => {
+        chai.expect(GetDataRecords.callCount).to.equal(1);
+        chai.expect(GetDataRecords.args[0][0]).to.deep.equal([1, 2, 3]);
+        chai.expect(result).to.deep.equal([
+          { _id: 1 }, { _id: 2 }, { _id: 3 }
+        ]);
+      });
+    });
+
+    it('has no effect when docIds is undefined', () => {
+      searchStub.resolves([1, 2, 3]);
+      GetDataRecords.withArgs([1, 2, 3]).resolves([
+        { _id: 1 }, { _id: 2 }, { _id: 3 }
+      ]);
+
+      return service('reports', {}, {}, {}).then(result => {
+        chai.expect(GetDataRecords.callCount).to.equal(1);
+        chai.expect(GetDataRecords.args[0][0]).to.deep.equal([1, 2, 3]);
+        chai.expect(result).to.deep.equal([
+          { _id: 1 }, { _id: 2 }, { _id: 3 }
+        ]);
+      });
+    });
+  });
 });


### PR DESCRIPTION
# Description

Adds support for truly refreshing the `LiveList`.
This is achieved by providing a list of currently loaded doc_ids to webapp's `Search` service. 
After querying `Search` shared lib as usual, the results are merged with the provided `doc_ids` prior to calling `GetDataRecords` and other operations, ensuring that all existent items from the `LiveList` are updated.
This mechanism is only triggered for Contacts when sorting is by `last_visited_date` and change with a visit report about an existent item is received.

medic/medic-webapp#4782

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.