### PR TITLE
4625 - Reports pages should not hide fields which are not explicitly hidden

### DIFF
--- a/webapp/src/js/services/report-view-model-generator.js
+++ b/webapp/src/js/services/report-view-model-generator.js
@@ -69,7 +69,7 @@ angular.module('inboxServices').factory('ReportViewModelGenerator',
       hide.push('inputs');
       return _.reject(fields, function(field) {
         return _.some(hide, function(h) {
-          return field.label.indexOf(label + '.' + h) === 0;
+          return label + '.' + h === field.label;
         });
       });
     };

--- a/webapp/src/js/services/report-view-model-generator.js
+++ b/webapp/src/js/services/report-view-model-generator.js
@@ -69,7 +69,8 @@ angular.module('inboxServices').factory('ReportViewModelGenerator',
       hide.push('inputs');
       return _.reject(fields, function(field) {
         return _.some(hide, function(h) {
-          return label + '.' + h === field.label;
+          const hiddenLabel = label + '.' + h;
+          return hiddenLabel === field.label || field.label.indexOf(hiddenLabel + '.') === 0;
         });
       });
     };

--- a/webapp/src/js/services/report-view-model-generator.js
+++ b/webapp/src/js/services/report-view-model-generator.js
@@ -69,7 +69,7 @@ angular.module('inboxServices').factory('ReportViewModelGenerator',
       hide.push('inputs');
       return _.reject(fields, function(field) {
         return _.some(hide, function(h) {
-          const hiddenLabel = label + '.' + h;
+          var hiddenLabel = label + '.' + h;
           return hiddenLabel === field.label || field.label.indexOf(hiddenLabel + '.') === 0;
         });
       });

--- a/webapp/tests/karma/unit/services/report-view-model-generator.js
+++ b/webapp/tests/karma/unit/services/report-view-model-generator.js
@@ -16,16 +16,16 @@ describe('ReportViewModelGenerator service', () => {
         _id: 'my-report',
         form: 'my-form',
         fields: {
+          field: 0,
           field1: 1,
-          field2: 2,
           field3: 3
         },
-        hidden_fields: ['field2'],
+        hidden_fields: ['field'],
         _attachments: {
-          content: { content_type: 'application/xml'},
+          content: { content_type: 'application/xml' },
+          'user-file/my-form/field': { something: '1' },
           'user-file/my-form/field1': { content_type: 'text/html' },
-          'user-file/my-form/field2': { something: '1' },
-          'user-file/my-form/fields/field21': { foo: 'bar' }
+          'user-file/my-form/fields/field21': { foo: 'bar' },
         }
       };
 

--- a/webapp/tests/karma/unit/services/report-view-model-generator.js
+++ b/webapp/tests/karma/unit/services/report-view-model-generator.js
@@ -69,7 +69,35 @@ describe('ReportViewModelGenerator service', () => {
       chai.expect(result.displayFields).to.deep.equal([
         { label: 'report.my-form.field1', value: 1, depth: 0 },
         { label: 'report.my-form.field3', value: 3, depth: 0 },
+      ]);
+    });
+  });
 
+  it('when fields are nested within hidden groups, the nested fields are hidden', () => {
+    lineageModelGenerator.report.resolves({ doc: report });
+    formatDataRecord.resolves({});
+    getSubjectSummaries.resolves([{}]);
+    getSummaries.resolves([{}]);
+
+    report.fields = {
+      field1: 1,
+      group: {
+        field2: 2,
+        group2: {
+          field3: 3,
+        }
+      },
+      group3: {
+        field4: 3,
+      },
+    };
+    report.hidden_fields = ['group'];
+
+    return service(report._id).then(result => {
+      chai.expect(result.displayFields).to.deep.equal([
+        { label: 'report.my-form.field1', value: 1, depth: 0 },
+        { label: 'report.my-form.group3', depth: 0 },
+        { label: 'report.my-form.group3.field4', value: 3, depth: 1 },
       ]);
     });
   });


### PR DESCRIPTION
# Description

A submitted report may have fields hidden that should be shown. Only the specific field that is marked with tag="hidden" should be hidden.

medic/medic-webapp#4625

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# Testing
I set up a repro of the example XForm in #4625. This is a screenshot of the final result after this change (prior to the change, name2 was hidden in the report). ![screenshot from 2018-09-12 23-30-16](https://user-images.githubusercontent.com/9014751/45471698-bd550880-b6e6-11e8-810d-e1a83f38df6e.png)

Instead of writing a new unit, I altered an existing test to capture the scenario (failed prior to code change). Happy to add a dedicated test if it is called for.

I'm unsure if the base branch for this should be `master` or some specific version. Also unsure if this should be in the changelog or if this is done via tooling.