### PR TITLE
4837 - Font awesome icons not loading in the administration console

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -208,7 +208,7 @@ module.exports = function(grunt) {
       },
       admin: {
         files: {
-          'build/ddocs/medic-admin/_attachments/main.css':
+          'build/ddocs/medic-admin/_attachments/css/main.css':
             'admin/src/css/main.less',
         },
       },
@@ -221,8 +221,8 @@ module.exports = function(grunt) {
         files: {
           'build/ddocs/medic/_attachments/css/inbox.css':
             'build/ddocs/medic/_attachments/css/inbox.css',
-          'build/ddocs/medic-admin/_attachments/main.css':
-            'build/ddocs/medic-admin/_attachments/main.css',
+          'build/ddocs/medic-admin/_attachments/css/main.css':
+            'build/ddocs/medic-admin/_attachments/css/main.css',
         },
       },
     },
@@ -422,38 +422,38 @@ module.exports = function(grunt) {
         'if [ -z $COUCH_URL ] || [ -z $API_URL ] || [ -z $COUCH_NODE_NAME ]; then ' +
         'echo "Missing required env var.  Check that all are set: ' +
         'COUCH_URL, API_URL, COUCH_NODE_NAME" && exit 1; fi',
-      'undo-patches': {
-        cmd: function() {
-          var modulesToPatch = [
-            'bootstrap-daterangepicker',
-            'font-awesome',
-            'moment',
-          ];
-          return modulesToPatch
-            .map(function(module) {
-              var backupPath = 'webapp/node_modules_backup/' + module;
-              var modulePath = 'webapp/node_modules/' + module;
-              return (
-                '[ -d ' +
-                backupPath +
-                ' ]' +
-                ' && rm -rf ' +
-                modulePath +
-                ' && mv ' +
-                backupPath +
-                ' ' +
-                modulePath +
-                ' && echo "Module restored: ' +
-                module +
-                '"' +
-                ' || echo "No restore required for: ' +
-                module +
-                '"'
-              );
-            })
-            .join(' && ');
+        'undo-patches': {
+          cmd: function() {
+            var modulesToPatch = [
+              'bootstrap-daterangepicker',
+              'font-awesome',
+              'moment',
+            ];
+            return modulesToPatch
+              .map(function(module) {
+                var backupPath = 'webapp/node_modules_backup/' + module;
+                var modulePath = 'webapp/node_modules/' + module;
+                return (
+                  '[ -d ' +
+                  backupPath +
+                  ' ]' +
+                  ' && rm -rf ' +
+                  modulePath +
+                  ' && mv ' +
+                  backupPath +
+                  ' ' +
+                  modulePath +
+                  ' && echo "Module restored: ' +
+                  module +
+                  '"' +
+                  ' || echo "No restore required for: ' +
+                  module +
+                  '"'
+                );
+              })
+              .join(' && ');
+          },
         },
-      },
       'shared-lib-unit': {
         cmd: () => {
           const fs = require('fs');

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -422,38 +422,38 @@ module.exports = function(grunt) {
         'if [ -z $COUCH_URL ] || [ -z $API_URL ] || [ -z $COUCH_NODE_NAME ]; then ' +
         'echo "Missing required env var.  Check that all are set: ' +
         'COUCH_URL, API_URL, COUCH_NODE_NAME" && exit 1; fi',
-        'undo-patches': {
-          cmd: function() {
-            var modulesToPatch = [
-              'bootstrap-daterangepicker',
-              'font-awesome',
-              'moment',
-            ];
-            return modulesToPatch
-              .map(function(module) {
-                var backupPath = 'webapp/node_modules_backup/' + module;
-                var modulePath = 'webapp/node_modules/' + module;
-                return (
-                  '[ -d ' +
-                  backupPath +
-                  ' ]' +
-                  ' && rm -rf ' +
-                  modulePath +
-                  ' && mv ' +
-                  backupPath +
-                  ' ' +
-                  modulePath +
-                  ' && echo "Module restored: ' +
-                  module +
-                  '"' +
-                  ' || echo "No restore required for: ' +
-                  module +
-                  '"'
-                );
-              })
-              .join(' && ');
-          },
+      'undo-patches': {
+        cmd: function() {
+          var modulesToPatch = [
+            'bootstrap-daterangepicker',
+            'font-awesome',
+            'moment',
+          ];
+          return modulesToPatch
+            .map(function(module) {
+              var backupPath = 'webapp/node_modules_backup/' + module;
+              var modulePath = 'webapp/node_modules/' + module;
+              return (
+                '[ -d ' +
+                backupPath +
+                ' ]' +
+                ' && rm -rf ' +
+                modulePath +
+                ' && mv ' +
+                backupPath +
+                ' ' +
+                modulePath +
+                ' && echo "Module restored: ' +
+                module +
+                '"' +
+                ' || echo "No restore required for: ' +
+                module +
+                '"'
+              );
+            })
+            .join(' && ');
         },
+      },
       'shared-lib-unit': {
         cmd: () => {
           const fs = require('fs');

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -130,7 +130,7 @@ module.exports = function(grunt) {
       },
       admin: {
         src: 'admin/src/js/main.js',
-        dest: 'build/ddocs/medic-admin/_attachments/main.js',
+        dest: 'build/ddocs/medic-admin/_attachments/js/main.js',
         options: {
           transform: ['browserify-ngannotate'],
           alias: {
@@ -151,10 +151,10 @@ module.exports = function(grunt) {
             'build/ddocs/medic/_attachments/js/templates.js',
           'build/ddocs/medic/_attachments/js/inbox.js':
             'build/ddocs/medic/_attachments/js/inbox.js',
-          'build/ddocs/medic-admin/_attachments/main.js':
-            'build/ddocs/medic-admin/_attachments/main.js',
-          'build/ddocs/medic-admin/_attachments/templates.js':
-            'build/ddocs/medic-admin/_attachments/templates.js',
+          'build/ddocs/medic-admin/_attachments/js/main.js':
+            'build/ddocs/medic-admin/_attachments/js/main.js',
+          'build/ddocs/medic-admin/_attachments/js/templates.js':
+            'build/ddocs/medic-admin/_attachments/js/templates.js',
         },
       },
     },
@@ -671,7 +671,7 @@ module.exports = function(grunt) {
       adminApp: {
         cwd: 'admin/src',
         src: ['templates/**/*.html', '!templates/index.html'],
-        dest: 'build/ddocs/medic-admin/_attachments/templates.js',
+        dest: 'build/ddocs/medic-admin/_attachments/js/templates.js',
         options: {
           htmlmin: {
             collapseBooleanAttributes: true,
@@ -776,10 +776,10 @@ module.exports = function(grunt) {
         'build/ddocs/medic/_attachments/js/inbox.js',
       'build/ddocs/medic/_attachments/js/templates.js':
         'build/ddocs/medic/_attachments/js/templates.js',
-      'build/ddocs/medic-admin/_attachments/main.js':
-        'build/ddocs/medic-admin/_attachments/main.js',
-      'build/ddocs/medic-admin/_attachments/templates.js':
-        'build/ddocs/medic-admin/_attachments/templates.js',
+      'build/ddocs/medic-admin/_attachments/js/main.js':
+        'build/ddocs/medic-admin/_attachments/js/main.js',
+      'build/ddocs/medic-admin/_attachments/js/templates.js':
+        'build/ddocs/medic-admin/_attachments/js/templates.js',
     },
   });
 

--- a/admin/src/templates/index.html
+++ b/admin/src/templates/index.html
@@ -26,7 +26,7 @@
       </div>
       <div class="content" ui-view></div>
     </div>
-    <script src="main.js"></script>
-    <script src="templates.js"></script>
+    <script src="js/main.js"></script>
+    <script src="js/templates.js"></script>
   </body>
 </html>

--- a/admin/src/templates/index.html
+++ b/admin/src/templates/index.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <link href="main.css" rel="stylesheet" type="text/css" media="screen">
+    <link href="css/main.css" rel="stylesheet" type="text/css" media="screen">
     <title>Medic Mobile administration console</title>
   </head>
   <body ng-controller="MainCtrl">

--- a/admin/tests/karma-unit.conf.js
+++ b/admin/tests/karma-unit.conf.js
@@ -31,8 +31,8 @@ module.exports = function(config) {
       '../webapp/tests/karma/q.js',
 
       // application code
-      '../build/ddocs/medic-admin/_attachments/main.js',
-      '../build/ddocs/medic-admin/_attachments/templates.js',
+      '../build/ddocs/medic-admin/_attachments/js/main.js',
+      '../build/ddocs/medic-admin/_attachments/js/templates.js',
 
       // test-specific code
       '../node_modules/chai/chai.js',

--- a/api/tests/mocha/ddoc-extraction.js
+++ b/api/tests/mocha/ddoc-extraction.js
@@ -75,7 +75,7 @@ describe('DDoc extraction', () => {
       {
         _id: '_design/updated',
         _attachments: {
-          'main.css': {
+          'css/main.css': {
             'content_type': 'text/css',
             'data': changedData1
           },
@@ -88,7 +88,7 @@ describe('DDoc extraction', () => {
       {
         _id: '_design/unchanged',
         _attachments: {
-          'main.css': {
+          'css/main.css': {
             'content_type': 'text/css',
             'data': unchangedData1
           },
@@ -120,7 +120,7 @@ describe('DDoc extraction', () => {
       _id: '_design/updated',
       _rev: '1',
       _attachments: {
-        'main.css': {
+        'css/main.css': {
           'content_type': 'text/css',
           'revpos': 442,
           'digest': 'md5-GuGMKFfYIWFhkG0apv8qYg==',
@@ -140,7 +140,7 @@ describe('DDoc extraction', () => {
       _id: '_design/unchanged',
       _rev: '1',
       _attachments: {
-        'main.css': {
+        'css/main.css': {
           'content_type': 'text/css',
           'revpos': 442,
           'digest': 'md5-auGMKFfYIWFhkG0apv8qYg==',

--- a/api/tests/mocha/ddoc-extraction.js
+++ b/api/tests/mocha/ddoc-extraction.js
@@ -79,7 +79,7 @@ describe('DDoc extraction', () => {
             'content_type': 'text/css',
             'data': changedData1
           },
-          'main.js': {
+          'js/main.js': {
             'content_type': 'application/javascript',
             'data': changedData2
           }
@@ -92,7 +92,7 @@ describe('DDoc extraction', () => {
             'content_type': 'text/css',
             'data': unchangedData1
           },
-          'main.js': {
+          'js/main.js': {
             'content_type': 'application/javascript',
             'data': unchangedData2
           }
@@ -127,7 +127,7 @@ describe('DDoc extraction', () => {
           'length': 201807,
           'data': changedData1
         },
-        'main.js': {
+        'js/main.js': {
           'content_type': 'application/javascript',
           'revpos': 442,
           'digest': 'md5-fuGMKFfYIWFhkG0apv8qYg==',
@@ -147,7 +147,7 @@ describe('DDoc extraction', () => {
           'length': 201807,
           'data': unchangedData1
         },
-        'main.js': {
+        'js/main.js': {
           'content_type': 'application/javascript',
           'revpos': 442,
           'digest': 'md5-buGMKFfYIWFhkG0apv8qYg==',

--- a/ddocs/medic-admin/rewrites.json
+++ b/ddocs/medic-admin/rewrites.json
@@ -1,6 +1,7 @@
 [
   {"from": "/",             "to": "index.html"},
-  {"from": "/main.css",     "to": "main.css"},
+  {"from": "/css/*",        "to": "css/*"},
+  {"from": "/fonts/*",      "to": "fonts/*"},
   {"from": "/main.js",      "to": "main.js"},
   {"from": "/templates.js", "to": "templates.js"}
 ]

--- a/ddocs/medic-admin/rewrites.json
+++ b/ddocs/medic-admin/rewrites.json
@@ -2,6 +2,5 @@
   {"from": "/",             "to": "index.html"},
   {"from": "/css/*",        "to": "css/*"},
   {"from": "/fonts/*",      "to": "fonts/*"},
-  {"from": "/main.js",      "to": "main.js"},
-  {"from": "/templates.js", "to": "templates.js"}
+  {"from": "/js/*",         "to": "js/*"}
 ]

--- a/tests/e2e/api/routing.js
+++ b/tests/e2e/api/routing.js
@@ -502,7 +502,7 @@ describe('routing', () => {
         .all([
           utils.requestOnTestDb(_.defaults({ path: '/_design/medic-admin/_rewrite' }, offlineRequestOptions), false, true),
           utils.requestOnTestDb(_.defaults({ path: '/_design/medic-admin/_rewrite/' }, offlineRequestOptions), false, true),
-          utils.requestOnTestDb(_.defaults({ path: '/_design/medic-admin/main.css' }, offlineRequestOptions), false, true)
+          utils.requestOnTestDb(_.defaults({ path: '/_design/medic-admin/css/main.css' }, offlineRequestOptions), false, true)
         ])
         .then(results => {
           expect(results[0].includes('administration console')).toBe(true);

--- a/webapp/src/js/services/location.js
+++ b/webapp/src/js/services/location.js
@@ -7,7 +7,7 @@ angular.module('inboxServices').factory('Location',
     var location = $window.location;
     var dbName = location.pathname.split('/')[1];
     var path = '/' + dbName + '/_design/medic/_rewrite';
-    var adminPath = '/' + dbName + '/_design/medic-admin/_rewrite/';
+    var adminPath = '/' + dbName + '/_design/medic-admin/_rewrite';
     var port = location.port ? ':' + location.port : '';
     var url = location.protocol + '//' + location.hostname + port + '/' + dbName;
 

--- a/webapp/src/js/services/location.js
+++ b/webapp/src/js/services/location.js
@@ -7,7 +7,7 @@ angular.module('inboxServices').factory('Location',
     var location = $window.location;
     var dbName = location.pathname.split('/')[1];
     var path = '/' + dbName + '/_design/medic/_rewrite';
-    var adminPath = '/' + dbName + '/_design/medic-admin/_rewrite';
+    var adminPath = '/' + dbName + '/_design/medic-admin/_rewrite/';
     var port = location.port ? ':' + location.port : '';
     var url = location.protocol + '//' + location.hostname + port + '/' + dbName;
 


### PR DESCRIPTION
# Description

Font awesome icons not loading in the administration console. Relative paths to FontAwesome rely on a trailing `/` at the end of the url.  `/medic/_design/medic-admin/_rewrite/`

medic/medic-webapp#4837

This relative pathing seems a tad brittle.

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.