### PR TITLE
3423 remove infodoc

### DIFF
--- a/sentinel/src/db-pouch.js
+++ b/sentinel/src/db-pouch.js
@@ -14,6 +14,7 @@ if(UNIT_TEST_ENV) {
     allDocs: stubMe('allDocs'),
     bulkDocs: stubMe('bulkDocs'),
     put: stubMe('put'),
+    remove: stubMe('remove'),
     post: stubMe('post'),
     query: stubMe('query'),
     get: stubMe('get'),

--- a/sentinel/src/lib/feed.js
+++ b/sentinel/src/lib/feed.js
@@ -5,7 +5,7 @@ const followFeed = (seq, queue) => {
   return db.medic.changes({ live: true, since: seq })
     .on('change', change => {
       // skip uninteresting documents
-      if (change.id.match(/^_design\//)) {
+      if (change.id.match(/^_design\/|-info$/)) {
         return;
       }
       queue.push(change);

--- a/sentinel/tests/unit/lib/infodoc.js
+++ b/sentinel/tests/unit/lib/infodoc.js
@@ -1,0 +1,31 @@
+const assert = require('chai').assert,
+  sinon = require('sinon').sandbox.create(),
+  db = require('../../../src/db-pouch'),
+  infodoc = require('../../../src/lib/infodoc');
+
+describe('infodoc', () => {
+  afterEach(() => sinon.restore());
+
+  it('gets infodoc from medic and moves it to sentinel', () => {
+    const change = {id: 'messages-en'};
+    const rev = '123';
+    const info = {_id: 'messages-en-info', _rev: rev, transitions: []};
+
+    const getSentinelInfo = sinon.stub(db.sentinel, 'get').resolves(null);
+    const getMedicInfo = sinon.stub(db.medic, 'get').resolves(info);
+    const removeLegacyInfo = sinon.stub(db.medic, 'remove').resolves(info);
+    const updateSentinelInfo = sinon.stub(db.sentinel, 'put').resolves({});
+
+    return infodoc.get(change).then(() => {
+      assert(getSentinelInfo.calledOnce);
+      assert.equal(getSentinelInfo.args[0], info._id);
+      assert(getMedicInfo.calledOnce);
+      assert.equal(getMedicInfo.args[0], info._id);
+      assert(removeLegacyInfo.calledOnce);
+      assert.deepEqual(removeLegacyInfo.args[0], [info._id, rev]);
+      assert.equal(updateSentinelInfo.args[0][0]._id, info._id);
+      assert(!updateSentinelInfo.args[0][0]._rev);
+      assert.deepEqual(updateSentinelInfo.args[0][0].transitions, []);
+    });
+  });
+});


### PR DESCRIPTION
# Description

Moves existing -info doc from medic to medic-sentinel db after medic changes/updates.

medic/medic-webapp#3423

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.