### PR TITLE
Fixes replication of invalid patient id reports

### DIFF
--- a/ddocs/medic/views/docs_by_replication_key/map.js
+++ b/ddocs/medic/views/docs_by_replication_key/map.js
@@ -17,8 +17,9 @@ function (doc) {
       // report
       if (doc.contact && doc.errors && doc.errors.length) {
         for (var i = 0; i < doc.errors.length; i++) {
-          // no patient found, fall back to using contact. #3437
-          if (doc.errors[i].code === 'registration_not_found') {
+          // invalid or no patient found, fall back to using contact. #3437
+          if (doc.errors[i].code === 'registration_not_found' ||
+              doc.errors[i].code === 'invalid_patient_id') {
             return doc.contact._id;
           }
         }

--- a/tests/e2e/docs-by-replication-key-view.js
+++ b/tests/e2e/docs-by-replication-key-view.js
@@ -73,6 +73,17 @@ describe('view docs_by_replication_key', () => {
         _id: 'testuser'
       },
       errors: [ { code: 'registration_not_found' } ]
+    },
+    {
+      _id: 'report_with_invalid_patient_id',
+      reported_date: 1,
+      form: 'V',
+      type: 'data_record',
+      patient_id: 'invalid_patient',
+      contact: {
+        _id: 'testuser'
+      },
+      errors: [ { code: 'invalid_patient_id' } ]
     }
   ];
 
@@ -232,6 +243,10 @@ describe('view docs_by_replication_key', () => {
     it('Falls back to contact id when unknown patient', () => {
       expect(docByPlaceIds).toContain('report_with_unknown_patient_id');
     });
+
+    it('Falls back to contact id when invalid patient', () => {
+      expect(docByPlaceIds).toContain('report_with_invalid_patient_id');
+    });
   });
 
   describe('Documents that only pass when unassigned == true', () => {
@@ -259,4 +274,3 @@ describe('view docs_by_replication_key', () => {
   // TODO: test these branches:
   //  - OK() no query id
 });
-


### PR DESCRIPTION
# Description

When the patient report fails the patient id validation, 
the replication key falls back to the contact ID. 
This allows for the CHW and supervisors to see the report and
resubmit with the correct patient id.

medic/medic-webapp#4621

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
