### PR TITLE
Blocks offline users from accessing admin app

### DIFF
--- a/api/src/controllers/db-doc.js
+++ b/api/src/controllers/db-doc.js
@@ -96,7 +96,7 @@ module.exports = {
 
     // offline users are allowed to access the admin app
     if (req.params.ddocId === 'medic-admin') {
-      return next();
+      return permissionsError(res);
     }
 
     req.params.docId = `_design/${req.params.ddocId}`;

--- a/api/tests/mocha/controllers/db-doc.spec.js
+++ b/api/tests/mocha/controllers/db-doc.spec.js
@@ -277,15 +277,16 @@ describe('db-doc controller', () => {
         });
     });
 
-    it('forwards medic-admin requests to the next middleware', () => {
+    it('blocks requests to medic-admin', () => {
       testReq.params = { ddocId: 'medic-admin' };
-      return controller
-        .requestDdoc('medic', testReq, testRes, next)
-        .then(() => {
-          next.callCount.should.equal(1);
-          next.args[0].should.deep.equal([]);
-          service.filterOfflineRequest.callCount.should.equal(0);
-        });
+      controller.requestDdoc('medic', testReq, testRes, next);
+      service.filterOfflineRequest.callCount.should.equal(0);
+      next.callCount.should.equal(0);
+
+      testRes.status.callCount.should.equal(1);
+      testRes.status.args[0].should.deep.equal([403]);
+      testRes.json.callCount.should.deep.equal(1);
+      testRes.json.args[0].should.deep.equal([{ error: 'forbidden', reason: 'Insufficient privileges' }]);
     });
 
     it('constructs correct docId when ddoc is not appddoc and continues request when allowed', () => {

--- a/tests/e2e/api/controllers/db-doc.spec.js
+++ b/tests/e2e/api/controllers/db-doc.spec.js
@@ -866,13 +866,13 @@ describe('db-doc handler', () => {
   });
 
   describe('interactions with ddocs', () => {
-    it('allows GETting _design/medic-client and _design/medic-admin, blocks all other ddoc GET requests', () => {
+    it('allows GETting _design/medic-client blocks all other ddoc GET requests', () => {
       return Promise
         .all([
           utils.requestOnTestDb(_.defaults({ path: '/_design/medic-client' }, offlineRequestOptions)),
           utils.requestOnTestDb(_.defaults({ path: '/_design/medic' }, offlineRequestOptions)).catch(err => err),
           utils.requestOnTestDb(_.defaults({ path: '/_design/something' }, offlineRequestOptions)).catch(err => err),
-          utils.requestOnTestDb(_.defaults({ path: '/_design/medic-admin' }, offlineRequestOptions))
+          utils.requestOnTestDb(_.defaults({ path: '/_design/medic-admin' }, offlineRequestOptions)).catch(err => err)
         ])
         .then(results => {
           expect(results[0]._id).toEqual('_design/medic-client');
@@ -883,7 +883,8 @@ describe('db-doc handler', () => {
           expect(results[2].statusCode).toEqual(403);
           expect(results[2].responseBody.error).toEqual('forbidden');
 
-          expect(results[3]._id).toEqual('_design/medic-admin');
+          expect(results[3].statusCode).toEqual(403);
+          expect(results[3].responseBody.error).toEqual('forbidden');
         });
     });
 

--- a/tests/e2e/api/routing.js
+++ b/tests/e2e/api/routing.js
@@ -497,17 +497,21 @@ describe('routing', () => {
         });
     });
 
-    it('allows access to the admin app', () => {
+    it('blocks access to the admin app', () => {
       return Promise
         .all([
-          utils.requestOnTestDb(_.defaults({ path: '/_design/medic-admin/_rewrite' }, offlineRequestOptions), false, true),
-          utils.requestOnTestDb(_.defaults({ path: '/_design/medic-admin/_rewrite/' }, offlineRequestOptions), false, true),
-          utils.requestOnTestDb(_.defaults({ path: '/_design/medic-admin/main.css' }, offlineRequestOptions), false, true)
+          utils
+            .requestOnTestDb(_.defaults({ path: '/_design/medic-admin/_rewrite' }, offlineRequestOptions), false, true)
+            .catch(err => err),
+          utils
+            .requestOnTestDb(_.defaults({ path: '/_design/medic-admin/_rewrite/' }, offlineRequestOptions), false, true)
+            .catch(err => err),
+          utils
+            .requestOnTestDb(_.defaults({ path: '/_design/medic-admin/main.css' }, offlineRequestOptions), false, true)
+            .catch(err => err)
         ])
         .then(results => {
-          expect(results[0].includes('administration console')).toBe(true);
-          expect(results[1].includes('administration console')).toBe(true);
-          expect(results[2].includes('html')).toBe(true);
+          expect(results.every(result => result.statusCode === 401 && result.responseBody.error === 'unauthorized'));
         });
     });
 

--- a/webapp/src/js/directives/auth.js
+++ b/webapp/src/js/directives/auth.js
@@ -1,12 +1,23 @@
 var _ = require('underscore');
 
-angular.module('inboxDirectives').directive('mmAuth', function($log, Auth, $parse) {
+angular.module('inboxDirectives').directive('mmAuth', function($log, Auth, $parse, $q) {
   'use strict';
   'ngInject';
   var link = function(scope, element, attributes) {
+    var promises = [];
     if (attributes.mmAuth) {
       element.addClass('hidden');
-      Auth(attributes.mmAuth.split(','))
+      promises.push(Auth(attributes.mmAuth.split(',')));
+    }
+
+    if (attributes.mmAuthRole) {
+      element.addClass('hidden');
+      promises.push( Auth.roles(attributes.mmAuthRole.split(',')));
+    }
+
+    if (promises.length) {
+      $q
+        .all(promises)
         .then(function () {
           element.removeClass('hidden');
         })
@@ -46,6 +57,12 @@ angular.module('inboxDirectives').directive('mmAuth', function($log, Auth, $pars
         .any(permissionsGroups)
         .then(function() {
           element.removeClass('hidden');
+        })
+        .catch(function (err) {
+          if (err) {
+            $log.error('Error checking authorization', err);
+          }
+          element.addClass('hidden');
         });
     };
 

--- a/webapp/src/js/services/auth.js
+++ b/webapp/src/js/services/auth.js
@@ -164,10 +164,10 @@ angular.module('inboxServices').factory('Auth',
           return $q.resolve();
         }
 
-        if (_.intersection(requiredRoles, userRoles).length !== requiredRoles.length) {
+        if (!_.every(requiredRoles, _.partial(_.includes, userRoles))) {
           return authFail('missing required role', roles, userRoles);
         }
-        if (_.intersection(disallowedRoles, userRoles).length) {
+        if (_.some(disallowedRoles, _.partial(_.includes, userRoles))) {
           return authFail('found disallowed role', roles, userRoles);
         }
 

--- a/webapp/src/js/services/auth.js
+++ b/webapp/src/js/services/auth.js
@@ -148,6 +148,33 @@ angular.module('inboxServices').factory('Auth',
       });
     };
 
+    auth.roles = function(roles) {
+      if (!_.isArray(roles)) {
+        roles = [ roles ];
+      }
+
+      var requiredRoles = getRequired(roles);
+      var disallowedRoles = getDisallowed(roles);
+
+      return getRoles().then(function(userRoles) {
+        if (_.contains(userRoles, '_admin')) {
+          if (disallowedRoles.length > 0) {
+            return authFail('disallowed role(s) found for admin', roles, userRoles);
+          }
+          return $q.resolve();
+        }
+
+        if (_.intersection(requiredRoles, userRoles).length !== requiredRoles.length) {
+          return authFail('missing required role', roles, userRoles);
+        }
+        if (_.intersection(disallowedRoles, userRoles).length) {
+          return authFail('found disallowed role', roles, userRoles);
+        }
+
+        return $q.resolve();
+      });
+    };
+
     return auth;
   }
 );

--- a/webapp/src/templates/partials/header.html
+++ b/webapp/src/templates/partials/header.html
@@ -48,7 +48,7 @@
               <span translate>Analytics</span>
             </a>
           </li>
-          <li role="presentation" mm-auth="can_configure">
+          <li role="presentation" mm-auth="can_configure" mm-auth-role="mm-online">
             <a href="../../medic-admin/_rewrite/" role="menuitem" tabindex="-1" target="_blank" rel="noopener noreferrer">
               <i class="fa fa-fw fa-cog"></i>
               <span translate>Configuration</span>

--- a/webapp/tests/karma/unit/directives/auth.js
+++ b/webapp/tests/karma/unit/directives/auth.js
@@ -22,41 +22,39 @@ describe('auth directive', function() {
     });
   });
 
-  describe('mmAuth', () => {
-    it('should be shown when auth does not error', function(done) {
-      Auth.returns(Promise.resolve());
-      var element = compile('<a mm-auth="can_do_stuff">')(scope);
-      scope.$digest();
-      setTimeout(function() {
-        chai.expect(element.hasClass('hidden')).to.equal(false);
-        chai.expect(Auth.callCount).to.equal(1);
-        chai.expect(Auth.args[0][0]).to.deep.equal(['can_do_stuff']);
-        done();
-      });
+  it('should be shown when auth does not error', function(done) {
+    Auth.returns(Promise.resolve());
+    var element = compile('<a mm-auth="can_do_stuff">')(scope);
+    scope.$digest();
+    setTimeout(function() {
+      chai.expect(element.hasClass('hidden')).to.equal(false);
+      chai.expect(Auth.callCount).to.equal(1);
+      chai.expect(Auth.args[0][0]).to.deep.equal(['can_do_stuff']);
+      done();
     });
+  });
 
-    it('should be hidden when auth errors', function(done) {
-      Auth.returns(Promise.reject('boom'));
-      var element = compile('<a mm-auth="can_do_stuff">')(scope);
-      scope.$digest();
-      setTimeout(function() {
-        chai.expect(element.hasClass('hidden')).to.equal(true);
-        chai.expect(Auth.callCount).to.equal(1);
-        chai.expect(Auth.args[0][0]).to.deep.equal(['can_do_stuff']);
-        done();
-      });
+  it('should be hidden when auth errors', function(done) {
+    Auth.returns(Promise.reject('boom'));
+    var element = compile('<a mm-auth="can_do_stuff">')(scope);
+    scope.$digest();
+    setTimeout(function() {
+      chai.expect(element.hasClass('hidden')).to.equal(true);
+      chai.expect(Auth.callCount).to.equal(1);
+      chai.expect(Auth.args[0][0]).to.deep.equal(['can_do_stuff']);
+      done();
     });
+  });
 
-    it('splits comma separated permissions', function(done) {
-      Auth.returns(Promise.resolve());
-      var element = compile('<a mm-auth="can_do_stuff,!can_not_do_stuff">')(scope);
-      scope.$digest();
-      setTimeout(function() {
-        chai.expect(element.hasClass('hidden')).to.equal(false);
-        chai.expect(Auth.callCount).to.equal(1);
-        chai.expect(Auth.args[0][0]).to.deep.equal(['can_do_stuff', '!can_not_do_stuff']);
-        done();
-      });
+  it('splits comma separated permissions', function(done) {
+    Auth.returns(Promise.resolve());
+    var element = compile('<a mm-auth="can_do_stuff,!can_not_do_stuff">')(scope);
+    scope.$digest();
+    setTimeout(function() {
+      chai.expect(element.hasClass('hidden')).to.equal(false);
+      chai.expect(Auth.callCount).to.equal(1);
+      chai.expect(Auth.args[0][0]).to.deep.equal(['can_do_stuff', '!can_not_do_stuff']);
+      done();
     });
   });
 


### PR DESCRIPTION
# Description

Offline users no longer have access to `_design/medic-admin` or it's attachments. 
Additionally, the `Configuration` link in Webapp is hidden for users with offline roles, even if they have `can_configure` permission.

medic/medic-webapp#4786

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.