### PR TITLE
Report attachment names relative to form id

### DIFF
--- a/webapp/src/js/services/enketo.js
+++ b/webapp/src/js/services/enketo.js
@@ -432,8 +432,8 @@ angular.module('inboxServices').service('Enketo',
 
       var attach = function(elem, file, type, alreadyEncoded, xpath) {
         xpath = xpath || xpathPath(elem);
-        // replace rootElement node name with form ID
-        var filename = 'user-file/' + doc.form + xpath.slice(xpath.indexOf('/', 1));
+        // replace instance root element node name with form internal ID
+        var filename = xpath.replace(/^\/[^\/]*/, 'user-file' + '/' + doc.form);
         AddAttachment(doc, filename, file, type, alreadyEncoded);
       };
 

--- a/webapp/src/js/services/enketo.js
+++ b/webapp/src/js/services/enketo.js
@@ -432,7 +432,8 @@ angular.module('inboxServices').service('Enketo',
 
       var attach = function(elem, file, type, alreadyEncoded, xpath) {
         xpath = xpath || xpathPath(elem);
-        var filename = 'user-file' + xpath;
+        // replace rootElement node name with form ID
+        var filename = 'user-file/' + doc.form + xpath.slice(xpath.indexOf('/', 1));
         AddAttachment(doc, filename, file, type, alreadyEncoded);
       };
 

--- a/webapp/src/js/services/enketo.js
+++ b/webapp/src/js/services/enketo.js
@@ -433,7 +433,8 @@ angular.module('inboxServices').service('Enketo',
       var attach = function(elem, file, type, alreadyEncoded, xpath) {
         xpath = xpath || xpathPath(elem);
         // replace instance root element node name with form internal ID
-        var filename = xpath.replace(/^\/[^\/]+/, 'user-file' + '/' + doc.form);
+        var filename = 'user-file' +
+                       (xpath.startsWith('/' + doc.form) ? xpath : xpath.replace(/^\/[^\/]+/, '/' + doc.form));
         AddAttachment(doc, filename, file, type, alreadyEncoded);
       };
 

--- a/webapp/src/js/services/enketo.js
+++ b/webapp/src/js/services/enketo.js
@@ -433,7 +433,7 @@ angular.module('inboxServices').service('Enketo',
       var attach = function(elem, file, type, alreadyEncoded, xpath) {
         xpath = xpath || xpathPath(elem);
         // replace instance root element node name with form internal ID
-        var filename = xpath.replace(/^\/[^\/]*/, 'user-file' + '/' + doc.form);
+        var filename = xpath.replace(/^\/[^\/]+/, 'user-file' + '/' + doc.form);
         AddAttachment(doc, filename, file, type, alreadyEncoded);
       };
 

--- a/webapp/tests/karma/unit/services/enketo.js
+++ b/webapp/tests/karma/unit/services/enketo.js
@@ -131,7 +131,8 @@ describe('Enketo service', function() {
   });
 
   afterEach(function() {
-    KarmaUtils.restore(EnketoForm, enketoInit, dbGetAttachment, dbGet, dbBulkDocs, transform, createObjectURL, ContactSummary, FileReader.utf8, UserContact, form.validate, form.getDataStr, Language, TranslateFrom, AddAttachment, Search, LineageModelGenerator.contact, $.fn.find);
+    KarmaUtils.restore(EnketoForm, enketoInit, dbGetAttachment, dbGet, dbBulkDocs, transform, createObjectURL, ContactSummary, FileReader.utf8, UserContact, form.validate, form.getDataStr, Language, TranslateFrom, AddAttachment, Search, LineageModelGenerator.contact);
+    sinon.restore();
   });
 
   describe('render', function() {

--- a/webapp/tests/karma/unit/services/enketo.js
+++ b/webapp/tests/karma/unit/services/enketo.js
@@ -827,10 +827,10 @@ describe('Enketo service', function() {
       $.fn.find.callsFake(jqFind);
       $.fn.find
         .withArgs('input[type=file][name="/my-root-element/my_file"]')
-        .returns([{ files: [{ type: 'image' }] }]);
+        .returns([{ files: [{ type: 'image', foo: 'bar' }] }]);
       $.fn.find
         .withArgs('input[type=file][name="/my-root-element/sub_element/sub_sub_element/other_file"]')
-        .returns([{ files: [{ type: 'mytype' }] }]);
+        .returns([{ files: [{ type: 'mytype', foo: 'baz' }] }]);
       form.validate.resolves(true);
       const content = `
         <my-root-element>
@@ -855,12 +855,12 @@ describe('Enketo service', function() {
         chai.expect(AddAttachment.args[0][1]).to.equal('content');
 
         chai.expect(AddAttachment.args[1][1]).to.equal('user-file/my-form-internal-id/my_file');
-        chai.expect(AddAttachment.args[1][2]).to.deep.equal({ type: 'image' });
+        chai.expect(AddAttachment.args[1][2]).to.deep.equal({ type: 'image', foo: 'bar' });
         chai.expect(AddAttachment.args[1][3]).to.equal('image');
 
         chai.expect(AddAttachment.args[2][1])
           .to.equal('user-file/my-form-internal-id/sub_element/sub_sub_element/other_file');
-        chai.expect(AddAttachment.args[2][2]).to.deep.equal({ type: 'mytype' });
+        chai.expect(AddAttachment.args[2][2]).to.deep.equal({ type: 'mytype', foo: 'baz' });
         chai.expect(AddAttachment.args[2][3]).to.equal('mytype');
       });
     });

--- a/webapp/tests/karma/unit/services/report-view-model-generator.js
+++ b/webapp/tests/karma/unit/services/report-view-model-generator.js
@@ -1,0 +1,124 @@
+describe('ReportViewModelGenerator service', () => {
+
+  'use strict';
+
+  let service,
+      formatDataRecord,
+      lineageModelGenerator,
+      getSubjectSummaries,
+      getSummaries,
+      report,
+      formatted;
+
+  beforeEach(() => {
+    module('inboxApp');
+    module($provide => {
+      report = {
+        _id: 'my-report',
+        form: 'my-form',
+        fields: {
+          field1: 1,
+          field2: 2,
+          field3: 3
+        },
+        hidden_fields: ['field2'],
+        _attachments: {
+          content: { content_type: 'application/xml'},
+          'user-file/my-form/field1': { content_type: 'text/html' },
+          'user-file/my-form/field2': { something: '1' },
+          'user-file/my-form/fields/field21': { foo: 'bar' }
+        }
+      };
+
+      formatted = { formatted1: 1, formatted2: 2 };
+
+      lineageModelGenerator = { report: sinon.stub().resolves({ doc: report }) };
+      formatDataRecord = sinon.stub().resolves(formatted);
+      getSubjectSummaries = sinon.stub().resolves([{ summary: true, subject: 'subject' }]);
+      getSummaries = sinon.stub().resolves([{ summary: true }]);
+
+      $provide.value('LineageModelGenerator', lineageModelGenerator);
+      $provide.value('FormatDataRecord', formatDataRecord);
+      $provide.value('GetSubjectSummaries', getSubjectSummaries);
+      $provide.value('GetSummaries', getSummaries);
+      $provide.value('DB', {});
+    });
+    inject(_ReportViewModelGenerator_ => service = _ReportViewModelGenerator_);
+  });
+
+  it('calls services with correct params, returns formatted data and display fields', () => {
+    return service(report._id).then(result => {
+      chai.expect(lineageModelGenerator.report.callCount).to.equal(1);
+      chai.expect(lineageModelGenerator.report.args[0]).to.deep.equal([ 'my-report', { merge: true } ]);
+
+      chai.expect(formatDataRecord.callCount).to.equal(1);
+      chai.expect(formatDataRecord.args[0]).to.deep.equal([report]);
+
+      chai.expect(getSummaries.callCount).to.equal(1);
+      chai.expect(getSummaries.args[0]).to.deep.equal([[ 'my-report' ]]);
+
+      chai.expect(getSubjectSummaries.callCount).to.equal(1);
+      chai.expect(getSubjectSummaries.args[0]).to.deep.equal([[{ summary: true }], true]);
+
+      chai.expect(result.doc).to.deep.equal(report);
+      chai.expect(result.formatted).to.deep.equal({ formatted1: 1, formatted2: 2, subject: 'subject' });
+      console.log(result.displayFields);
+      chai.expect(result.displayFields).to.deep.equal([
+        { label: 'report.my-form.field1', value: 1, depth: 0 },
+        { label: 'report.my-form.field3', value: 3, depth: 0 },
+
+      ]);
+    });
+  });
+
+  it('returns correct deep display fields', () => {
+    report.fields = {
+      field1: 1,
+      fields: {
+        field21: 1,
+        fields: {
+          field31: 1,
+          fields: {
+            field41: 1,
+            fields: {
+              field51: 1
+            }
+          }
+        }
+      }
+    };
+
+    return service(report._id).then(result => {
+      chai.expect(result.displayFields).to.deep.equal([
+        { label: 'report.my-form.field1', value: 1, depth: 0 },
+        { label: 'report.my-form.fields', depth: 0 },
+        { label: 'report.my-form.fields.field21', value: 1, depth: 1 },
+        { label: 'report.my-form.fields.fields', depth: 1 },
+        { label: 'report.my-form.fields.fields.field31', value: 1, depth: 2 },
+        { label: 'report.my-form.fields.fields.fields', depth: 2 },
+        { label: 'report.my-form.fields.fields.fields.field41', value: 1, depth: 3 },
+        { label: 'report.my-form.fields.fields.fields.fields', depth: 3 },
+        { label: 'report.my-form.fields.fields.fields.fields.field51', value: 1, depth: 3 }
+      ]);
+    });
+  });
+
+  it('returns correct image path', () => {
+    report.fields.image = 'some image';
+    report.fields.deep = { image2: 'other' };
+    report._attachments = {
+      'user-file/my-form/image': { content_type: 'image/gif' },
+      'user-file/my-form/deep/image2': { content_type: 'image/png' }
+    };
+
+    return service(report._id).then(result => {
+      chai.expect(result.displayFields).to.deep.equal([
+        { label: 'report.my-form.field1', value: 1, depth: 0 },
+        { label: 'report.my-form.field3', value: 3, depth: 0 },
+        { label: 'report.my-form.image', value: 'some image', depth: 0, imagePath: 'user-file/my-form/image' },
+        { label: 'report.my-form.deep', depth: 0 },
+        { label: 'report.my-form.deep.image2', value: 'other', depth: 1, imagePath: 'user-file/my-form/deep/image2' }
+      ]);
+    });
+  });
+});

--- a/webapp/tests/karma/unit/services/report-view-model-generator.js
+++ b/webapp/tests/karma/unit/services/report-view-model-generator.js
@@ -7,8 +7,7 @@ describe('ReportViewModelGenerator service', () => {
       lineageModelGenerator,
       getSubjectSummaries,
       getSummaries,
-      report,
-      formatted;
+      report;
 
   beforeEach(() => {
     module('inboxApp');
@@ -30,12 +29,10 @@ describe('ReportViewModelGenerator service', () => {
         }
       };
 
-      formatted = { formatted1: 1, formatted2: 2 };
-
-      lineageModelGenerator = { report: sinon.stub().resolves({ doc: report }) };
-      formatDataRecord = sinon.stub().resolves(formatted);
-      getSubjectSummaries = sinon.stub().resolves([{ summary: true, subject: 'subject' }]);
-      getSummaries = sinon.stub().resolves([{ summary: true }]);
+      lineageModelGenerator = { report: sinon.stub() };
+      formatDataRecord = sinon.stub();
+      getSubjectSummaries = sinon.stub();
+      getSummaries = sinon.stub();
 
       $provide.value('LineageModelGenerator', lineageModelGenerator);
       $provide.value('FormatDataRecord', formatDataRecord);
@@ -46,7 +43,14 @@ describe('ReportViewModelGenerator service', () => {
     inject(_ReportViewModelGenerator_ => service = _ReportViewModelGenerator_);
   });
 
+  afterEach(() => sinon.restore());
+
   it('calls services with correct params, returns formatted data and display fields', () => {
+    lineageModelGenerator.report.resolves({ doc: report });
+    formatDataRecord.resolves({ formatted1: 1, formatted2: 2 });
+    getSubjectSummaries.resolves([{ summary: true, subject: 'subject' }]);
+    getSummaries.resolves([{ summary: true }]);
+
     return service(report._id).then(result => {
       chai.expect(lineageModelGenerator.report.callCount).to.equal(1);
       chai.expect(lineageModelGenerator.report.args[0]).to.deep.equal([ 'my-report', { merge: true } ]);
@@ -62,7 +66,6 @@ describe('ReportViewModelGenerator service', () => {
 
       chai.expect(result.doc).to.deep.equal(report);
       chai.expect(result.formatted).to.deep.equal({ formatted1: 1, formatted2: 2, subject: 'subject' });
-      console.log(result.displayFields);
       chai.expect(result.displayFields).to.deep.equal([
         { label: 'report.my-form.field1', value: 1, depth: 0 },
         { label: 'report.my-form.field3', value: 3, depth: 0 },
@@ -72,6 +75,11 @@ describe('ReportViewModelGenerator service', () => {
   });
 
   it('returns correct deep display fields', () => {
+    lineageModelGenerator.report.resolves({ doc: report });
+    formatDataRecord.resolves({});
+    getSubjectSummaries.resolves([{}]);
+    getSummaries.resolves([{}]);
+
     report.fields = {
       field1: 1,
       fields: {
@@ -104,6 +112,11 @@ describe('ReportViewModelGenerator service', () => {
   });
 
   it('returns correct image path', () => {
+    lineageModelGenerator.report.resolves({ doc: report });
+    formatDataRecord.resolves({});
+    getSubjectSummaries.resolves([{}]);
+    getSummaries.resolves([{}]);
+
     report.fields.image = 'some image';
     report.fields.deep = { image2: 'other' };
     report._attachments = {


### PR DESCRIPTION
# Description

Replaces form root element node name with form internal ID when generating attachment names for forms with file uploads. 

medic/medic-webapp#4755

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.