### PR TITLE
[master] Make sure that <inputs> are always included in saved Enketo form output

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -304,6 +304,7 @@ module.exports = function(grunt) {
             cwd: 'webapp/node_modules',
             src: [
               'bootstrap-daterangepicker/**',
+              'enketo-core/**',
               'font-awesome/**',
               'moment/**',
             ],
@@ -432,6 +433,7 @@ module.exports = function(grunt) {
         cmd: function() {
           var modulesToPatch = [
             'bootstrap-daterangepicker',
+            'enketo-core',
             'font-awesome',
             'moment',
           ];
@@ -493,6 +495,9 @@ module.exports = function(grunt) {
 
             // patch moment.js to use western arabic (european) numerals in Hindi
             'patch webapp/node_modules/moment/locale/hi.js < webapp/patches/moment-hindi-use-euro-numerals.patch',
+
+            // patch enketo to always mark the /inputs group as relevant
+            'patch webapp/node_modules/enketo-core/src/js/Form.js < webapp/patches/enketo-inputs-always-relevant.patch',
           ];
           return patches.join(' && ');
         },

--- a/webapp/patches/enketo-inputs-always-relevant.patch
+++ b/webapp/patches/enketo-inputs-always-relevant.patch
@@ -1,0 +1,14 @@
+*** unpatched	2018-10-18 19:54:23.332051962 +0200
+--- patched	2018-10-18 19:56:45.975224812 +0200
+***************
+*** 469,474 ****
+--- 469,477 ----
+          var path = that.input.getName( $node );
+          var context;
+  
++         // /inputs is ALWAYS relevant #4875
++         if(/\/inputs$/.test(path)) return;
++ 
+          /* 
+           * Copied from branch.js:
+           * 


### PR DESCRIPTION
Issue: #4875

# Description

Here's a horrible hack which makes sure that our special `<inputs>` group is always included in enketo form output, even when `relevant` evaluates to `false`.