### PR TITLE
Fixes accept_patient_reports to call getRegistrations with correct db

### DIFF
--- a/sentinel/src/transitions/accept_patient_reports.js
+++ b/sentinel/src/transitions/accept_patient_reports.js
@@ -8,6 +8,7 @@ var _ = require('underscore'),
   transitionUtils = require('./utils'),
   date = require('../date'),
   db = require('../db-pouch'),
+  dbNano = require('../db-nano'),
   NAME = 'accept_patient_reports';
 
 const _hasConfig = doc => {
@@ -164,7 +165,7 @@ const addMessagesToDoc = (doc, config, registrations) => {
 const handleReport = (doc, config, callback) => {
   utils.getRegistrations(
     {
-      db: db,
+      db: dbNano,
       id: doc.fields.patient_id,
     },
     (err, registrations) => {


### PR DESCRIPTION
# Description

In `accept_patient_reports` transition, switches `utils.getRegistrations` call from PouchDB back to Nano. 

medic/medic-webapp#4962

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
