### PR TITLE
OutputToXml calls flush after write

### DIFF
--- a/api/src/controllers/export-data.js
+++ b/api/src/controllers/export-data.js
@@ -55,17 +55,17 @@ module.exports = {
           if (err) {
             return serverUtils.error(err, req, res);
           }
-  
+
           writeExportHeaders(res, req.params.type, formats[req.query.format] || formats.csv);
-  
+
           if (_.isFunction(exportDataResult)) {
             // wants to stream the result back
-            exportDataResult(res.write.bind(res), res.end.bind(res));
+            exportDataResult(res.write.bind(res), res.end.bind(res), res.flush.bind(res));
           } else {
             // has already generated result to return
             res.send(exportDataResult);
           }
-        });   
+        });
       }).catch(err => serverUtils.error(err, req, res));
   },
   routeV2: (req, res) => {

--- a/api/src/services/export-data.js
+++ b/api/src/services/export-data.js
@@ -130,9 +130,12 @@ var outputToCsv = function(options, tabs, callback) {
 };
 
 var outputToXml = function(options, tabs, callback) {
-  callback(null, function(write, done) {
+  callback(null, function(write, done, flush) {
     var workbook = xmlbuilder
-      .begin({ allowSurrogateChars: true, allowEmpty: true }, write)
+      .begin({ allowSurrogateChars: true, allowEmpty: true }, data => {
+        write(data);
+        flush();
+      })
       .dec({ encoding: 'UTF-8' })
       .ele('Workbook')
       .att('xmlns', 'urn:schemas-microsoft-com:office:spreadsheet')


### PR DESCRIPTION
# Description

Because of `compression` package, it's necessary to call `flush` after `write` so data is actually compressed and sent to the client.
(https://github.com/expressjs/compression#server-sent-events)

medic/medic-webapp#4802

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.