### PR TITLE
4829 - Use an absolute instead of relative url to link to configuration

### DIFF
--- a/webapp/src/js/controllers/inbox.js
+++ b/webapp/src/js/controllers/inbox.js
@@ -136,6 +136,7 @@ var feedback = require('../modules/feedback'),
       $scope.actionBar = {};
       $scope.tours = [];
       $scope.baseUrl = Location.path;
+      $scope.adminUrl = Location.adminPath;
       $scope.enketoStatus = { saving: false };
       $scope.isAdmin = Session.isAdmin();
 

--- a/webapp/src/js/services/location.js
+++ b/webapp/src/js/services/location.js
@@ -7,11 +7,13 @@ angular.module('inboxServices').factory('Location',
     var location = $window.location;
     var dbName = location.pathname.split('/')[1];
     var path = '/' + dbName + '/_design/medic/_rewrite';
+    var adminPath = '/' + dbName + '/_design/medic-admin/_rewrite';
     var port = location.port ? ':' + location.port : '';
     var url = location.protocol + '//' + location.hostname + port + '/' + dbName;
 
     return {
       path: path,
+      adminPath: adminPath,
       dbName: dbName,
       url: url
     };

--- a/webapp/src/templates/partials/header.html
+++ b/webapp/src/templates/partials/header.html
@@ -49,7 +49,7 @@
             </a>
           </li>
           <li role="presentation" mm-auth="can_configure">
-            <a href="../../medic-admin/_rewrite/" role="menuitem" tabindex="-1" target="_blank" rel="noopener noreferrer">
+            <a ng-href="{{adminUrl}}" role="menuitem" tabindex="-1" target="_blank" rel="noopener noreferrer">
               <i class="fa fa-fw fa-cog"></i>
               <span translate>Configuration</span>
             </a>


### PR DESCRIPTION
# Description

Use an absolute instead of relative url to link to configuration
#4829

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.