### PR TITLE
Explicitly set return_docs for pouch change() calls

### DIFF
--- a/api/src/config.js
+++ b/api/src/config.js
@@ -135,7 +135,7 @@ module.exports = {
   },
   listen: () => {
     db.medic
-      .changes({ live: true, since: 'now' })
+      .changes({ live: true, since: 'now', return_docs: false })
       .on('change', change => {
         if (change.id === '_design/medic') {
           logger.info('Detected ddoc change - reloading');

--- a/api/src/controllers/changes.js
+++ b/api/src/controllers/changes.js
@@ -170,8 +170,8 @@ const restartNormalFeed = feed => {
 };
 
 const getChanges = feed => {
-
-  const options = _.pick(feed.req.query, 'since', 'style', 'conflicts', 'seq_interval');
+  const options = { return_docs: true };
+  _.extend(options, _.pick(feed.req.query, 'since', 'style', 'conflicts', 'seq_interval'));
   options.doc_ids = feed.allowedDocIds;
   options.since = options.since || 0;
 
@@ -332,6 +332,7 @@ const initContinuousFeed = since => {
     .changes({
       live: true,
       include_docs: true,
+      return_docs: false,
       since: since || 'now',
       timeout: false,
     })

--- a/api/tests/mocha/config.js
+++ b/api/tests/mocha/config.js
@@ -102,7 +102,7 @@ describe('Config', () => {
       chai.expect(db.medic.changes.callCount).to.equal(1);
       chai
         .expect(db.medic.changes.args[0])
-        .to.deep.equal([{ live: true, since: 'now' }]);
+        .to.deep.equal([{ live: true, since: 'now', return_docs: false }]);
     });
 
     it('does nothing for irrelevant change', () => {

--- a/api/tests/mocha/controllers/changes.js
+++ b/api/tests/mocha/controllers/changes.js
@@ -132,6 +132,7 @@ describe('Changes controller', () => {
         include_docs: true,
         since: 'now',
         timeout: false,
+        return_docs: false,
       });
       controller._inited().should.equal(true);
       controller._getContinuousFeed().should.equal(emitters[0]);
@@ -267,19 +268,21 @@ describe('Changes controller', () => {
       authorization.getAllowedDocIds.resolves(['d1', 'd2', 'd3']);
       controller.request(testReq, testRes);
       return nextTick()
-      .then(nextTick).then(() => {
-        authorization.getAllowedDocIds.callCount.should.equal(1);
-        changesSpy.callCount.should.equal(2);
-        changesSpy.args[1][0].should.deep.equal({
-          since: 0,
-          batch_size: 4,
-          doc_ids: ['d1', 'd2', 'd3']
+        .then(nextTick)
+        .then(() => {
+          authorization.getAllowedDocIds.callCount.should.equal(1);
+          changesSpy.callCount.should.equal(2);
+          changesSpy.args[1][0].should.deep.equal({
+            since: 0,
+            batch_size: 4,
+            doc_ids: ['d1', 'd2', 'd3'],
+            return_docs: true,
         });
       });
     });
 
     it('requests changes with correct query parameters', () => {
-      testReq.query = { limit: 20, view: 'test', something: 'else', conflicts: true, seq_interval: false, since: '22'};
+      testReq.query = { limit: 20, view: 'test', something: 'else', conflicts: true, seq_interval: false, since: '22', return_docs: false };
       authorization.getAllowedDocIds.resolves(['d1', 'd2', 'd3']);
       controller.request(testReq, testRes);
       return nextTick().then(() => {
@@ -289,7 +292,8 @@ describe('Changes controller', () => {
           batch_size: 4,
           doc_ids: ['d1', 'd2', 'd3'],
           conflicts: true,
-          seq_interval: false
+          seq_interval: false,
+          return_docs: true,
         });
       });
     });
@@ -1198,7 +1202,8 @@ describe('Changes controller', () => {
           changesSpy.args[1][0].should.deep.equal({
             batch_size: 3,
             doc_ids: ['a', 'b'],
-            since: 'seq'
+            since: 'seq',
+            return_docs: true,
           });
           controller._getNormalFeeds().forEach(feed => {
             feed.upstreamRequest.complete(null, { results: [], last_seq: 5 });
@@ -1236,7 +1241,8 @@ describe('Changes controller', () => {
           changesSpy.args[2][0].should.deep.equal({
             batch_size: 5,
             doc_ids: ['a', 'b', 'c', 'd'],
-            since: 'seq'
+            since: 'seq',
+            return_docs: true,
           });
 
           controller._getLongpollFeeds().length.should.equal(0);


### PR DESCRIPTION
Unless we're listening for the `complete` event, we have no need for the `changes()` call to collect docs.  We changed this in webapp at d4beeaf78b, but not in other parts of the app.

Note that in pouch 7.0.0, this value defaults to `false` if `live` is `true`.  This means that we could in theory remove the setting in webapp and 2 of the cases in this PR, but the consequence of forgetting to set this value if we ever change to non-live listeners is big memory overhead.