### PR TITLE
4097 - Log each valid `POST /api/v1/users/{username}` with field names

### DIFF
--- a/api/src/controllers/users.js
+++ b/api/src/controllers/users.js
@@ -66,9 +66,10 @@ module.exports = {
       hasFullPermission(req),
       isUpdatingSelf(req, credentials, username),
       basicAuthValid(credentials, username),
-      isChangingPassword(req)
+      isChangingPassword(req),
+      auth.getUserCtx(req)
     ])
-      .then(([fullPermission, updatingSelf, basic, changingPassword]) => {
+      .then(([fullPermission, updatingSelf, basic, changingPassword, requesterContext]) => {
 
         if (basic === false) {
           // If you're passing basic auth we're going to validate it, even if we
@@ -82,25 +83,27 @@ module.exports = {
           });
         }
 
-        if (fullPermission) {
-          return usersService.updateUser(username, req.body, true);
+        if (!fullPermission) {
+          if (!updatingSelf) {
+            return Promise.reject({
+              message: 'You do not have permissions to modify this person',
+              code: 403
+            });
+          }
+
+          if (_.isUndefined(basic) && changingPassword) {
+            return Promise.reject({
+              message: 'You must authenticate with Basic Auth to modify your password',
+              code: 403
+            });
+          }
         }
 
-        if (!updatingSelf) {
-          return Promise.reject({
-            message: 'You do not have permissions to modify this person',
-            code: 403
-          });
-        }
-
-        if (_.isUndefined(basic) && changingPassword) {
-          return Promise.reject({
-            message: 'You must authenticate with Basic Auth to modify your password',
-            code: 403
-          });
-        }
-
-        return usersService.updateUser(username, req.body, false);
+        return usersService
+          .updateUser(username, req.body, !!fullPermission)
+          .then(() => {
+            console.log(`REQ ${req.id} - Updated user '${username}'. Setting field(s) '${Object.keys(req.body).join(',')}'. Requested by '${requesterContext && requesterContext.name}'.`);
+          })
       })
       .then(body => res.json(body))
       .catch(err => serverUtils.error(err, req, res));

--- a/api/src/controllers/users.js
+++ b/api/src/controllers/users.js
@@ -101,8 +101,9 @@ module.exports = {
 
         return usersService
           .updateUser(username, req.body, !!fullPermission)
-          .then(() => {
+          .then(result => {
             console.log(`REQ ${req.id} - Updated user '${username}'. Setting field(s) '${Object.keys(req.body).join(',')}'. Requested by '${requesterContext && requesterContext.name}'.`);
+            return result;
           });
       })
       .then(body => res.json(body))

--- a/api/src/controllers/users.js
+++ b/api/src/controllers/users.js
@@ -103,7 +103,7 @@ module.exports = {
           .updateUser(username, req.body, !!fullPermission)
           .then(() => {
             console.log(`REQ ${req.id} - Updated user '${username}'. Setting field(s) '${Object.keys(req.body).join(',')}'. Requested by '${requesterContext && requesterContext.name}'.`);
-          })
+          });
       })
       .then(body => res.json(body))
       .catch(err => serverUtils.error(err, req, res));

--- a/api/src/services/users.js
+++ b/api/src/services/users.js
@@ -529,11 +529,6 @@ module.exports = {
       getUpdatedSettingsDoc(username, data),
     ])
       .then(([ user, settings ]) => {
-        // TODO log out what is going to happen
-        //      we need the authenticated username as well
-        //      as the given username and data we already have
-        // https://github.com/medic/medic-webapp/issues/4097
-
         const response = {};
 
         return Promise.resolve()

--- a/tests/e2e/api/controllers/users.js
+++ b/tests/e2e/api/controllers/users.js
@@ -6,12 +6,12 @@ const user = n => `org.couchdb.user:${n}`;
 
 describe('Users API', () => {
   describe('POST /api/v1/users/{username}', () => {
-    const username = 'testapiuser';
+    const username = 'test' + new Date().getTime();
     const password = 'pass1234!';
     const _usersUser = {
       _id: user(username),
       type: 'user',
-      name: 'testapiuser',
+      name: username,
       password: password,
       facility_id: null,
       roles: [
@@ -20,7 +20,7 @@ describe('Users API', () => {
       ]
     };
 
-    const newPlaceId = 'NewPlaceId';
+    const newPlaceId = 'NewPlaceId' + new Date().getTime();
 
     let cookie;
 
@@ -29,7 +29,7 @@ describe('Users API', () => {
         _id: user(username),
         facility_id: null,
         contact_id: null,
-        name: 'testapiuser',
+        name: username,
         fullname: 'Test Apiuser',
         type: 'user-settings',
         roles: [
@@ -118,12 +118,12 @@ describe('Users API', () => {
           'Content-Type': 'application/json'
         },
         body: {
-          place: 'NewPlaceId'
+          place: newPlaceId
         }
       })
       .then(() => utils.getDoc(user(username)))
       .then(doc => {
-        expect(doc.facility_id).toBe('NewPlaceId');
+        expect(doc.facility_id).toBe(newPlaceId);
       }));
 
     it('401s if a user without the right permissions attempts to modify someone else', () =>
@@ -134,7 +134,7 @@ describe('Users API', () => {
           'Content-Type': 'application/json'
         },
         body: {
-          place: 'NewPlaceId'
+          place: newPlaceId
         },
         auth: `${username}:${password}`
       })


### PR DESCRIPTION
# Description

#4097
> Log who changed which user, and what fields they changed, but not the actual changes (ie don't log the password, just that it was changed).

This logs out all fields in the request body, which is not necessarily the exact field which is updated on the user object (eg. place in request body maps to user.facility_id). If this is required, I'd need to do some refactoring within the user service. 

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

Sample Console Output

`REQ 3ea280b0-d469-403a-9273-13edb0b8f758 ::1 - POST /api/v1/users/kenn HTTP/1.1`
`REQ 3ea280b0-d469-403a-9273-13edb0b8f758 - Update user 'kenn'. Setting field(s) 'fullname,known,foo'. Requested by 'admin'.`