### PR TITLE
4331 - Reports incorrectly filtered if filter changes before search returns

### DIFF
--- a/webapp/src/js/services/search.js
+++ b/webapp/src/js/services/search.js
@@ -39,13 +39,13 @@ var _ = require('underscore'),
       // Silently cancel repeated queries.
       var debounce = function(type, filters, options) {
         if (type === _currentQuery.type &&
-            filters === _currentQuery.filters &&
-            _.isEqual(options, _currentQuery.options)) {
+          _.isEqual(filters, _currentQuery.filters) &&
+          _.isEqual(options, _currentQuery.options)) {
           return true;
         }
         _currentQuery.type = type;
-        _currentQuery.filters = filters;
-        _currentQuery.options = options;
+        _currentQuery.filters = Object.assign({}, filters);
+        _currentQuery.options = Object.assign({}, options);
         return false;
       };
 

--- a/webapp/tests/karma/unit/services/search.js
+++ b/webapp/tests/karma/unit/services/search.js
@@ -86,6 +86,27 @@ describe('Search service', function() {
         });
     });
 
+    it('does not debounce different queries - medic/medic-webapp/issues/4331)', function() {
+      GetDataRecords
+        .onFirstCall().returns(Promise.resolve([ { id: 'a' } ]))
+        .onSecondCall().returns(Promise.resolve([ { id: 'b' } ]));
+
+      var firstReturned = false;
+      const filters = { foo: 'bar' };
+      service('reports', filters)
+        .then(function(actual) {
+          chai.expect(actual).to.deep.equal([ { id: 'a' } ]);
+          firstReturned = true;
+        });
+      
+      filters.foo = 'test';
+      return service('reports', filters)
+        .then(function(actual) {
+          chai.expect(actual).to.deep.equal([ { id: 'b' } ]);
+          chai.expect(firstReturned).to.equal(true);
+        });
+    });
+
     it('does not debounce different queries', function() {
       GetDataRecords
         .onFirstCall().returns(Promise.resolve([ { id: 'a' } ]))


### PR DESCRIPTION
# Description

Any change to report filters are ignored while reports are being fetched. The function `debounce()` in `services/search.js` is effectively bouncing everything until the first query finishes. `_currentQuery.filters` is a reference to the underlying filters object (in this case `$scope.filters` from `controllers/reports.js`). Fix is to cache a copy of the objects instead of a reference.

medic/medic-webapp#4331

Good demo of the underlying issue is to comment out [this](https://github.com/medic/medic-webapp/blob/master/webapp/src/js/services/search.js#L142) line and the filters will never update.

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.