### PR TITLE
Change translations structure

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -186,6 +186,8 @@ module.exports = function(grunt) {
           'sentinel/src/lib/pupil/**',
           'build/**',
           'config/**',
+          'api/src/migrations/convert-translation-messages.js',               // until jshint
+          'api/tests/integration/migrations/convert-translation-messages.js'  // supports await/async
         ],
       },
       all: [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -185,9 +185,7 @@ module.exports = function(grunt) {
           '**/node_modules/**',
           'sentinel/src/lib/pupil/**',
           'build/**',
-          'config/**',
-          'api/src/migrations/convert-translation-messages.js',               // until jshint
-          'api/tests/integration/migrations/convert-translation-messages.js'  // supports await/async
+          'config/**'
         ],
       },
       all: [

--- a/api/src/config.js
+++ b/api/src/config.js
@@ -86,7 +86,7 @@ const loadTranslations = () => {
       return;
     }
     result.rows.forEach(row => {
-      translationCache[row.doc.code] = Object.assign(row.doc.custom, row.doc.default);
+      translationCache[row.doc.code] = Object.assign(row.doc.custom || {}, row.doc.default);
     });
   });
 };

--- a/api/src/config.js
+++ b/api/src/config.js
@@ -86,7 +86,7 @@ const loadTranslations = () => {
       return;
     }
     result.rows.forEach(row => {
-      translationCache[row.doc.code] = Object.assign(row.doc.custom || {}, row.doc.default);
+      translationCache[row.doc.code] = Object.assign(row.doc.custom || {}, row.doc.generic);
     });
   });
 };

--- a/api/src/config.js
+++ b/api/src/config.js
@@ -86,7 +86,7 @@ const loadTranslations = () => {
       return;
     }
     result.rows.forEach(row => {
-      translationCache[row.doc.code] = row.doc.values;
+      translationCache[row.doc.code] = Object.assign(row.doc.custom, row.doc.default);
     });
   });
 };

--- a/api/src/migrations/convert-translation-messages.js
+++ b/api/src/migrations/convert-translation-messages.js
@@ -1,7 +1,7 @@
 const _ = require('underscore'),
   { promisify } = require('util'),
   db = require('../db-nano'),
-  properties = require('properties'),;
+  properties = require('properties');
 
 module.exports = {
   name: 'convert-translation-messages',

--- a/api/src/migrations/convert-translation-messages.js
+++ b/api/src/migrations/convert-translation-messages.js
@@ -1,82 +1,57 @@
 const _ = require('underscore'),
   { promisify } = require('util'),
-  db = require('../db-nano'),
-  properties = require('properties');
+  db = require('../db-pouch'),
+  properties = require('properties'),
+  DDOC_ID = '_design/medic';
+
+const getAttachment = name => {
+  return db.medic.getAttachment(DDOC_ID, name)
+    .then(attachment => {
+      return new Promise((resolve, reject) => {
+        properties.parse(attachment.toString('utf8'), (err, values) => {
+          if (err) {
+            return reject(err);
+          }
+          resolve(values);
+        });
+      });
+    });
+};
 
 module.exports = {
   name: 'convert-translation-messages',
   created: new Date(2018, 11, 8),
-  run: promisify((callback) => {
-	  db.request({
-      db: db.settings.db,
-      method: 'GET',
-      path: '_design/medic',
-    },
-    (err, result) => {
-      if (err) {
-        return callback(err);
-      }
+  run: promisify(async (callback) => {
+    const ddoc = await db.medic.get(DDOC_ID);
+    const translationAttachmentKeys = Object.keys(ddoc._attachments).filter(k => k.includes('translations'));
+    translationAttachmentKeys.forEach((translationAttachmentKey) => {
 
-      let translationAttachmentKeys = Object.keys(result._attachments).filter(k => k.includes('translations'));
-      translationAttachmentKeys.forEach((translationAttachmentKey) => {
-        let translationMessageKey = translationAttachmentKey.match(/translations\/(.+).properties/)[1];
-        let translationMessageKeys = [translationMessageKey, translationMessageKey + '-backup'];
-        translationMessageKeys.forEach((translationMessageKey) => {
-          db.request({
-            db: db.settings.db,
-            method: 'GET',
-            path: translationMessageKey,
-          },
-          (err, translationMessageValues) => {
-            if (_.has(translationMessageValues, 'values')) {
-              db.request({
-                db: db.settings.db,
-                method: 'GET',
-                path: '_design/medic/' + translationAttachmentKey,
-              },
-              (err, translationAttachmentValue) => {
-                if (err) {
-                  return callback(err);
-                }
+      const translationMessageKey = translationAttachmentKey.match(/translations\/(.+).properties/)[1];
+      const translationMessageKeys = [translationMessageKey, translationMessageKey + '-backup'];
 
-                properties.parse(translationAttachmentValue.toString('utf8'), (err, translationAttachmentValues) => {
-                  if (err) {
-                    return callback(err);
-                  }
+      translationMessageKeys.forEach(async (translationMessageKey) => {
+        const translationMessageValues = await db.medic.get(translationMessageKey);
+        if (_.has(translationMessageValues, 'values')) {
+          const translationAttachmentValues = await getAttachment(translationAttachmentKey);
 
-                  let defaultTranslations = {};
-                  let customTranslations = {};
-                  Object.keys(translationMessageValues.values).forEach((translationMessageKey) => {
-                    if (_.has(translationAttachmentValues, translationMessageKey)) {
-                      defaultTranslations[translationMessageKey] = translationMessageValues.values[translationMessageKey];
-                    } else {
-                      customTranslations[translationMessageKey] = translationMessageValues.values[translationMessageKey];
-                    }
-                  });
-
-                  delete translationMessageValues.values;
-                  translationMessageValues.custom = customTranslations;
-                  translationMessageValues.default = defaultTranslations;
-
-                  db.request({
-                    db: db.settings.db,
-                    method: 'PUT',
-                    path: translationMessageKey,
-                    body: translationMessageValues
-                  },
-                  (err) => {
-                    if (err) {
-                      return callback(err);
-                    }
-                  });
-                });
-              });
+          let defaultTranslations = {};
+          let customTranslations = {};
+          Object.keys(translationMessageValues.values).forEach((translationMessageKey) => {
+            if (_.has(translationAttachmentValues, translationMessageKey)) {
+              defaultTranslations[translationMessageKey] = translationMessageValues.values[translationMessageKey];
+            } else {
+              customTranslations[translationMessageKey] = translationMessageValues.values[translationMessageKey];
             }
           });
-        });
-      });
 
-      callback();
+          delete translationMessageValues.values;
+          translationMessageValues.custom = customTranslations;
+          translationMessageValues.default = defaultTranslations;
+
+          await db.medic.put(translationMessageValues);
+        }
+      });
     });
+    callback();
   })
 };

--- a/api/src/migrations/convert-translation-messages.js
+++ b/api/src/migrations/convert-translation-messages.js
@@ -1,5 +1,4 @@
 const _ = require('underscore'),
-  { promisify } = require('util'),
   db = require('../db-pouch'),
   properties = require('properties'),
   DDOC_ID = '_design/medic';
@@ -21,7 +20,7 @@ const getAttachment = name => {
 module.exports = {
   name: 'convert-translation-messages',
   created: new Date(2018, 11, 8),
-  run: promisify((callback) => {
+  run: () => {
       return db.medic.get(DDOC_ID)
         .then(function(ddoc) {
           const translationAttachmentKeys = Object.keys(ddoc._attachments).filter(k => k.includes('translations'));
@@ -51,8 +50,6 @@ module.exports = {
                 } 
               });
             }));
-        })
-        .then(() => callback())
-        .catch(callback);
-  })
+        });
+  }
 };

--- a/api/src/migrations/convert-translation-messages.js
+++ b/api/src/migrations/convert-translation-messages.js
@@ -1,0 +1,75 @@
+const _ = require('underscore'),
+  { promisify } = require('util'),
+  db = require('../db-nano');
+
+module.exports = {
+  name: 'convert-translation-messages',
+  created: new Date(2018, 11, 8),
+  run: promisify((callback) => {
+	  db.request({
+      db: db.settings.db,
+      method: 'GET',
+      path: '_design/medic',
+    },
+    (err, result) => {
+      if (err) {
+        return callback(err);
+      }
+
+      let translationAttachmentKeys = Object.keys(result._attachments).filter(k => k.includes('translations'));
+      translationAttachmentKeys.forEach((translationAttachmentKey) => {
+        let translationMessageKey = translationAttachmentKey.match(/translations\/(.+).properties/)[1];
+        let translationMessageKeys = [translationMessageKey, translationMessageKey + '-backup'];
+        translationMessageKeys.forEach((translationMessageKey) => {
+          db.request({
+            db: db.settings.db,
+            method: 'GET',
+            path: translationMessageKey,
+          },
+          (err, translationMessageValues) => {
+            if (_.has(translationMessageValues, 'values')) {
+              db.request({
+                db: db.settings.db,
+                method: 'GET',
+                path: '_design/medic/' + translationAttachmentKey,
+              },
+              (err, translationAttachmentValue) => {
+                if (err) {
+                  return callback(err);
+                }
+
+                let defaultTranslations = {};
+                let customTranslations = {};
+                Object.keys(translationMessageValues.values).forEach((translationMessageKey) => {
+                  if (translationAttachmentValue.includes(translationMessageKey.replace(' ', '\\ '))) {
+                    defaultTranslations[translationMessageKey] = translationMessageValues.values[translationMessageKey];
+                  } else {
+                    customTranslations[translationMessageKey] = translationMessageValues.values[translationMessageKey];
+                  }
+                });
+
+                delete translationMessageValues.values;
+                translationMessageValues.custom = customTranslations;
+                translationMessageValues.default = defaultTranslations;
+
+                db.request({
+                  db: db.settings.db,
+                  method: 'PUT',
+                  path: translationMessageKey,
+                  body: translationMessageValues
+                },
+                (err) => {
+                  if (err) {
+                    return callback(err);
+                  }
+                });
+              });
+            }
+          });
+        });
+      });
+
+      callback();
+    });
+  })
+};

--- a/api/src/migrations/convert-translation-messages.js
+++ b/api/src/migrations/convert-translation-messages.js
@@ -32,11 +32,11 @@ module.exports = {
         if (_.has(translationMessageValues, 'values')) {
           const translationAttachmentValues = await getAttachment(translationAttachmentKey);
 
-          let defaultTranslations = {};
+          let genericTranslations = {};
           let customTranslations = {};
           await Promise.all(Object.keys(translationMessageValues.values).map(async (translationMessageKey) => {
             if (_.has(translationAttachmentValues, translationMessageKey)) {
-              defaultTranslations[translationMessageKey] = translationMessageValues.values[translationMessageKey];
+              genericTranslations[translationMessageKey] = translationMessageValues.values[translationMessageKey];
             } else {
               customTranslations[translationMessageKey] = translationMessageValues.values[translationMessageKey];
             }
@@ -44,7 +44,7 @@ module.exports = {
 
           delete translationMessageValues.values;
           translationMessageValues.custom = customTranslations;
-          translationMessageValues.default = defaultTranslations;
+          translationMessageValues.generic = genericTranslations;
 
           await db.medic.put(translationMessageValues);
         }

--- a/api/src/migrations/convert-translation-messages.js
+++ b/api/src/migrations/convert-translation-messages.js
@@ -46,7 +46,7 @@ module.exports = {
                         translationMessageValues.custom = customTranslations;
                         translationMessageValues.generic = genericTranslations;
                         return db.medic.put(translationMessageValues);
-                      })             
+                      });             
                     });
                 } 
               });

--- a/api/src/migrations/convert-translation-messages.js
+++ b/api/src/migrations/convert-translation-messages.js
@@ -22,36 +22,40 @@ module.exports = {
   name: 'convert-translation-messages',
   created: new Date(2018, 11, 8),
   run: promisify(async (callback) => {
-    const ddoc = await db.medic.get(DDOC_ID);
-    const translationAttachmentKeys = Object.keys(ddoc._attachments).filter(k => k.includes('translations'));
-    translationAttachmentKeys.forEach((translationAttachmentKey) => {
+    try {
+      const ddoc = await db.medic.get(DDOC_ID);
+      const translationAttachmentKeys = Object.keys(ddoc._attachments).filter(k => k.includes('translations'));
+      translationAttachmentKeys.forEach((translationAttachmentKey) => {
 
-      const translationMessageKey = translationAttachmentKey.match(/translations\/(.+).properties/)[1];
-      const translationMessageKeys = [translationMessageKey, translationMessageKey + '-backup'];
+        const translationMessageKey = translationAttachmentKey.match(/translations\/(.+).properties/)[1];
+        const translationMessageKeys = [translationMessageKey, translationMessageKey + '-backup'];
 
-      translationMessageKeys.forEach(async (translationMessageKey) => {
-        const translationMessageValues = await db.medic.get(translationMessageKey);
-        if (_.has(translationMessageValues, 'values')) {
-          const translationAttachmentValues = await getAttachment(translationAttachmentKey);
+        translationMessageKeys.forEach(async (translationMessageKey) => {
+          const translationMessageValues = await db.medic.get(translationMessageKey);
+          if (_.has(translationMessageValues, 'values')) {
+            const translationAttachmentValues = await getAttachment(translationAttachmentKey);
 
-          let defaultTranslations = {};
-          let customTranslations = {};
-          Object.keys(translationMessageValues.values).forEach((translationMessageKey) => {
-            if (_.has(translationAttachmentValues, translationMessageKey)) {
-              defaultTranslations[translationMessageKey] = translationMessageValues.values[translationMessageKey];
-            } else {
-              customTranslations[translationMessageKey] = translationMessageValues.values[translationMessageKey];
-            }
-          });
+            let defaultTranslations = {};
+            let customTranslations = {};
+            Object.keys(translationMessageValues.values).forEach((translationMessageKey) => {
+              if (_.has(translationAttachmentValues, translationMessageKey)) {
+                defaultTranslations[translationMessageKey] = translationMessageValues.values[translationMessageKey];
+              } else {
+                customTranslations[translationMessageKey] = translationMessageValues.values[translationMessageKey];
+              }
+            });
 
-          delete translationMessageValues.values;
-          translationMessageValues.custom = customTranslations;
-          translationMessageValues.default = defaultTranslations;
+            delete translationMessageValues.values;
+            translationMessageValues.custom = customTranslations;
+            translationMessageValues.default = defaultTranslations;
 
-          await db.medic.put(translationMessageValues);
-        }
+            await db.medic.put(translationMessageValues);
+          }
+        });
       });
-    });
-    callback();
+      callback();
+    } catch (e) {
+      callback(e);
+    }
   })
 };

--- a/api/src/migrations/convert-translation-messages.js
+++ b/api/src/migrations/convert-translation-messages.js
@@ -21,37 +21,38 @@ const getAttachment = name => {
 module.exports = {
   name: 'convert-translation-messages',
   created: new Date(2018, 11, 8),
-  run: promisify(async (callback) => {
-    try {
-      const ddoc = await db.medic.get(DDOC_ID);
-      const translationAttachmentKeys = Object.keys(ddoc._attachments).filter(k => k.includes('translations'));
-      await Promise.all(translationAttachmentKeys.map(async (translationAttachmentKey) => {
-        const translationMessageKey = translationAttachmentKey.match(/translations\/(.+).properties/)[1];
-        const translationMessageValues = await db.medic.get(translationMessageKey);
-
-        if (_.has(translationMessageValues, 'values')) {
-          const translationAttachmentValues = await getAttachment(translationAttachmentKey);
-
-          let genericTranslations = {};
-          let customTranslations = {};
-          await Promise.all(Object.keys(translationMessageValues.values).map(async (translationMessageKey) => {
-            if (_.has(translationAttachmentValues, translationMessageKey)) {
-              genericTranslations[translationMessageKey] = translationMessageValues.values[translationMessageKey];
-            } else {
-              customTranslations[translationMessageKey] = translationMessageValues.values[translationMessageKey];
-            }
-          }));
-
-          delete translationMessageValues.values;
-          translationMessageValues.custom = customTranslations;
-          translationMessageValues.generic = genericTranslations;
-
-          await db.medic.put(translationMessageValues);
-        }
-      }));
-      callback();
-    } catch (e) {
-      callback(e);
-    }
+  run: promisify((callback) => {
+      return db.medic.get(DDOC_ID)
+        .then(function(ddoc) {
+          const translationAttachmentKeys = Object.keys(ddoc._attachments).filter(k => k.includes('translations'));
+          return Promise.all(translationAttachmentKeys.map((translationAttachmentKey) => {
+            const translationMessageKey = translationAttachmentKey.match(/translations\/(.+).properties/)[1];
+            return db.medic.get(translationMessageKey)
+              .then(function(translationMessageValues) {
+                if (_.has(translationMessageValues, 'values')) {
+                  return getAttachment(translationAttachmentKey)
+                    .then((translationAttachmentValues) => {
+                      let genericTranslations = {};
+                      let customTranslations = {}; 
+                      return Promise.all(Object.keys(translationMessageValues.values).map((translationMessageKey) => {
+                        if (_.has(translationAttachmentValues, translationMessageKey)) {
+                          genericTranslations[translationMessageKey] = translationMessageValues.values[translationMessageKey];
+                        } else {
+                          customTranslations[translationMessageKey] = translationMessageValues.values[translationMessageKey];
+                        }
+                      }))
+                      .then (() => {
+                        delete translationMessageValues.values;
+                        translationMessageValues.custom = customTranslations;
+                        translationMessageValues.generic = genericTranslations;
+                        return db.medic.put(translationMessageValues);
+                      })             
+                    });
+                } 
+              });
+            }));
+        })
+        .then(() => callback())
+        .catch(callback);
   })
 };

--- a/api/src/migrations/extract-translations.js
+++ b/api/src/migrations/extract-translations.js
@@ -37,14 +37,14 @@ var mergeTranslations = function(settings, docs) {
       var doc = _.findWhere(docs, { code: translation.locale });
       if (doc) {
         if (_.has(doc, 'values')) {
-          if (!doc.values[setting.key] || translation.content !== translation.default) {
+          if (!doc.values[setting.key] || translation.content !== translation.generic) {
             // only update the doc if it was changed from the default
             doc.values[setting.key] = translation.content;
           }
         } else { 
-          if (!doc.default[setting.key] || translation.content !== translation.default) {
+          if (!doc.generic[setting.key] || translation.content !== translation.generic) {
             // only update the doc if it was changed from the default
-            doc.default[setting.key] = translation.content;
+            doc.generic[setting.key] = translation.content;
           }
         }
       }

--- a/api/src/migrations/extract-translations.js
+++ b/api/src/migrations/extract-translations.js
@@ -37,12 +37,12 @@ var mergeTranslations = function(settings, docs) {
       var doc = _.findWhere(docs, { code: translation.locale });
       if (doc) {
         if (_.has(doc, 'values')) {
-          if (!doc.values[setting.key] || translation.content !== translation.generic) {
+          if (!doc.values[setting.key] || translation.content !== translation.default) {
             // only update the doc if it was changed from the default
             doc.values[setting.key] = translation.content;
           }
         } else { 
-          if (!doc.generic[setting.key] || translation.content !== translation.generic) {
+          if (!doc.generic[setting.key] || translation.content !== translation.default) {
             // only update the doc if it was changed from the default
             doc.generic[setting.key] = translation.content;
           }

--- a/api/src/migrations/extract-translations.js
+++ b/api/src/migrations/extract-translations.js
@@ -36,9 +36,16 @@ var mergeTranslations = function(settings, docs) {
     setting.translations.forEach(function(translation) {
       var doc = _.findWhere(docs, { code: translation.locale });
       if (doc) {
-        if (!doc.values[setting.key] || translation.content !== translation.default) {
-          // only update the doc if it was changed from the default
-          doc.values[setting.key] = translation.content;
+        if (_.has(doc, 'values')) {
+          if (!doc.values[setting.key] || translation.content !== translation.default) {
+            // only update the doc if it was changed from the default
+            doc.values[setting.key] = translation.content;
+          }
+        } else { 
+          if (!doc.default[setting.key] || translation.content !== translation.default) {
+            // only update the doc if it was changed from the default
+            doc.default[setting.key] = translation.content;
+          }
         }
       }
     });

--- a/api/src/translations.js
+++ b/api/src/translations.js
@@ -3,8 +3,7 @@ const _ = require('underscore'),
       db = require('./db-pouch'),
       DDOC_ID = '_design/medic',
       TRANSLATION_FILE_NAME_REGEX = /translations\/messages\-([a-z]*)\.properties/,
-      DOC_TYPE = 'translations',
-      BACKUP_TYPE = 'translations-backup';
+      DOC_TYPE = 'translations';
 
 const LOCAL_NAME_MAP = {
   bm: 'Bamanankan (Bambara)',
@@ -35,7 +34,7 @@ const createDoc = attachment => {
   };
 };
 
-const overwrite = (attachments, backups, docs) => {
+const overwrite = (attachments, docs) => {
   const updatedDocs = [];
   const english = _.findWhere(attachments, { code: 'en' });
   const knownKeys = english ? Object.keys(english.default) : [];
@@ -52,10 +51,6 @@ const overwrite = (attachments, backups, docs) => {
         attachment.default[knownKey] = String(value);
       }
     });
-    const backup = _.findWhere(backups, { code: code });
-    if (backup) {
-      db.medic.remove(backup);
-    }
     const doc = _.findWhere(docs, { code: code });
     if (doc) {
       if (!_.isEqual(doc.default, attachment.default)) {
@@ -123,7 +118,7 @@ module.exports = {
           return;
         }
         return Promise.all([ getTranslationDocs() ])
-          .then(([ backups, docs ]) => overwrite(attachments, backups, docs))
+          .then(([ docs ]) => overwrite(attachments, docs))
           .then(updated => {
             if (updated.length) {
               return db.medic.bulkDocs(updated);

--- a/api/src/translations.js
+++ b/api/src/translations.js
@@ -107,13 +107,6 @@ const getDocs = options => {
     });
 };
 
-const getBackups = () => {
-  return getDocs({
-    key: [ BACKUP_TYPE ],
-    include_docs: true
-  });
-};
-
 const getTranslationDocs = () => {
   return getDocs({
     startkey: [ DOC_TYPE, false ],
@@ -129,7 +122,7 @@ module.exports = {
         if (!attachments.length) {
           return;
         }
-        return Promise.all([ getBackups(), getTranslationDocs() ])
+        return Promise.all([ getTranslationDocs() ])
           .then(([ backups, docs ]) => overwrite(attachments, backups, docs))
           .then(updated => {
             if (updated.length) {

--- a/api/src/translations.js
+++ b/api/src/translations.js
@@ -30,32 +30,32 @@ const createDoc = attachment => {
     code: attachment.code,
     name: LOCAL_NAME_MAP[attachment.code] || attachment.code,
     enabled: true,
-    default: attachment.default
+    generic: attachment.generic
   };
 };
 
 const overwrite = (attachments, docs) => {
   const updatedDocs = [];
   const english = _.findWhere(attachments, { code: 'en' });
-  const knownKeys = english ? Object.keys(english.default) : [];
+  const knownKeys = english ? Object.keys(english.generic) : [];
   attachments.forEach(attachment => {
     const code = attachment.code;
     if (!code) {
       return;
     }
     knownKeys.forEach(knownKey => {
-      const value = attachment.default[knownKey];
+      const value = attachment.generic[knownKey];
       if (_.isUndefined(value) || value === null) {
-        attachment.default[knownKey] = knownKey;
+        attachment.generic[knownKey] = knownKey;
       } else if (typeof value !== 'string') {
-        attachment.default[knownKey] = String(value);
+        attachment.generic[knownKey] = String(value);
       }
     });
     const doc = _.findWhere(docs, { code: code });
     if (doc) {
-      if (!_.isEqual(doc.default, attachment.default)) {
+      if (!_.isEqual(doc.generic, attachment.generic)) {
         // backup the modified attachment
-        doc.default = attachment.default;
+        doc.generic = attachment.generic;
         updatedDocs.push(doc);
       }
     } else {
@@ -75,7 +75,7 @@ const getAttachment = name => {
           }
           resolve({
             code: extractLocaleCode(name),
-            default: values
+            generic: values
           });
         });
       });

--- a/api/src/translations.js
+++ b/api/src/translations.js
@@ -24,15 +24,6 @@ const extractLocaleCode = filename => {
   }
 };
 
-const createBackup = attachment => {
-  return {
-    _id: [ 'messages', attachment.code, 'backup' ].join('-'),
-    type: BACKUP_TYPE,
-    code: attachment.code,
-    default: attachment.default
-  };
-};
-
 const createDoc = attachment => {
   return {
     _id: [ 'messages', attachment.code ].join('-'),
@@ -62,11 +53,8 @@ const overwrite = (attachments, backups, docs) => {
       }
     });
     const backup = _.findWhere(backups, { code: code });
-    if (!backup) {
-      // new language
-      updatedDocs.push(createDoc(attachment));
-      updatedDocs.push(createBackup(attachment));
-      return;
+    if (backup) {
+      db.medic.remove(backup);
     }
     const doc = _.findWhere(docs, { code: code });
     if (doc) {
@@ -75,11 +63,8 @@ const overwrite = (attachments, backups, docs) => {
         doc.default = attachment.default;
         updatedDocs.push(doc);
       }
-    }
-    if (!_.isEqual(backup.default, attachment.default)) {
-      // backup the modified attachment
-      backup.default = attachment.default;
-      updatedDocs.push(backup);
+    } else {
+      updatedDocs.push(createDoc(attachment));
     }
   });
   return updatedDocs;

--- a/api/tests/integration/migrations/convert-translation-messages.js
+++ b/api/tests/integration/migrations/convert-translation-messages.js
@@ -36,7 +36,7 @@ describe('convert-translation-messages migration', function() {
         _id: 'messages-en',
         code: 'en',
         type: 'translations',
-        default: { Contact: 'Contact', From: 'From' },
+        generic: { Contact: 'Contact', From: 'From' },
         custom: { hello: 'Hello', bye: 'Goodbye CUSTOMISED' },
       }
     ]);
@@ -50,7 +50,7 @@ describe('convert-translation-messages migration', function() {
         _id: 'messages-en',
         code: 'en',
         type: 'translations',
-        default: { Contact: 'Contact', From: 'From', hello: 'Hello', bye: 'Goodbye CUSTOMISED' }
+        generic: { Contact: 'Contact', From: 'From', hello: 'Hello', bye: 'Goodbye CUSTOMISED' }
       }
     ]);
 
@@ -71,7 +71,7 @@ describe('convert-translation-messages migration', function() {
         _id: 'messages-en',
         code: 'en',
         type: 'translations',
-        default: { Contact: 'Contact', From: 'From', hello: 'Hello', bye: 'Goodbye CUSTOMISED' }
+        generic: { Contact: 'Contact', From: 'From', hello: 'Hello', bye: 'Goodbye CUSTOMISED' }
       }
     ]);
   });

--- a/api/tests/integration/migrations/convert-translation-messages.js
+++ b/api/tests/integration/migrations/convert-translation-messages.js
@@ -1,0 +1,79 @@
+var utils = require('./utils'),
+    db = require('../../../src/db-pouch'),
+    DDOC_ID = '_design/medic';
+
+describe('convert-translation-messages migration', function() {
+  afterEach(function() {
+    return utils.tearDown();
+  });
+
+  it('converts translation messages structure', async () => {
+
+    // given
+    await utils.initDb([
+      {
+        _id: 'messages-en',
+        code: 'en',
+        type: 'translations',
+        values: { Contact: 'Contact', From: 'From', hello: 'Hello', bye: 'Goodbye CUSTOMISED' }
+      }
+    ]);
+
+    const ddoc = await utils.getDdoc(DDOC_ID);
+    const attachment = {
+      content_type: 'application/octet-stream',
+      content: "Contact = Contact\nFrom = From",
+      key: 'translations/messages-en.properties'
+    };     
+    await utils.insertAttachment(ddoc, attachment);
+
+    // when
+    await utils.runMigration('convert-translation-messages');
+
+    // expect
+    await utils.assertDb([
+      {
+        _id: 'messages-en',
+        code: 'en',
+        type: 'translations',
+        default: { Contact: 'Contact', From: 'From' },
+        custom: { hello: 'Hello', bye: 'Goodbye CUSTOMISED' },
+      }
+    ]);
+  });
+
+  it('does nothing when translation messages have the new structure', async () => {
+
+    // given
+    await utils.initDb([
+      {
+        _id: 'messages-en',
+        code: 'en',
+        type: 'translations',
+        default: { Contact: 'Contact', From: 'From', hello: 'Hello', bye: 'Goodbye CUSTOMISED' }
+      }
+    ]);
+
+    const ddoc = await utils.getDdoc(DDOC_ID);
+    const attachment = {
+      content_type: 'application/octet-stream',
+      content: "Contact = Contact\nFrom = From",
+      key: 'translations/messages-en.properties'
+    };     
+    await utils.insertAttachment(ddoc, attachment);
+
+    // when
+    await utils.runMigration('convert-translation-messages');
+
+    // expect
+    await utils.assertDb([
+      {
+        _id: 'messages-en',
+        code: 'en',
+        type: 'translations',
+        default: { Contact: 'Contact', From: 'From', hello: 'Hello', bye: 'Goodbye CUSTOMISED' }
+      }
+    ]);
+  });
+
+});

--- a/api/tests/integration/migrations/convert-translation-messages.js
+++ b/api/tests/integration/migrations/convert-translation-messages.js
@@ -1,5 +1,4 @@
 var utils = require('./utils'),
-    db = require('../../../src/db-pouch'),
     DDOC_ID = '_design/medic';
 
 describe('convert-translation-messages migration', function() {
@@ -24,7 +23,7 @@ describe('convert-translation-messages migration', function() {
     .then(function(ddoc) {
       const attachment = {
         content_type: 'application/octet-stream',
-        content: "Contact = Contact\nFrom = From",
+        content: 'Contact = Contact\nFrom = From',
         key: 'translations/messages-en.properties'
       };      
       
@@ -64,7 +63,7 @@ describe('convert-translation-messages migration', function() {
     .then(function(ddoc) {
       const attachment = {
         content_type: 'application/octet-stream',
-        content: "Contact = Contact\nFrom = From",
+        content: 'Contact = Contact\nFrom = From',
         key: 'translations/messages-en.properties'
       };     
       return utils.insertAttachment(ddoc, attachment);      

--- a/api/tests/integration/migrations/utils.js
+++ b/api/tests/integration/migrations/utils.js
@@ -437,6 +437,34 @@ function getSettings() {
   });
 }
 
+function getDdoc(ddocId) {
+  return new Promise(function(resolve, reject) {
+    db.medic.get(ddocId, function(err, ddoc) {
+      if (err) {
+        return reject(err);
+      }
+      resolve(ddoc);
+    });
+  });
+}
+
+function insertAttachment(ddoc, attachment) {
+  return new Promise(function(resolve, reject) {
+    db.medic.attachment.insert(
+        ddoc._id, 
+        attachment.key, 
+        attachment.content, 
+        attachment.content_type,
+        { rev: ddoc._rev }, 
+        function(err, body) {
+          if (err) {
+            return reject(err);
+          }
+          resolve();
+    });  
+  });
+}
+
 module.exports = {
   assertDb: assertDb,
   initDb: initDb,
@@ -444,4 +472,6 @@ module.exports = {
   getSettings: getSettings,
   runMigration: runMigration,
   tearDown: tearDown,
+  getDdoc: getDdoc,
+  insertAttachment: insertAttachment
 };

--- a/api/tests/integration/migrations/utils.js
+++ b/api/tests/integration/migrations/utils.js
@@ -384,24 +384,10 @@ function tearDown() {
 }
 
 function runMigration(migration) {
-  try {
-    var migrationPath = '../../../src/migrations/' + migration;
-    migration = require(migrationPath);
-    return new Promise(function(resolve, reject) {
-      try {
-        migration.run(function(err) {
-          if (err) {
-            return reject(err);
-          }
-          resolve();
-        });
-      } catch (err) {
-        reject(err);
-      }
-    });
-  } catch (err) {
-    return Promise.reject(err);
-  }
+  var migrationPath = '../../../src/migrations/' + migration;
+  migration = require(migrationPath);
+  return migration
+    .run();
 }
 
 function initSettings(settings) {

--- a/api/tests/integration/migrations/utils.js
+++ b/api/tests/integration/migrations/utils.js
@@ -456,7 +456,7 @@ function insertAttachment(ddoc, attachment) {
         attachment.content, 
         attachment.content_type,
         { rev: ddoc._rev }, 
-        function(err, body) {
+        function(err) {
           if (err) {
             return reject(err);
           }

--- a/api/tests/integration/res/migrations/reverse-names.js
+++ b/api/tests/integration/res/migrations/reverse-names.js
@@ -4,9 +4,10 @@ var _ = require('underscore'),
 module.exports = {
   name: 'extract-person-contacts',
   created: new Date(),
-  run: function(callback) {
-    db.medic.list({ include_docs:true }, function(err, body) {
-      Promise.all(_.map(body.rows, function(row) {
+  run: function() {
+    return new Promise(function(resolve, reject) {
+      db.medic.list({ include_docs:true }, function(err, body) {
+        Promise.all(_.map(body.rows, function(row) {
           return new Promise(function(resolve, reject) {
             var doc = row.doc;
             if(doc._id.indexOf('_design/') === 0) { return resolve(); }
@@ -17,10 +18,9 @@ module.exports = {
             });
           });
         }))
-        .then(function() {
-          callback();
-        })
-        .catch(callback);
+        .then(resolve)
+        .catch(reject);
+      });
     });
   }
 };

--- a/api/tests/mocha/translations.spec.js
+++ b/api/tests/mocha/translations.spec.js
@@ -86,7 +86,7 @@ describe('translations', () => {
       _id: 'messages-en',
       code: 'en',
       type: 'translations',
-      default: { hello: 'Gidday' }
+      generic: { hello: 'Gidday' }
     } } ];
     const dbGet = sinon.stub(db.medic, 'get').resolves(ddoc);
     const dbAttachment = sinon.stub(db.medic, 'getAttachment').resolves('some buffer');
@@ -105,7 +105,7 @@ describe('translations', () => {
           _id: 'messages-en',
           code: 'en',
           type: 'translations',
-          default: { hello: 'Hello' }
+          generic: { hello: 'Hello' }
         }
       ]);
     });
@@ -117,7 +117,7 @@ describe('translations', () => {
       _id: 'messages-en',
       code: 'en',
       type: 'translations',
-      default: { hello: 'Hello', bye: 'Goodbye CUSTOMISED' }
+      generic: { hello: 'Hello', bye: 'Goodbye CUSTOMISED' }
     } } ];
     const dbGet = sinon.stub(db.medic, 'get').resolves(ddoc);
     const dbAttachment = sinon.stub(db.medic, 'getAttachment').resolves('some buffer');
@@ -141,7 +141,7 @@ describe('translations', () => {
       _id: 'messages-en',
       code: 'en',
       type: 'translations',
-      default: { hello: 'Hello', bye: 'Goodbye CUSTOMISED' }
+      generic: { hello: 'Hello', bye: 'Goodbye CUSTOMISED' }
     } } ];
     const dbGet = sinon.stub(db.medic, 'get').resolves(ddoc);
     const dbAttachment = sinon.stub(db.medic, 'getAttachment').resolves('some buffer');
@@ -160,7 +160,7 @@ describe('translations', () => {
           _id: 'messages-en',
           code: 'en',
           type: 'translations',
-          default: {
+          generic: {
             hello: 'Hello UPDATED',
             bye: 'Goodbye UPDATED',
             added: 'ADDED'
@@ -177,7 +177,7 @@ describe('translations', () => {
       _id: 'messages-en',
       code: 'en',
       type: 'translations',
-      default: { empty: '' }
+      generic: { empty: '' }
     } } ];
     sinon.stub(db.medic, 'get').resolves(ddoc);
     sinon.stub(db.medic, 'getAttachment').resolves('some buffer');
@@ -196,7 +196,7 @@ describe('translations', () => {
       _id: 'messages-en',
       code: 'en',
       type: 'translations',
-      default: { hello: 'Hello', bye: 'Goodbye CUSTOMISED' }
+      generic: { hello: 'Hello', bye: 'Goodbye CUSTOMISED' }
     } } ];
     const dbGet = sinon.stub(db.medic, 'get').resolves(ddoc);
     const dbAttachment = sinon.stub(db.medic, 'getAttachment').resolves('some buffer');
@@ -217,7 +217,7 @@ describe('translations', () => {
           code: 'fr',
           name: 'Français (French)',
           enabled: true,
-          default: {
+          generic: {
             hello: 'Hello UPDATED',
             bye: 'Goodbye UPDATED',
             added: 'ADDED'
@@ -235,7 +235,7 @@ describe('translations', () => {
       _id: 'messages-en',
       type: 'translations',
       code: 'en',
-      default: { hello: 'Hello', bye: 'Goodbye' }
+      generic: { hello: 'Hello', bye: 'Goodbye' }
     } } ];
     const dbGet = sinon.stub(db.medic, 'get').resolves(ddoc);
     const dbAttachment = sinon.stub(db.medic, 'getAttachment').resolves('some buffer');
@@ -254,7 +254,7 @@ describe('translations', () => {
           _id: 'messages-fr',
           code: 'fr',
           type: 'translations',
-          default: {
+          generic: {
             hello: 'Hello UPDATED',
             bye: 'Goodbye UPDATED',
             added: 'ADDED'
@@ -276,13 +276,13 @@ describe('translations', () => {
         _id: 'messages-en',
         code: 'en',
         type: 'translations',
-        default: { hello: 'Hello EN', bye: 'Goodbye EN CUSTOMISED' }
+        generic: { hello: 'Hello EN', bye: 'Goodbye EN CUSTOMISED' }
       } },
       { doc: {
         _id: 'messages-fr',
         code: 'fr',
         type: 'translations',
-        default: { hello: 'Hello FR', bye: 'Goodbye FR CUSTOMISED' }
+        generic: { hello: 'Hello FR', bye: 'Goodbye FR CUSTOMISED' }
       } }
     ];
     const dbGet = sinon.stub(db.medic, 'get').resolves(ddoc);
@@ -304,7 +304,7 @@ describe('translations', () => {
           _id: 'messages-en',
           code: 'en',
           type: 'translations',
-          default: {
+          generic: {
             hello: 'Hello EN UPDATED',
             bye: 'Goodbye EN UPDATED',
             added: 'EN ADDED'
@@ -314,7 +314,7 @@ describe('translations', () => {
           _id: 'messages-fr',
           code: 'fr',
           type: 'translations',
-          default: {
+          generic: {
             hello: 'Hello FR UPDATED',
             bye: 'Goodbye FR UPDATED',
             added: 'FR ADDED'
@@ -333,7 +333,7 @@ describe('translations', () => {
         _id: 'messages-en',
         code: 'en',
         type: 'translations',
-        default: { hello: null, bye: 'Goodbye' }
+        generic: { hello: null, bye: 'Goodbye' }
       } }
     ];
     const dbGet = sinon.stub(db.medic, 'get').resolves(ddoc);
@@ -354,7 +354,7 @@ describe('translations', () => {
           _id: 'messages-en',
           code: 'en',
           type: 'translations',
-          default: {
+          generic: {
             hello: 'hello',
             bye: 'Goodbye'
           }
@@ -373,13 +373,13 @@ describe('translations', () => {
         _id: 'messages-en',
         code: 'en',
         type: 'translations',
-        default: { hello: 'Hello', bye: 'Goodbye' }
+        generic: { hello: 'Hello', bye: 'Goodbye' }
       } },
       { doc: {
         _id: 'messages-ne',
         code: 'ne',
         type: 'translations',
-        default: { bye: 'Goodbye' }
+        generic: { bye: 'Goodbye' }
       } }
     ];
     const dbGet = sinon.stub(db.medic, 'get').resolves(ddoc);
@@ -401,7 +401,7 @@ describe('translations', () => {
           _id: 'messages-ne',
           code: 'ne',
           type: 'translations',
-          default: {
+          generic: {
             hello: 'hello', // defaults to the translation key
             bye: 'Goodbye'
           }
@@ -419,7 +419,7 @@ describe('translations', () => {
           _id: 'messages-en',
           code: 'en',
           type: 'translations',
-          default: { hello: null, bye: 0, ciao: false, adios: 23, salut: true }
+          generic: { hello: null, bye: 0, ciao: false, adios: 23, salut: true }
         } }
     ];
     const dbGet = sinon.stub(db.medic, 'get').resolves(ddoc);
@@ -440,7 +440,7 @@ describe('translations', () => {
           _id: 'messages-en',
           code: 'en',
           type: 'translations',
-          default: {
+          generic: {
             hello: 'hello',
             bye: '0',
             ciao: 'false',

--- a/api/tests/mocha/translations.spec.js
+++ b/api/tests/mocha/translations.spec.js
@@ -77,12 +77,6 @@ describe('translations', () => {
       chai.expect(dbAttachment.callCount).to.equal(1);
       chai.expect(parse.callCount).to.equal(1);
       chai.expect(dbView.callCount).to.equal(1);
-      chai.expect(dbView.args[1][0]).to.equal('medic-client/doc_by_type');
-      chai.expect(dbView.args[1][1].startkey[0]).to.equal('translations');
-      chai.expect(dbView.args[1][1].startkey[1]).to.equal(false);
-      chai.expect(dbView.args[1][1].endkey[0]).to.equal('translations');
-      chai.expect(dbView.args[1][1].endkey[1]).to.equal(true);
-      chai.expect(dbView.args[1][1].include_docs).to.equal(true);
     });
   });
 
@@ -255,7 +249,20 @@ describe('translations', () => {
       chai.expect(parse.callCount).to.equal(1);
       chai.expect(dbView.callCount).to.equal(1);
       chai.expect(dbBulk.callCount).to.equal(1);
-      chai.expect(dbBulk.args[0][0]).to.deep.equal([]);
+      chai.expect(dbBulk.args[0][0]).to.deep.equal([
+        {
+          _id: 'messages-fr',
+          code: 'fr',
+          type: 'translations',
+          default: {
+            hello: 'Hello UPDATED',
+            bye: 'Goodbye UPDATED',
+            added: 'ADDED'
+          },
+          name: 'Français (French)',
+          enabled: true
+        }
+      ]);
     });
   });
 

--- a/api/tests/mocha/translations.spec.js
+++ b/api/tests/mocha/translations.spec.js
@@ -206,7 +206,7 @@ describe('translations', () => {
           type: 'translations',
           default: {
             hello: 'Hello UPDATED',
-            bye: 'Goodbye CUSTOMISED',
+            bye: 'Goodbye UPDATED',
             added: 'ADDED'
           }
         },
@@ -412,7 +412,7 @@ describe('translations', () => {
           type: 'translations',
           default: {
             hello: 'Hello EN UPDATED',
-            bye: 'Goodbye EN CUSTOMISED',
+            bye: 'Goodbye EN UPDATED',
             added: 'EN ADDED'
           }
         },
@@ -432,7 +432,7 @@ describe('translations', () => {
           type: 'translations',
           default: {
             hello: 'Hello FR UPDATED',
-            bye: 'Goodbye FR CUSTOMISED',
+            bye: 'Goodbye FR UPDATED',
             added: 'FR ADDED'
           }
         },

--- a/api/tests/mocha/translations.spec.js
+++ b/api/tests/mocha/translations.spec.js
@@ -66,19 +66,17 @@ describe('translations', () => {
 
   it('run returns errors from getting translations files', () => {
     const ddoc = { _attachments: { 'translations/messages-en.properties': {} } };
-    const backups = [ { doc: { _id: 'messages-en-backup', default: { hello: 'Hello' } } } ];
     const dbGet = sinon.stub(db.medic, 'get').resolves(ddoc);
     const dbAttachment = sinon.stub(db.medic, 'getAttachment').resolves('some buffer');
     const parse = sinon.stub(properties, 'parse').callsArgWith(1, null, { first: '1st' });
     const dbView = sinon.stub(db.medic, 'query');
-    dbView.onCall(0).resolves({ rows: backups });
-    dbView.onCall(1).returns(Promise.reject('boom'));
+    dbView.onCall(0).returns(Promise.reject('boom'));
     return translations.run().catch(err => {
       chai.expect(err).to.equal('boom');
       chai.expect(dbGet.callCount).to.equal(1);
       chai.expect(dbAttachment.callCount).to.equal(1);
       chai.expect(parse.callCount).to.equal(1);
-      chai.expect(dbView.callCount).to.equal(2);
+      chai.expect(dbView.callCount).to.equal(1);
       chai.expect(dbView.args[1][0]).to.equal('medic-client/doc_by_type');
       chai.expect(dbView.args[1][1].startkey[0]).to.equal('translations');
       chai.expect(dbView.args[1][1].startkey[1]).to.equal(false);

--- a/api/tests/mocha/translations.spec.js
+++ b/api/tests/mocha/translations.spec.js
@@ -81,7 +81,7 @@ describe('translations', () => {
 
   it('run returns errors from getting translations files', () => {
     const ddoc = { _attachments: { 'translations/messages-en.properties': {} } };
-    const backups = [ { doc: { _id: 'messages-en-backup', values: { hello: 'Hello' } } } ];
+    const backups = [ { doc: { _id: 'messages-en-backup', default: { hello: 'Hello' } } } ];
     const dbGet = sinon.stub(db.medic, 'get').resolves(ddoc);
     const dbAttachment = sinon.stub(db.medic, 'getAttachment').resolves('some buffer');
     const parse = sinon.stub(properties, 'parse').callsArgWith(1, null, { first: '1st' });
@@ -109,13 +109,13 @@ describe('translations', () => {
       _id: 'messages-en-backup',
       code: 'en',
       type: 'translations-backup',
-      values: { hello: 'Hello' }
+      default: { hello: 'Hello' }
     } } ];
     const docs = [ { doc: {
       _id: 'messages-en',
       code: 'en',
       type: 'translations',
-      values: { hello: 'Gidday' }
+      default: { hello: 'Gidday' }
     } } ];
     const dbGet = sinon.stub(db.medic, 'get').resolves(ddoc);
     const dbAttachment = sinon.stub(db.medic, 'getAttachment').resolves('some buffer');
@@ -137,13 +137,13 @@ describe('translations', () => {
       _id: 'messages-en-backup',
       code: 'en',
       type: 'translations-backup',
-      values: { hello: 'Hello', bye: 'Goodbye' }
+      default: { hello: 'Hello', bye: 'Goodbye' }
     } } ];
     const docs = [ { doc: {
       _id: 'messages-en',
       code: 'en',
       type: 'translations',
-      values: { hello: 'Hello', bye: 'Goodbye CUSTOMISED' }
+      default: { hello: 'Hello', bye: 'Goodbye CUSTOMISED' }
     } } ];
     const dbGet = sinon.stub(db.medic, 'get').resolves(ddoc);
     const dbAttachment = sinon.stub(db.medic, 'getAttachment').resolves('some buffer');
@@ -168,13 +168,13 @@ describe('translations', () => {
       _id: 'messages-en-backup',
       code: 'en',
       type: 'translations-backup',
-      values: { hello: 'Hello', bye: 'Goodbye' }
+      default: { hello: 'Hello', bye: 'Goodbye' }
     } } ];
     const docs = [ { doc: {
       _id: 'messages-en',
       code: 'en',
       type: 'translations',
-      values: { hello: 'Hello', bye: 'Goodbye CUSTOMISED' }
+      default: { hello: 'Hello', bye: 'Goodbye CUSTOMISED' }
     } } ];
     const dbGet = sinon.stub(db.medic, 'get').resolves(ddoc);
     const dbAttachment = sinon.stub(db.medic, 'getAttachment').resolves('some buffer');
@@ -194,7 +194,7 @@ describe('translations', () => {
           _id: 'messages-en',
           code: 'en',
           type: 'translations',
-          values: {
+          default: {
             hello: 'Hello UPDATED',
             bye: 'Goodbye CUSTOMISED',
             added: 'ADDED'
@@ -204,7 +204,7 @@ describe('translations', () => {
           _id: 'messages-en-backup',
           code: 'en',
           type: 'translations-backup',
-          values: {
+          default: {
             hello: 'Hello UPDATED',
             bye: 'Goodbye UPDATED',
             added: 'ADDED'
@@ -221,13 +221,13 @@ describe('translations', () => {
       _id: 'messages-en-backup',
       code: 'en',
       type: 'translations-backup',
-      values: { empty: '' }
+      default: { empty: '' }
     } } ];
     const docs = [ { doc: {
       _id: 'messages-en',
       code: 'en',
       type: 'translations',
-      values: { empty: '' }
+      default: { empty: '' }
     } } ];
     sinon.stub(db.medic, 'get').resolves(ddoc);
     sinon.stub(db.medic, 'getAttachment').resolves('some buffer');
@@ -247,13 +247,13 @@ describe('translations', () => {
       _id: 'messages-en-backup',
       code: 'en',
       type: 'translations-backup',
-      values: { hello: 'Hello', bye: 'Goodbye' }
+      default: { hello: 'Hello', bye: 'Goodbye' }
     } } ];
     const docs = [ { doc: {
       _id: 'messages-en',
       code: 'en',
       type: 'translations',
-      values: { hello: 'Hello', bye: 'Goodbye CUSTOMISED' }
+      default: { hello: 'Hello', bye: 'Goodbye CUSTOMISED' }
     } } ];
     const dbGet = sinon.stub(db.medic, 'get').resolves(ddoc);
     const dbAttachment = sinon.stub(db.medic, 'getAttachment').resolves('some buffer');
@@ -275,7 +275,7 @@ describe('translations', () => {
           code: 'fr',
           name: 'Français (French)',
           enabled: true,
-          values: {
+          default: {
             hello: 'Hello UPDATED',
             bye: 'Goodbye UPDATED',
             added: 'ADDED'
@@ -285,7 +285,7 @@ describe('translations', () => {
           _id: 'messages-fr-backup',
           type: 'translations-backup',
           code: 'fr',
-          values: {
+          default: {
             hello: 'Hello UPDATED',
             bye: 'Goodbye UPDATED',
             added: 'ADDED'
@@ -304,20 +304,20 @@ describe('translations', () => {
         _id: 'messages-en-backup',
         type: 'translations-backup',
         code: 'en',
-        values: { hello: 'Hello', bye: 'Goodbye' }
+        default: { hello: 'Hello', bye: 'Goodbye' }
       } },
       { doc: {
         _id: 'messages-fr-backup',
         type: 'translations-backup',
         code: 'fr',
-        values: { hello: 'Hello', bye: 'Goodbye' }
+        default: { hello: 'Hello', bye: 'Goodbye' }
       } }
     ];
     const docs = [ { doc: {
       _id: 'messages-en',
       type: 'translations',
       code: 'en',
-      values: { hello: 'Hello', bye: 'Goodbye' }
+      default: { hello: 'Hello', bye: 'Goodbye' }
     } } ];
     const dbGet = sinon.stub(db.medic, 'get').resolves(ddoc);
     const dbAttachment = sinon.stub(db.medic, 'getAttachment').resolves('some buffer');
@@ -337,7 +337,7 @@ describe('translations', () => {
           _id: 'messages-fr-backup',
           type: 'translations-backup',
           code: 'fr',
-          values: {
+          default: {
             hello: 'Hello UPDATED',
             bye: 'Goodbye UPDATED',
             added: 'ADDED'
@@ -357,13 +357,13 @@ describe('translations', () => {
         _id: 'messages-en-backup',
         code: 'en',
         type: 'translations-backup',
-        values: { hello: 'Hello EN', bye: 'Goodbye EN' }
+        default: { hello: 'Hello EN', bye: 'Goodbye EN' }
       } },
       { doc: {
         _id: 'messages-fr-backup',
         code: 'fr',
         type: 'translations-backup',
-        values: { hello: 'Hello FR', bye: 'Goodbye FR' }
+        default: { hello: 'Hello FR', bye: 'Goodbye FR' }
       } }
     ];
     const docs = [
@@ -371,13 +371,13 @@ describe('translations', () => {
         _id: 'messages-en',
         code: 'en',
         type: 'translations',
-        values: { hello: 'Hello EN', bye: 'Goodbye EN CUSTOMISED' }
+        default: { hello: 'Hello EN', bye: 'Goodbye EN CUSTOMISED' }
       } },
       { doc: {
         _id: 'messages-fr',
         code: 'fr',
         type: 'translations',
-        values: { hello: 'Hello FR', bye: 'Goodbye FR CUSTOMISED' }
+        default: { hello: 'Hello FR', bye: 'Goodbye FR CUSTOMISED' }
       } }
     ];
     const dbGet = sinon.stub(db.medic, 'get').resolves(ddoc);
@@ -400,7 +400,7 @@ describe('translations', () => {
           _id: 'messages-en',
           code: 'en',
           type: 'translations',
-          values: {
+          default: {
             hello: 'Hello EN UPDATED',
             bye: 'Goodbye EN CUSTOMISED',
             added: 'EN ADDED'
@@ -410,7 +410,7 @@ describe('translations', () => {
           _id: 'messages-en-backup',
           code: 'en',
           type: 'translations-backup',
-          values: {
+          default: {
             hello: 'Hello EN UPDATED',
             bye: 'Goodbye EN UPDATED',
             added: 'EN ADDED'
@@ -420,7 +420,7 @@ describe('translations', () => {
           _id: 'messages-fr',
           code: 'fr',
           type: 'translations',
-          values: {
+          default: {
             hello: 'Hello FR UPDATED',
             bye: 'Goodbye FR CUSTOMISED',
             added: 'FR ADDED'
@@ -430,7 +430,7 @@ describe('translations', () => {
           _id: 'messages-fr-backup',
           code: 'fr',
           type: 'translations-backup',
-          values: {
+          default: {
             hello: 'Hello FR UPDATED',
             bye: 'Goodbye FR UPDATED',
             added: 'FR ADDED'
@@ -449,7 +449,7 @@ describe('translations', () => {
         _id: 'messages-en-backup',
         code: 'en',
         type: 'translations-backup',
-        values: { hello: null, bye: 'Goodbye' }
+        default: { hello: null, bye: 'Goodbye' }
       } }
     ];
     const docs = [
@@ -457,7 +457,7 @@ describe('translations', () => {
         _id: 'messages-en',
         code: 'en',
         type: 'translations',
-        values: { hello: null, bye: 'Goodbye' }
+        default: { hello: null, bye: 'Goodbye' }
       } }
     ];
     const dbGet = sinon.stub(db.medic, 'get').resolves(ddoc);
@@ -479,7 +479,7 @@ describe('translations', () => {
           _id: 'messages-en',
           code: 'en',
           type: 'translations',
-          values: {
+          default: {
             hello: 'hello',
             bye: 'Goodbye'
           }
@@ -488,7 +488,7 @@ describe('translations', () => {
           _id: 'messages-en-backup',
           code: 'en',
           type: 'translations-backup',
-          values: {
+          default: {
             hello: 'hello',
             bye: 'Goodbye'
           }
@@ -507,13 +507,13 @@ describe('translations', () => {
         _id: 'messages-en-backup',
         code: 'en',
         type: 'translations-backup',
-        values: { hello: 'Hello', bye: 'Goodbye' }
+        default: { hello: 'Hello', bye: 'Goodbye' }
       } },
       { doc: {
         _id: 'messages-ne-backup',
         code: 'ne',
         type: 'translations-backup',
-        values: { bye: 'Goodbye' }
+        default: { bye: 'Goodbye' }
       } }
     ];
     const docs = [
@@ -521,13 +521,13 @@ describe('translations', () => {
         _id: 'messages-en',
         code: 'en',
         type: 'translations',
-        values: { hello: 'Hello', bye: 'Goodbye' }
+        default: { hello: 'Hello', bye: 'Goodbye' }
       } },
       { doc: {
         _id: 'messages-ne',
         code: 'ne',
         type: 'translations',
-        values: { bye: 'Goodbye' }
+        default: { bye: 'Goodbye' }
       } }
     ];
     const dbGet = sinon.stub(db.medic, 'get').resolves(ddoc);
@@ -550,7 +550,7 @@ describe('translations', () => {
           _id: 'messages-ne',
           code: 'ne',
           type: 'translations',
-          values: {
+          default: {
             hello: 'hello', // defaults to the translation key
             bye: 'Goodbye'
           }
@@ -559,7 +559,7 @@ describe('translations', () => {
           _id: 'messages-ne-backup',
           code: 'ne',
           type: 'translations-backup',
-          values: {
+          default: {
             hello: 'hello',
             bye: 'Goodbye'
           }
@@ -577,7 +577,7 @@ describe('translations', () => {
           _id: 'messages-en-backup',
           code: 'en',
           type: 'translations-backup',
-          values: { hello: null, bye: 0, ciao: false, adios: 23, salut: true }
+          default: { hello: null, bye: 0, ciao: false, adios: 23, salut: true }
         } }
     ];
     const docs = [
@@ -585,7 +585,7 @@ describe('translations', () => {
           _id: 'messages-en',
           code: 'en',
           type: 'translations',
-          values: { hello: null, bye: 0, ciao: false, adios: 23, salut: true }
+          default: { hello: null, bye: 0, ciao: false, adios: 23, salut: true }
         } }
     ];
     const dbGet = sinon.stub(db.medic, 'get').resolves(ddoc);
@@ -607,7 +607,7 @@ describe('translations', () => {
           _id: 'messages-en',
           code: 'en',
           type: 'translations',
-          values: {
+          default: {
             hello: 'hello',
             bye: '0',
             ciao: 'false',
@@ -619,7 +619,7 @@ describe('translations', () => {
           _id: 'messages-en-backup',
           code: 'en',
           type: 'translations-backup',
-          values: {
+          default: {
             hello: 'hello',
             bye: '0',
             ciao: 'false',

--- a/sentinel/src/config.js
+++ b/sentinel/src/config.js
@@ -24,7 +24,7 @@ const loadTranslations = () => {
   return db.medic
     .query('medic-client/doc_by_type', options)
     .then(result => {
-      result.rows.forEach(row => (translations[row.doc.code] = Object.assign(row.doc.custom || {}, row.doc.default)));
+      result.rows.forEach(row => (translations[row.doc.code] = Object.assign(row.doc.custom || {}, row.doc.generic)));
     })
     .catch(err => {
       logger.error('Error loading translations - starting up anyway: %o', err);

--- a/sentinel/src/config.js
+++ b/sentinel/src/config.js
@@ -24,7 +24,7 @@ const loadTranslations = () => {
   return db.medic
     .query('medic-client/doc_by_type', options)
     .then(result => {
-      result.rows.forEach(row => (translations[row.doc.code] = Object.assign(row.doc.custom, row.doc.default)));
+      result.rows.forEach(row => (translations[row.doc.code] = Object.assign(row.doc.custom || {}, row.doc.default)));
     })
     .catch(err => {
       logger.error('Error loading translations - starting up anyway: %o', err);

--- a/sentinel/src/config.js
+++ b/sentinel/src/config.js
@@ -24,7 +24,7 @@ const loadTranslations = () => {
   return db.medic
     .query('medic-client/doc_by_type', options)
     .then(result => {
-      result.rows.forEach(row => (translations[row.doc.code] = row.doc.values));
+      result.rows.forEach(row => (translations[row.doc.code] = Object.assign(row.doc.custom, row.doc.default)));
     })
     .catch(err => {
       logger.error('Error loading translations - starting up anyway: %o', err);

--- a/webapp/src/js/services/translation-loader.js
+++ b/webapp/src/js/services/translation-loader.js
@@ -36,7 +36,7 @@ angular.module('inboxServices').factory('TranslationLoader',
           return DB().get(DOC_ID_PREFIX + locale);
         })
         .then(function(doc) {
-          let values = Object.assign(doc.default || {}, doc.custom || {});
+          let values = Object.assign(doc.generic || {}, doc.custom || {});
           if (testing) {
             mapTesting(values);
           }

--- a/webapp/src/js/services/translation-loader.js
+++ b/webapp/src/js/services/translation-loader.js
@@ -36,10 +36,11 @@ angular.module('inboxServices').factory('TranslationLoader',
           return DB().get(DOC_ID_PREFIX + locale);
         })
         .then(function(doc) {
+          let values = Object.assign(doc.default || {}, doc.custom || {});
           if (testing) {
-            mapTesting(doc.values);
+            mapTesting(values);
           }
-          return doc.values;
+          return values;
         })
         .catch(function(err) {
           if (err.status !== 404) {

--- a/webapp/tests/karma/unit/services/translation-loader.js
+++ b/webapp/tests/karma/unit/services/translation-loader.js
@@ -55,7 +55,7 @@ describe('TranslationLoader service', function() {
       prawn: 'shrimp',
       bbq: 'barbie'
     };
-    DBGet.returns(Promise.resolve({ values: expected }));
+    DBGet.returns(Promise.resolve({ custom: expected }));
     return service(options).then(function(actual) {
       chai.expect(actual).to.deep.equal(expected);
       chai.expect(Settings.callCount).to.equal(0);
@@ -72,7 +72,7 @@ describe('TranslationLoader service', function() {
       bbq: 'grill'
     };
     Settings.returns(Promise.resolve(settings));
-    DBGet.returns(Promise.resolve({ values: expected }));
+    DBGet.returns(Promise.resolve({ custom: expected }));
     return service(options).then(function(actual) {
       chai.expect(actual).to.deep.equal(expected);
       chai.expect(Settings.callCount).to.equal(1);
@@ -89,7 +89,7 @@ describe('TranslationLoader service', function() {
       bbq: 'barbeque'
     };
     Settings.returns(Promise.resolve(settings));
-    DBGet.returns(Promise.resolve({ values: expected }));
+    DBGet.returns(Promise.resolve({ custom: expected }));
     return service(options).then(function(actual) {
       chai.expect(actual).to.deep.equal(expected);
       chai.expect(Settings.callCount).to.equal(1);
@@ -108,7 +108,7 @@ describe('TranslationLoader service', function() {
       prawn: '-prawn-',
       bbq: '-barbeque-'
     };
-    DBGet.returns(Promise.resolve({ values: doc }));
+    DBGet.returns(Promise.resolve({ custom: doc }));
     return service(options).then(function(actual) {
       chai.expect(actual).to.deep.equal(expected);
       chai.expect(Settings.callCount).to.equal(0);


### PR DESCRIPTION
# Description

Changed the structure of translations to enable full overwrite in order to reflect addition/deletion of translation keys.
Now, the structure of the translation doc is: `{....., "custom":{...}, "default":{...}}`
* `"custom":{...}` has the custom translations uploaded via `medic-conf`
* `"default":{...}` has the default translations

Related `medic-conf` PR: https://github.com/medic/medic-conf/pull/110

medic/medic-webapp#3128

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
