### PR TITLE
[admin/users] show loader when controller starts

### DIFF
--- a/admin/src/js/controllers/users.js
+++ b/admin/src/js/controllers/users.js
@@ -12,6 +12,8 @@ angular.module('controllers').controller('UsersCtrl',
     'use strict';
     'ngInject';
 
+    $scope.loading = true;
+
     Settings()
       .then(function(settings) {
         $scope.roles = settings.roles;


### PR DESCRIPTION
I had a case where an empty users table was shown instead of the loader.  I thought this was because `Settings()` failed before `updateList()` was called, but on inspection of the code that seems unlikely...