### PR TITLE
After searching, the RHS should clear of anything

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_script:
 
 script:
   - |
-    if [[ "$TEST_SUITE" = 'normal' ]]; then
+    if [[ "$TEST_SUITE" = "normal" ]]; then
       node --stack_size=10000 `which grunt` ci-unit &&
       node --stack_size=10000 `which grunt` ci-integration-e2e
     elif [[ "$TEST_SUITE" = 'performance' ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_script:
 
 script:
   - |
-    if [[ "$TEST_SUITE" = "normal" ]]; then
+    if [[ "$TEST_SUITE" = 'normal' ]]; then
       node --stack_size=10000 `which grunt` ci-unit &&
       node --stack_size=10000 `which grunt` ci-integration-e2e
     elif [[ "$TEST_SUITE" = 'performance' ]]; then

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -130,7 +130,7 @@ module.exports = function(grunt) {
       },
       admin: {
         src: 'admin/src/js/main.js',
-        dest: 'build/ddocs/medic-admin/_attachments/main.js',
+        dest: 'build/ddocs/medic-admin/_attachments/js/main.js',
         options: {
           transform: ['browserify-ngannotate'],
           alias: {
@@ -151,10 +151,10 @@ module.exports = function(grunt) {
             'build/ddocs/medic/_attachments/js/templates.js',
           'build/ddocs/medic/_attachments/js/inbox.js':
             'build/ddocs/medic/_attachments/js/inbox.js',
-          'build/ddocs/medic-admin/_attachments/main.js':
-            'build/ddocs/medic-admin/_attachments/main.js',
-          'build/ddocs/medic-admin/_attachments/templates.js':
-            'build/ddocs/medic-admin/_attachments/templates.js',
+          'build/ddocs/medic-admin/_attachments/js/main.js':
+            'build/ddocs/medic-admin/_attachments/js/main.js',
+          'build/ddocs/medic-admin/_attachments/js/templates.js':
+            'build/ddocs/medic-admin/_attachments/js/templates.js',
         },
       },
     },
@@ -208,7 +208,7 @@ module.exports = function(grunt) {
       },
       admin: {
         files: {
-          'build/ddocs/medic-admin/_attachments/main.css':
+          'build/ddocs/medic-admin/_attachments/css/main.css':
             'admin/src/css/main.less',
         },
       },
@@ -221,8 +221,8 @@ module.exports = function(grunt) {
         files: {
           'build/ddocs/medic/_attachments/css/inbox.css':
             'build/ddocs/medic/_attachments/css/inbox.css',
-          'build/ddocs/medic-admin/_attachments/main.css':
-            'build/ddocs/medic-admin/_attachments/main.css',
+          'build/ddocs/medic-admin/_attachments/css/main.css':
+            'build/ddocs/medic-admin/_attachments/css/main.css',
         },
       },
     },
@@ -671,7 +671,7 @@ module.exports = function(grunt) {
       adminApp: {
         cwd: 'admin/src',
         src: ['templates/**/*.html', '!templates/index.html'],
-        dest: 'build/ddocs/medic-admin/_attachments/templates.js',
+        dest: 'build/ddocs/medic-admin/_attachments/js/templates.js',
         options: {
           htmlmin: {
             collapseBooleanAttributes: true,
@@ -776,10 +776,10 @@ module.exports = function(grunt) {
         'build/ddocs/medic/_attachments/js/inbox.js',
       'build/ddocs/medic/_attachments/js/templates.js':
         'build/ddocs/medic/_attachments/js/templates.js',
-      'build/ddocs/medic-admin/_attachments/main.js':
-        'build/ddocs/medic-admin/_attachments/main.js',
-      'build/ddocs/medic-admin/_attachments/templates.js':
-        'build/ddocs/medic-admin/_attachments/templates.js',
+      'build/ddocs/medic-admin/_attachments/js/main.js':
+        'build/ddocs/medic-admin/_attachments/js/main.js',
+      'build/ddocs/medic-admin/_attachments/js/templates.js':
+        'build/ddocs/medic-admin/_attachments/js/templates.js',
     },
   });
 

--- a/admin/src/templates/index.html
+++ b/admin/src/templates/index.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <link href="main.css" rel="stylesheet" type="text/css" media="screen">
+    <link href="css/main.css" rel="stylesheet" type="text/css" media="screen">
     <title>Medic Mobile administration console</title>
   </head>
   <body ng-controller="MainCtrl">
@@ -26,7 +26,7 @@
       </div>
       <div class="content" ui-view></div>
     </div>
-    <script src="main.js"></script>
-    <script src="templates.js"></script>
+    <script src="js/main.js"></script>
+    <script src="js/templates.js"></script>
   </body>
 </html>

--- a/admin/tests/karma-unit.conf.js
+++ b/admin/tests/karma-unit.conf.js
@@ -31,8 +31,8 @@ module.exports = function(config) {
       '../webapp/tests/karma/q.js',
 
       // application code
-      '../build/ddocs/medic-admin/_attachments/main.js',
-      '../build/ddocs/medic-admin/_attachments/templates.js',
+      '../build/ddocs/medic-admin/_attachments/js/main.js',
+      '../build/ddocs/medic-admin/_attachments/js/templates.js',
 
       // test-specific code
       '../node_modules/chai/chai.js',

--- a/api/tests/mocha/ddoc-extraction.js
+++ b/api/tests/mocha/ddoc-extraction.js
@@ -75,11 +75,11 @@ describe('DDoc extraction', () => {
       {
         _id: '_design/updated',
         _attachments: {
-          'main.css': {
+          'css/main.css': {
             'content_type': 'text/css',
             'data': changedData1
           },
-          'main.js': {
+          'js/main.js': {
             'content_type': 'application/javascript',
             'data': changedData2
           }
@@ -88,11 +88,11 @@ describe('DDoc extraction', () => {
       {
         _id: '_design/unchanged',
         _attachments: {
-          'main.css': {
+          'css/main.css': {
             'content_type': 'text/css',
             'data': unchangedData1
           },
-          'main.js': {
+          'js/main.js': {
             'content_type': 'application/javascript',
             'data': unchangedData2
           }
@@ -120,14 +120,14 @@ describe('DDoc extraction', () => {
       _id: '_design/updated',
       _rev: '1',
       _attachments: {
-        'main.css': {
+        'css/main.css': {
           'content_type': 'text/css',
           'revpos': 442,
           'digest': 'md5-GuGMKFfYIWFhkG0apv8qYg==',
           'length': 201807,
           'data': changedData1
         },
-        'main.js': {
+        'js/main.js': {
           'content_type': 'application/javascript',
           'revpos': 442,
           'digest': 'md5-fuGMKFfYIWFhkG0apv8qYg==',
@@ -140,14 +140,14 @@ describe('DDoc extraction', () => {
       _id: '_design/unchanged',
       _rev: '1',
       _attachments: {
-        'main.css': {
+        'css/main.css': {
           'content_type': 'text/css',
           'revpos': 442,
           'digest': 'md5-auGMKFfYIWFhkG0apv8qYg==',
           'length': 201807,
           'data': unchangedData1
         },
-        'main.js': {
+        'js/main.js': {
           'content_type': 'application/javascript',
           'revpos': 442,
           'digest': 'md5-buGMKFfYIWFhkG0apv8qYg==',

--- a/ddocs/medic-admin/rewrites.json
+++ b/ddocs/medic-admin/rewrites.json
@@ -1,6 +1,6 @@
 [
   {"from": "/",             "to": "index.html"},
-  {"from": "/main.css",     "to": "main.css"},
-  {"from": "/main.js",      "to": "main.js"},
-  {"from": "/templates.js", "to": "templates.js"}
+  {"from": "/css/*",        "to": "css/*"},
+  {"from": "/fonts/*",      "to": "fonts/*"},
+  {"from": "/js/*",         "to": "js/*"}
 ]

--- a/tests/e2e/api/routing.js
+++ b/tests/e2e/api/routing.js
@@ -502,7 +502,7 @@ describe('routing', () => {
         .all([
           utils.requestOnTestDb(_.defaults({ path: '/_design/medic-admin/_rewrite' }, offlineRequestOptions), false, true),
           utils.requestOnTestDb(_.defaults({ path: '/_design/medic-admin/_rewrite/' }, offlineRequestOptions), false, true),
-          utils.requestOnTestDb(_.defaults({ path: '/_design/medic-admin/main.css' }, offlineRequestOptions), false, true)
+          utils.requestOnTestDb(_.defaults({ path: '/_design/medic-admin/css/main.css' }, offlineRequestOptions), false, true)
         ])
         .then(results => {
           expect(results[0].includes('administration console')).toBe(true);

--- a/tests/e2e/common/common.specs.js
+++ b/tests/e2e/common/common.specs.js
@@ -1,5 +1,5 @@
 const commonElements = require('../../page-objects/common/common.po.js'),
-      utils = require('../../utils');
+  utils = require('../../utils');
 
 describe('Navigation tests : ', () => {
   beforeEach(utils.beforeEach);
@@ -19,19 +19,18 @@ describe('Navigation tests : ', () => {
   it('should open Reports or History tab', () => {
     commonElements.goToReports();
     expect(commonElements.isAt('reports-list'));
-    expect(browser.getCurrentUrl()).toEqual(utils.getBaseUrl() + 'reports/');
+    expect(browser.getCurrentUrl()).toEqual(utils.getBaseUrl() + 'reports');
   });
 
   it('should open Contacts or Peoples tab', () => {
     commonElements.goToPeople();
     expect(commonElements.isAt('contacts-list'));
-    expect(browser.getCurrentUrl()).toEqual(utils.getBaseUrl() + 'contacts/');
+    expect(browser.getCurrentUrl()).toEqual(utils.getBaseUrl() + 'contacts');
   });
 
   it('should open Analytics or Targets tab', () => {
     commonElements.goToAnalytics();
     expect(browser.getCurrentUrl()).toEqual(utils.getBaseUrl() + 'analytics');
-
   });
 
   it('should open Configuration tab', () => {

--- a/tests/e2e/common/common.specs.js
+++ b/tests/e2e/common/common.specs.js
@@ -19,13 +19,13 @@ describe('Navigation tests : ', () => {
   it('should open Reports or History tab', () => {
     commonElements.goToReports();
     expect(commonElements.isAt('reports-list'));
-    expect(browser.getCurrentUrl()).toEqual(utils.getBaseUrl() + 'reports');
+    expect(browser.getCurrentUrl()).toEqual(utils.getBaseUrl() + 'reports/');
   });
 
   it('should open Contacts or Peoples tab', () => {
     commonElements.goToPeople();
     expect(commonElements.isAt('contacts-list'));
-    expect(browser.getCurrentUrl()).toEqual(utils.getBaseUrl() + 'contacts');
+    expect(browser.getCurrentUrl()).toEqual(utils.getBaseUrl() + 'contacts/');
   });
 
   it('should open Analytics or Targets tab', () => {

--- a/webapp/src/js/controllers/contacts.js
+++ b/webapp/src/js/controllers/contacts.js
@@ -253,19 +253,19 @@ var _ = require('underscore'),
         });
     };
 
-    var clearSelected = function() {
+    var clearSelection = function() {
       $scope.selected = null;
       LiveList.contacts.clearSelected();
       LiveList['contact-search'].clearSelected();
     };
 
     $scope.$on('ClearSelected', function() {
-      clearSelected();
+      clearSelection();
     });
 
     $scope.search = function() {
-      $location.path('/contacts/');
-      clearSelected();
+      $state.go('contacts', null, { notify: false });
+      clearSelection();
       $scope.loading = true;
       if ($scope.filters.search || $scope.filters.simprintsIdentities) {
         $scope.filtered = true;

--- a/webapp/src/js/controllers/contacts.js
+++ b/webapp/src/js/controllers/contacts.js
@@ -253,13 +253,19 @@ var _ = require('underscore'),
         });
     };
 
-    $scope.$on('ClearSelected', function() {
+    var clearSelected = function() {
       $scope.selected = null;
       LiveList.contacts.clearSelected();
       LiveList['contact-search'].clearSelected();
+    };
+
+    $scope.$on('ClearSelected', function() {
+      clearSelected();
     });
 
     $scope.search = function() {
+      $location.path('/contacts/');
+      clearSelected();
       $scope.loading = true;
       if ($scope.filters.search || $scope.filters.simprintsIdentities) {
         $scope.filtered = true;

--- a/webapp/src/js/controllers/contacts.js
+++ b/webapp/src/js/controllers/contacts.js
@@ -264,7 +264,8 @@ var _ = require('underscore'),
     });
 
     $scope.search = function() {
-      $state.go('contacts', null, { notify: false });
+      $state.go('contacts.detail', { id: null }, { notify: false });
+
       clearSelection();
       $scope.loading = true;
       if ($scope.filters.search || $scope.filters.simprintsIdentities) {

--- a/webapp/src/js/controllers/reports.js
+++ b/webapp/src/js/controllers/reports.js
@@ -255,8 +255,8 @@ angular
     };
 
     $scope.search = function() {
-      $location.path('/reports/');
-      clearSelected();
+      $state.go('reports', null, { notify: false });
+      clearSelection();
       if ($scope.isMobile() && $scope.showContent) {
         // leave content shown
         return;
@@ -289,7 +289,7 @@ angular
       setRightActionBar();
     });
 
-    var clearSelected = function() {
+    var clearSelection = function() {
       $scope.selected = [];
       $('#reports-list input[type="checkbox"]').prop('checked', false);
       LiveList.reports.clearSelected();
@@ -298,7 +298,7 @@ angular
     };
 
     $scope.$on('ClearSelected', function() {
-      clearSelected();
+      clearSelection();
     });
 
     $scope.$on('VerifyReport', function(e, valid) {

--- a/webapp/src/js/controllers/reports.js
+++ b/webapp/src/js/controllers/reports.js
@@ -255,6 +255,8 @@ angular
     };
 
     $scope.search = function() {
+      $location.path('/reports/');
+      clearSelected();
       if ($scope.isMobile() && $scope.showContent) {
         // leave content shown
         return;
@@ -287,12 +289,16 @@ angular
       setRightActionBar();
     });
 
-    $scope.$on('ClearSelected', function() {
+    var clearSelected = function() {
       $scope.selected = [];
       $('#reports-list input[type="checkbox"]').prop('checked', false);
       LiveList.reports.clearSelected();
       LiveList['report-search'].clearSelected();
       $scope.verifyingReport = false;
+    };
+
+    $scope.$on('ClearSelected', function() {
+      clearSelected();
     });
 
     $scope.$on('VerifyReport', function(e, valid) {

--- a/webapp/src/js/controllers/reports.js
+++ b/webapp/src/js/controllers/reports.js
@@ -255,7 +255,7 @@ angular
     };
 
     $scope.search = function() {
-      $state.go('reports', null, { notify: false });
+      $state.go('reports.detail', { id: null }, { notify: false });
       clearSelection();
       if ($scope.isMobile() && $scope.showContent) {
         // leave content shown
@@ -480,7 +480,7 @@ angular
           $timeout(function() {
             $link.removeClass('mm-icon-disabled');
           }, 2000);
-          
+
           Export(exportFilters, 'reports');
         },
       });

--- a/webapp/src/js/services/search.js
+++ b/webapp/src/js/services/search.js
@@ -39,13 +39,13 @@ var _ = require('underscore'),
       // Silently cancel repeated queries.
       var debounce = function(type, filters, options) {
         if (type === _currentQuery.type &&
-            filters === _currentQuery.filters &&
-            _.isEqual(options, _currentQuery.options)) {
+          _.isEqual(filters, _currentQuery.filters) &&
+          _.isEqual(options, _currentQuery.options)) {
           return true;
         }
         _currentQuery.type = type;
-        _currentQuery.filters = filters;
-        _currentQuery.options = options;
+        _currentQuery.filters = Object.assign({}, filters);
+        _currentQuery.options = Object.assign({}, options);
         return false;
       };
 

--- a/webapp/tests/karma/unit/controllers/contacts.js
+++ b/webapp/tests/karma/unit/controllers/contacts.js
@@ -393,7 +393,7 @@ describe('Contacts controller', () => {
         });
     });
 
-    it("when user doesn't have facility_id", () => {
+    it(`when user doesn't have facility_id`, () => {
       userSettings = KarmaUtils.promiseService(null, {});
       getDataRecords = KarmaUtils.promiseService();
       return createController()

--- a/webapp/tests/karma/unit/controllers/contacts.js
+++ b/webapp/tests/karma/unit/controllers/contacts.js
@@ -278,7 +278,7 @@ describe('Contacts controller', () => {
       });
     });
 
-    it("sets the actionbar partially if it couldn't get forms", () => {
+    it(`sets the actionbar partially if it couldn't get forms`, () => {
       xmlForms.callsArgWith(2, { error: 'no forms brew' }); // call the callback
       return testRightActionBar({ doc: person }, actionBarArgs => {
         assert.equal(actionBarArgs.relevantForms, undefined);

--- a/webapp/tests/karma/unit/controllers/contacts.js
+++ b/webapp/tests/karma/unit/controllers/contacts.js
@@ -1,38 +1,37 @@
 describe('Contacts controller', () => {
-
   'use strict';
 
   let assert = chai.assert,
-      buttonLabel,
-      contactsLiveList,
-      childType,
-      contactSchema,
-      createController,
-      district,
-      forms,
-      icon,
-      isAdmin = false,
-      person,
-      scope,
-      userSettings,
-      searchResults,
-      searchService,
-      getDataRecords,
-      typeLabel,
-      xmlForms,
-      $rootScope,
-      scrollLoaderStub,
-      scrollLoaderCallback,
-      changes,
-      changesCallback,
-      changesFilter,
-      contactSearchLiveList,
-      deadListFind,
-      settings,
-      auth,
-      deadListContains,
-      deadList,
-      contactSummary;
+    buttonLabel,
+    contactsLiveList,
+    childType,
+    contactSchema,
+    createController,
+    district,
+    forms,
+    icon,
+    isAdmin = false,
+    person,
+    scope,
+    userSettings,
+    searchResults,
+    searchService,
+    getDataRecords,
+    typeLabel,
+    xmlForms,
+    $rootScope,
+    scrollLoaderStub,
+    scrollLoaderCallback,
+    changes,
+    changesCallback,
+    changesFilter,
+    contactSearchLiveList,
+    deadListFind,
+    settings,
+    auth,
+    deadListContains,
+    deadList,
+    contactSummary;
 
   beforeEach(module('inboxApp'));
 
@@ -42,14 +41,15 @@ describe('Contacts controller', () => {
     deadList = () => {
       let elements = [];
 
-      return  {
+      return {
         getList: () => elements,
         initialised: sinon.stub(),
         setSelected: sinon.stub(),
+        clearSelected: sinon.stub(),
         refresh: sinon.stub(),
         count: () => elements.length,
         insert: e => elements.push(e),
-        set: es => elements = es,
+        set: es => (elements = es),
         update: e => {
           if (e !== district || elements[0] !== district) {
             elements.push(e);
@@ -62,7 +62,7 @@ describe('Contacts controller', () => {
           return false;
         },
         contains: deadListContains,
-        containsDeleteStub: sinon.stub()
+        containsDeleteStub: sinon.stub(),
       };
     };
 
@@ -83,16 +83,27 @@ describe('Contacts controller', () => {
       get: sinon.stub(),
       getChildPlaceType: sinon.stub(),
       getPlaceTypes: sinon.stub(),
-      getTypes: sinon.stub()
+      getTypes: sinon.stub(),
     };
-    contactSchema.get.returns({ icon: icon, addButtonLabel : buttonLabel, label: typeLabel });
+    contactSchema.get.returns({
+      icon: icon,
+      addButtonLabel: buttonLabel,
+      label: typeLabel,
+    });
     contactSchema.getChildPlaceType.returns(childType);
     contactSchema.getPlaceTypes.returns(['district_hospital']);
-    contactSchema.getTypes.returns(['person', 'district_hospital', 'clinic', 'health_center']);
+    contactSchema.getTypes.returns([
+      'person',
+      'district_hospital',
+      'clinic',
+      'health_center',
+    ]);
     xmlForms = sinon.stub();
     forms = [{ internalId: 'a-form', icon: 'an-icon', title: 'A Form' }];
     xmlForms.callsArgWith(2, null, forms); // call the callback
-    userSettings = KarmaUtils.promiseService(null, { facility_id: district._id });
+    userSettings = KarmaUtils.promiseService(null, {
+      facility_id: district._id,
+    });
     contactsLiveList = deadList();
     contactSearchLiveList = deadList();
     getDataRecords = KarmaUtils.promiseService(null, district);
@@ -102,10 +113,10 @@ describe('Contacts controller', () => {
     scrollLoaderStub = {
       init: callback => {
         scrollLoaderCallback = callback;
-      }
+      },
     };
 
-    changes = (options) =>  {
+    changes = options => {
       changesFilter = options.filter;
       changesCallback = options.callback;
       return { unsubscribe: () => {} };
@@ -122,61 +133,70 @@ describe('Contacts controller', () => {
       searchService.returns(Promise.resolve(searchResults));
 
       return $controller('ContactsCtrl', {
-        '$element': sinon.stub(),
-        '$log': { error: sinon.stub() },
-        '$q': Q,
-        '$scope': scope,
-        '$state': { includes: sinon.stub() },
-        '$timeout': work => work(),
-        '$translate': $translate,
-        'Auth': auth,
-        'Changes': changes,
-        'ContactSchema': contactSchema,
-        'ContactSummary': contactSummary,
-        'Export': () => {},
-        'GetDataRecords': getDataRecords,
-        'LiveList': { contacts: contactsLiveList, 'contact-search': contactSearchLiveList },
-        'Search': searchService,
-        'SearchFilters': { freetext: sinon.stub(), reset: sinon.stub()},
-        'Session': {
-          isAdmin: () => { return isAdmin; }
+        $element: sinon.stub(),
+        $log: { error: sinon.stub() },
+        $q: Q,
+        $scope: scope,
+        $state: { includes: sinon.stub(), go: sinon.stub() },
+        $timeout: work => work(),
+        $translate: $translate,
+        Auth: auth,
+        Changes: changes,
+        ContactSchema: contactSchema,
+        ContactSummary: contactSummary,
+        Export: () => {},
+        GetDataRecords: getDataRecords,
+        LiveList: {
+          contacts: contactsLiveList,
+          'contact-search': contactSearchLiveList,
         },
-        'Settings': settings,
-        'Simprints': { enabled: () => false },
-        'Tour': () => {},
-        'TranslateFrom': key => `TranslateFrom:${key}`,
-        'UserSettings': userSettings,
-        'XmlForms': xmlForms
+        Search: searchService,
+        SearchFilters: { freetext: sinon.stub(), reset: sinon.stub() },
+        Session: {
+          isAdmin: () => {
+            return isAdmin;
+          },
+        },
+        Settings: settings,
+        Simprints: { enabled: () => false },
+        Tour: () => {},
+        TranslateFrom: key => `TranslateFrom:${key}`,
+        UserSettings: userSettings,
+        XmlForms: xmlForms,
       });
     };
   }));
 
   it('sets title', () => {
-    return createController().getSetupPromiseForTesting()
+    return createController()
+      .getSetupPromiseForTesting()
       .then(() => {
         return scope.setSelected({ doc: district });
       })
       .then(() => {
         assert(scope.setTitle.called, 'title should be set');
-        assert.equal(scope.setTitle.getCall(0).args[0], typeLabel + 'translated');
+        assert.equal(
+          scope.setTitle.getCall(0).args[0],
+          typeLabel + 'translated'
+        );
       });
   });
 
   describe('selecting contacts', () => {
-    const testContactSelection = (selected) => {
-      return createController().getSetupPromiseForTesting()
+    const testContactSelection = selected => {
+      return createController()
+        .getSetupPromiseForTesting()
         .then(() => {
           return scope.setSelected(selected);
         });
     };
 
     it('set selected contact', () => {
-      return testContactSelection({ doc: district })
-        .then(() => {
-          assert.deepEqual(scope.selected.doc, district);
-          assert(scope.setRightActionBar.called);
-          assert(scope.setRightActionBar.args[0][0].selected);
-        });
+      return testContactSelection({ doc: district }).then(() => {
+        assert.deepEqual(scope.selected.doc, district);
+        assert(scope.setRightActionBar.called);
+        assert(scope.setRightActionBar.args[0][0].selected);
+      });
     });
 
     it('throws an error, sets a scope variable and resets the action bar when contact cannot be selected', () => {
@@ -191,17 +211,20 @@ describe('Contacts controller', () => {
           assert.deepEqual(scope.setRightActionBar.args[0], []);
         });
     });
-
   });
 
   describe('sets right actionBar', () => {
     const testRightActionBar = (selected, assertions) => {
-      return createController().getSetupPromiseForTesting()
+      return createController()
+        .getSetupPromiseForTesting()
         .then(() => {
           return scope.setSelected(selected);
         })
         .then(() => {
-          assert(scope.setRightActionBar.called, 'right actionBar should be set');
+          assert(
+            scope.setRightActionBar.called,
+            'right actionBar should be set'
+          );
           const actionBarArgs = scope.setRightActionBar.getCall(0).args[0];
           assertions(actionBarArgs);
         });
@@ -217,7 +240,10 @@ describe('Contacts controller', () => {
       return testRightActionBar({ doc: district }, actionBarArgs => {
         assert.equal(actionBarArgs.selected[0].child.type, childType);
         assert.equal(actionBarArgs.selected[0].child.icon, icon);
-        assert.equal(actionBarArgs.selected[0].child.addPlaceLabel, buttonLabel);
+        assert.equal(
+          actionBarArgs.selected[0].child.addPlaceLabel,
+          buttonLabel
+        );
       });
     });
 
@@ -252,15 +278,18 @@ describe('Contacts controller', () => {
       });
     });
 
-    it('sets the actionbar partially if it couldn\'t get forms', () => {
-      xmlForms.callsArgWith(2, { error: 'no forms brew'}); // call the callback
+    it("sets the actionbar partially if it couldn't get forms", () => {
+      xmlForms.callsArgWith(2, { error: 'no forms brew' }); // call the callback
       return testRightActionBar({ doc: person }, actionBarArgs => {
         assert.equal(actionBarArgs.relevantForms, undefined);
         assert.deepEqual(actionBarArgs.sendTo, person);
         assert.equal(actionBarArgs.selected[0]._id, person._id);
         assert.equal(actionBarArgs.selected[0].child.type, childType);
         assert.equal(actionBarArgs.selected[0].child.icon, icon);
-        assert.equal(actionBarArgs.selected[0].child.addPlaceLabel, buttonLabel);
+        assert.equal(
+          actionBarArgs.selected[0].child.addPlaceLabel,
+          buttonLabel
+        );
       });
     });
 
@@ -277,33 +306,45 @@ describe('Contacts controller', () => {
     });
 
     it('disables deleting for places with child places', () => {
-      return testRightActionBar({ doc: district, children: { places: [ district ] } }, actionBarArgs => {
-        assert.equal(actionBarArgs.canDelete, false);
-      });
+      return testRightActionBar(
+        { doc: district, children: { places: [district] } },
+        actionBarArgs => {
+          assert.equal(actionBarArgs.canDelete, false);
+        }
+      );
     });
 
     it('disables deleting for places with child people', () => {
-      return testRightActionBar({ doc: district, children: { persons: [ person ] } }, actionBarArgs => {
-        assert.equal(actionBarArgs.canDelete, false);
-      });
+      return testRightActionBar(
+        { doc: district, children: { persons: [person] } },
+        actionBarArgs => {
+          assert.equal(actionBarArgs.canDelete, false);
+        }
+      );
     });
 
     it('enables deleting for leaf nodes', () => {
-      return testRightActionBar({ doc: district, children: { persons: [], places: [] } }, actionBarArgs => {
-        assert.equal(actionBarArgs.canDelete, true);
-      });
+      return testRightActionBar(
+        { doc: district, children: { persons: [], places: [] } },
+        actionBarArgs => {
+          assert.equal(actionBarArgs.canDelete, true);
+        }
+      );
     });
 
     describe('translates form titles', () => {
-
       const testTranslation = (form, expectedTitle) => {
-        xmlForms.callsArgWith(2, null, [ form ]);
-        return createController().getSetupPromiseForTesting()
+        xmlForms.callsArgWith(2, null, [form]);
+        return createController()
+          .getSetupPromiseForTesting()
           .then(() => {
             return scope.setSelected({ doc: district });
           })
           .then(() => {
-            assert(scope.setRightActionBar.called, 'right actionBar should be set');
+            assert(
+              scope.setRightActionBar.called,
+              'right actionBar should be set'
+            );
             const actionBarArgs = scope.setRightActionBar.getCall(0).args[0];
             assert.deepEqual(actionBarArgs.relevantForms.length, 1);
             assert.equal(actionBarArgs.relevantForms[0].title, expectedTitle);
@@ -311,7 +352,11 @@ describe('Contacts controller', () => {
       };
 
       it('uses the translation_key', () => {
-        const form = { internalId: 'a', icon: 'a-icon', translation_key: 'a.form.key' };
+        const form = {
+          internalId: 'a',
+          icon: 'a-icon',
+          translation_key: 'a.form.key',
+        };
         return testTranslation(form, 'a.form.keytranslated');
       });
 
@@ -321,7 +366,12 @@ describe('Contacts controller', () => {
       });
 
       it('uses the translation_key in preference to the title', () => {
-        const form = { internalId: 'a', icon: 'a-icon', translation_key: 'a.form.key', title: 'My Form' };
+        const form = {
+          internalId: 'a',
+          icon: 'a-icon',
+          translation_key: 'a.form.key',
+          title: 'My Form',
+        };
         return testTranslation(form, 'a.form.keytranslated');
       });
     });
@@ -329,129 +379,177 @@ describe('Contacts controller', () => {
 
   describe('sets left actionBar', () => {
     it('when user has facility_id', () => {
-      createController().getSetupPromiseForTesting().then(() => {
-        assert(scope.setLeftActionBar.called, 'left actionBar should be set');
-        const actionBarArgs = scope.setLeftActionBar.getCall(0).args[0];
-        assert.deepEqual(actionBarArgs.userChildPlace, { type: childType, icon: icon });
-        assert.equal(actionBarArgs.userFacilityId, district._id);
-        assert.equal(actionBarArgs.addPlaceLabel, buttonLabel);
-      });
+      createController()
+        .getSetupPromiseForTesting()
+        .then(() => {
+          assert(scope.setLeftActionBar.called, 'left actionBar should be set');
+          const actionBarArgs = scope.setLeftActionBar.getCall(0).args[0];
+          assert.deepEqual(actionBarArgs.userChildPlace, {
+            type: childType,
+            icon: icon,
+          });
+          assert.equal(actionBarArgs.userFacilityId, district._id);
+          assert.equal(actionBarArgs.addPlaceLabel, buttonLabel);
+        });
     });
 
-    it('when user doesn\'t have facility_id', () => {
+    it("when user doesn't have facility_id", () => {
       userSettings = KarmaUtils.promiseService(null, {});
       getDataRecords = KarmaUtils.promiseService();
-      return createController().getSetupPromiseForTesting().then(() => {
-        assert(scope.setLeftActionBar.called);
-      });
+      return createController()
+        .getSetupPromiseForTesting()
+        .then(() => {
+          assert(scope.setLeftActionBar.called);
+        });
     });
   });
 
   describe('Search', () => {
-
     it('Puts the home place at the top of the list', () => {
       searchResults = [
         {
-          _id: 'search-result'
-        }
+          _id: 'search-result',
+        },
       ];
 
-      return createController().getSetupPromiseForTesting().then(() => {
-        const lhs = contactsLiveList.getList();
-        assert.equal(lhs.length, 2, 'both home place and search results are shown');
-        assert.equal(lhs[0]._id, district._id, 'first item is home place');
-        assert.equal(lhs[1]._id, 'search-result', 'second item is search result');
-      });
+      return createController()
+        .getSetupPromiseForTesting()
+        .then(() => {
+          const lhs = contactsLiveList.getList();
+          assert.equal(
+            lhs.length,
+            2,
+            'both home place and search results are shown'
+          );
+          assert.equal(lhs[0]._id, district._id, 'first item is home place');
+          assert.equal(
+            lhs[1]._id,
+            'search-result',
+            'second item is search result'
+          );
+        });
     });
 
     it('Only displays the home place once', () => {
       searchResults = [
         {
-          _id: 'search-result'
+          _id: 'search-result',
         },
         {
-          _id: district._id
-        }
+          _id: district._id,
+        },
       ];
 
-      return createController().getSetupPromiseForTesting().then(() => {
-        const lhs = contactsLiveList.getList();
-        assert.equal(lhs.length, 2, 'both home place and search results are shown');
-        assert.equal(lhs[0]._id, district._id, 'first item is home place');
-        assert.equal(lhs[1]._id, 'search-result', 'second item is search result');
-      });
+      return createController()
+        .getSetupPromiseForTesting()
+        .then(() => {
+          const lhs = contactsLiveList.getList();
+          assert.equal(
+            lhs.length,
+            2,
+            'both home place and search results are shown'
+          );
+          assert.equal(lhs[0]._id, district._id, 'first item is home place');
+          assert.equal(
+            lhs[1]._id,
+            'search-result',
+            'second item is search result'
+          );
+        });
     });
 
     it('Only searches for top-level places as an admin', () => {
       isAdmin = true;
-      userSettings = KarmaUtils.promiseService(null, { facility_id: undefined });
+      userSettings = KarmaUtils.promiseService(null, {
+        facility_id: undefined,
+      });
       searchResults = [
         {
-          _id: 'search-result'
-        }
+          _id: 'search-result',
+        },
       ];
 
-      return createController().getSetupPromiseForTesting().then(() => {
-        assert.deepEqual(searchService.args[0][1], {types: { selected: ['district_hospital']}});
-        const lhs = contactsLiveList.getList();
-        assert.equal(lhs.length, 1, 'both home place and search results are shown');
-      });
+      return createController()
+        .getSetupPromiseForTesting()
+        .then(() => {
+          assert.deepEqual(searchService.args[0][1], {
+            types: { selected: ['district_hospital'] },
+          });
+          const lhs = contactsLiveList.getList();
+          assert.equal(
+            lhs.length,
+            1,
+            'both home place and search results are shown'
+          );
+        });
     });
 
     it('when paginating, does not skip the extra place for admins #4085', () => {
       isAdmin = true;
-      userSettings = KarmaUtils.promiseService(null, { facility_id: undefined });
+      userSettings = KarmaUtils.promiseService(null, {
+        facility_id: undefined,
+      });
       const searchResult = { _id: 'search-result' };
       searchResults = Array(50).fill(searchResult);
 
-      return createController().getSetupPromiseForTesting({ scrollLoaderStub }).then(() => {
-        const lhs = contactsLiveList.getList();
-        assert.equal(lhs.length, 50);
-        scrollLoaderCallback();
-        assert.equal(searchService.args[1][2].skip, 50);
-        assert.equal(searchService.args[1][2].limit, 50);
-      });
+      return createController()
+        .getSetupPromiseForTesting({ scrollLoaderStub })
+        .then(() => {
+          const lhs = contactsLiveList.getList();
+          assert.equal(lhs.length, 50);
+          scrollLoaderCallback();
+          assert.equal(searchService.args[1][2].skip, 50);
+          assert.equal(searchService.args[1][2].limit, 50);
+        });
     });
 
     it('when paginating, does modify skip for non-admins #4085', () => {
       const searchResult = { _id: 'search-result' };
       searchResults = Array(50).fill(searchResult);
 
-      return createController().getSetupPromiseForTesting({ scrollLoaderStub }).then(() => {
-        const lhs = contactsLiveList.getList();
-        assert.equal(lhs.length, 51);
-        scrollLoaderCallback();
-        assert.equal(searchService.args[1][2].skip, 50);
-        assert.equal(searchService.args[1][2].limit, 50);
-      });
+      return createController()
+        .getSetupPromiseForTesting({ scrollLoaderStub })
+        .then(() => {
+          const lhs = contactsLiveList.getList();
+          assert.equal(lhs.length, 51);
+          scrollLoaderCallback();
+          assert.equal(searchService.args[1][2].skip, 50);
+          assert.equal(searchService.args[1][2].limit, 50);
+        });
     });
 
     it('when refreshing list as admin, does not modify limit #4085', () => {
       isAdmin = true;
-      userSettings = KarmaUtils.promiseService(null, { facility_id: undefined });
+      userSettings = KarmaUtils.promiseService(null, {
+        facility_id: undefined,
+      });
       const searchResult = { _id: 'search-result' };
       searchResults = Array(10).fill(searchResult);
 
-      return createController().getSetupPromiseForTesting({ scrollLoaderStub }).then(() => {
-        const lhs = contactsLiveList.getList();
-        changesCallback({});
-        assert.equal(lhs.length, 10);
-        assert.equal(searchService.args[1][2].limit, 10);
-        assert.equal(searchService.args[1][2].skip, undefined);
-      });
+      return createController()
+        .getSetupPromiseForTesting({ scrollLoaderStub })
+        .then(() => {
+          const lhs = contactsLiveList.getList();
+          changesCallback({});
+          assert.equal(lhs.length, 10);
+          assert.equal(searchService.args[1][2].limit, 10);
+          assert.equal(searchService.args[1][2].skip, undefined);
+        });
     });
 
     it('when refreshing list as non-admin, does modify limit #4085', () => {
       const searchResult = { _id: 'search-result' };
       searchResults = Array(10).fill(searchResult);
 
-      return createController().getSetupPromiseForTesting({ scrollLoaderStub }).then(() => {
-        const lhs = contactsLiveList.getList();
-        assert.equal(lhs.length, 11);
-        changesCallback({});
-        assert.equal(searchService.args[1][2].limit, 10);
-        assert.equal(searchService.args[1][2].skip, undefined);
-      });
+      return createController()
+        .getSetupPromiseForTesting({ scrollLoaderStub })
+        .then(() => {
+          const lhs = contactsLiveList.getList();
+          assert.equal(lhs.length, 11);
+          changesCallback({});
+          assert.equal(searchService.args[1][2].limit, 10);
+          assert.equal(searchService.args[1][2].skip, undefined);
+        });
     });
 
     it('resets limit/skip modifier when filtering #4085', () => {
@@ -464,7 +562,7 @@ describe('Contacts controller', () => {
         .then(() => {
           lhs = contactsLiveList.getList();
           assert.equal(lhs.length, 11);
-          scope.filters = {search: true};
+          scope.filters = { search: true };
           searchResults = Array(50).fill(searchResult);
           searchService.returns(Promise.resolve(searchResults));
           scope.search();
@@ -487,13 +585,15 @@ describe('Contacts controller', () => {
       searchResults = Array(49).fill(searchResult);
       searchResults.push(district);
 
-      return createController().getSetupPromiseForTesting({ scrollLoaderStub }).then(() => {
-        const lhs = contactsLiveList.getList();
-        assert.equal(lhs.length, 50);
-        scrollLoaderCallback();
-        assert.equal(searchService.args[1][2].skip, 50);
-        assert.equal(searchService.args[1][2].limit, 50);
-      });
+      return createController()
+        .getSetupPromiseForTesting({ scrollLoaderStub })
+        .then(() => {
+          const lhs = contactsLiveList.getList();
+          assert.equal(lhs.length, 50);
+          scrollLoaderCallback();
+          assert.equal(searchService.args[1][2].skip, 50);
+          assert.equal(searchService.args[1][2].limit, 50);
+        });
     });
 
     it('when paginating, does not modify the skip when it finds homeplace on subsequent pages #4085', () => {
@@ -532,39 +632,48 @@ describe('Contacts controller', () => {
 
   describe('Changes feed filtering', () => {
     it('filtering returns true for `contact` type documents #4080', () => {
-      return createController().getSetupPromiseForTesting().then(() => {
-        assert.equal(changesFilter({ doc: { type: 'person' } }), true);
-        assert.equal(changesFilter({ doc: { type: 'clinic' } }), true);
-        assert.equal(changesFilter({ doc: { type: 'health_center' } }), true);
-        assert.equal(changesFilter({ doc: { type: 'district_hospital' } }), true);
-        assert.equal(contactsLiveList.containsDeleteStub.callCount, 0);
-      });
+      return createController()
+        .getSetupPromiseForTesting()
+        .then(() => {
+          assert.equal(changesFilter({ doc: { type: 'person' } }), true);
+          assert.equal(changesFilter({ doc: { type: 'clinic' } }), true);
+          assert.equal(changesFilter({ doc: { type: 'health_center' } }), true);
+          assert.equal(
+            changesFilter({ doc: { type: 'district_hospital' } }),
+            true
+          );
+          assert.equal(contactsLiveList.containsDeleteStub.callCount, 0);
+        });
     });
 
     it('filtering returns false for non-`contact` type documents #4080', () => {
-      return createController().getSetupPromiseForTesting().then(() => {
-        assert.isNotOk(changesFilter({ doc: { } }));
-        assert.isNotOk(changesFilter({ doc: { type: 'data_record' } }));
-        assert.isNotOk(changesFilter({ doc: { type: '' } }));
-        assert.equal(contactsLiveList.containsDeleteStub.callCount, 3);
-      });
+      return createController()
+        .getSetupPromiseForTesting()
+        .then(() => {
+          assert.isNotOk(changesFilter({ doc: {} }));
+          assert.isNotOk(changesFilter({ doc: { type: 'data_record' } }));
+          assert.isNotOk(changesFilter({ doc: { type: '' } }));
+          assert.equal(contactsLiveList.containsDeleteStub.callCount, 3);
+        });
     });
 
     it('refreshes contacts list when receiving a contact change #4080', () => {
       searchResults = [
         {
-          _id: 'search-result'
+          _id: 'search-result',
         },
         {
-          _id: district._id
-        }
+          _id: district._id,
+        },
       ];
 
-      return createController().getSetupPromiseForTesting().then(() => {
-        changesCallback({ doc: { _id: '123'} });
-        assert.equal(searchService.callCount, 2);
-        assert.equal(searchService.args[1][2].limit, 2);
-      });
+      return createController()
+        .getSetupPromiseForTesting()
+        .then(() => {
+          changesCallback({ doc: { _id: '123' } });
+          assert.equal(searchService.callCount, 2);
+          assert.equal(searchService.args[1][2].limit, 2);
+        });
     });
 
     it('when handling deletes, does not shorten the LiveList #4080', () => {
@@ -572,7 +681,9 @@ describe('Contacts controller', () => {
       searchResults = Array(30).fill(searchResult);
 
       isAdmin = true;
-      userSettings = KarmaUtils.promiseService(null, { facility_id: undefined });
+      userSettings = KarmaUtils.promiseService(null, {
+        facility_id: undefined,
+      });
 
       return createController()
         .getSetupPromiseForTesting()
@@ -588,8 +699,8 @@ describe('Contacts controller', () => {
       return createController()
         .getSetupPromiseForTesting()
         .then(() => {
-          assert.equal(changesFilter({ doc: { } }), true);
-      });
+          assert.equal(changesFilter({ doc: {} }), true);
+        });
     });
   });
 
@@ -597,7 +708,8 @@ describe('Contacts controller', () => {
     it('does not enable LastVisitedDate features not allowed', function() {
       auth.rejects();
 
-      return createController().getSetupPromiseForTesting()
+      return createController()
+        .getSetupPromiseForTesting()
         .then(() => {
           assert.equal(auth.callCount, 1);
           assert.deepEqual(auth.args[0], ['can_view_last_visited_date']);
@@ -613,7 +725,7 @@ describe('Contacts controller', () => {
             { types: { selected: ['childType'] } },
             { limit: 50 },
             {},
-            undefined
+            undefined,
           ]);
 
           scope.sortDirection = 'something';
@@ -625,7 +737,8 @@ describe('Contacts controller', () => {
     it('enables LastVisitedDate features when allowed', function() {
       auth.resolves();
 
-      return createController().getSetupPromiseForTesting()
+      return createController()
+        .getSetupPromiseForTesting()
         .then(() => {
           assert.equal(auth.callCount, 1);
           assert.deepEqual(auth.args[0], ['can_view_last_visited_date']);
@@ -642,9 +755,9 @@ describe('Contacts controller', () => {
             { limit: 50 },
             {
               displayLastVisitedDate: true,
-              visitCountSettings: {}
+              visitCountSettings: {},
             },
-            undefined
+            undefined,
           ]);
         });
     });
@@ -656,18 +769,22 @@ describe('Contacts controller', () => {
           contacts_default_sort: false,
           visit_count: {
             month_start_date: false,
-            visit_count_goal: 1
-          }
-        }
+            visit_count_goal: 1,
+          },
+        },
       });
 
-      return createController().getSetupPromiseForTesting()
+      return createController()
+        .getSetupPromiseForTesting()
         .then(() => {
           assert.equal(auth.callCount, 1);
           assert.deepEqual(auth.args[0], ['can_view_last_visited_date']);
 
           assert.equal(scope.lastVisitedDateExtras, true);
-          assert.deepEqual(scope.visitCountSettings, { monthStartDate: false, visitCountGoal: 1 });
+          assert.deepEqual(scope.visitCountSettings, {
+            monthStartDate: false,
+            visitCountGoal: 1,
+          });
           assert.equal(scope.sortDirection, 'alpha');
           assert.equal(settings.callCount, 1);
 
@@ -678,9 +795,9 @@ describe('Contacts controller', () => {
             { limit: 50 },
             {
               displayLastVisitedDate: true,
-              visitCountSettings: { monthStartDate: false, visitCountGoal: 1 }
+              visitCountSettings: { monthStartDate: false, visitCountGoal: 1 },
             },
-            undefined
+            undefined,
           ]);
         });
     });
@@ -692,18 +809,22 @@ describe('Contacts controller', () => {
           contacts_default_sort: 'something',
           visit_count: {
             month_start_date: false,
-            visit_count_goal: 1
-          }
-        }
+            visit_count_goal: 1,
+          },
+        },
       });
 
-      return createController().getSetupPromiseForTesting()
+      return createController()
+        .getSetupPromiseForTesting()
         .then(() => {
           assert.equal(auth.callCount, 1);
           assert.deepEqual(auth.args[0], ['can_view_last_visited_date']);
 
           assert.equal(scope.lastVisitedDateExtras, true);
-          assert.deepEqual(scope.visitCountSettings, { monthStartDate: false, visitCountGoal: 1 });
+          assert.deepEqual(scope.visitCountSettings, {
+            monthStartDate: false,
+            visitCountGoal: 1,
+          });
           assert.equal(scope.sortDirection, 'something');
           assert.equal(settings.callCount, 1);
 
@@ -714,9 +835,9 @@ describe('Contacts controller', () => {
             { limit: 50 },
             {
               displayLastVisitedDate: true,
-              visitCountSettings: { monthStartDate: false, visitCountGoal: 1 }
+              visitCountSettings: { monthStartDate: false, visitCountGoal: 1 },
             },
-            undefined
+            undefined,
           ]);
 
           scope.sortDirection = 'somethingElse';
@@ -732,18 +853,22 @@ describe('Contacts controller', () => {
           contacts_default_sort: 'last_visited_date',
           visit_count: {
             month_start_date: 25,
-            visit_count_goal: 125
-          }
-        }
+            visit_count_goal: 125,
+          },
+        },
       });
 
-      return createController().getSetupPromiseForTesting()
+      return createController()
+        .getSetupPromiseForTesting()
         .then(() => {
           assert.equal(auth.callCount, 1);
           assert.deepEqual(auth.args[0], ['can_view_last_visited_date']);
 
           assert.equal(scope.lastVisitedDateExtras, true);
-          assert.deepEqual(scope.visitCountSettings, { monthStartDate: 25, visitCountGoal: 125 });
+          assert.deepEqual(scope.visitCountSettings, {
+            monthStartDate: 25,
+            visitCountGoal: 125,
+          });
           assert.equal(scope.sortDirection, 'last_visited_date');
           assert.equal(scope.defaultSortDirection, 'last_visited_date');
           assert.equal(settings.callCount, 1);
@@ -756,9 +881,9 @@ describe('Contacts controller', () => {
             {
               displayLastVisitedDate: true,
               visitCountSettings: { monthStartDate: 25, visitCountGoal: 125 },
-              sortByLastVisitedDate: true
+              sortByLastVisitedDate: true,
             },
-            undefined
+            undefined,
           ]);
 
           scope.sortDirection = 'something';
@@ -769,68 +894,131 @@ describe('Contacts controller', () => {
 
     it('changes listener filters relevant last visited reports when feature is enabled', () => {
       auth.resolves();
-      const relevantReport = { type: 'data_record', form: 'home_visit', fields: { visited_contact_uuid: 'something' } };
-      const deletedReport = { type: 'data_record', form: 'home_visit', fields: { visited_contact_uuid: 'deleted' }, _deleted: true };
+      const relevantReport = {
+        type: 'data_record',
+        form: 'home_visit',
+        fields: { visited_contact_uuid: 'something' },
+      };
+      const deletedReport = {
+        type: 'data_record',
+        form: 'home_visit',
+        fields: { visited_contact_uuid: 'deleted' },
+        _deleted: true,
+      };
       const irrelevantReports = [
-        { type: 'data_record', form: 'home_visit', fields: { visited_contact_uuid: 'else' }},
-        { type: 'data_record', form: 'home_visit', fields: { uuid: 'bla' }},
+        {
+          type: 'data_record',
+          form: 'home_visit',
+          fields: { visited_contact_uuid: 'else' },
+        },
+        { type: 'data_record', form: 'home_visit', fields: { uuid: 'bla' } },
         { type: 'data_record', form: 'home_visit' },
-        { type: 'something', form: 'home_visit', fields: { visited_contact_uuid: 'something' }},
+        {
+          type: 'something',
+          form: 'home_visit',
+          fields: { visited_contact_uuid: 'something' },
+        },
       ];
 
       deadListContains.returns(false);
       deadListContains.withArgs({ _id: 'something' }).returns(true);
 
-      return createController().getSetupPromiseForTesting().then(() => {
-        assert.equal(!!changesFilter({ doc: relevantReport }), true);
-        assert.equal(!!changesFilter({ doc: irrelevantReports[0] }), false);
-        assert.equal(!!changesFilter({ doc: irrelevantReports[1] }), false);
-        assert.equal(!!changesFilter({ doc: irrelevantReports[2] }), false);
-        assert.equal(!!changesFilter({ doc: irrelevantReports[3] }), false);
-        assert.equal(!!changesFilter({ doc: deletedReport, deleted: true }), false);
-      });
+      return createController()
+        .getSetupPromiseForTesting()
+        .then(() => {
+          assert.equal(!!changesFilter({ doc: relevantReport }), true);
+          assert.equal(!!changesFilter({ doc: irrelevantReports[0] }), false);
+          assert.equal(!!changesFilter({ doc: irrelevantReports[1] }), false);
+          assert.equal(!!changesFilter({ doc: irrelevantReports[2] }), false);
+          assert.equal(!!changesFilter({ doc: irrelevantReports[3] }), false);
+          assert.equal(
+            !!changesFilter({ doc: deletedReport, deleted: true }),
+            false
+          );
+        });
     });
 
     it('changes listener filters deleted visit reports when sorting by last visited date', () => {
       auth.resolves();
-      const deletedReport = { type: 'data_record', form: 'home_visit', fields: { visited_contact_uuid: 'deleted' }, _deleted: true };
+      const deletedReport = {
+        type: 'data_record',
+        form: 'home_visit',
+        fields: { visited_contact_uuid: 'deleted' },
+        _deleted: true,
+      };
       deadListContains.returns(false);
-      return createController().getSetupPromiseForTesting().then(() => {
-        scope.sortDirection = 'last_visited_date';
-        assert.equal(!!changesFilter({ doc: deletedReport, deleted: true }), true);
-      });
+      return createController()
+        .getSetupPromiseForTesting()
+        .then(() => {
+          scope.sortDirection = 'last_visited_date';
+          assert.equal(
+            !!changesFilter({ doc: deletedReport, deleted: true }),
+            true
+          );
+        });
     });
 
     it('changes listener does not filter last visited reports when feature is disabled', () => {
       auth.rejects();
-      const relevantReport = { type: 'data_record', form: 'home_visit', fields: { visited_contact_uuid: 'something' } };
+      const relevantReport = {
+        type: 'data_record',
+        form: 'home_visit',
+        fields: { visited_contact_uuid: 'something' },
+      };
       const irrelevantReports = [
-        { type: 'data_record', form: 'home_visit', fields: { visited_contact_uuid: 'else' }},
-        { type: 'data_record', form: 'home_visit', fields: { uuid: 'bla' }},
+        {
+          type: 'data_record',
+          form: 'home_visit',
+          fields: { visited_contact_uuid: 'else' },
+        },
+        { type: 'data_record', form: 'home_visit', fields: { uuid: 'bla' } },
         { type: 'data_record', form: 'home_visit' },
-        { type: 'something', form: 'home_visit', fields: { visited_contact_uuid: 'something' }},
+        {
+          type: 'something',
+          form: 'home_visit',
+          fields: { visited_contact_uuid: 'something' },
+        },
       ];
 
       deadListContains.returns(false);
       deadListContains.withArgs({ _id: 'something' }).returns(true);
 
-      return createController().getSetupPromiseForTesting().then(() => {
-        assert.equal(!!changesFilter({ doc: relevantReport }), false);
-        assert.equal(!!changesFilter({ doc: irrelevantReports[0] }), false);
-        assert.equal(!!changesFilter({ doc: irrelevantReports[1] }), false);
-        assert.equal(!!changesFilter({ doc: irrelevantReports[2] }), false);
-        assert.equal(!!changesFilter({ doc: irrelevantReports[3] }), false);
+      return createController()
+        .getSetupPromiseForTesting()
+        .then(() => {
+          assert.equal(!!changesFilter({ doc: relevantReport }), false);
+          assert.equal(!!changesFilter({ doc: irrelevantReports[0] }), false);
+          assert.equal(!!changesFilter({ doc: irrelevantReports[1] }), false);
+          assert.equal(!!changesFilter({ doc: irrelevantReports[2] }), false);
+          assert.equal(!!changesFilter({ doc: irrelevantReports[3] }), false);
 
-        assert.equal(deadListContains.callCount, 0);
-      });
+          assert.equal(deadListContains.callCount, 0);
+        });
     });
 
     describe('fully refreshing LHS list', () => {
-      const relevantVisitReport = { type: 'data_record', form: 'home_visit', fields: { visited_contact_uuid: 4 } },
-            irrelevantReport = { type: 'data_record', form: 'somethibg', fields: {} },
-            irrelevantVisitReport = { type: 'data_record', form: 'home_visit', fields: { visited_contact_uuid: 122 } },
-            deletedVisitReport = { type: 'data_record', form: 'home_visit', fields: { visited_contact_uuid: 122 }, _deleted: true },
-            someContact = { type: 'person', _id: 1 };
+      const relevantVisitReport = {
+          type: 'data_record',
+          form: 'home_visit',
+          fields: { visited_contact_uuid: 4 },
+        },
+        irrelevantReport = {
+          type: 'data_record',
+          form: 'somethibg',
+          fields: {},
+        },
+        irrelevantVisitReport = {
+          type: 'data_record',
+          form: 'home_visit',
+          fields: { visited_contact_uuid: 122 },
+        },
+        deletedVisitReport = {
+          type: 'data_record',
+          form: 'home_visit',
+          fields: { visited_contact_uuid: 122 },
+          _deleted: true,
+        },
+        someContact = { type: 'person', _id: 1 };
 
       describe('uhc visits enabled', () => {
         beforeEach(() => {
@@ -839,18 +1027,20 @@ describe('Contacts controller', () => {
         });
         describe('alpha default sorting', () => {
           it('does not require refreshing when sorting is `alpha` and visit report is received', () => {
-            return createController().getSetupPromiseForTesting().then(() => {
-              Array.apply(null, Array(5)).forEach((k, i) => contactsLiveList.insert({ _id: i }));
-              assert.equal(searchService.callCount, 1);
-              return Promise
-                .all([
+            return createController()
+              .getSetupPromiseForTesting()
+              .then(() => {
+                Array.apply(null, Array(5)).forEach((k, i) =>
+                  contactsLiveList.insert({ _id: i })
+                );
+                assert.equal(searchService.callCount, 1);
+                return Promise.all([
                   changesCallback({ doc: relevantVisitReport }),
                   changesCallback({ doc: irrelevantReport }),
                   changesCallback({ doc: irrelevantVisitReport }),
                   changesCallback({ doc: deletedVisitReport, deleted: true }),
-                  changesCallback({ doc: someContact })
-                ])
-                .then(() => {
+                  changesCallback({ doc: someContact }),
+                ]).then(() => {
                   assert.equal(searchService.callCount, 6);
 
                   for (let i = 1; i < 6; i++) {
@@ -858,36 +1048,42 @@ describe('Contacts controller', () => {
                       'contacts',
                       { types: { selected: ['childType'] } },
                       { limit: 5, withIds: false, silent: true },
-                      { displayLastVisitedDate: true, visitCountSettings: {}, },
-                      undefined
+                      { displayLastVisitedDate: true, visitCountSettings: {} },
+                      undefined,
                     ]);
                   }
                 });
-            });
+              });
           });
 
           it('does require refreshing when sorting is `last_visited_date` and visit report is received', () => {
-            return createController().getSetupPromiseForTesting().then(() => {
-              Array.apply(null, Array(5)).forEach((k, i) => contactsLiveList.insert({ _id: i }));
-              assert.equal(searchService.callCount, 1);
-              scope.sortDirection = 'last_visited_date';
+            return createController()
+              .getSetupPromiseForTesting()
+              .then(() => {
+                Array.apply(null, Array(5)).forEach((k, i) =>
+                  contactsLiveList.insert({ _id: i })
+                );
+                assert.equal(searchService.callCount, 1);
+                scope.sortDirection = 'last_visited_date';
 
-              return Promise
-                .all([
+                return Promise.all([
                   changesCallback({ doc: relevantVisitReport }),
                   changesCallback({ doc: irrelevantReport }),
                   changesCallback({ doc: irrelevantVisitReport }),
                   changesCallback({ doc: deletedVisitReport, deleted: true }),
-                  changesCallback({ doc: someContact })
-                ])
-                .then(() => {
+                  changesCallback({ doc: someContact }),
+                ]).then(() => {
                   assert.equal(searchService.callCount, 6);
                   assert.deepEqual(searchService.args[1], [
                     'contacts',
                     { types: { selected: ['childType'] } },
                     { limit: 5, withIds: true, silent: true },
-                    { displayLastVisitedDate: true, visitCountSettings: {}, sortByLastVisitedDate: true },
-                    ['abcde', 0, 1, 2, 3, 4]
+                    {
+                      displayLastVisitedDate: true,
+                      visitCountSettings: {},
+                      sortByLastVisitedDate: true,
+                    },
+                    ['abcde', 0, 1, 2, 3, 4],
                   ]);
 
                   for (let i = 2; i < 6; i++) {
@@ -895,34 +1091,42 @@ describe('Contacts controller', () => {
                       'contacts',
                       { types: { selected: ['childType'] } },
                       { limit: 5, withIds: false, silent: true },
-                      { displayLastVisitedDate: true, visitCountSettings: {}, sortByLastVisitedDate: true },
-                      undefined
+                      {
+                        displayLastVisitedDate: true,
+                        visitCountSettings: {},
+                        sortByLastVisitedDate: true,
+                      },
+                      undefined,
                     ]);
                   }
                 });
-            });
+              });
           });
         });
 
         describe('last_visited_date default sorting', () => {
           beforeEach(() => {
-            settings.resolves({ uhc: { contacts_default_sort: 'last_visited_date', } });
+            settings.resolves({
+              uhc: { contacts_default_sort: 'last_visited_date' },
+            });
           });
 
           it('does not require refreshing when sorting is `alpha` and visit report is received', () => {
-            return createController().getSetupPromiseForTesting().then(() => {
-              scope.sortDirection = 'alpha';
-              Array.apply(null, Array(5)).forEach((k, i) => contactsLiveList.insert({ _id: i }));
-              assert.equal(searchService.callCount, 1);
-              return Promise
-                .all([
+            return createController()
+              .getSetupPromiseForTesting()
+              .then(() => {
+                scope.sortDirection = 'alpha';
+                Array.apply(null, Array(5)).forEach((k, i) =>
+                  contactsLiveList.insert({ _id: i })
+                );
+                assert.equal(searchService.callCount, 1);
+                return Promise.all([
                   changesCallback({ doc: relevantVisitReport }),
                   changesCallback({ doc: irrelevantReport }),
                   changesCallback({ doc: irrelevantVisitReport }),
                   changesCallback({ doc: deletedVisitReport, deleted: true }),
-                  changesCallback({ doc: someContact })
-                ])
-                .then(() => {
+                  changesCallback({ doc: someContact }),
+                ]).then(() => {
                   assert.equal(searchService.callCount, 6);
 
                   for (let i = 1; i < 6; i++) {
@@ -930,35 +1134,41 @@ describe('Contacts controller', () => {
                       'contacts',
                       { types: { selected: ['childType'] } },
                       { limit: 5, withIds: false, silent: true },
-                      { displayLastVisitedDate: true, visitCountSettings: {}, },
-                      undefined
+                      { displayLastVisitedDate: true, visitCountSettings: {} },
+                      undefined,
                     ]);
                   }
                 });
-            });
+              });
           });
 
           it('does require refreshing when sorting is `last_visited_date` and visit report is received', () => {
-            return createController().getSetupPromiseForTesting().then(() => {
-              Array.apply(null, Array(5)).forEach((k, i) => contactsLiveList.insert({ _id: i }));
-              assert.equal(searchService.callCount, 1);
+            return createController()
+              .getSetupPromiseForTesting()
+              .then(() => {
+                Array.apply(null, Array(5)).forEach((k, i) =>
+                  contactsLiveList.insert({ _id: i })
+                );
+                assert.equal(searchService.callCount, 1);
 
-              return Promise
-                .all([
+                return Promise.all([
                   changesCallback({ doc: relevantVisitReport }),
                   changesCallback({ doc: irrelevantReport }),
                   changesCallback({ doc: irrelevantVisitReport }),
                   changesCallback({ doc: deletedVisitReport, deleted: true }),
-                  changesCallback({ doc: someContact })
-                ])
-                .then(() => {
+                  changesCallback({ doc: someContact }),
+                ]).then(() => {
                   assert.equal(searchService.callCount, 6);
                   assert.deepEqual(searchService.args[1], [
                     'contacts',
                     { types: { selected: ['childType'] } },
                     { limit: 5, withIds: true, silent: true },
-                    { displayLastVisitedDate: true, visitCountSettings: {}, sortByLastVisitedDate: true },
-                    ['abcde', 0, 1, 2, 3, 4]
+                    {
+                      displayLastVisitedDate: true,
+                      visitCountSettings: {},
+                      sortByLastVisitedDate: true,
+                    },
+                    ['abcde', 0, 1, 2, 3, 4],
                   ]);
 
                   for (let i = 2; i < 6; i++) {
@@ -966,12 +1176,16 @@ describe('Contacts controller', () => {
                       'contacts',
                       { types: { selected: ['childType'] } },
                       { limit: 5, withIds: false, silent: true },
-                      { displayLastVisitedDate: true, visitCountSettings: {}, sortByLastVisitedDate: true },
-                      undefined
+                      {
+                        displayLastVisitedDate: true,
+                        visitCountSettings: {},
+                        sortByLastVisitedDate: true,
+                      },
+                      undefined,
                     ]);
                   }
                 });
-            });
+              });
           });
         });
       });
@@ -984,18 +1198,20 @@ describe('Contacts controller', () => {
 
         describe('alpha default sorting', () => {
           it('does not require refreshing when sorting is `alpha` and visit report is received', () => {
-            return createController().getSetupPromiseForTesting().then(() => {
-              Array.apply(null, Array(5)).forEach((k, i) => contactsLiveList.insert({ _id: i }));
-              assert.equal(searchService.callCount, 1);
-              return Promise
-                .all([
+            return createController()
+              .getSetupPromiseForTesting()
+              .then(() => {
+                Array.apply(null, Array(5)).forEach((k, i) =>
+                  contactsLiveList.insert({ _id: i })
+                );
+                assert.equal(searchService.callCount, 1);
+                return Promise.all([
                   changesCallback({ doc: relevantVisitReport }),
                   changesCallback({ doc: irrelevantReport }),
                   changesCallback({ doc: irrelevantVisitReport }),
                   changesCallback({ doc: deletedVisitReport, deleted: true }),
-                  changesCallback({ doc: someContact })
-                ])
-                .then(() => {
+                  changesCallback({ doc: someContact }),
+                ]).then(() => {
                   assert.equal(searchService.callCount, 6);
 
                   for (let i = 1; i < 6; i++) {
@@ -1004,33 +1220,37 @@ describe('Contacts controller', () => {
                       { types: { selected: ['childType'] } },
                       { limit: 5, withIds: false, silent: true },
                       {},
-                      undefined
+                      undefined,
                     ]);
                   }
                 });
-            });
+              });
           });
         });
 
         describe('last_visited_date default sorting', () => {
           beforeEach(() => {
-            settings.resolves({ uhc: { contacts_default_sort: 'last_visited_date', } });
+            settings.resolves({
+              uhc: { contacts_default_sort: 'last_visited_date' },
+            });
           });
 
           it('does require refreshing when sorting is `last_visited_date` and visit report is received', () => {
-            return createController().getSetupPromiseForTesting().then(() => {
-              Array.apply(null, Array(5)).forEach((k, i) => contactsLiveList.insert({ _id: i }));
-              assert.equal(searchService.callCount, 1);
+            return createController()
+              .getSetupPromiseForTesting()
+              .then(() => {
+                Array.apply(null, Array(5)).forEach((k, i) =>
+                  contactsLiveList.insert({ _id: i })
+                );
+                assert.equal(searchService.callCount, 1);
 
-              return Promise
-                .all([
+                return Promise.all([
                   changesCallback({ doc: relevantVisitReport }),
                   changesCallback({ doc: irrelevantReport }),
                   changesCallback({ doc: irrelevantVisitReport }),
                   changesCallback({ doc: deletedVisitReport, deleted: true }),
-                  changesCallback({ doc: someContact })
-                ])
-                .then(() => {
+                  changesCallback({ doc: someContact }),
+                ]).then(() => {
                   assert.equal(searchService.callCount, 6);
 
                   for (let i = 1; i < 6; i++) {
@@ -1039,11 +1259,11 @@ describe('Contacts controller', () => {
                       { types: { selected: ['childType'] } },
                       { limit: 5, withIds: false, silent: true },
                       {},
-                      undefined
+                      undefined,
                     ]);
                   }
                 });
-            });
+              });
           });
         });
       });

--- a/webapp/tests/karma/unit/services/search.js
+++ b/webapp/tests/karma/unit/services/search.js
@@ -86,6 +86,27 @@ describe('Search service', function() {
         });
     });
 
+    it('does not debounce different queries - medic/medic-webapp/issues/4331)', function() {
+      GetDataRecords
+        .onFirstCall().returns(Promise.resolve([ { id: 'a' } ]))
+        .onSecondCall().returns(Promise.resolve([ { id: 'b' } ]));
+
+      var firstReturned = false;
+      const filters = { foo: 'bar' };
+      service('reports', filters)
+        .then(function(actual) {
+          chai.expect(actual).to.deep.equal([ { id: 'a' } ]);
+          firstReturned = true;
+        });
+      
+      filters.foo = 'test';
+      return service('reports', filters)
+        .then(function(actual) {
+          chai.expect(actual).to.deep.equal([ { id: 'b' } ]);
+          chai.expect(firstReturned).to.equal(true);
+        });
+    });
+
     it('does not debounce different queries', function() {
       GetDataRecords
         .onFirstCall().returns(Promise.resolve([ { id: 'a' } ]))


### PR DESCRIPTION
This applies to search on both the People tab and on the Reports tab. We also reset the location so that the user can select the same item that was previously selected.

medic/medic-webapp#4825
