### PR TITLE
Make future birthdates to display in red

### DIFF
--- a/webapp/src/css/material.less
+++ b/webapp/src/css/material.less
@@ -31,6 +31,9 @@
     div {
       flex-grow: 100;
     }
+    .age .span.relative-date.future {
+      color: red;
+    }
   }
   ul:last-child mm-content-row:last-child,
   .deceased {
@@ -135,7 +138,7 @@
     max-width: 568px;
     border-radius: 2px 2px 0 0;
     background-color: @medic-slate-color;
-    color: #FFFFFF;
+    color: #ffffff;
     margin: 0 auto;
     text-overflow: ellipsis;
     overflow: hidden;

--- a/webapp/src/templates/partials/contacts_content.html
+++ b/webapp/src/templates/partials/contacts_content.html
@@ -34,7 +34,7 @@
             <div class="col col-xs-12 col-sm-{{field.width || 12}}" ng-repeat="field in selected.summary.fields">
               <div class="cell">
                 <span ng-if="field.icon" class="field-icon" ng-bind-html="field.icon | resourceIcon"></span>
-                <div>
+                <div class="{{field.label}}">
                   <label translate ng-show="field.label">{{field.label}}</label>
                   <p ng-if="field.translate" translate translate-values="{{field.context}}">{{field.value}}</p>
                   <p ng-if="!field.translate && field.filter" ng-bind-html="field.value"></p>


### PR DESCRIPTION
# Description

[description]

medic/medic-webapp#[number]

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.