### PR TITLE
Log which db is being watched

### DIFF
--- a/webapp/src/js/services/changes.js
+++ b/webapp/src/js/services/changes.js
@@ -59,7 +59,7 @@ angular.module('inboxServices').factory('Changes',
     var watches = [];
 
     var watchChanges = function(meta) {
-      $log.info('Initiating changes watch');
+      $log.info(`Initiating changes watch (meta=${meta})`);
       var watch = DB({ meta: meta })
         .changes({
           live: true,


### PR DESCRIPTION
Make it clearer in logging that changes watcher is being started on different databases.