### PR TITLE
Allow offline users access to the admin app

### DIFF
--- a/api/src/controllers/db-doc.js
+++ b/api/src/controllers/db-doc.js
@@ -81,9 +81,14 @@ module.exports = {
   },
 
   requestDdoc: (appDdoc, req, res, next) => {
-    // offline users are allowed to access app _rewrites, which are authorized by another route
+    // offline users are allowed to access app, which are authorized by another route
     if (req.params.ddocId === appDdoc) {
       return next('route');
+    }
+
+    // offline users are allowed to access the admin app
+    if (req.params.ddocId === 'medic-admin') {
+      return next();
     }
 
     req.params.docId = `_design/${req.params.ddocId}`;

--- a/api/src/controllers/db-doc.js
+++ b/api/src/controllers/db-doc.js
@@ -81,7 +81,7 @@ module.exports = {
   },
 
   requestDdoc: (appDdoc, req, res, next) => {
-    // offline users are allowed to access app, which are authorized by another route
+    // offline users are allowed to access app _rewrites, which are authorized by another route
     if (req.params.ddocId === appDdoc) {
       return next('route');
     }

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -378,7 +378,8 @@ app.get(
   ddocPath,
   authorization.checkAuth,
   onlineUserProxy,
-  _.partial(dbDocHandler.requestDdoc, db.settings.ddoc)
+  _.partial(dbDocHandler.requestDdoc, db.settings.ddoc),
+  authorization.setAuthorized // adds the `authorized` flag to the `req` object, so it passes the firewall
 );
 
 app.get(

--- a/api/tests/mocha/controllers/db-doc.spec.js
+++ b/api/tests/mocha/controllers/db-doc.spec.js
@@ -206,6 +206,17 @@ describe('db-doc controller', () => {
         });
     });
 
+    it('forwards medic-admin requests to the next middleware', () => {
+      testReq.params = { ddocId: 'medic-admin' };
+      return controller
+        .requestDdoc('medic', testReq, testRes, next)
+        .then(() => {
+          next.callCount.should.equal(1);
+          next.args[0].should.deep.equal([undefind]);
+          service.filterOfflineRequest.callCount.should.equal(0);
+        });
+    });
+
     it('constructs correct docId when ddoc is not appddoc and continues request when allowed', () => {
       service.filterOfflineRequest.resolves(true);
       return controller

--- a/api/tests/mocha/controllers/db-doc.spec.js
+++ b/api/tests/mocha/controllers/db-doc.spec.js
@@ -212,7 +212,7 @@ describe('db-doc controller', () => {
         .requestDdoc('medic', testReq, testRes, next)
         .then(() => {
           next.callCount.should.equal(1);
-          next.args[0].should.deep.equal([undefind]);
+          next.args[0].should.deep.equal([]);
           service.filterOfflineRequest.callCount.should.equal(0);
         });
     });

--- a/tests/e2e/api/controllers/db-doc.spec.js
+++ b/tests/e2e/api/controllers/db-doc.spec.js
@@ -791,12 +791,13 @@ describe('db-doc handler', () => {
   });
 
   describe('interactions with ddocs', () => {
-    it('allows GETting _design/medic-client, blocks all other ddoc GET requests', () => {
+    it('allows GETting _design/medic-client and _design/medic-admin, blocks all other ddoc GET requests', () => {
       return Promise
         .all([
           utils.requestOnTestDb(_.defaults({ path: '/_design/medic-client' }, offlineRequestOptions)),
           utils.requestOnTestDb(_.defaults({ path: '/_design/medic' }, offlineRequestOptions)).catch(err => err),
           utils.requestOnTestDb(_.defaults({ path: '/_design/something' }, offlineRequestOptions)).catch(err => err),
+          utils.requestOnTestDb(_.defaults({ path: '/_design/medic-admin' }, offlineRequestOptions))
         ])
         .then(results => {
           expect(results[0]._id).toEqual('_design/medic-client');
@@ -806,6 +807,8 @@ describe('db-doc handler', () => {
 
           expect(results[2].statusCode).toEqual(403);
           expect(results[2].responseBody.error).toEqual('forbidden');
+
+          expect(results[3]._id).toEqual('_design/medic-admin');
         });
     });
 
@@ -827,6 +830,9 @@ describe('db-doc handler', () => {
           utils
             .requestOnTestDb(_.defaults({ path: '/_design/something' }, request, offlineRequestOptions))
             .catch(err => err),
+          utils
+            .requestOnTestDb(_.defaults({ path: '/_design/medic-admin' }, request, offlineRequestOptions))
+            .catch(err => err),
         ])
         .then(results => {
           expect(results[0].statusCode).toEqual(403);
@@ -837,6 +843,9 @@ describe('db-doc handler', () => {
 
           expect(results[2].statusCode).toEqual(403);
           expect(results[2].responseBody.error).toEqual('forbidden');
+
+          expect(results[3].statusCode).toEqual(403);
+          expect(results[3].responseBody.error).toEqual('forbidden');
         });
     });
 
@@ -856,6 +865,9 @@ describe('db-doc handler', () => {
           utils
             .requestOnTestDb(_.defaults({ path: '/_design/something' }, request, offlineRequestOptions))
             .catch(err => err),
+          utils
+            .requestOnTestDb(_.defaults({ path: '/_design/medic-admin' }, request, offlineRequestOptions))
+            .catch(err => err),
         ])
         .then(results => {
           expect(results[0].statusCode).toEqual(403);
@@ -866,6 +878,9 @@ describe('db-doc handler', () => {
 
           expect(results[2].statusCode).toEqual(403);
           expect(results[2].responseBody.error).toEqual('forbidden');
+
+          expect(results[3].statusCode).toEqual(403);
+          expect(results[3].responseBody.error).toEqual('forbidden');
         });
     });
   });

--- a/tests/e2e/api/routing.js
+++ b/tests/e2e/api/routing.js
@@ -497,6 +497,20 @@ describe('routing', () => {
         });
     });
 
+    it('allows access to the admin app', () => {
+      return Promise
+        .all([
+          utils.requestOnTestDb(_.defaults({ path: '/_design/medic-admin/_rewrite' }, offlineRequestOptions), false, true),
+          utils.requestOnTestDb(_.defaults({ path: '/_design/medic-admin/_rewrite/' }, offlineRequestOptions), false, true),
+          utils.requestOnTestDb(_.defaults({ path: '/_design/medic-admin/main.css' }, offlineRequestOptions), false, true)
+        ])
+        .then(results => {
+          expect(results[0].includes('administration console')).toBe(true);
+          expect(results[1].includes('administration console')).toBe(true);
+          expect(results[2].includes('html')).toBe(true);
+        });
+    });
+
     it('blocks direct access to CouchDB and to fauxton', () => {
       return Promise
         .all([


### PR DESCRIPTION
# Description

Offline users can now GET `medic-admin` ddoc and have access to the admin app. 

medic/medic-webapp#4786

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.