### PR TITLE
Adds support for db-doc GET requests with open revs for offline users

### DIFF
--- a/api/src/services/db-doc.js
+++ b/api/src/services/db-doc.js
@@ -88,6 +88,7 @@ module.exports = {
       });
   },
 
+  // db-doc GET requests with `open_revs` return a list of requested revisions of the requested doc id
   filterOfflineOpenRevsRequest: (userCtx, params, query) => {
     return Promise
       .all([

--- a/api/tests/mocha/controllers/db-doc.spec.js
+++ b/api/tests/mocha/controllers/db-doc.spec.js
@@ -215,6 +215,19 @@ describe('db-doc controller', () => {
           });
       });
 
+      it('sends empty results - no allowed revs correctly', () => {
+        testReq.query = { open_revs: 'something' };
+        service.filterOfflineOpenRevsRequest.resolves([]);
+
+        return controller
+          .request(testReq, testRes, next)
+          .then(() => {
+            next.callCount.should.equal(0);
+            testRes.json.callCount.should.equal(1);
+            testRes.json.args[0].should.deep.equal([[]]);
+          });
+      });
+
       it('processes non open_revs requests properly', () => {
         service.filterOfflineOpenRevsRequest.resolves(false);
         service.filterOfflineRequest.resolves(true);

--- a/api/tests/mocha/services/db-doc.spec.js
+++ b/api/tests/mocha/services/db-doc.spec.js
@@ -763,7 +763,8 @@ describe('db-doc service', () => {
         { missing: 3 },
         { ok: { _id: 'id', _rev: 4 } },
         { ok: { _id: 'id', _rev: 5 } },
-        { ok: { _id: 'id', _rev: 6, _deleted: true } }
+        { ok: { _id: 'id', _rev: 6, _deleted: true } },
+        { error: { _id: 'id', _rev: 7 } }
       ]);
 
       authorization.getViewResults.callsFake(doc => doc._rev);

--- a/tests/e2e/api/controllers/db-doc.spec.js
+++ b/tests/e2e/api/controllers/db-doc.spec.js
@@ -270,7 +270,8 @@ describe('db-doc handler', () => {
 
       const docs = [
         { _id: 'a1_revs', type: 'clinic', parent: { _id: 'fixture:offline' }, name: 'Allowed Contact 1' },
-        { _id: 'd1_revs', type: 'clinic', parent: { _id: 'fixture:online' }, name: 'Denied Contact 1' }
+        { _id: 'd1_revs', type: 'clinic', parent: { _id: 'fixture:online' }, name: 'Denied Contact 1' },
+        { _id: 'd2_revs', type: 'clinic', parent: { _id: 'fixture:online' }, name: 'Denied Contact 2' }
       ];
 
       return utils
@@ -290,10 +291,10 @@ describe('db-doc handler', () => {
         })
         .then(results => {
           const deletes = [];
-          results.forEach((result, key) => {
-            docs[key]._rev = result.rev;
-            deletes.push({ _id: docs[key]._id, _rev: result.rev, _deleted: true });
-          });
+          results.forEach((result, key) => docs[key]._rev = result.rev);
+
+          deletes.push({ _id: docs[0]._id, _rev: docs[0]._rev, _deleted: true });
+          deletes.push({ _id: docs[1]._id, _rev: docs[1]._rev, _deleted: true });
 
           return utils.saveDocs(deletes);
         })
@@ -331,8 +332,11 @@ describe('db-doc handler', () => {
                                             (result.ok._deleted || result.ok.parent._id === 'fixture:offline'))
           ).toBe(true);
 
-          expect(results[1].length).toEqual(1);
-          expect(results[1][0].ok._deleted).toBe(true);
+          expect(results[3].length).toEqual(1);
+          expect(results[3][0].ok._deleted).toBe(true);
+
+          expect(results[4].length).toEqual(0);
+          expect(results[5].length).toEqual(0);
         });
     });
 

--- a/tests/e2e/forms/submit-photo-upload-form.spec.js
+++ b/tests/e2e/forms/submit-photo-upload-form.spec.js
@@ -56,9 +56,12 @@ describe('Submit Photo Upload form', () => {
 
     element(by.css('#photo-upload input[type=file]'))
       .sendKeys(path.join(__dirname, '../../../webapp/src/img/simprints.png'));
+    browser.wait(() => element(by.css('#photo-upload .file-picker .file-preview img')).isPresent(), 10000);
     //submit
     photoUpload.submit();
+    browser.wait(() => element(by.css('div.details')).isPresent(), 10000);
     expect(element(by.css('div.details')).isPresent()).toBeTruthy();
+    browser.wait(() => element(by.css('.report-image')).isPresent(), 10000);
     expect(element(by.css('.report-image')).isPresent()).toBeTruthy();
   });
 });


### PR DESCRIPTION
# Description

PouchDB uses db-doc GET requests with `open_revs` param as a fallback if`_bulk_get` endpoint is not available when replicating. 

medic/medic-webapp#4778

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.