### PR TITLE
Fix exporting messages from reports with scheduled_tasks

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -15,11 +15,13 @@
     "toc": "doctoc --github --maxlevel 2 README.md"
   },
   "dependencies": {
+    "@shared-libs/message-utils": "file:../shared-libs/message-utils",
     "@shared-libs/registration-utils": "file:../shared-libs/registration-utils",
     "@shared-libs/server-checks": "file:../shared-libs/server-checks",
     "@shared-libs/tombstone-utils": "file:../shared-libs/tombstone-utils",
     "@shared-libs/view-map-utils": "file:../shared-libs/view-map-utils",
     "async": "^2.6.0",
+    "bikram-sambat": "^1.5.0",
     "body-parser": "^1.18.2",
     "buffer-shims": "^1.0.0",
     "bulk-docs-utils": "file:../shared-libs/bulk-docs-utils",
@@ -28,6 +30,7 @@
     "express": "^4.16.3",
     "fast-csv": "^2.4.1",
     "google-libphonenumber": "^3.1.11",
+    "gsm": "^0.1.4",
     "helmet": "^3.13.0",
     "http-proxy": "^1.17.0",
     "lineage": "file:../shared-libs/lineage",

--- a/api/src/services/export/message-mapper.js
+++ b/api/src/services/export/message-mapper.js
@@ -181,12 +181,12 @@ module.exports = {
         });
 
         if (!needRegistrations.length) {
-          return Promise.resolve(records);
+          return records;
         }
 
         const patientIds = needRegistrations.map(record => record.patient && record.patient.patient_id);
         if (!patientIds.length) {
-          return Promise.resolve(records);
+          return records;
         }
 
         return db.medic

--- a/api/src/services/export/message-mapper.js
+++ b/api/src/services/export/message-mapper.js
@@ -135,7 +135,6 @@ module.exports = {
       ],
       getRows: record => {
         const tasks = normalizeTasks(record);
-
         return _.flatten(tasks.map(task => {
           const history = buildHistory(task);
 

--- a/api/src/services/export/message-mapper.js
+++ b/api/src/services/export/message-mapper.js
@@ -140,7 +140,10 @@ module.exports = {
           const history = buildHistory(task);
 
           if (!task.messages) {
-            const templateContext = _.pick(record, 'patient', 'registrations');
+            const context = {
+              patient: record.patient,
+              registrations: record.registrations
+            };
             const content = {
               translationKey: task.message_key,
               message: task.message
@@ -151,7 +154,7 @@ module.exports = {
               record,
               content,
               task.recipient,
-              templateContext
+              context
             );
           }
 
@@ -199,8 +202,9 @@ module.exports = {
         return db.medic
           .query('medic-client/registered_patients', { keys: patientIds, include_docs: true })
           .then(result => {
-            const registrations = result.rows.filter(row =>
-              registrationUtils.isValidRegistration(row.doc, config.get()));
+            const registrations = result.rows.filter(row => {
+              return registrationUtils.isValidRegistration(row.doc, config.get());
+            });
 
             records.forEach(record => {
               record.registrations = getRecordRegistrations(registrations, record);

--- a/api/src/services/export/message-mapper.js
+++ b/api/src/services/export/message-mapper.js
@@ -155,12 +155,16 @@ module.exports = {
             );
           }
 
+          const taskType = (task.translation_key && config.translate(task.translation_key, { group: task.group })) ||
+                           task.type ||
+                           'Task Message';
+
           return task.messages.map(message => [
             record._id,
-            record.patient_id,
+            record.patient_id || (record.patient && record.patient.patient_id),
             formatDate(record.reported_date),
             record.from,
-            task.type || 'Task Message',
+            taskType,
             task.state,
             getStateDate('received', task, history),
             getStateDate('scheduled', task, history),
@@ -184,7 +188,10 @@ module.exports = {
           return records;
         }
 
-        const patientIds = needRegistrations.map(record => record.patient && record.patient.patient_id);
+        const patientIds = needRegistrations
+          .map(record => record.patient && record.patient.patient_id)
+          .filter((patientId, idx, self) => patientId && self.indexOf(patientId) === idx);
+
         if (!patientIds.length) {
           return records;
         }

--- a/api/tests/mocha/services/export/message-mapper.js
+++ b/api/tests/mocha/services/export/message-mapper.js
@@ -85,6 +85,400 @@ describe('Message mapper', () => {
           chai.expect(db.medic.query.callCount).to.equal(0);
         });
       });
+
+      it('queries for registrations with all patient ids', () => {
+        const records = [
+          { _id: 1, scheduled_tasks: [{ foo: 'bar' }], patient: { patient_id: 'a' } },
+          { _id: 2, scheduled_tasks: [{ foo: 'bar' }], patient: { patient_id: false} },
+          { _id: 3, scheduled_tasks: [{ foo: 'bar' }], patient: { patient_id: 'b' } },
+          { _id: 4, scheduled_tasks: [{ foo: 'bar' }], patient: { patient_id: 'a' } },
+        ];
+
+        db.medic.query.withArgs('medic-client/registered_patients').resolves({ rows: [] });
+
+        return service.map().then(({ hydrate }) => {
+          return hydrate(records).then(result => {
+            chai.expect(result).to.deep.equal([
+              { _id: 1, scheduled_tasks: [{ foo: 'bar' }], patient: { patient_id: 'a' }, registrations: [] },
+              { _id: 2, scheduled_tasks: [{ foo: 'bar' }], patient: { patient_id: false}, registrations: [] },
+              { _id: 3, scheduled_tasks: [{ foo: 'bar' }], patient: { patient_id: 'b' }, registrations: [] },
+              { _id: 4, scheduled_tasks: [{ foo: 'bar' }], patient: { patient_id: 'a' }, registrations: [] },
+            ]);
+
+            chai.expect(db.medic.query.callCount).to.equal(1);
+            chai.expect(db.medic.query.args[0][1]).to.deep.equal({ keys: ['a', 'b'], include_docs: true });
+            chai.expect(registrationUtils.isValidRegistration.callCount).to.equal(0);
+          });
+        });
+      });
+
+      it('filters for valid registrations and connects them to the records', () => {
+        const records = [
+          { _id: 1, scheduled_tasks: [{ foo: 'bar' }], patient: { patient_id: 'a' } },
+          { _id: 2, scheduled_tasks: [{ foo: 'bar' }], patient: { patient_id: 'c'} },
+          { _id: 3, scheduled_tasks: [{ foo: 'bar' }], patient: { patient_id: 'b' } },
+          { _id: 4, scheduled_tasks: [{ foo: 'bar' }], patient: { patient_id: 'a' } },
+          { _id: 4, scheduled_tasks: [{ foo: 'bar' }], patient: { patient_id: 'd' } },
+        ];
+
+        db.medic.query.withArgs('medic-client/registered_patients').resolves({
+          rows: [
+            { key: 'a', doc: { _id: 'r1', patient_id: 'a', valid: false } },
+            { key: 'b', doc: { _id: 'r2', patient_id: 'b', valid: true } },
+            { key: 'c', doc: { _id: 'r3', fields: { patient_id: 'c' }, valid: true  } },
+            { key: 'b', doc: { _id: 'r4', patient_id: 'b', valid: false } },
+            { key: 'a', doc: { _id: 'r5', patient_id: 'a', valid: true } },
+            { key: 'b', doc: { _id: 'r6', fields: { patient_id: 'b' }, valid: true } }
+          ]
+        });
+
+        registrationUtils.isValidRegistration
+          .withArgs(sinon.match({ valid: false })).returns(false)
+          .withArgs(sinon.match({ valid: true })).returns(true);
+
+        return service.map().then(({ hydrate }) => {
+          return hydrate(records).then(result => {
+            chai.expect(db.medic.query.callCount).to.equal(1);
+            chai.expect(db.medic.query.args[0][1]).to.deep.equal({ keys: ['a', 'c', 'b', 'd'], include_docs: true });
+            chai.expect(registrationUtils.isValidRegistration.callCount).to.equal(6);
+            chai.expect(registrationUtils.isValidRegistration.args[0][0])
+              .to.deep.equal({ _id: 'r1', patient_id: 'a', valid: false });
+            chai.expect(registrationUtils.isValidRegistration.args[1][0])
+              .to.deep.equal({ _id: 'r2', patient_id: 'b', valid: true });
+            chai.expect(registrationUtils.isValidRegistration.args[2][0])
+              .to.deep.equal({ _id: 'r3', fields: { patient_id: 'c' }, valid: true  });
+            chai.expect(registrationUtils.isValidRegistration.args[3][0])
+              .to.deep.equal({ _id: 'r4', patient_id: 'b', valid: false });
+            chai.expect(registrationUtils.isValidRegistration.args[4][0])
+              .to.deep.equal({ _id: 'r5', patient_id: 'a', valid: true } );
+            chai.expect(registrationUtils.isValidRegistration.args[5][0])
+              .to.deep.equal({ _id: 'r6', fields: { patient_id: 'b' }, valid: true });
+
+            chai.expect(result[0].registrations).to.deep.equal([
+              { _id: 'r5', patient_id: 'a', valid: true }
+            ]);
+            chai.expect(result[1].registrations).to.deep.equal([
+              { _id: 'r3', fields: { patient_id: 'c' }, valid: true  }
+            ]);
+            chai.expect(result[2].registrations).to.deep.equal([
+              { _id: 'r2', patient_id: 'b', valid: true },
+              { _id: 'r6', fields: { patient_id: 'b' }, valid: true }
+            ]);
+            chai.expect(result[3].registrations).to.deep.equal([
+              { _id: 'r5', patient_id: 'a', valid: true }
+            ]);
+            chai.expect(result[4].registrations).to.deep.equal([]);
+          });
+        });
+      });
+
+      it('throws query errors', () => {
+        const records = [{ _id: 1, scheduled_tasks: [{ foo: 'bar' }], patient: { patient_id: 'a' } }];
+        db.medic.query.rejects({ some: 'error' });
+
+        return service.map().then(({ hydrate }) => {
+          return hydrate(records)
+            .then(() => chai.expect(0).to.equal('should have thrown'))
+            .catch(err => chai.expect(err).to.deep.equal({ some: 'error' }));
+        });
+      });
+    });
+
+    describe('getRows', () => {
+      it('works when message has no messages', () => {
+        const record = {
+          _id: 1,
+          patient: { patient_id: 'a' },
+          type: 'data-record',
+          form: 'frm',
+          reported_date: new Date('2018-01-01 12:00:00').getTime()
+        };
+
+        return service.map().then(({ getRows }) => {
+          const result = getRows(record);
+          chai.expect(result).to.deep.equal([]);
+        });
+      });
+
+      it('works for responses', () => {
+        const record = {
+          _id: 'record_id',
+          patient: { patient_id: '123' },
+          reported_date: new Date('2018-01-01 12:00:00').getTime(),
+          from: '12345678',
+          responses: [
+            { to: '898989', message: 'the response', uuid: '1' },
+            { to: '909090', message: 'the response 2', uuid: '2' }
+          ]
+        };
+
+        return service.map().then(({ getRows }) => {
+          const result = getRows(record);
+          chai.expect(result.length).to.equal(2);
+          chai.expect(result[0]).to.deep.equal([
+            'record_id',
+            '123',
+            new Date('2018-01-01 12:00:00').getTime(),
+            '12345678',
+            'Automated Reply',
+            'sent',
+            '',
+            '',
+            '',
+            new Date('2018-01-01 12:00:00').getTime(),
+            '',
+            '',
+            '1',
+            undefined,
+            '898989',
+            'the response'
+          ]);
+
+          chai.expect(result[1]).to.deep.equal([
+            'record_id',
+            '123',
+            new Date('2018-01-01 12:00:00').getTime(),
+            '12345678',
+            'Automated Reply',
+            'sent',
+            '',
+            '',
+            '',
+            new Date('2018-01-01 12:00:00').getTime(),
+            '',
+            '',
+            '2',
+            undefined,
+            '909090',
+            'the response 2'
+          ]);
+        });
+      });
+
+      it('works for sms_messages', () => {
+        const record = {
+          _id: 'record_id',
+          patient: { patient_id: '123' },
+          reported_date: new Date('2018-01-01 12:00:00').getTime(),
+          from: '12345678',
+          sms_message: {
+            message: 'the message'
+          }
+        };
+
+        return service.map().then(({ getRows }) => {
+          const result = getRows(record);
+          chai.expect(result.length).to.equal(1);
+          chai.expect(result[0]).to.deep.equal([
+            'record_id',
+            '123',
+            new Date('2018-01-01 12:00:00').getTime(),
+            '12345678',
+            'Message',
+            'received',
+            new Date('2018-01-01 12:00:00').getTime(),
+            '',
+            '',
+            '',
+            '',
+            '',
+            undefined,
+            '12345678',
+            undefined,
+            'the message'
+          ]);
+        });
+      });
+
+      it('works with tasks', () => {
+        const record = {
+          _id: 'id_record',
+          patient: { patient_id: '456' },
+          reported_date: new Date('2017-02-01 12:00:00').getTime(),
+          from: '12345678',
+          tasks: [{
+            state: 'pending',
+            timestamp: new Date('2017-02-01 12:00:00').getTime(),
+            state_history: [{
+              state: 'pending',
+              timestamp: new Date('2017-02-01 12:00:00').getTime(),
+            }],
+            messages: [{
+              message: 'message1',
+              to: 'phone1',
+              uuid: 1
+            }]
+          }, {
+            state: 'forwarded-to-gateway',
+            timestamp: new Date('2017-02-01 12:00:00').getTime(),
+            state_history: [{
+              state: 'pending',
+              timestamp: new Date('2017-02-01 14:00:00').getTime(),
+            }, {
+              state: 'forwarded-to-gateway',
+              timestamp: new Date('2017-02-02 12:00:00').getTime(),
+            }],
+            messages: [{
+              message: 'message2',
+              to: 'phone2',
+              uuid: 2
+            }]
+          }]
+        };
+
+        return service.map().then(({ getRows }) => {
+          const result = getRows(record);
+          chai.expect(result.length).to.equal(2);
+          chai.expect(result[0]).to.deep.equal([
+            'id_record',
+            '456',
+            new Date('2017-02-01 12:00:00').getTime(),
+            '12345678',
+            'Task Message',
+            'pending',
+            '',
+            '',
+            new Date('2017-02-01 12:00:00').getTime(),
+            '',
+            '',
+            '',
+            1,
+            undefined,
+            'phone1',
+            'message1'
+          ]);
+
+          chai.expect(result[1]).to.deep.equal([
+            'id_record',
+            '456',
+            new Date('2017-02-01 12:00:00').getTime(),
+            '12345678',
+            'Task Message',
+            'forwarded-to-gateway',
+            '',
+            '',
+            new Date('2017-02-01 14:00:00').getTime(),
+            '',
+            '',
+            '',
+            2,
+            undefined,
+            'phone2',
+            'message2'
+          ]);
+        });
+      });
+
+      it('works with scheduled tasks (generates messages and translates task names)', () => {
+        const record = {
+          _id: 'record',
+          patient: { patient_id: '12345' },
+          reported_date: new Date('2017-02-01 12:00:00').getTime(),
+          from: '12345678',
+          registrations: [{ _id: 'r1' }, { _id: 'r2' }],
+          scheduled_tasks: [{
+            state: 'scheduled',
+            timestamp: new Date('2017-02-01 12:00:00').getTime(),
+            state_history: [{
+              state: 'scheduled',
+              timestamp: new Date('2017-02-01 12:00:00').getTime(),
+            }],
+            due: new Date('2017-03-01').getTime(),
+            type: 'my task type',
+            messages: [{
+              message: 'message1',
+              to: 'phone1',
+              uuid: 1
+            }]
+          }, {
+            state: 'pending',
+            timestamp: new Date('2017-02-01 12:00:00').getTime(),
+            state_history: [{
+              state: 'scheduled',
+              timestamp: new Date('2017-02-01 12:00:00').getTime(),
+            }, {
+              state: 'pending',
+              timestamp: new Date('2017-02-02 12:00:00').getTime(),
+            }],
+            translation_key: 'task-translation-key',
+            group: 'gr',
+            message_key: 'alpha',
+            recipient: 'random recipient',
+            due: new Date('2017-02-01').getTime()
+          }]
+        };
+
+        config.translate.withArgs('task-translation-key').returns('my translated task name');
+        messageUtils.generate.returns([{
+          uuid: 'uuid2',
+          to: 'phone2',
+          message: 'message2'
+        }]);
+
+        config.get.returns({ config: 1 });
+
+        return service.map().then(({ getRows }) => {
+          const result = getRows(record);
+
+          chai.expect(config.translate.callCount).to.equal(1);
+          chai.expect(config.translate.args[0]).to.deep.equal(['task-translation-key', { group: 'gr' }]);
+
+          chai.expect(messageUtils.generate.callCount).to.deep.equal(1);
+          chai.expect(messageUtils.generate.args[0]).to.deep.equal([
+            { config: 1 },
+            config.translate,
+            record,
+            {
+              translationKey: 'alpha',
+              message: undefined
+            },
+            'random recipient',
+            {
+              patient: record.patient,
+              registrations: record.registrations
+            }
+          ]);
+
+          chai.expect(result.length).to.equal(2);
+          chai.expect(result[0]).to.deep.equal([
+            'record',
+            '12345',
+            new Date('2017-02-01 12:00:00').getTime(),
+            '12345678',
+            'my task type',
+            'scheduled',
+            '',
+            new Date('2017-03-01').getTime(),
+            '',
+            '',
+            '',
+            '',
+            1,
+            undefined,
+            'phone1',
+            'message1'
+          ]);
+
+          chai.expect(result[1]).to.deep.equal([
+            'record',
+            '12345',
+            new Date('2017-02-01 12:00:00').getTime(),
+            '12345678',
+            'my translated task name',
+            'pending',
+            '',
+            new Date('2017-02-01').getTime(),
+            new Date('2017-02-02 12:00:00').getTime(),
+            '',
+            '',
+            '',
+            'uuid2',
+            undefined,
+            'phone2',
+            'message2'
+          ]);
+        });
+      });
     });
   });
 });

--- a/api/tests/mocha/services/export/message-mapper.js
+++ b/api/tests/mocha/services/export/message-mapper.js
@@ -1,0 +1,90 @@
+const sinon = require('sinon'),
+      chai = require('chai'),
+      service = require('../../../../src/services/export/message-mapper'),
+      messageUtils = require('@shared-libs/message-utils'),
+      registrationUtils = require('@shared-libs/registration-utils'),
+      db = require('../../../../src/db-pouch'),
+      config = require('../../../../src/config');
+
+describe('Message mapper', () => {
+
+  beforeEach(() => {
+    sinon.stub(db.medic, 'query');
+    sinon.stub(messageUtils, 'generate');
+    sinon.stub(registrationUtils, 'isValidRegistration');
+    sinon.stub(config, 'get');
+    sinon.stub(config, 'translate');
+  });
+
+  afterEach(() => sinon.restore());
+
+  describe('getDocIds', () => {
+    it('queries task-messages and returns message ids', () => {
+      const options = { some: 'option' };
+
+      db.medic.query.resolves({
+        rows: [{ id: 1, value: 1 }, { id: 1, value: 2 }, { id: 1, value: 3 }, { id: 2, value: 1 }]
+      });
+      return service.getDocIds(options).then(result => {
+        chai.expect(db.medic.query.callCount).to.equal(1);
+        chai.expect(db.medic.query.args[0]).to.deep.equal([ 'medic-sms/tasks_messages', options ]);
+        chai.expect(result).to.deep.equal([1, 1, 1, 2]);
+      });
+    });
+  });
+
+  describe('map', () => {
+    it('should return correct headers', () => {
+      return service.map().then(result => {
+        chai.expect(result.header).to.deep.equal([
+          'id',
+          'patient_id',
+          'reported_date',
+          'from',
+          'type',
+          'state',
+          'received',
+          'scheduled',
+          'pending',
+          'sent',
+          'cleared',
+          'muted',
+          'message_id',
+          'sent_by',
+          'to_phone',
+          'content'
+        ]);
+      });
+    });
+
+    describe('hydrate', () => {
+      it('echoes when no records with scheduled tasks missing messages are found', () => {
+        const records = [
+          { _id: 1, tasks: [1, 2, 3] },
+          { _id: 2, tasks: [1, 2, 3], scheduled_tasks: [] },
+          { _id: 3, tasks: [1, 2, 3], scheduled_tasks: [{ messages: [{ some: 'message' }] }] }
+        ];
+
+        return service.map().then(({ hydrate }) => {
+          const result = hydrate(records);
+          chai.expect(result).to.deep.equal(records);
+          chai.expect(db.medic.query.callCount).to.equal(0);
+        });
+      });
+
+      it('echoes when records with scheduled tasks missing messages dont have patient ids', () => {
+        const records = [
+          { _id: 1, scheduled_tasks: [{ foo: 'bar' }] },
+          { _id: 2, scheduled_tasks: [{ foo: 'bar' }], patient: {} },
+          { _id: 3, scheduled_tasks: [{ foo: 'bar' }], patient: { patient_id: false } },
+        ];
+
+        return service.map().then(({ hydrate }) => {
+          const result = hydrate(records);
+          chai.expect(result).to.deep.equal(records);
+          chai.expect(db.medic.query.callCount).to.equal(0);
+        });
+      });
+    });
+  });
+});

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@shared-libs/message-utils@file:../shared-libs/message-utils":
+  version "1.0.0"
+  dependencies:
+    underscore "^1.9.1"
+
 "@shared-libs/registration-utils@file:../shared-libs/registration-utils":
   version "1.0.0"
 
@@ -13,6 +18,8 @@
 
 "@shared-libs/tombstone-utils@file:../shared-libs/tombstone-utils":
   version "1.0.0"
+  dependencies:
+    underscore "^1.9.1"
 
 "@shared-libs/view-map-utils@file:../shared-libs/view-map-utils":
   version "1.0.0"
@@ -111,6 +118,12 @@ bcrypt-pbkdf@^1.0.0:
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
   dependencies:
     tweetnacl "^0.14.3"
+
+bikram-sambat@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bikram-sambat/-/bikram-sambat-1.5.0.tgz#675ce234e2a9ca08670a280bfb76509a816996b8"
+  dependencies:
+    eurodigit "^3.1.1"
 
 body-parser@1.18.2:
   version "1.18.2"
@@ -411,6 +424,10 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
 
+eurodigit@^3.1.1:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/eurodigit/-/eurodigit-3.1.3.tgz#a3b66a2383f4faa02a37749e19c24b60bd2849c2"
+
 eventemitter3@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
@@ -561,6 +578,10 @@ getpass@^0.1.1:
 google-libphonenumber@^3.1.11:
   version "3.1.11"
   resolved "https://registry.yarnpkg.com/google-libphonenumber/-/google-libphonenumber-3.1.11.tgz#894eafe874fbd456e794e322501b832871b7c568"
+
+gsm@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/gsm/-/gsm-0.1.4.tgz#f827624d8a24762fa50bc49bfca82c2006d1eb0a"
 
 har-schema@^2.0.0:
   version "2.0.0"
@@ -764,6 +785,8 @@ jsprim@^1.2.2:
 
 "lineage@file:../shared-libs/lineage":
   version "1.0.0"
+  dependencies:
+    underscore "^1.9.1"
 
 lodash.isempty@^4.4.0:
   version "4.4.0"


### PR DESCRIPTION
# Description

Fixes bug where exporting reports with scheduled_tasks, with not yet generated messages, would cause errors in API. As a fix, all scheduled messages are generated prior to exporting. 

medic/medic-webapp#4816

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.