### PR TITLE
Use less globals in angular

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -862,6 +862,37 @@ module.exports = function(grunt) {
           pattern: /console\./g,
         },
       },
+      'timeouts-in-angular': {
+        // $timeout() sould be used in place of setTimeout()
+        // $timeout.cancel() should be used in place of clearTimeout()
+        // see: https://docs.angularjs.org/api/ng/service/$timeout
+        files: [
+          {
+            src: [
+              'webapp/src/js/services/**/*.js',
+              'webapp/src/js/controllers/**/*.js',
+            ],
+          },
+        ],
+        options: {
+          pattern: /(set|clear)Timeout/g,
+        },
+      },
+      'window-in-angular': {
+        // $window should be used in preference to window in angular code
+        // see: https://docs.angularjs.org/api/ng/service/$window
+        files: [
+          {
+            src: [
+              'webapp/src/js/services/**/*.js',
+              'webapp/src/js/controllers/**/*.js',
+            ],
+          },
+        ],
+        options: {
+          pattern: /[^$]window\./g,
+        },
+      },
     },
     xmlmin: {
       'enketo-xslt': {

--- a/webapp/src/js/controllers/about.js
+++ b/webapp/src/js/controllers/about.js
@@ -3,6 +3,7 @@ angular.module('inboxControllers').controller('AboutCtrl',
     $interval,
     $log,
     $scope,
+    $window,
     DB,
     Debug,
     Session,
@@ -11,7 +12,7 @@ angular.module('inboxControllers').controller('AboutCtrl',
     'use strict';
     'ngInject';
 
-    $scope.url = window.location.hostname;
+    $scope.url = $window.location.hostname;
     $scope.userCtx = Session.userCtx();
 
     $scope.debugOptionEnabled = $scope.url.indexOf('localhost') >= 0;
@@ -52,18 +53,18 @@ angular.module('inboxControllers').controller('AboutCtrl',
       });
 
     $scope.reload = function() {
-      window.location.reload(false);
+      $window.location.reload(false);
     };
     $scope.enableDebugModel = {
       val: Debug.get()
     };
     $scope.$watch('enableDebugModel.val', Debug.set);
 
-    if (window.medicmobile_android && typeof window.medicmobile_android.getDataUsage === 'function') {
-      $scope.androidDataUsage = JSON.parse(window.medicmobile_android.getDataUsage());
+    if ($window.medicmobile_android && typeof $window.medicmobile_android.getDataUsage === 'function') {
+      $scope.androidDataUsage = JSON.parse($window.medicmobile_android.getDataUsage());
 
       var dataUsageUpdate = $interval(function() {
-        $scope.androidDataUsage = JSON.parse(window.medicmobile_android.getDataUsage());
+        $scope.androidDataUsage = JSON.parse($window.medicmobile_android.getDataUsage());
       }, 2000);
 
       $scope.$on('$destroy', function() {

--- a/webapp/src/js/controllers/bulk-delete-confirm.js
+++ b/webapp/src/js/controllers/bulk-delete-confirm.js
@@ -2,6 +2,7 @@ angular.module('inboxControllers').controller('BulkDeleteConfirm',
   function(
     $scope,
     $timeout,
+    $window,
     $translate,
     $uibModalInstance,
     DeleteDocs
@@ -19,13 +20,13 @@ angular.module('inboxControllers').controller('BulkDeleteConfirm',
 
     $scope.$on('modal.closing', function() {
       if ($scope.deleteComplete) {
-        return window.location.reload();
+        return $window.location.reload();
       }
     });
 
     $scope.submit = function() {
       if ($scope.deleteComplete) {
-        return window.location.reload();
+        return $window.location.reload();
       }
 
       var docs = $scope.model.docs;

--- a/webapp/src/js/controllers/guided-setup-modal.js
+++ b/webapp/src/js/controllers/guided-setup-modal.js
@@ -6,6 +6,7 @@ angular.module('inboxControllers').controller('GuidedSetupModalCtrl',
   function(
     $log,
     $scope,
+    $timeout,
     $translate,
     $uibModalInstance,
     DB,
@@ -124,7 +125,7 @@ angular.module('inboxControllers').controller('GuidedSetupModalCtrl',
         Settings()
           .then(function(res) {
             if (res.setup_complete) {
-              setTimeout(function() {
+              $timeout(function() {
                 $('#guided-setup [name=default-country-code]').val(res.default_country_code).change();
                 $('#guided-setup [name=gateway-number]').val(res.gateway_number).trigger('input');
                 $('#primary-contact-content a[data-value=' + res.care_coordinator + ']').trigger('click');

--- a/webapp/src/js/controllers/inbox.js
+++ b/webapp/src/js/controllers/inbox.js
@@ -72,7 +72,7 @@ var feedback = require('../modules/feedback'),
 
     Session.init();
 
-    if (window.location.href.indexOf('localhost') !== -1) {
+    if ($window.location.href.indexOf('localhost') !== -1) {
       Debug.set(Debug.get()); // Initialize with cookie
     } else {
       // Disable debug for everything but localhost
@@ -704,15 +704,15 @@ var feedback = require('../modules/feedback'),
       },
     });
 
-    if (window.applicationCache) {
-      window.applicationCache.addEventListener('updateready', showUpdateReady);
-      window.applicationCache.addEventListener('error', function(err) {
+    if ($window.applicationCache) {
+      $window.applicationCache.addEventListener('updateready', showUpdateReady);
+      $window.applicationCache.addEventListener('error', function(err) {
         // TODO: once we trigger this work out what a 401 looks like and redirect
         //       to the login page
         $log.error('Application cache update error', err);
       });
       if (
-        window.applicationCache.status === window.applicationCache.UPDATEREADY
+        $window.applicationCache.status === $window.applicationCache.UPDATEREADY
       ) {
         showUpdateReady();
       }
@@ -728,10 +728,10 @@ var feedback = require('../modules/feedback'),
         },
         callback: function() {
           // if the manifest hasn't changed, prompt user to reload settings
-          window.applicationCache.addEventListener('noupdate', showUpdateReady);
+          $window.applicationCache.addEventListener('noupdate', showUpdateReady);
           // check if the manifest has changed. if it has, download and prompt
           try {
-            window.applicationCache.update();
+            $window.applicationCache.update();
           } catch (e) {
             // chrome incognito mode active
             $log.error('Error updating the appcache.', e);

--- a/webapp/src/js/controllers/inbox.js
+++ b/webapp/src/js/controllers/inbox.js
@@ -56,18 +56,18 @@ var feedback = require('../modules/feedback'),
   ) {
     'ngInject';
 
-    window.startupTimes.angularBootstrapped = performance.now();
+    $window.startupTimes.angularBootstrapped = performance.now();
     Telemetry.record(
       'boot_time:1:to_first_code_execution',
-      window.startupTimes.firstCodeExecution - window.startupTimes.start
+      $window.startupTimes.firstCodeExecution - $window.startupTimes.start
     );
     Telemetry.record(
       'boot_time:2:to_bootstrap',
-      window.startupTimes.bootstrapped - window.startupTimes.firstCodeExecution
+      $window.startupTimes.bootstrapped - $window.startupTimes.firstCodeExecution
     );
     Telemetry.record(
       'boot_time:3:to_angular_bootstrap',
-      window.startupTimes.angularBootstrapped - window.startupTimes.bootstrapped
+      $window.startupTimes.angularBootstrapped - $window.startupTimes.bootstrapped
     );
 
     Session.init();
@@ -142,11 +142,11 @@ var feedback = require('../modules/feedback'),
       var dbWarmed = performance.now();
       Telemetry.record(
         'boot_time:4:to_db_warmed',
-        dbWarmed - window.startupTimes.bootstrapped
+        dbWarmed - $window.startupTimes.bootstrapped
       );
-      Telemetry.record('boot_time', dbWarmed - window.startupTimes.start);
+      Telemetry.record('boot_time', dbWarmed - $window.startupTimes.start);
 
-      delete window.startupTimes;
+      delete $window.startupTimes;
     });
 
     feedback.init({

--- a/webapp/src/js/controllers/reloading-modal.js
+++ b/webapp/src/js/controllers/reloading-modal.js
@@ -1,5 +1,5 @@
 /*
-Controller for the Modal service which executes window.reload when submitted.
+Controller for the Modal service which executes $window.reload when submitted.
 */
 angular.module('inboxControllers').controller('ReloadingModalCtrl',
   function (

--- a/webapp/src/js/controllers/tasks.js
+++ b/webapp/src/js/controllers/tasks.js
@@ -12,6 +12,7 @@ var _ = require('underscore');
       $state,
       $stateParams,
       $timeout,
+      $window,
       $translate,
       LiveList,
       RulesEngine,
@@ -49,7 +50,7 @@ var _ = require('underscore');
       };
 
       $scope.refreshTaskList = function() {
-        window.location.reload();
+        $window.location.reload();
       };
 
       $scope.$on('ClearSelected', function() {

--- a/webapp/src/js/services/android-api.js
+++ b/webapp/src/js/services/android-api.js
@@ -9,6 +9,7 @@ angular.module('inboxServices').factory('AndroidApi',
     $log,
     $rootScope,
     $state,
+    $window,
     MRDT,
     Session,
     Simprints
@@ -55,7 +56,7 @@ angular.module('inboxServices').factory('AndroidApi',
 
       // On an Enketo form, go to the previous page (if there is one)
       if ($container.find('.enketo .btn.previous-page:visible:enabled:not(".disabled")').length) {
-        window.history.back();
+        $window.history.back();
         return true;
       }
 

--- a/webapp/src/js/services/debug.js
+++ b/webapp/src/js/services/debug.js
@@ -8,8 +8,13 @@
  *   - display $log.debug() output throughout the app
  *
  */
-angular.module('inboxServices').config([
-  '$provide', '$logProvider', function($provide, $logProvider) {
+angular.module('inboxServices').config(
+  function(
+      $logProvider,
+      $provide,
+      $window
+  ) {
+    'ngInject';
     'use strict';
 
     $provide.service('Debug', [
@@ -22,7 +27,7 @@ angular.module('inboxServices').config([
           // this changes the default angular behavior and hides debug level
           // log messages.
           $logProvider.debugEnabled(bool);
-          var db = pouchDB.debug ? pouchDB : window.PouchDB;
+          var db = pouchDB.debug ? pouchDB : $window.PouchDB;
           if (bool) {
             db.debug.enable('*');
             ipCookie(cookieName, bool, { expires: 360, path: '/' });
@@ -38,4 +43,4 @@ angular.module('inboxServices').config([
       }
     ]);
   }
-]);
+);

--- a/webapp/src/js/services/debug.js
+++ b/webapp/src/js/services/debug.js
@@ -8,41 +8,34 @@
  *   - display $log.debug() output throughout the app
  *
  */
-angular.module('inboxServices').config(
-  function(
-    $logProvider,
-    $provide
-  ) {
-    'ngInject';
+angular.module('inboxServices').config([
+  '$provide', '$logProvider', function($provide, $logProvider) {
     'use strict';
 
-    $provide.service('Debug', function(
-      $window,
-      ipCookie,
-      pouchDB
-    ) {
-      'ngInject';
-      var cookieName = 'medic-webapp-debug';
-      var get = function() {
-        return Boolean(ipCookie(cookieName));
-      };
-      var set = function(bool) {
-        // this changes the default angular behavior and hides debug level
-        // log messages.
-        $logProvider.debugEnabled(bool);
-        var db = pouchDB.debug ? pouchDB : $window.PouchDB;
-        if (bool) {
-          db.debug.enable('*');
-          ipCookie(cookieName, bool, { expires: 360, path: '/' });
-        } else {
-          db.debug.disable();
-          ipCookie.remove(cookieName, { path: '/' });
-        }
-      };
-      return {
-        get: get,
-        set: set
-      };
-    });
+    $provide.service('Debug', [
+      '$window', 'ipCookie', 'pouchDB', function($window, ipCookie, pouchDB) {
+        var cookieName = 'medic-webapp-debug';
+        var get = function() {
+          return Boolean(ipCookie(cookieName));
+        };
+        var set = function(bool) {
+          // this changes the default angular behavior and hides debug level
+          // log messages.
+          $logProvider.debugEnabled(bool);
+          var db = pouchDB.debug ? pouchDB : $window.PouchDB;
+          if (bool) {
+            db.debug.enable('*');
+            ipCookie(cookieName, bool, { expires: 360, path: '/' });
+          } else {
+            db.debug.disable();
+            ipCookie.remove(cookieName, { path: '/' });
+          }
+        };
+        return {
+          get: get,
+          set: set
+        };
+      }
+    ]);
   }
-);
+]);

--- a/webapp/src/js/services/debug.js
+++ b/webapp/src/js/services/debug.js
@@ -10,37 +10,39 @@
  */
 angular.module('inboxServices').config(
   function(
-      $logProvider,
-      $provide,
-      $window
+    $logProvider,
+    $provide
   ) {
     'ngInject';
     'use strict';
 
-    $provide.service('Debug', [
-      'ipCookie', 'pouchDB', function(ipCookie, pouchDB) {
-        var cookieName = 'medic-webapp-debug';
-        var get = function() {
-          return Boolean(ipCookie(cookieName));
-        };
-        var set = function(bool) {
-          // this changes the default angular behavior and hides debug level
-          // log messages.
-          $logProvider.debugEnabled(bool);
-          var db = pouchDB.debug ? pouchDB : $window.PouchDB;
-          if (bool) {
-            db.debug.enable('*');
-            ipCookie(cookieName, bool, { expires: 360, path: '/' });
-          } else {
-            db.debug.disable();
-            ipCookie.remove(cookieName, { path: '/' });
-          }
-        };
-        return {
-          get: get,
-          set: set
-        };
-      }
-    ]);
+    $provide.service('Debug', function(
+      $window,
+      ipCookie,
+      pouchDB
+    ) {
+      'ngInject';
+      var cookieName = 'medic-webapp-debug';
+      var get = function() {
+        return Boolean(ipCookie(cookieName));
+      };
+      var set = function(bool) {
+        // this changes the default angular behavior and hides debug level
+        // log messages.
+        $logProvider.debugEnabled(bool);
+        var db = pouchDB.debug ? pouchDB : $window.PouchDB;
+        if (bool) {
+          db.debug.enable('*');
+          ipCookie(cookieName, bool, { expires: 360, path: '/' });
+        } else {
+          db.debug.disable();
+          ipCookie.remove(cookieName, { path: '/' });
+        }
+      };
+      return {
+        get: get,
+        set: set
+      };
+    });
   }
 );

--- a/webapp/src/js/services/enketo.js
+++ b/webapp/src/js/services/enketo.js
@@ -9,6 +9,7 @@ angular.module('inboxServices').service('Enketo',
     $log,
     $q,
     $translate,
+    $timeout,
     $window,
     AddAttachment,
     ContactSummary,
@@ -170,7 +171,7 @@ angular.module('inboxServices').service('Enketo',
             // Delay focussing on the next field, so that keybaord close and
             // open events both register.  This should mean that the on-screen
             // keyboard is maintained between fields.
-            setTimeout(function() {
+            $timeout(function() {
               $nextQuestion.first().trigger('focus');
             }, 10);
           }
@@ -279,7 +280,7 @@ angular.module('inboxServices').service('Enketo',
         wrapper.find('input').on('keydown', handleKeypressOnInputField);
 
         // handle page turning using browser history
-        window.history.replaceState({ enketo_page_number: 0 }, '');
+        $window.history.replaceState({ enketo_page_number: 0 }, '');
         overrideNavigationButtons(currentForm, wrapper);
         addPopStateHandler(currentForm, wrapper);
         forceRecalculate(currentForm);
@@ -295,7 +296,7 @@ angular.module('inboxServices').service('Enketo',
           form.pages.next()
             .then(function(newPageIndex) {
               if(typeof newPageIndex === 'number') {
-                window.history.pushState({ enketo_page_number: newPageIndex }, '');
+                $window.history.pushState({ enketo_page_number: newPageIndex }, '');
               }
               forceRecalculate(form);
             });
@@ -305,14 +306,14 @@ angular.module('inboxServices').service('Enketo',
       $wrapper.find('.btn.previous-page')
         .off('.pagemode')
         .on('click.pagemode', function() {
-          window.history.back();
+          $window.history.back();
           forceRecalculate(form);
           return false;
         });
     };
 
     var addPopStateHandler = function(form, $wrapper) {
-      $(window).on('popstate.enketo-pagemode', function(event) {
+      $($window).on('popstate.enketo-pagemode', function(event) {
         if(event.originalEvent &&
             event.originalEvent.state &&
             typeof event.originalEvent.state.enketo_page_number === 'number') {
@@ -564,7 +565,7 @@ angular.module('inboxServices').service('Enketo',
     };
 
     this.unload = function(form) {
-      $(window).off('.enketo-pagemode');
+      $($window).off('.enketo-pagemode');
       if (form) {
         form.resetView();
       }

--- a/webapp/src/js/services/search-filters.js
+++ b/webapp/src/js/services/search-filters.js
@@ -9,8 +9,9 @@ var _ = require('underscore'),
 
   var ENTER_KEY_CODE = 13;
 
-  inboxServices.factory('SearchFilters', ['$translate',
-    function($translate) {
+  inboxServices.factory('SearchFilters',
+    function($timeout, $translate) {
+      'ngInject';
 
       var isEnter = function(e) {
         return e.which === ENTER_KEY_CODE;
@@ -189,7 +190,7 @@ var _ = require('underscore'),
           });
         })
         .on('show.daterangepicker', function(e, picker) {
-          setTimeout(function() {
+          $timeout(function() {
             if ($('#dateRangeDropdown').is('.disabled')) {
               picker.hide();
             }
@@ -224,6 +225,6 @@ var _ = require('underscore'),
         }
       };
     }
-  ]);
+  );
 
 }());

--- a/webapp/src/js/services/snackbar.js
+++ b/webapp/src/js/services/snackbar.js
@@ -2,9 +2,9 @@
  * Service to show a Material Design style snackbar transient notification.
  * Usage: Snackbar('My notification');
  */
-angular.module('inboxServices').service('Snackbar', [
-  function() {
-
+angular.module('inboxServices').service('Snackbar',
+  function($timeout) {
+    'ngInject';
     'use strict';
 
     var SHOW_DURATION = 5000;
@@ -16,11 +16,11 @@ angular.module('inboxServices').service('Snackbar', [
         .addClass('active')
         .find('.snackbar-content')
         .text(text);
-      hideTimer = setTimeout(hide, SHOW_DURATION);
+      hideTimer = $timeout(hide, SHOW_DURATION);
     };
 
     var hide = function() {
-      clearTimeout(hideTimer);
+      $timeout.cancel(hideTimer);
       hideTimer = null;
       $('#snackbar').removeClass('active');
     };
@@ -28,7 +28,7 @@ angular.module('inboxServices').service('Snackbar', [
     return function(text) {
       if (hideTimer) {
         hide();
-        setTimeout(function() {
+        $timeout(function() {
           show(text);
         }, ANIMATION_DURATION);
       } else {
@@ -36,4 +36,4 @@ angular.module('inboxServices').service('Snackbar', [
       }
     };
   }
-]);
+);

--- a/webapp/src/js/services/tour.js
+++ b/webapp/src/js/services/tour.js
@@ -74,7 +74,7 @@ angular.module('inboxServices').service('Tour',
 
     var mmOpenDropdown = function(elem) {
       if (!isMobile()) {
-        window.setTimeout(function() {
+        $timeout(function() {
           $(elem).addClass('open');
         }, 1);
       }

--- a/webapp/src/js/services/update-user.js
+++ b/webapp/src/js/services/update-user.js
@@ -8,7 +8,8 @@
     function(
       $http,
       $location,
-      $log
+      $log,
+      $window
     ) {
       'ngInject';
 
@@ -37,7 +38,7 @@
         };
 
         if (basicAuthUser) {
-          headers.Authorization = 'Basic ' + window.btoa(basicAuthUser + ':' + basicAuthPass);
+          headers.Authorization = 'Basic ' + $window.btoa(basicAuthUser + ':' + basicAuthPass);
         }
 
         $log.debug('UpdateUser', url, updates);

--- a/webapp/tests/karma/unit/services/enketo.js
+++ b/webapp/tests/karma/unit/services/enketo.js
@@ -108,7 +108,8 @@ describe('Enketo service', function() {
       $provide.value('XSLT', { transform: transform });
       $provide.value('$window', {
         angular: { callbacks: [] },
-        URL: { createObjectURL: createObjectURL }
+        URL: { createObjectURL: createObjectURL },
+        history: { replaceState: () => {} }
       });
       $provide.value('ContactSummary', ContactSummary);
       $provide.value('Form2Sms', Form2Sms);


### PR DESCRIPTION
Angular suggests using:

* `$window` instead of `window`,
* `$timeout()` instead of `setTimeout()`, and
* `$timeout.cancel()` instead of `clearTimeout()`

This corrects those uses, and adds regex checks for these to grunt.
