### PR TITLE
Fixed: fa icons not being loaded on administrator console

### DIFF
--- a/webapp/src/js/services/location.js
+++ b/webapp/src/js/services/location.js
@@ -1,21 +1,18 @@
-angular.module('inboxServices').factory('Location',
-  function($window) {
+angular.module('inboxServices').factory('Location', function($window) {
+  'use strict';
+  'ngInject';
 
-    'use strict';
-    'ngInject';
+  var location = $window.location;
+  var dbName = location.pathname.split('/')[1];
+  var path = '/' + dbName + '/_design/medic/_rewrite';
+  var adminPath = '/' + dbName + '/_design/medic-admin/_rewrite/';
+  var port = location.port ? ':' + location.port : '';
+  var url = location.protocol + '//' + location.hostname + port + '/' + dbName;
 
-    var location = $window.location;
-    var dbName = location.pathname.split('/')[1];
-    var path = '/' + dbName + '/_design/medic/_rewrite';
-    var adminPath = '/' + dbName + '/_design/medic-admin/_rewrite';
-    var port = location.port ? ':' + location.port : '';
-    var url = location.protocol + '//' + location.hostname + port + '/' + dbName;
-
-    return {
-      path: path,
-      adminPath: adminPath,
-      dbName: dbName,
-      url: url
-    };
-  }
-);
+  return {
+    path: path,
+    adminPath: adminPath,
+    dbName: dbName,
+    url: url,
+  };
+});


### PR DESCRIPTION
# Description

Font awesome icons not loading in the administration console. Relative paths to FontAwesome rely on a trailing / at the end of the url. /medic/_design/medic-admin/_rewrite/

This relative pathing seems a tad brittle.

medic/medic-webapp#4837

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.