### PR TITLE
Issue 4865: grunt watch doesn't deploy inbox.html changes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -259,6 +259,16 @@ module.exports = function(grunt) {
           },
         ],
       },
+      'inbox-file-attachment': {
+        files: [
+          {
+            expand: true,
+            cwd: 'webapp/src/',
+            src: ['templates/inbox.html'],
+            dest: 'build/ddocs/medic/_attachments/',
+          },
+        ],
+      },
       'ddoc-attachments': {
         files: [
           {
@@ -567,7 +577,7 @@ module.exports = function(grunt) {
       },
       'inbox-html-template': {
         files: 'webapp/src/templates/inbox.html',
-        tasks: ['copy:ddoc-attachments', 'watch-webapp-templates'],
+        tasks: ['copy:inbox-file-attachment', 'watch-webapp-templates'],
       },
       'primary-ddoc': {
         files: ['ddocs/medic/**/*'],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -260,14 +260,10 @@ module.exports = function(grunt) {
         ],
       },
       'inbox-file-attachment': {
-        files: [
-          {
-            expand: true,
-            cwd: 'webapp/src/',
-            src: ['templates/inbox.html'],
-            dest: 'build/ddocs/medic/_attachments/',
-          },
-        ],
+        expand: true,
+        cwd: 'webapp/src/',
+        src: 'templates/inbox.html',
+        dest: 'build/ddocs/medic/_attachments/',
       },
       'ddoc-attachments': {
         files: [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -569,11 +569,21 @@ module.exports = function(grunt) {
           'webapp/src/templates/**/*',
           '!webapp/src/templates/inbox.html',
         ],
-        tasks: ['ngtemplates:inboxApp', 'watch-webapp-templates'],
+        tasks: [
+          'ngtemplates:inboxApp',
+          'appcache',
+          'couch-compile:primary',
+          'deploy',
+        ],
       },
       'inbox-html-template': {
         files: 'webapp/src/templates/inbox.html',
-        tasks: ['copy:inbox-file-attachment', 'watch-webapp-templates'],
+        tasks: [
+          'copy:inbox-file-attachment',
+          'appcache',
+          'couch-compile:primary',
+          'deploy',
+        ],
       },
       'primary-ddoc': {
         files: ['ddocs/medic/**/*'],
@@ -864,12 +874,6 @@ module.exports = function(grunt) {
     'build-node-modules',
     'Build and pack api and sentinel bundles',
     ['exec:bundle-dependencies', 'exec:pack-node-modules']
-  );
-
-  grunt.registerTask(
-    'watch-webapp-templates',
-    'Watch templates change and deploy',
-    ['appcache', 'couch-compile:primary', 'deploy']
   );
 
   // Test tasks

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -563,12 +563,11 @@ module.exports = function(grunt) {
           'webapp/src/templates/**/*',
           '!webapp/src/templates/inbox.html',
         ],
-        tasks: [
-          'ngtemplates:inboxApp',
-          'appcache',
-          'couch-compile:primary',
-          'deploy',
-        ],
+        tasks: ['ngtemplates:inboxApp', 'watch-webapp-templates'],
+      },
+      'inbox-html-template': {
+        files: 'webapp/src/templates/inbox.html',
+        tasks: ['copy:ddoc-attachments', 'watch-webapp-templates'],
       },
       'primary-ddoc': {
         files: ['ddocs/medic/**/*'],
@@ -859,6 +858,12 @@ module.exports = function(grunt) {
     'build-node-modules',
     'Build and pack api and sentinel bundles',
     ['exec:bundle-dependencies', 'exec:pack-node-modules']
+  );
+
+  grunt.registerTask(
+    'watch-webapp-templates',
+    'Watch templates change and deploy',
+    ['appcache', 'couch-compile:primary', 'deploy']
   );
 
   // Test tasks


### PR DESCRIPTION
# Description

Grunt watch doesn't deploy inbox.html changes

medic/medic-webapp#4865

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.