### PR TITLE
4821 - "Standard" config is missing permission definitions for can_access_*

### DIFF
--- a/config/standard/app_settings.json
+++ b/config/standard/app_settings.json
@@ -321,6 +321,41 @@
       "roles": [
         "national_admin"
       ]
+    },
+    {
+      "name": "can_access_tasks",
+      "roles": [
+        "district_admin"
+      ]
+    },
+    {
+      "name": "can_access_messages",
+      "roles": [
+        "national_admin",
+        "district_admin"
+      ]
+    },
+    {
+      "name": "can_access_contacts",
+      "roles": [
+        "national_admin",
+        "district_admin"
+      ]
+    },
+    {
+      "name": "can_access_analytics",
+      "roles": [
+        "national_admin",
+        "district_admin",
+        "analytics"
+      ]
+    },
+    {
+      "name": "can_access_reports",
+      "roles": [
+        "national_admin",
+        "district_admin"
+      ]
     }
   ],
   "setup_complete": true,


### PR DESCRIPTION
# Description

When using the **standard** configuration that is included in `medic-webapp`, I was unable to use the app due to permission errors.

medic/medic-webapp#4821

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.