### PR TITLE
Linking the visit report to the task message that triggered it

### DIFF
--- a/sentinel/src/transitions/accept_patient_reports.js
+++ b/sentinel/src/transitions/accept_patient_reports.js
@@ -114,35 +114,41 @@ const addRegistrationToDoc = (doc, registrations) => {
   }
 };
 
-const addReportUUIDToRegistration = (doc, registrations) => {
+const addReportUUIDToRegistration = (doc, registrations, callback) => {
   if (registrations.length) {
+    var validRegistration;
     var visitReportedDate = doc.reported_date;
 
-    var messageFound = false;
-    registrations.forEach(function(registration) {
-      if (registration.scheduled_tasks) {
-        registration.scheduled_tasks.forEach(function(task, index) {
-          if (!messageFound) {
-            if (
-              (task.state === 'delivered' || task.state === 'sent') &&
-              task.messages
-            ) {
-              var nextTask = registration.scheduled_tasks[index + 1];
-              if (
-                typeof nextTask !== 'undefined' &&
-                moment(nextTask.due) > moment(visitReportedDate)
-              ) {
-                registration.scheduled_tasks[index].report_uuid = doc._id;
+    outerloop: {
+      for (var i = 0; i < registrations.length; i++) {
+        var registration = registrations[i];
+        if (registration.scheduled_tasks) {
+          for (var j = 0; j < registration.scheduled_tasks.length; j++) {
+            var task = registration.scheduled_tasks[j];
+            if (['delivered', 'sent'].includes(task.state)) {
+              var nextTask = registration.scheduled_tasks[j + 1] || { due: moment(visitReportedDate).add(1, 'd') };
+              if (nextTask && moment(nextTask.due) > moment(visitReportedDate)) {
+                // We loop through tasks. Once we find one that has either the status "delivered" or "sent" with
+                // a future task with a due date that is after the visit reported date then we have found the task 
+                // linked to the visit. We always link if this is the last scheduled task delivered or sent.
+                validRegistration = registration;
+                validRegistration.scheduled_tasks[j].report_uuid = doc._id;
 
-                db.audit.saveDoc(registration, function() {});
-
-                messageFound = true;
+                break outerloop;
               }
-            }
+            }          
           }
-        });
-      }
-    });
+        }
+      }    
+    }
+
+    if (validRegistration) {
+      db.medic.put(validRegistration, function(err) {
+        if (err) {
+          return callback(err);
+        }
+      });
+    }  
   }
 };
 
@@ -207,6 +213,7 @@ const handleReport = (doc, config, callback) => {
 
       addMessagesToDoc(doc, config, registrations);
       addRegistrationToDoc(doc, registrations);
+      addReportUUIDToRegistration(doc, registrations, callback);
 
       module.exports.silenceRegistrations(config, doc, registrations, callback);
     }

--- a/sentinel/src/transitions/accept_patient_reports.js
+++ b/sentinel/src/transitions/accept_patient_reports.js
@@ -141,7 +141,7 @@ const findValidRegistration = (doc, registrations) => {
 const addReportUUIDToRegistration = (doc, registrations, callback) => {
     const validRegistration = registrations.length && findValidRegistration(doc, registrations);
     if (validRegistration) {
-      db.medic.put(validRegistration, callback);
+      return db.medic.put(validRegistration, callback);
     }
     
     callback();

--- a/sentinel/src/transitions/accept_patient_reports.js
+++ b/sentinel/src/transitions/accept_patient_reports.js
@@ -120,16 +120,17 @@ const findValidRegistration = (doc, registrations) => {
     for (var i = 0; i < registrations.length; i++) {
       var registration = registrations[i];
       if (registration.scheduled_tasks) {
-        registration.scheduled_tasks = _.sortBy(registration.scheduled_tasks, 'due');
-        for (var j = 0; j < registration.scheduled_tasks.length; j++) {
-          var task = registration.scheduled_tasks[j];
+        var scheduled_tasks = _.sortBy(registration.scheduled_tasks, 'due');
+        for (var j = 0; j < scheduled_tasks.length; j++) {
+          var task = scheduled_tasks[j];
           if (['delivered', 'sent'].includes(task.state)) {
-            var nextTask = registration.scheduled_tasks[j + 1] || { due: moment(visitReportedDate).add(1, 'd') };
+            var nextTask = scheduled_tasks[j + 1] || { due: moment(visitReportedDate).add(1, 'd') };
             if (nextTask && moment(nextTask.due) > moment(visitReportedDate)) {
               // We loop through tasks. Once we find one that has either the status "delivered" or "sent" with
               // a future task with a due date that is after the visit reported date then we have found the task 
               // linked to the visit. We always link if this is the last scheduled task delivered or sent.
-              registration.scheduled_tasks[j].report_uuid = doc._id;
+              var taskIndex = _.findIndex(registration.scheduled_tasks, {"due": task.due});
+              registration.scheduled_tasks[taskIndex].report_uuid = doc._id;
               return registration;
             }
           }          

--- a/sentinel/src/transitions/accept_patient_reports.js
+++ b/sentinel/src/transitions/accept_patient_reports.js
@@ -129,7 +129,7 @@ const findValidRegistration = (doc, registrations) => {
               // We loop through tasks. Once we find one that has either the status "delivered" or "sent" with
               // a future task with a due date that is after the visit reported date then we have found the task 
               // linked to the visit. We always link if this is the last scheduled task delivered or sent.
-              var taskIndex = _.findIndex(registration.scheduled_tasks, {"due": task.due});
+              var taskIndex = _.findIndex(registration.scheduled_tasks, { due: task.due });
               registration.scheduled_tasks[taskIndex].report_uuid = doc._id;
               return registration;
             }

--- a/sentinel/src/transitions/accept_patient_reports.js
+++ b/sentinel/src/transitions/accept_patient_reports.js
@@ -120,6 +120,7 @@ const findValidRegistration = (doc, registrations) => {
     for (var i = 0; i < registrations.length; i++) {
       var registration = registrations[i];
       if (registration.scheduled_tasks) {
+        registration.scheduled_tasks = _.sortBy(registration.scheduled_tasks, 'due');
         for (var j = 0; j < registration.scheduled_tasks.length; j++) {
           var task = registration.scheduled_tasks[j];
           if (['delivered', 'sent'].includes(task.state)) {
@@ -135,22 +136,15 @@ const findValidRegistration = (doc, registrations) => {
         }
       }
     } 
-
-    return null;
 };
 
 const addReportUUIDToRegistration = (doc, registrations, callback) => {
-  if (registrations.length) {
-    const validRegistration = findValidRegistration(doc, registrations);
-
+    const validRegistration = registrations.length && findValidRegistration(doc, registrations);
     if (validRegistration) {
       db.medic.put(validRegistration, callback);
-    } else {
-      callback();
-    } 
-  } else {
+    }
+    
     callback();
-  }
 };
 
 const silenceRegistrations = (config, doc, registrations, callback) => {
@@ -214,7 +208,7 @@ const handleReport = (doc, config, callback) => {
 
       addMessagesToDoc(doc, config, registrations);
       addRegistrationToDoc(doc, registrations);
-      addReportUUIDToRegistration(doc, registrations, function(err) {
+      addReportUUIDToRegistration(doc, registrations, err => {
         if (err) {
           return callback(err);
         }

--- a/sentinel/tests/unit/transitions/accept_patient_reports.js
+++ b/sentinel/tests/unit/transitions/accept_patient_reports.js
@@ -265,9 +265,7 @@ describe('accept_patient_reports', () => {
         .callsArgWith(1, null, registrations);
       transition._handleReport(doc, config, (err, complete) => {
         complete.should.equal(true);
-        doc.message_uuid.should.equal(
-          registrations[0].scheduled_tasks[0].messages[0].uuid
-        );
+        doc._id.should.equal(registrations[0].scheduled_tasks[0].report_uuid);
         done();
       });
     });
@@ -338,9 +336,7 @@ describe('accept_patient_reports', () => {
         .callsArgWith(1, null, registrations);
       transition._handleReport(doc, config, (err, complete) => {
         complete.should.equal(true);
-        doc.message_uuid.should.equal(
-          registrations[0].scheduled_tasks[2].messages[0].uuid
-        );
+        doc._id.should.equal(registrations[0].scheduled_tasks[2].report_uuid);
         done();
       });
     });

--- a/sentinel/tests/unit/transitions/accept_patient_reports.js
+++ b/sentinel/tests/unit/transitions/accept_patient_reports.js
@@ -308,8 +308,7 @@ describe('accept_patient_reports', () => {
               messages: [
                 {
                   uuid: 'k4',
-                  message:
-                    "Please remind Patient1 (63344) to visit the health facility for ANC visit this week. When she does let us know with 'V 63374'. Thanks!",
+                  message: `Please remind Patient1 (63344) to visit the health facility for ANC visit this week. When she does let us know with 'V 63374'. Thanks!`,
                 },
               ],
             },

--- a/sentinel/tests/unit/transitions/accept_patient_reports.js
+++ b/sentinel/tests/unit/transitions/accept_patient_reports.js
@@ -228,6 +228,7 @@ describe('accept_patient_reports', () => {
     });
     
     it('adds report_uuid property', done => {
+      sinon.stub(db.medic, 'post').resolves({});
       sinon.stub(transition, '_silenceReminders').callsArgWith(3, null, true);
       const doc = {
         _id: 'z',
@@ -272,6 +273,7 @@ describe('accept_patient_reports', () => {
     });
 
     it('if there are multiple scheduled tasks uses the oldest valid one', done => {
+      sinon.stub(db.medic, 'post').resolves({});
       sinon.stub(transition, '_silenceReminders').callsArgWith(3, null, true);
       const doc = {
         _id: 'z',
@@ -369,6 +371,7 @@ describe('accept_patient_reports', () => {
         utils.getRegistrations.args[0][0].should.deep.equal({ db: dbNano, id: 'x' });
         done();
       });
+      
     });
   });
 

--- a/sentinel/tests/unit/transitions/accept_patient_reports.js
+++ b/sentinel/tests/unit/transitions/accept_patient_reports.js
@@ -343,7 +343,7 @@ describe('accept_patient_reports', () => {
       transition._handleReport(doc, config, (err, complete) => {
         complete.should.equal(true);
         putRegistration.callCount.should.equal(1);
-        registrations[0].scheduled_tasks[3].report_uuid.should.equal(doc._id);
+        registrations[0].scheduled_tasks[2].report_uuid.should.equal(doc._id);
         done();
       });
     });

--- a/sentinel/tests/unit/transitions/accept_patient_reports.js
+++ b/sentinel/tests/unit/transitions/accept_patient_reports.js
@@ -226,7 +226,8 @@ describe('accept_patient_reports', () => {
       });
 
     });
-    it('adds message_uuid property', done => {
+    
+    it('adds report_uuid property', done => {
       sinon.stub(transition, '_silenceReminders').callsArgWith(3, null, true);
       const doc = {
         _id: 'z',
@@ -337,6 +338,35 @@ describe('accept_patient_reports', () => {
       transition._handleReport(doc, config, (err, complete) => {
         complete.should.equal(true);
         doc._id.should.equal(registrations[0].scheduled_tasks[2].report_uuid);
+        done();
+      });
+    });
+
+    it('should call utils.getRegistrations with correct DB (#4962)', done => {
+      const doc = {
+        fields: { patient_id: 'x' },
+        from: '+123',
+      };
+      sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, []);
+
+      const config = {
+        messages: [
+          {
+            event_type: 'registration_not_found',
+            message: [
+              {
+                content: 'not found {{patient_id}}',
+                locale: 'en',
+              },
+            ],
+            recipient: 'reporting_unit',
+          },
+        ],
+      };
+
+      transition._handleReport(doc, config, () => {
+        utils.getRegistrations.callCount.should.equal(1);
+        utils.getRegistrations.args[0][0].should.deep.equal({ db: dbNano, id: 'x' });
         done();
       });
     });

--- a/sentinel/tests/unit/transitions/accept_patient_reports.js
+++ b/sentinel/tests/unit/transitions/accept_patient_reports.js
@@ -228,7 +228,7 @@ describe('accept_patient_reports', () => {
     });
     
     it('adds report_uuid property', done => {
-      sinon.stub(db.medic, 'post').resolves({});
+      const putRegistration = sinon.stub(db.medic, 'put').resolves({});
       sinon.stub(transition, '_silenceReminders').callsArgWith(3, null, true);
       const doc = {
         _id: 'z',
@@ -267,13 +267,14 @@ describe('accept_patient_reports', () => {
         .callsArgWith(1, null, registrations);
       transition._handleReport(doc, config, (err, complete) => {
         complete.should.equal(true);
-        doc._id.should.equal(registrations[0].scheduled_tasks[0].report_uuid);
+        registrations[0].scheduled_tasks[0].report_uuid.should.equal(doc._id);
+        putRegistration.callCount.should.equal(1);
         done();
       });
     });
 
     it('if there are multiple scheduled tasks uses the oldest valid one', done => {
-      sinon.stub(db.medic, 'post').resolves({});
+      const putRegistration = sinon.stub(db.medic, 'put').resolves({});
       sinon.stub(transition, '_silenceReminders').callsArgWith(3, null, true);
       const doc = {
         _id: 'z',
@@ -339,7 +340,8 @@ describe('accept_patient_reports', () => {
         .callsArgWith(1, null, registrations);
       transition._handleReport(doc, config, (err, complete) => {
         complete.should.equal(true);
-        doc._id.should.equal(registrations[0].scheduled_tasks[2].report_uuid);
+        registrations[0].scheduled_tasks[2].report_uuid.should.equal(doc._id);
+        putRegistration.callCount.should.equal(1);
         done();
       });
     });

--- a/sentinel/tests/unit/transitions/accept_patient_reports.js
+++ b/sentinel/tests/unit/transitions/accept_patient_reports.js
@@ -231,7 +231,7 @@ describe('accept_patient_reports', () => {
       const doc = {
         _id: 'z',
         fields: { patient_id: 'x' },
-        sms_message: { message: 'V 63374' },
+        reported_date: '2018-09-28T18:45:00.000Z',
       };
       const config = { silence_type: 'x', messages: [] };
       const registrations = [
@@ -241,10 +241,19 @@ describe('accept_patient_reports', () => {
           scheduled_tasks: [
             {
               due: '2018-09-26T18:45:00.000Z',
+              state: 'sent',
               messages: [
                 {
                   uuid: 'k',
-                  message: `Please remind Patient1 (63344) to visit the health facility for ANC visit this week. When she does let us know with 'V 63374'. Thanks!`,
+                },
+              ],
+            },
+            {
+              due: '2018-10-26T18:45:00.000Z',
+              state: 'scheduled',
+              messages: [
+                {
+                  uuid: 'j',
                 },
               ],
             },
@@ -268,7 +277,7 @@ describe('accept_patient_reports', () => {
       const doc = {
         _id: 'z',
         fields: { patient_id: 'x' },
-        sms_message: { message: 'V 63374' },
+        reported_date: '2019-01-10T18:45:00.000Z',
       };
       const config = { silence_type: 'x', messages: [] };
       const registrations = [
@@ -278,37 +287,46 @@ describe('accept_patient_reports', () => {
           scheduled_tasks: [
             {
               due: '2018-09-26T18:45:00.000Z',
+              state: 'sent',
               messages: [
                 {
                   uuid: 'k1',
-                  message: `Please remind Patient1 (63344) to visit the health facility for ANC visit this week. When she does let us know with 'V 63374'. Thanks!`,
                 },
               ],
             },
             {
               due: '2018-11-26T18:45:00.000Z',
+              state: 'sent',
               messages: [
                 {
                   uuid: 'k2',
-                  message: `Please remind Patient1 (63344) to visit the health facility for ANC visit this week. When she does let us know with 'V 63374'. Thanks!`,
                 },
               ],
             },
             {
               due: '2018-12-26T18:45:00.000Z',
+              state: 'delivered',
               messages: [
                 {
                   uuid: 'k3',
-                  message: `Please remind Patient1 (63344) to visit the health facility for ANC visit this week. When she does let us know with 'V 63384'. Thanks!`,
                 },
               ],
             },
             {
-              due: '2018-10-26T18:45:00.000Z',
+              due: '2019-01-26T18:45:00.000Z',
+              state: 'scheduled',
               messages: [
                 {
                   uuid: 'k4',
-                  message: `Please remind Patient1 (63344) to visit the health facility for ANC visit this week. When she does let us know with 'V 63374'. Thanks!`,
+                },
+              ],
+            },
+            {
+              due: '2019-02-26T18:45:00.000Z',
+              state: 'scheduled',
+              messages: [
+                {
+                  uuid: 'k5',
                 },
               ],
             },
@@ -321,7 +339,7 @@ describe('accept_patient_reports', () => {
       transition._handleReport(doc, config, (err, complete) => {
         complete.should.equal(true);
         doc.message_uuid.should.equal(
-          registrations[0].scheduled_tasks[1].messages[0].uuid
+          registrations[0].scheduled_tasks[2].messages[0].uuid
         );
         done();
       });

--- a/sentinel/tests/unit/transitions/accept_patient_reports.js
+++ b/sentinel/tests/unit/transitions/accept_patient_reports.js
@@ -243,6 +243,15 @@ describe('accept_patient_reports', () => {
           reported_date: '2017-02-05T09:23:07.853Z',
           scheduled_tasks: [
             {
+              due: '2019-02-26T18:45:00.000Z',
+              state: 'scheduled',
+              messages: [
+                {
+                  uuid: 'k5',
+                },
+              ],
+            },
+            {
               due: '2018-09-26T18:45:00.000Z',
               state: 'sent',
               messages: [
@@ -325,15 +334,6 @@ describe('accept_patient_reports', () => {
                 },
               ],
             },
-            {
-              due: '2019-02-26T18:45:00.000Z',
-              state: 'scheduled',
-              messages: [
-                {
-                  uuid: 'k5',
-                },
-              ],
-            },
           ],
         },
       ];
@@ -343,7 +343,7 @@ describe('accept_patient_reports', () => {
       transition._handleReport(doc, config, (err, complete) => {
         complete.should.equal(true);
         putRegistration.callCount.should.equal(1);
-        registrations[0].scheduled_tasks[2].report_uuid.should.equal(doc._id);
+        registrations[0].scheduled_tasks[3].report_uuid.should.equal(doc._id);
         done();
       });
     });

--- a/sentinel/tests/unit/transitions/accept_patient_reports.js
+++ b/sentinel/tests/unit/transitions/accept_patient_reports.js
@@ -228,7 +228,8 @@ describe('accept_patient_reports', () => {
     });
     
     it('adds report_uuid property', done => {
-      const putRegistration = sinon.stub(db.medic, 'put').resolves({});
+      const putRegistration = sinon.stub(db.medic, 'put');
+      putRegistration.callsArg(1);
       sinon.stub(transition, '_silenceReminders').callsArgWith(3, null, true);
       const doc = {
         _id: 'z',
@@ -267,14 +268,15 @@ describe('accept_patient_reports', () => {
         .callsArgWith(1, null, registrations);
       transition._handleReport(doc, config, (err, complete) => {
         complete.should.equal(true);
-        registrations[0].scheduled_tasks[0].report_uuid.should.equal(doc._id);
         putRegistration.callCount.should.equal(1);
+        registrations[0].scheduled_tasks[0].report_uuid.should.equal(doc._id);
         done();
       });
     });
 
     it('if there are multiple scheduled tasks uses the oldest valid one', done => {
-      const putRegistration = sinon.stub(db.medic, 'put').resolves({});
+      const putRegistration = sinon.stub(db.medic, 'put');
+      putRegistration.callsArg(1);
       sinon.stub(transition, '_silenceReminders').callsArgWith(3, null, true);
       const doc = {
         _id: 'z',
@@ -340,8 +342,8 @@ describe('accept_patient_reports', () => {
         .callsArgWith(1, null, registrations);
       transition._handleReport(doc, config, (err, complete) => {
         complete.should.equal(true);
-        registrations[0].scheduled_tasks[2].report_uuid.should.equal(doc._id);
         putRegistration.callCount.should.equal(1);
+        registrations[0].scheduled_tasks[2].report_uuid.should.equal(doc._id);
         done();
       });
     });

--- a/sentinel/tests/unit/transitions/accept_patient_reports.js
+++ b/sentinel/tests/unit/transitions/accept_patient_reports.js
@@ -244,8 +244,7 @@ describe('accept_patient_reports', () => {
               messages: [
                 {
                   uuid: 'k',
-                  message:
-                    "Please remind Patient1 (63344) to visit the health facility for ANC visit this week. When she does let us know with 'V 63374'. Thanks!",
+                  message: `Please remind Patient1 (63344) to visit the health facility for ANC visit this week. When she does let us know with 'V 63374'. Thanks!`,
                 },
               ],
             },
@@ -282,8 +281,7 @@ describe('accept_patient_reports', () => {
               messages: [
                 {
                   uuid: 'k1',
-                  message:
-                    "Please remind Patient1 (63344) to visit the health facility for ANC visit this week. When she does let us know with 'V 63374'. Thanks!",
+                  message: `Please remind Patient1 (63344) to visit the health facility for ANC visit this week. When she does let us know with 'V 63374'. Thanks!`,
                 },
               ],
             },
@@ -292,8 +290,7 @@ describe('accept_patient_reports', () => {
               messages: [
                 {
                   uuid: 'k2',
-                  message:
-                    "Please remind Patient1 (63344) to visit the health facility for ANC visit this week. When she does let us know with 'V 63374'. Thanks!",
+                  message: `Please remind Patient1 (63344) to visit the health facility for ANC visit this week. When she does let us know with 'V 63374'. Thanks!`,
                 },
               ],
             },
@@ -302,8 +299,7 @@ describe('accept_patient_reports', () => {
               messages: [
                 {
                   uuid: 'k3',
-                  message:
-                    "Please remind Patient1 (63344) to visit the health facility for ANC visit this week. When she does let us know with 'V 63384'. Thanks!",
+                  message: `Please remind Patient1 (63344) to visit the health facility for ANC visit this week. When she does let us know with 'V 63384'. Thanks!`,
                 },
               ],
             },

--- a/sentinel/tests/unit/transitions/accept_patient_reports.js
+++ b/sentinel/tests/unit/transitions/accept_patient_reports.js
@@ -197,127 +197,6 @@ describe('accept_patient_reports', () => {
       });
     });
 
-    it('adds report_uuid property', done => {
-      const putRegistration = sinon.stub(db.medic, 'put');
-      putRegistration.callsArg(1);
-      sinon.stub(transition, '_silenceReminders').callsArgWith(3, null, true);
-      const doc = {
-        _id: 'z',
-        fields: { patient_id: 'x' },
-        reported_date: '2018-09-28T18:45:00.000Z',
-      };
-      const config = { silence_type: 'x', messages: [] };
-      const registrations = [
-        {
-          _id: 'a',
-          reported_date: '2017-02-05T09:23:07.853Z',
-          scheduled_tasks: [
-            {
-              due: '2018-09-26T18:45:00.000Z',
-              state: 'sent',
-              messages: [
-                {
-                  uuid: 'k',
-                },
-              ],
-            },
-            {
-              due: '2018-10-26T18:45:00.000Z',
-              state: 'scheduled',
-              messages: [
-                {
-                  uuid: 'j',
-                },
-              ],
-            },
-          ],
-        },
-      ];
-      sinon
-        .stub(utils, 'getRegistrations')
-        .callsArgWith(1, null, registrations);
-      transition._handleReport(doc, config, (err, complete) => {
-        complete.should.equal(true);
-        putRegistration.callCount.should.equal(1);
-        registrations[0].scheduled_tasks[0].report_uuid.should.equal(doc._id);
-        done();
-      });
-    });
-
-    it('if there are multiple scheduled tasks uses the oldest valid one', done => {
-      const putRegistration = sinon.stub(db.medic, 'put');
-      putRegistration.callsArg(1);
-      sinon.stub(transition, '_silenceReminders').callsArgWith(3, null, true);
-      const doc = {
-        _id: 'z',
-        fields: { patient_id: 'x' },
-        reported_date: '2019-01-10T18:45:00.000Z',
-      };
-      const config = { silence_type: 'x', messages: [] };
-      const registrations = [
-        {
-          _id: 'a',
-          reported_date: '2017-02-05T09:23:07.853Z',
-          scheduled_tasks: [
-            {
-              due: '2019-02-26T18:45:00.000Z',
-              state: 'scheduled',
-              messages: [
-                {
-                  uuid: 'k5',
-                },
-              ],
-            },
-            {
-              due: '2018-09-26T18:45:00.000Z',
-              state: 'sent',
-              messages: [
-                {
-                  uuid: 'k1',
-                },
-              ],
-            },
-            {
-              due: '2018-11-26T18:45:00.000Z',
-              state: 'sent',
-              messages: [
-                {
-                  uuid: 'k2',
-                },
-              ],
-            },
-            {
-              due: '2018-12-26T18:45:00.000Z',
-              state: 'delivered',
-              messages: [
-                {
-                  uuid: 'k3',
-                },
-              ],
-            },
-            {
-              due: '2019-01-26T18:45:00.000Z',
-              state: 'scheduled',
-              messages: [
-                {
-                  uuid: 'k4',
-                },
-              ],
-            },
-          ],
-        },
-      ];
-      sinon
-        .stub(utils, 'getRegistrations')
-        .callsArgWith(1, null, registrations);
-      transition._handleReport(doc, config, (err, complete) => {
-        complete.should.equal(true);
-        putRegistration.callCount.should.equal(1);
-        registrations[0].scheduled_tasks[2].report_uuid.should.equal(doc._id);
-        done();
-      });
-    });
-
     it('should call utils.getRegistrations with correct DB (#4962)', done => {
       const doc = {
         fields: { patient_id: 'x' },
@@ -398,7 +277,7 @@ describe('accept_patient_reports', () => {
       transition._handleReport(doc, config, (err, complete) => {
         complete.should.equal(true);
         putRegistration.callCount.should.equal(1);
-        registrations[0].scheduled_tasks[0].report_uuid.should.equal(doc._id);
+        registrations[0].scheduled_tasks[1].report_uuid.should.equal(doc._id);
         done();
       });
     });
@@ -468,34 +347,6 @@ describe('accept_patient_reports', () => {
       });
     });
 
-    it('should call utils.getRegistrations with correct DB (#4962)', done => {
-      const doc = {
-        fields: { patient_id: 'x' },
-        from: '+123',
-      };
-      sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, []);
-
-      const config = {
-        messages: [
-          {
-            event_type: 'registration_not_found',
-            message: [
-              {
-                content: 'not found {{patient_id}}',
-                locale: 'en',
-              },
-            ],
-            recipient: 'reporting_unit',
-          },
-        ],
-      };
-
-      transition._handleReport(doc, config, () => {
-        utils.getRegistrations.callCount.should.equal(1);
-        utils.getRegistrations.args[0][0].should.deep.equal({ db: dbNano, id: 'x' });
-        done();
-      });
-    });
   });
 
   describe('silenceReminders', () => {

--- a/sentinel/tests/unit/transitions/accept_patient_reports.js
+++ b/sentinel/tests/unit/transitions/accept_patient_reports.js
@@ -371,7 +371,6 @@ describe('accept_patient_reports', () => {
         utils.getRegistrations.args[0][0].should.deep.equal({ db: dbNano, id: 'x' });
         done();
       });
-      
     });
   });
 


### PR DESCRIPTION
We want to be able to to show that CHWs receive our SMS and then respond to them.

medic/medic-webapp#4694

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.