### PR TITLE
Fixes z-score calculation errors

### DIFF
--- a/tests/e2e/forms/submit-z-score-form.spec.js
+++ b/tests/e2e/forms/submit-z-score-form.spec.js
@@ -1,6 +1,5 @@
 const helper = require('../../helper'),
       ZScoreForm = require('../../page-objects/forms/z-score.po'),
-      common = require('../../page-objects/common/common.po.js'),
       utils = require('../../utils');
 
 const contactId = 'some_contact_id';
@@ -26,7 +25,7 @@ describe('Submit Z-Score form', () => {
       .catch(done.fail);
   });
 
-  afterEach(done =>{
+  afterEach(done => {
     utils.resetBrowser();
     done();
   });
@@ -34,25 +33,7 @@ describe('Submit Z-Score form', () => {
   afterAll(utils.afterEach);
 
   it('Autofills zscore fields with correct values', () => {
-    common.goToReports();
-    browser.wait(() => {
-      return element(by.css('.action-container .general-actions:not(.ng-hide) .fa-plus')).isPresent();
-    }, 10000);
-
-    browser.sleep(1000); // let the refresh work here - #3691
-
-    // select form
-    const addButton = element(by.css('.action-container .general-actions:not(.ng-hide) .fa-plus'));
-    browser.wait(() => {
-      return addButton.isPresent();
-    }, 10000);
-    helper.clickElement(addButton);
-    element(by.css('.action-container .general-actions .dropup.open .dropdown-menu li:first-child a')).click();
-
-    browser.wait(() => {
-      return element(by.css('[name="/data/my_sex"][value="female"]')).isPresent();
-    }, 10000);
-
+    ZScoreForm.load();
 
     ZScoreForm.setPatient({ sex: 'female', height: 45, weight: 2, age: 0 });
     browser.sleep(100);
@@ -84,25 +65,7 @@ describe('Submit Z-Score form', () => {
   });
 
   it('saves z-score values', () => {
-    common.goToReports();
-    browser.wait(() => {
-      return element(by.css('.action-container .general-actions:not(.ng-hide) .fa-plus')).isPresent();
-    }, 10000);
-
-    browser.sleep(1000); // let the refresh work here - #3691
-
-    // select form
-    const addButton = element(by.css('.action-container .general-actions:not(.ng-hide) .fa-plus'));
-    browser.wait(() => {
-      return addButton.isPresent();
-    }, 10000);
-    helper.clickElement(addButton);
-    element(by.css('.action-container .general-actions .dropup.open .dropdown-menu li:first-child a')).click();
-
-    browser.wait(() => {
-      return element(by.css('[name="/data/my_sex"][value="female"]')).isPresent();
-    }, 10000);
-
+    ZScoreForm.load();
 
     ZScoreForm.setPatient({ sex: 'female', height: 45.1, weight: 3, age: 2 });
     browser.sleep(100);

--- a/tests/e2e/forms/submit-z-score-form.spec.js
+++ b/tests/e2e/forms/submit-z-score-form.spec.js
@@ -1,0 +1,125 @@
+const helper = require('../../helper'),
+      ZScoreForm = require('../../page-objects/forms/z-score.po'),
+      common = require('../../page-objects/common/common.po.js'),
+      utils = require('../../utils');
+
+const contactId = 'some_contact_id';
+const doc = {
+  _id: contactId,
+  name: 'Jack',
+  date_of_birth: '',
+  phone: '+64274444444',
+  alternate_phone: '',
+  notes: '',
+  type: 'person',
+  reported_date: 1478469976421,
+  parent: {
+    _id: 'some_parent'
+  }
+};
+
+describe('Submit Z-Score form', () => {
+  beforeAll(done => {
+    utils
+      .saveDoc(doc)
+      .then(() => ZScoreForm.configureForm(contactId, done))
+      .catch(done.fail);
+  });
+
+  afterEach(done =>{
+    utils.resetBrowser();
+    done();
+  });
+
+  afterAll(utils.afterEach);
+
+  it('Autofills zscore fields with correct values', () => {
+    common.goToReports();
+    browser.wait(() => {
+      return element(by.css('.action-container .general-actions:not(.ng-hide) .fa-plus')).isPresent();
+    }, 10000);
+
+    browser.sleep(1000); // let the refresh work here - #3691
+
+    // select form
+    const addButton = element(by.css('.action-container .general-actions:not(.ng-hide) .fa-plus'));
+    browser.wait(() => {
+      return addButton.isPresent();
+    }, 10000);
+    helper.clickElement(addButton);
+    element(by.css('.action-container .general-actions .dropup.open .dropdown-menu li:first-child a')).click();
+
+    browser.wait(() => {
+      return element(by.css('[name="/data/my_sex"][value="female"]')).isPresent();
+    }, 10000);
+
+
+    ZScoreForm.setPatient({ sex: 'female', height: 45, weight: 2, age: 0 });
+    browser.sleep(100);
+
+    expect(ZScoreForm.getHeightForAge()).toEqual('-2.226638023630504');
+    expect(ZScoreForm.getWeightForAge()).toEqual('-3.091160220994475');
+    expect(ZScoreForm.getWeightForHeight()).toEqual('-2.402439024390243');
+
+    ZScoreForm.setPatient({ sex: 'male', height: 45, weight: 2, age: 0 });
+    browser.sleep(100);
+
+    expect(ZScoreForm.getHeightForAge()).toEqual('-2.5800316957210767');
+    expect(ZScoreForm.getWeightForAge()).toEqual('-3.211081794195251');
+    expect(ZScoreForm.getWeightForHeight()).toEqual('-2.259036144578314');
+
+    ZScoreForm.setPatient({ sex: 'female', height: 45.2, weight: 5, age: 1 });
+    browser.sleep(100);
+
+    expect(ZScoreForm.getHeightForAge()).toEqual('-2.206434316353886');
+    expect(ZScoreForm.getWeightForAge()).toEqual('3.323129251700681');
+    expect(ZScoreForm.getWeightForHeight()).toEqual('4');
+
+    ZScoreForm.setPatient({ sex: 'male', height: 45.2, weight: 5, age: 1 });
+    browser.sleep(100);
+
+    expect(ZScoreForm.getHeightForAge()).toEqual('-2.5651715039577816');
+    expect(ZScoreForm.getWeightForAge()).toEqual('2.9789983844911148');
+    expect(ZScoreForm.getWeightForHeight()).toEqual('4');
+  });
+
+  it('saves z-score values', () => {
+    common.goToReports();
+    browser.wait(() => {
+      return element(by.css('.action-container .general-actions:not(.ng-hide) .fa-plus')).isPresent();
+    }, 10000);
+
+    browser.sleep(1000); // let the refresh work here - #3691
+
+    // select form
+    const addButton = element(by.css('.action-container .general-actions:not(.ng-hide) .fa-plus'));
+    browser.wait(() => {
+      return addButton.isPresent();
+    }, 10000);
+    helper.clickElement(addButton);
+    element(by.css('.action-container .general-actions .dropup.open .dropdown-menu li:first-child a')).click();
+
+    browser.wait(() => {
+      return element(by.css('[name="/data/my_sex"][value="female"]')).isPresent();
+    }, 10000);
+
+
+    ZScoreForm.setPatient({ sex: 'female', height: 45.1, weight: 3, age: 2 });
+    browser.sleep(100);
+
+    expect(ZScoreForm.getHeightForAge()).toEqual('-2.346895074946466');
+    expect(ZScoreForm.getWeightForAge()).toEqual('-0.4708520179372194');
+    expect(ZScoreForm.getWeightForHeight()).toEqual('2.0387096774193547');
+
+    ZScoreForm.submit();
+
+    expect(helper.getTextFromElement(element(by.css('#reports-content .details li:nth-child(1) p')))).toEqual('45.1');
+    expect(helper.getTextFromElement(element(by.css('#reports-content .details li:nth-child(2) p')))).toEqual('3');
+    expect(helper.getTextFromElement(element(by.css('#reports-content .details li:nth-child(3) p')))).toEqual('female');
+    expect(helper.getTextFromElement(element(by.css('#reports-content .details li:nth-child(4) p')))).toEqual('2');
+
+    expect(helper.getTextFromElement(element(by.css('#reports-content .details li:nth-child(5) p')))).toEqual('2.0387096774193547');
+    expect(helper.getTextFromElement(element(by.css('#reports-content .details li:nth-child(6) p')))).toEqual('-0.4708520179372194');
+    expect(helper.getTextFromElement(element(by.css('#reports-content .details li:nth-child(7) p')))).toEqual('-2.346895074946466');
+  });
+});

--- a/tests/page-objects/forms/z-score.po.js
+++ b/tests/page-objects/forms/z-score.po.js
@@ -1,5 +1,6 @@
 const utils = require('../../utils'),
-      helper = require('../../helper');
+      helper = require('../../helper'),
+      common = require('../common/common.po');
 
 const xml = `<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
   <h:head>
@@ -138,6 +139,27 @@ const clearAndFill = (el, value) => {
 module.exports = {
   configureForm: (contactId, done) => {
     utils.seedTestData(done, contactId, docs);
+  },
+
+  load: () => {
+    common.goToReports();
+    browser.wait(() => {
+      return element(by.css('.action-container .general-actions:not(.ng-hide) .fa-plus')).isPresent();
+    }, 10000);
+
+    browser.sleep(1000); // let the refresh work here - #3691
+
+    // select form
+    const addButton = element(by.css('.action-container .general-actions:not(.ng-hide) .fa-plus'));
+    browser.wait(() => {
+      return addButton.isPresent();
+    }, 10000);
+    helper.clickElement(addButton);
+    element(by.css('.action-container .general-actions .dropup.open .dropdown-menu li:first-child a')).click();
+
+    browser.wait(() => {
+      return element(by.css('[name="/data/my_sex"][value="female"]')).isPresent();
+    }, 10000);
   },
 
   submit: () => {

--- a/tests/page-objects/forms/z-score.po.js
+++ b/tests/page-objects/forms/z-score.po.js
@@ -136,6 +136,11 @@ const clearAndFill = (el, value) => {
   el.clear().then(() => el.sendKeys(value));
 };
 
+const clickAndGetValue = el => {
+  el.click();
+  return el.getAttribute('value');
+};
+
 module.exports = {
   configureForm: (contactId, done) => {
     utils.seedTestData(done, contactId, docs);
@@ -185,16 +190,7 @@ module.exports = {
     module.exports.setWeight(patient.weight);
   },
 
-  getHeightForAge: () => {
-    element(by.css('[name="/data/hfa"]')).click();
-    return element(by.css('[name="/data/hfa"]')).getAttribute('value');
-  },
-  getWeightForAge: () => {
-    element(by.css('[name="/data/wfa"]')).click();
-    return element(by.css('[name="/data/wfa"]')).getAttribute('value');
-  },
-  getWeightForHeight: () => {
-    element(by.css('[name="/data/wfh"]')).click();
-    return element(by.css('[name="/data/wfh"]')).getAttribute('value');
-  },
+  getHeightForAge: () => clickAndGetValue(element(by.css('[name="/data/hfa"]'))),
+  getWeightForAge: () => clickAndGetValue(element(by.css('[name="/data/wfa"]'))),
+  getWeightForHeight: () => clickAndGetValue(element(by.css('[name="/data/wfh"]'))),
 };

--- a/tests/page-objects/forms/z-score.po.js
+++ b/tests/page-objects/forms/z-score.po.js
@@ -1,0 +1,178 @@
+const utils = require('../../utils'),
+      helper = require('../../helper');
+
+const xml = `<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+  <h:head>
+    <h:title>z-score() - Demo Form</h:title>
+
+    <model>
+      <instance>
+        <data id="z-score">
+          <my_height/>
+          <my_weight/>
+          <my_sex/>
+          <my_age/>
+          <wfh/>
+          <wfa/>
+          <hfa/>
+          <meta>
+            <instanceID/>
+          </meta>
+        </data>
+      </instance>
+
+      <bind nodeset="/data/my_height"/>
+      <bind nodeset="/data/my_weight"/>
+      <bind nodeset="/data/my_age"/>
+      <bind nodeset="/data/my_sex"/>
+      <bind nodeset="/data/hfa" type="string" calculate="z-score('height-for-age', ../my_sex, ../my_age, ../my_height)" readonly="true()"/>
+      <bind nodeset="/data/wfa" type="string" calculate="z-score('weight-for-age', ../my_sex, ../my_age, ../my_weight)" readonly="true()"/>
+      <bind nodeset="/data/wfh" type="string" calculate="z-score('weight-for-height', ../my_sex, ../my_height, ../my_weight)" readonly="true()"/>
+    </model>
+  </h:head>
+
+  <h:body>
+    <group appearance="field-list" ref="/data">
+      <select1 appearance="horizontal" ref="/data/my_sex">
+        <label>Gender</label>
+        <item>
+          <label>Female</label>
+          <value>female</value>
+        </item>
+        <item>
+          <label>Male</label>
+          <value>male</value>
+        </item>
+      </select1>
+      <input ref="/data/my_height">
+        <label>How tall are you? (cm)</label>
+      </input>
+      <input ref="/data/my_weight">
+        <label>How much do you weigh? (kg)</label>
+      </input>
+      <input ref="/data/my_age">
+        <label>How old are you? (days)</label>
+      </input>
+      <input ref="/data/hfa">
+        <label>height for age</label>
+      </input>
+      <input ref="/data/wfa">
+        <label>weight for age</label>
+      </input>
+      <input ref="/data/wfh">
+        <label>weight for height</label>
+      </input>
+    </group>
+  </h:body>
+</h:html>
+`;
+const charts = [
+  {
+    id: 'weight-for-age',
+    data: {
+      male: [
+        { key: 0, points: [  1.701, 2.08, 2.459, 2.881, 3.346, 3.859, 4.419, 5.031, 5.642 ] },
+        { key: 1, points: [ 1.692, 2.065, 2.437, 2.854, 3.317, 3.83, 4.394, 5.013, 5.633 ] },
+        { key: 2, points: [ 1.707, 2.08, 2.454, 2.872, 3.337, 3.852, 4.421, 5.045, 5.669 ] }
+      ],
+      female: [
+        { key: 0, points: [ 1.671, 2.033, 2.395, 2.794, 3.232, 3.711, 4.23, 4.793, 5.356 ] },
+        { key: 1, points: [ 1.635, 1.994, 2.352, 2.752, 3.196, 3.685, 4.222, 4.81, 5.398 ] },
+        { key: 2, points: [ 1.643, 2.002, 2.362, 2.764, 3.21, 3.704, 4.249, 4.846, 5.443 ] }
+      ],
+    }
+  },
+  {
+    id: 'height-for-age',
+    data: {
+      male: [
+        { key: 0, points: [ 42.312, 44.205, 46.098, 47.991, 49.884, 51.777, 53.67, 55.564, 57.457 ] },
+        { key: 1, points: [ 42.481, 44.376, 46.271, 48.165, 50.06, 51.955, 53.85, 55.744, 57.639 ] },
+        { key: 2, points: [ 42.65, 44.547, 46.443, 48.339, 50.236, 52.132, 54.029, 55.925, 57.822 ] }
+      ],
+      female: [
+        { key: 0, points: [ 41.697, 43.56, 45.422, 47.285, 49.148, 51.01, 52.873, 54.736, 56.598 ] },
+        { key: 1, points: [ 41.854, 43.72, 45.585, 47.451, 49.317, 51.182, 53.048, 54.914, 56.779 ] },
+        { key: 2, points: [ 42.011, 43.88, 45.748, 47.617, 49.485, 51.354, 53.223, 55.091, 56.96 ] }
+      ]
+    }
+  },
+  {
+    id: 'weight-for-height',
+    data: {
+      male: [
+        { key: 45, points: [ 1.71, 1.877, 2.043, 2.23, 2.441, 2.68, 2.951,  3.261, 3.571 ] },
+        { key: 45.1, points: [ 1.722, 1.89, 2.057, 2.245, 2.458, 2.698, 2.971, 3.283, 3.595 ] },
+        { key: 45.2, points: [ 1.734, 1.903, 2.072, 2.261, 2.474, 2.716, 2.991, 3.305, 3.618 ] }
+      ],
+      female: [
+        { key: 45, points: [ 1.737, 1.902, 2.066, 2.252, 2.461, 2.698, 2.967, 3.275, 3.584 ] },
+        { key: 45.1, points: [ 1.749, 1.915, 2.081, 2.267, 2.478, 2.716, 2.988, 3.298, 3.609 ] },
+        { key: 45.2, points: [ 1.761, 1.928, 2.095, 2.283, 2.495, 2.735, 3.008, 3.321, 3.633 ] }
+      ]
+    }
+  }
+];
+
+const docs = [
+  {
+    _id: 'form:z-score',
+    internalId: 'z-score',
+    title: 'Z-score',
+    type: 'form',
+    _attachments: {
+      xml: {
+        content_type: 'application/octet-stream',
+        data: new Buffer(xml).toString('base64')
+      }
+    }
+  }, {
+    _id: 'zscore-charts',
+    charts: charts
+  }];
+
+const clearAndFill = (el, value) => {
+  el.clear().then(() => el.sendKeys(value));
+};
+
+module.exports = {
+  configureForm: (contactId, done) => {
+    utils.seedTestData(done, contactId, docs);
+  },
+
+  submit: () => {
+    const submitButton = element(by.css('[ng-click="onSubmit()"]'));
+    helper.waitElementToBeClickable(submitButton);
+    submitButton.click();
+    helper.waitElementToBeVisible(element(by.css('div#reports-content')));
+  },
+
+  reset: () => {
+    element(by.css('.icon.icon-refresh')).click();
+  },
+
+  setHeight: height => clearAndFill(element(by.css(`[name="/data/my_height"]`)), height),
+  setWeight: weight => clearAndFill(element(by.css(`[name="/data/my_weight"]`)), weight),
+  setAge: age => clearAndFill(element(by.css(`[name="/data/my_age"]`)), age),
+  setSex: sex => element(by.css(`[name="/data/my_sex"][value="${sex}"]`)).click(),
+
+  setPatient: patient => {
+    module.exports.setSex(patient.sex);
+    module.exports.setAge(patient.age);
+    module.exports.setHeight(patient.height);
+    module.exports.setWeight(patient.weight);
+  },
+
+  getHeightForAge: () => {
+    element(by.css('[name="/data/hfa"]')).click();
+    return element(by.css('[name="/data/hfa"]')).getAttribute('value');
+  },
+  getWeightForAge: () => {
+    element(by.css('[name="/data/wfa"]')).click();
+    return element(by.css('[name="/data/wfa"]')).getAttribute('value');
+  },
+  getWeightForHeight: () => {
+    element(by.css('[name="/data/wfh"]')).click();
+    return element(by.css('[name="/data/wfh"]')).getAttribute('value');
+  },
+};

--- a/webapp/src/js/enketo/medic-xpath-extensions.js
+++ b/webapp/src/js/enketo/medic-xpath-extensions.js
@@ -6,8 +6,8 @@ var getValue = function(resultObject) {
     return resultObject;
   }
 
-  if (resultObject.t === 'arr') {
-    return resultObject.v.length > 1 ? resultObject.v : resultObject.v[0];
+  if (resultObject.t === 'arr' && resultObject.v.length) {
+    return resultObject.v[0];
   }
 
   return resultObject.v;
@@ -18,8 +18,11 @@ module.exports = {
     zscoreUtil = _zscoreUtil;
   },
   func: {
-    'z-score': function(chartId, sex, x, y) {
-      var result = zscoreUtil(getValue(chartId), getValue(sex), getValue(x), getValue(y));
+    'z-score': function() {
+      var args = Array.from(arguments).map(function(arg) {
+        return getValue(arg);
+      });
+      var result = zscoreUtil.apply(null, args);
       if (!result) {
           return { t: 'str', v: '' };
       }

--- a/webapp/src/js/enketo/medic-xpath-extensions.js
+++ b/webapp/src/js/enketo/medic-xpath-extensions.js
@@ -6,6 +6,7 @@ var getValue = function(resultObject) {
     return resultObject;
   }
 
+  // input fields, evaluated as `UNORDERED_NODE_ITERATOR_TYPE`, are received as arrays with one element
   if (resultObject.t === 'arr' && resultObject.v.length) {
     return resultObject.v[0];
   }

--- a/webapp/src/js/enketo/medic-xpath-extensions.js
+++ b/webapp/src/js/enketo/medic-xpath-extensions.js
@@ -1,4 +1,17 @@
-var zscoreUtil;
+var zscoreUtil,
+    _ = require('underscore');
+
+var getValue = function(resultObject) {
+  if (!_.isObject(resultObject) || !resultObject.t) {
+    return resultObject;
+  }
+
+  if (resultObject.t === 'arr') {
+    return resultObject.v.length > 1 ? resultObject.v : resultObject.v[0];
+  }
+
+  return resultObject.v;
+};
 
 module.exports = {
   init: function(_zscoreUtil) {
@@ -6,7 +19,7 @@ module.exports = {
   },
   func: {
     'z-score': function(chartId, sex, x, y) {
-      var result = zscoreUtil(chartId, sex, x, y);
+      var result = zscoreUtil(getValue(chartId), getValue(sex), getValue(x), getValue(y));
       if (!result) {
           return { t: 'str', v: '' };
       }


### PR DESCRIPTION
# Description

Because of https://github.com/medic/openrosa-xpath-evaluator/commit/722622554d0849e3f97d3e19647f083ead823a98 , z-score calculate function now receives object parameters (`{ t: <type>, v: <value> }`). 

medic/medic-webapp#4848

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.