### PR TITLE
Improves performance of UHC Contacts list

### DIFF
--- a/api/src/services/export/contact-mapper.js
+++ b/api/src/services/export/contact-mapper.js
@@ -2,7 +2,9 @@ const db = require('../../db-pouch'),
       search = require('search')(Promise, db.medic);
 
 module.exports = {
-  getDocIds: (options, filters) => search('contacts', filters, options),
+  getDocIds: (options, filters) => {
+    return search('contacts', filters, options).then(results => results.docIds);
+  },
   map: () => Promise.resolve({
     header: ['id', 'rev', 'name', 'patient_id', 'type'],
     getRows: record => [[record._id, record._rev, record.name, record.patient_id, record.type]]

--- a/api/src/services/export/report-mapper.js
+++ b/api/src/services/export/report-mapper.js
@@ -38,7 +38,9 @@ const flatten = (fields, prepend=[]) => {
 };
 
 module.exports = {
-  getDocIds: (options, filters) => search('reports', filters, options),
+  getDocIds: (options, filters) => {
+    return search('reports', filters, options).then(results => results.docIds);
+  },
   map: (filters) => {
     // Either selected forms or all currently used forms
     const getForms = () => {

--- a/ddocs/medic-client/views/visits_by_date/map.js
+++ b/ddocs/medic-client/views/visits_by_date/map.js
@@ -1,0 +1,10 @@
+function(doc) {
+  if (doc.type === 'data_record' &&
+      doc.form &&
+      doc.fields &&
+      doc.fields.visited_contact_uuid) {
+
+    // Is a visit report about a family
+    emit(doc.reported_date, doc.fields.visited_contact_uuid);
+  }
+}

--- a/shared-libs/search/src/generate-search-requests.js
+++ b/shared-libs/search/src/generate-search-requests.js
@@ -292,6 +292,6 @@ module.exports = {
     return builder(filters, extensions);
   },
   shouldSortByLastVisitedDate: function(extensions) {
-    return extensions && extensions.sortByLastVisitedDate;
+    return Boolean(extensions && extensions.sortByLastVisitedDate);
   }
 };

--- a/shared-libs/search/src/generate-search-requests.js
+++ b/shared-libs/search/src/generate-search-requests.js
@@ -242,7 +242,7 @@ var requestBuilders = {
       requests.push(defaultContactRequest());
     }
 
-    if (extensions && extensions.sortByLastVisitedDate) {
+    if (module.exports.shouldSortByLastVisitedDate(extensions)) {
       // Always push this last, search:getIntersection uses the last request
       // result and we'll need it later for sorting
       requests.push(sortByLastVisitedDate());
@@ -290,5 +290,8 @@ module.exports = {
       throw new Error('Unknown type: ' + type);
     }
     return builder(filters, extensions);
+  },
+  shouldSortByLastVisitedDate: function(extensions) {
+    return extensions && extensions.sortByLastVisitedDate;
   }
 };

--- a/shared-libs/search/src/search.js
+++ b/shared-libs/search/src/search.js
@@ -74,15 +74,22 @@ module.exports = function(Promise, DB) {
     return queryView(request);
   };
 
-  var getRows = function(type, requests, options) {
+  var getRows = function(type, requests, options, returnExtendedResults) {
     if (requests.length === 1 && requests[0].ordered) {
       // 1 ordered view - let the db do the pagination for us
       return queryViewPaginated(requests[0], options);
     }
     // multiple requests - have to manually paginate
+    var extendedResults;
     return Promise.all(requests.map(queryView))
       .then(getIntersection)
-      .then(_.partial(getPageRows, type, _, options));
+      .then(function(results) {
+        extendedResults = results;
+        return getPageRows(type, results, options);
+      })
+      .then(function(results) {
+        return returnExtendedResults ? { extendedResults: extendedResults, results: results } : results;
+      });
   };
 
   return function(type, filters, options, extensions) {
@@ -92,6 +99,7 @@ module.exports = function(Promise, DB) {
       skip: 0
     });
 
+    var extendedResults = GenerateSearchRequests.shouldSortByLastVisitedDate(extensions);
     var requests;
     try {
       requests = GenerateSearchRequests.generate(type, filters, extensions);
@@ -99,9 +107,16 @@ module.exports = function(Promise, DB) {
       return Promise.reject(err);
     }
 
-    return getRows(type, requests, options, extensions)
+    return getRows(type, requests, options, extendedResults)
       .then(function(results) {
-        return _.pluck(results, 'id');
+        if (extendedResults) {
+          return {
+            extendedResults: results.extendedResults,
+            results: _.pluck(results.results, 'id')
+          };
+        } else {
+          return _.pluck(results, 'id');
+        }
       });
   };
 };

--- a/shared-libs/search/src/search.js
+++ b/shared-libs/search/src/search.js
@@ -74,7 +74,7 @@ module.exports = function(Promise, DB) {
     return queryView(request);
   };
 
-  var getRows = function(type, requests, options, returnResultsCache) {
+  var getRows = function(type, requests, options, cacheQueryResults) {
     if (requests.length === 1 && requests[0].ordered) {
       // 1 ordered view - let the db do the pagination for us
       return queryViewPaginated(requests[0], options);
@@ -88,7 +88,7 @@ module.exports = function(Promise, DB) {
         return getPageRows(type, results, options);
       })
       .then(function(results) {
-        return returnResultsCache ? { queryResultsCache: queryResultsCache, docIds: results } : results;
+        return cacheQueryResults ? { queryResultsCache: queryResultsCache, docIds: results } : results;
       });
   };
 
@@ -99,7 +99,7 @@ module.exports = function(Promise, DB) {
       skip: 0
     });
 
-    var cacheResults = GenerateSearchRequests.shouldSortByLastVisitedDate(extensions);
+    var cacheQueryResults = GenerateSearchRequests.shouldSortByLastVisitedDate(extensions);
     var requests;
     try {
       requests = GenerateSearchRequests.generate(type, filters, extensions);
@@ -107,9 +107,9 @@ module.exports = function(Promise, DB) {
       return Promise.reject(err);
     }
 
-    return getRows(type, requests, options, cacheResults)
+    return getRows(type, requests, options, cacheQueryResults)
       .then(function(results) {
-        if (cacheResults) {
+        if (cacheQueryResults) {
           return {
             queryResultsCache: results.queryResultsCache,
             docIds: _.pluck(results.docIds, 'id')

--- a/shared-libs/search/test/generate-search-requests.js
+++ b/shared-libs/search/test/generate-search-requests.js
@@ -1,5 +1,6 @@
 var chai = require('chai'),
-    service = require('../src/generate-search-requests').generate;
+    GenerateSeachRequests = require('../src/generate-search-requests'),
+    service = GenerateSeachRequests.generate;
 
 describe('GenerateSearchRequests service', function() {
 
@@ -364,5 +365,25 @@ describe('GenerateSearchRequests service', function() {
       });
     });
 
+  });
+
+  describe('shouldSortByLastVisitedDate', function() {
+    it('should return false for falsy or empty inputs', function() {
+      chai.expect(GenerateSeachRequests.shouldSortByLastVisitedDate()).to.equal(false);
+      chai.expect(GenerateSeachRequests.shouldSortByLastVisitedDate(false)).to.equal(false);
+      chai.expect(GenerateSeachRequests.shouldSortByLastVisitedDate({})).to.equal(false);
+      chai.expect(GenerateSeachRequests.shouldSortByLastVisitedDate([])).to.equal(false);
+    });
+
+    it('should return false when not sorting by last visited date', function() {
+      chai.expect(GenerateSeachRequests.shouldSortByLastVisitedDate({ a: 1 })).to.equal(false);
+      chai.expect(GenerateSeachRequests.shouldSortByLastVisitedDate({ sortByLastVisitedDate: false })).to.equal(false);
+      chai.expect(GenerateSeachRequests.shouldSortByLastVisitedDate({ sortByLastVisitedDate: null })).to.equal(false);
+    });
+
+    it('should return true when sorting by last visited date', function() {
+      chai.expect(GenerateSeachRequests.shouldSortByLastVisitedDate({ sortByLastVisitedDate: true })).to.equal(true);
+      chai.expect(GenerateSeachRequests.shouldSortByLastVisitedDate({ sortByLastVisitedDate: 'aaa' })).to.equal(true);
+    });
   });
 });

--- a/webapp/src/js/controllers/contacts.js
+++ b/webapp/src/js/controllers/contacts.js
@@ -361,6 +361,10 @@ var _ = require('underscore'),
     };
 
     var canViewLastVisitedDate = function() {
+      if (Session.isDbAdmin()) {
+        // disable UHC for DB admins
+        return false;
+      }
       return Auth('can_view_last_visited_date')
         .then(function() {
           return true;

--- a/webapp/src/js/services/search.js
+++ b/webapp/src/js/services/search.js
@@ -54,17 +54,8 @@ var _ = require('underscore'),
 
       var getLastVisitedDates = function(searchResults, extendedResults, settings) {
         settings = settings || {};
-
         var interval = CalendarInterval.getCurrent(settings.monthStartDate),
             visitStats = {};
-
-        var setLastVisitedDate = function(rows) {
-          rows.forEach(function(row) {
-            if (visitStats[row.key]) {
-              visitStats[row.key].lastVisitedDate = row.value && row.value.max || row.value;
-            }
-          });
-        };
 
         searchResults.forEach(function(id) {
           visitStats[id] = { lastVisitedDate: -1, visitDates: [] };
@@ -82,8 +73,17 @@ var _ = require('underscore'),
             });
         };
 
+        var setLastVisitedDate = function(rows) {
+          rows.forEach(function(row) {
+            if (visitStats[row.key]) {
+              visitStats[row.key].lastVisitedDate = row.value && row.value.max || row.value;
+            }
+          });
+        };
+
         var getLastVisited = function() {
           if (extendedResults) {
+            // when sorting by last visited date, we receive the data from Search library
             return setLastVisitedDate(extendedResults);
           }
 
@@ -127,7 +127,7 @@ var _ = require('underscore'),
         return _search(type, filters, options, extensions)
           .then(function(searchResults) {
             var extendedResults;
-            if (_.isObject(searchResults) && searchResults.extendedResults) {
+            if (searchResults && searchResults.extendedResults) {
               extendedResults = searchResults.extendedResults;
               searchResults = searchResults.results;
             }
@@ -145,7 +145,11 @@ var _ = require('underscore'),
               return dataRecordsPromise;
             }
 
-            var lastVisitedDatePromise = getLastVisitedDates(searchResults, extendedResults, extensions.visitCountSettings);
+            var lastVisitedDatePromise = getLastVisitedDates(
+              searchResults,
+              extendedResults,
+              extensions.visitCountSettings
+            );
 
             return $q.all({
               dataRecords: dataRecordsPromise,

--- a/webapp/src/js/services/search.js
+++ b/webapp/src/js/services/search.js
@@ -77,7 +77,7 @@ var _ = require('underscore'),
         var setLastVisitedDate = function(rows) {
           rows.forEach(function(row) {
             if (visitStats[row.key]) {
-              visitStats[row.key].lastVisitedDate = row.value && row.value.max || row.value;
+              visitStats[row.key].lastVisitedDate = _.isObject(row.value) ? row.value.max : row.value;
             }
           });
         };

--- a/webapp/src/js/services/session.js
+++ b/webapp/src/js/services/session.js
@@ -99,6 +99,11 @@ var COOKIE_NAME = 'userCtx',
                hasRole(userCtx, 'national_admin'); // deprecated: kept for backwards compatibility: #4525
       };
 
+      var isDbAdmin = function(userCtx) {
+        userCtx = userCtx || getUserCtx();
+        return hasRole(userCtx, '_admin');
+      };
+
       return {
         logout: logout,
 
@@ -117,6 +122,10 @@ var COOKIE_NAME = 'userCtx',
          * @param {userCtx} (optional) Will get the current userCtx if not provided.
          */
         isAdmin: isAdmin,
+
+        // Returns true if the logged in user is a DB admin
+        // @param {userCtx} (optional) Will get the current userCtx if not provided.
+        isDbAdmin: isDbAdmin,
 
         /**
          * Returns true if the logged in user is online only

--- a/webapp/tests/karma/unit/controllers/contacts.js
+++ b/webapp/tests/karma/unit/controllers/contacts.js
@@ -31,7 +31,8 @@ describe('Contacts controller', () => {
     auth,
     deadListContains,
     deadList,
-    contactSummary;
+    contactSummary,
+    isDbAdmin;
 
   beforeEach(module('inboxApp'));
 
@@ -127,6 +128,7 @@ describe('Contacts controller', () => {
 
     settings = sinon.stub().resolves({});
     auth = sinon.stub().rejects();
+    isDbAdmin = sinon.stub();
 
     createController = () => {
       searchService = sinon.stub();
@@ -156,6 +158,7 @@ describe('Contacts controller', () => {
           isAdmin: () => {
             return isAdmin;
           },
+          isDbAdmin: isDbAdmin
         },
         Settings: settings,
         Simprints: { enabled: () => false },
@@ -1329,6 +1332,27 @@ describe('Contacts controller', () => {
                 });
               });
           });
+        });
+      });
+
+      describe('uhc disabled for DB admins', () => {
+        it('should disable UHC for DB admins', () => {
+          settings.resolves({ uhc: { contacts_default_sort: 'last_visited_date' }});
+          isDbAdmin.returns(true);
+
+          return createController()
+            .getSetupPromiseForTesting()
+            .then(() => {
+              assert.equal(auth.callCount, 0);
+              assert.equal(searchService.callCount, 1);
+              assert.deepEqual(searchService.args[0], [
+                'contacts',
+                { types: { selected: ['childType'] } },
+                { limit: 50 },
+                {},
+                undefined,
+              ]);
+            });
         });
       });
     });

--- a/webapp/tests/karma/unit/services/search.js
+++ b/webapp/tests/karma/unit/services/search.js
@@ -454,7 +454,7 @@ describe('Search service', function() {
               end_key: moment('2018-08-01').endOf('month').valueOf()
             }
           ]);
-          2
+
           chai.expect(result).to.deep.equal([
             {
               _id: '1',

--- a/webapp/tests/karma/unit/services/search.js
+++ b/webapp/tests/karma/unit/services/search.js
@@ -410,14 +410,14 @@ describe('Search service', function() {
       searchStub.resolves({
         results: ['1', '2', '3', '4'],
         extendedResults: [
-          { key: '1', value: { max: moment('2018-08-10').valueOf() } },
-            { key: '2', value: { max: moment('2018-08-18').valueOf() } },
-            { key: '3', value: { max: moment('2018-07-13').valueOf() } },
-            { key: '4', value: { max: -1 } },
-            { key: '5', value: { max: moment('2018-07-21').valueOf() } },
-            { key: '6', value: { max: moment('2018-06-01').valueOf() } },
-            { key: '7', value: { max: moment('2018-07-29').valueOf() } },
-            { key: '8', value: { max: moment('2018-07-30').valueOf() } },
+          { key: '1', value: moment('2018-08-10').valueOf() },
+            { key: '2', value: moment('2018-08-18').valueOf() },
+            { key: '3', value: moment('2018-07-13').valueOf() },
+            { key: '4', value: -1 },
+            { key: '5', value: moment('2018-07-21').valueOf() },
+            { key: '6', value: moment('2018-06-01').valueOf() },
+            { key: '7', value: moment('2018-07-29').valueOf() },
+            { key: '8', value: moment('2018-07-30').valueOf() },
           ]
       });
       GetDataRecords.resolves([{ _id: '1' }, { _id: '2' }, { _id: '3' }, { _id: '4' }]);

--- a/webapp/tests/karma/unit/services/search.js
+++ b/webapp/tests/karma/unit/services/search.js
@@ -98,7 +98,7 @@ describe('Search service', function() {
           chai.expect(actual).to.deep.equal([ { id: 'a' } ]);
           firstReturned = true;
         });
-      
+
       filters.foo = 'test';
       return service('reports', filters)
         .then(function(actual) {
@@ -175,31 +175,40 @@ describe('Search service', function() {
     });
 
     it('queries last visited dates when set', () => {
-      GetDataRecords.resolves([{ _id: '1' }, { _id: '2' }, { _id: '3' }]);
-      searchStub.resolves(['1', '2', '3']);
+      GetDataRecords.resolves([{ _id: '1' }, { _id: '2' }, { _id: '3' }, { _id: '4' }]);
+      searchStub.resolves(['1', '2', '3', '4']);
       db.query
         .withArgs('medic-client/contacts_by_last_visited')
         .resolves({
           rows: [
-            { key: '1', value: 0 },
-            { key: '1', value: moment('2017-09-10').valueOf() },
-            { key: '1', value: moment('2017-12-10').valueOf() },
-            { key: '1', value: moment('2018-01-10').valueOf() },
-            { key: '1', value: moment('2018-01-22').valueOf() },
-            { key: '1', value: moment('2018-03-20').valueOf() },
-            { key: '1', value: moment('2018-04-20').valueOf() },
-            { key: '1', value: moment('2018-07-31').valueOf() },
-            { key: '1', value: moment('2018-08-01').valueOf() },
-            { key: '1', value: moment('2018-08-10').valueOf() },
-            { key: '1', value: moment('2018-08-02').valueOf() },
+            { key: '1', value: { max: moment('2018-08-10').valueOf() } },
+            { key: '2', value: { max: moment('2018-08-18').valueOf() } },
+            { key: '3', value: { max: moment('2018-07-13').valueOf() } },
+            { key: '4', value: { max: -1 } },
+            { key: '5', value: { max: moment('2018-07-21').valueOf() } },
+            { key: '6', value: { max: moment('2018-06-01').valueOf() } },
+            { key: '7', value: { max: moment('2018-07-29').valueOf() } },
+            { key: '8', value: { max: moment('2018-07-30').valueOf() } },
+          ]
+        });
 
-            { key: '2', value: -1 },
-
-            { key: '3' , value: 0 },
-            { key: '3' , value: moment('2018-07-10').valueOf() },
-            { key: '3' , value: moment('2018-07-11').valueOf() },
-            { key: '3' , value: moment('2018-07-12').valueOf() },
-            { key: '3' , value: moment('2018-07-13').valueOf() },
+      db.query
+        .withArgs('medic-client/visits_by_date')
+        .resolves({
+          rows: [
+            { key: moment('2018-08-01').valueOf(), value: '1' },
+            { key: moment('2018-08-02').valueOf(), value: '2' },
+            { key: moment('2018-08-04').valueOf(), value: '2' },
+            { key: moment('2018-08-04').valueOf(), value: '5' },
+            { key: moment('2018-08-05').valueOf(), value: '5' },
+            { key: moment('2018-08-08').valueOf(), value: '5' },
+            { key: moment('2018-08-10').valueOf(), value: '1' },
+            { key: moment('2018-08-10').valueOf(), value: '1' },
+            { key: moment('2018-08-12').valueOf(), value: '6' },
+            { key: moment('2018-08-13').valueOf(), value: '6' },
+            { key: moment('2018-08-16').valueOf(), value: '2' },
+            { key: moment('2018-08-18').valueOf(), value: '2' },
+            { key: moment('2018-08-18').valueOf(), value: '2' },
           ]
         });
 
@@ -208,28 +217,44 @@ describe('Search service', function() {
           chai.expect(searchStub.callCount).to.equal(1);
           chai.expect(searchStub.args[0])
             .to.deep.equal(['contacts', {}, { limit: 50, skip: 0 }, { displayLastVisitedDate: true }]);
-          chai.expect(db.query.callCount).to.equal(1);
-          chai.expect(db.query.args[0])
-            .to.deep.equal([ 'medic-client/contacts_by_last_visited', {reduce: false, keys: ['1', '2', '3']} ]);
+          chai.expect(db.query.callCount).to.equal(2);
+          chai.expect(db.query.args[0]).to.deep.equal([
+            'medic-client/visits_by_date',
+            {
+              start_key: moment('2018-08-01').startOf('day').valueOf(),
+              end_key: moment('2018-08-01').endOf('month').valueOf()
+            }
+          ]);
+          chai.expect(db.query.args[1]).to.deep.equal([
+            'medic-client/contacts_by_last_visited',
+            { reduce: true, group: true }
+          ]);
 
           chai.expect(result).to.deep.equal([
             {
               _id: '1',
               lastVisitedDate: moment('2018-08-10 00:00:00').valueOf(),
               visitCountGoal: undefined,
-              visitCount: 3,
+              visitCount: 2,
               sortByLastVisitedDate: undefined
             },
             {
               _id: '2',
-              lastVisitedDate: -1,
+              lastVisitedDate: moment('2018-08-18 00:00:00').valueOf(),
               visitCountGoal: undefined,
-              visitCount: 0,
+              visitCount: 4,
               sortByLastVisitedDate: undefined
             },
             {
               _id: '3',
               lastVisitedDate: moment('2018-07-13 00:00:00').valueOf(),
+              visitCountGoal: undefined,
+              visitCount: 0,
+              sortByLastVisitedDate: undefined
+            },
+            {
+              _id: '4',
+              lastVisitedDate: -1,
               visitCountGoal: undefined,
               visitCount: 0,
               sortByLastVisitedDate: undefined
@@ -245,27 +270,26 @@ describe('Search service', function() {
         .withArgs('medic-client/contacts_by_last_visited')
         .resolves({
           rows: [
-            { key: '1', value: 0 },
-            { key: '1', value: moment('2017-09-10').valueOf() },
-            { key: '1', value: moment('2017-12-10').valueOf() },
-            { key: '1', value: moment('2018-01-10').valueOf() },
-            { key: '1', value: moment('2018-01-22').valueOf() },
-            { key: '1', value: moment('2018-03-20').valueOf() },
-            { key: '1', value: moment('2018-04-20').valueOf() },
-            { key: '1', value: moment('2018-07-24').valueOf() },
-            { key: '1', value: moment('2018-07-31').valueOf() },
-            { key: '1', value: moment('2018-08-01').valueOf() },
-            { key: '1', value: moment('2018-08-10').valueOf() },
-            { key: '1', value: moment('2018-08-02').valueOf() },
+            { key: '1', value: { max: moment('2018-08-10').valueOf() } },
+            { key: '2', value: { max: -1 } },
+            { key: '3', value: { max: moment('2018-07-25').valueOf() } },
+            { key: '4', value: { max: 0 } },
+            { key: '5', value: { max: -1 } },
+            { key: '6', value: { max: moment('2018-08-16').valueOf() } }
+          ]
+        });
 
-            { key: '2', value: -1 },
-
-            { key: '3', value: 0 },
-            { key: '3', value: moment('2018-07-10').valueOf() },
-            { key: '3', value: moment('2018-07-11').valueOf() },
-            { key: '3', value: moment('2018-07-12').valueOf() },
-            { key: '3', value: moment('2018-07-13').valueOf() },
-            { key: '3', value: moment('2018-07-25').valueOf() }
+      db.query
+        .withArgs('medic-client/visits_by_date')
+        .resolves({
+          rows: [
+            { key: moment('2018-07-25').valueOf(), value: '3' },
+            { key: moment('2018-07-29').valueOf(), value: '1' },
+            { key: moment('2018-08-02').valueOf(), value: '1' },
+            { key: moment('2018-08-03').valueOf(), value: '1' },
+            { key: moment('2018-08-10').valueOf(), value: '1' },
+            { key: moment('2018-08-10').valueOf(), value: '1' },
+            { key: moment('2018-08-16').valueOf(), value: '6' }
           ]
         });
 
@@ -283,9 +307,16 @@ describe('Search service', function() {
           chai.expect(searchStub.callCount).to.equal(1);
           chai.expect(searchStub.args[0])
             .to.deep.equal(['contacts', {}, { limit: 50, skip: 0 }, extensions]);
-          chai.expect(db.query.callCount).to.equal(1);
-          chai.expect(db.query.args[0])
-            .to.deep.equal([ 'medic-client/contacts_by_last_visited', { reduce: false, keys: ['1', '2', '3']} ]);
+          chai.expect(db.query.callCount).to.equal(2);
+          chai.expect(db.query.args[0]).to.deep.equal([
+            'medic-client/visits_by_date',
+            {
+              start_key: moment('2018-07-25').startOf('day').valueOf(),
+              end_key: moment('2018-08-24').endOf('day').valueOf()
+            }
+          ]);
+          chai.expect(db.query.args[1])
+            .to.deep.equal([ 'medic-client/contacts_by_last_visited', { reduce: true, group: true }]);
 
           chai.expect(result).to.deep.equal([
             {
@@ -320,14 +351,30 @@ describe('Search service', function() {
         .withArgs('medic-client/contacts_by_last_visited')
         .resolves({
           rows: [
-            { key: '1', value: moment('2018-08-10 23:59:00').valueOf() }, // count
-            { key: '1', value: moment('2018-08-11 00:01:00').valueOf() }, // count
-            { key: '1', value: moment('2018-08-11 12:00:00').valueOf() }, // dupe
-            { key: '1', value: moment('2018-08-11 23:59:00').valueOf() }, // dupe
-            { key: '1', value: moment('2018-08-12 00:01:00').valueOf() }, // count, last visited
-
-            { key: '2', value: moment('2018-08-11 12:00:00').valueOf() }, // count
-            { key: '2', value: moment('2018-08-11 20:00:00').valueOf() }, // dupe, last visited
+            { key: '1', value: { max: moment('2018-08-12 00:01:00').valueOf() } },
+            { key: '2', value: { max: moment('2018-08-11 20:00:00').valueOf() } },
+            { key: '3', value: { max: moment('2018-08-03').valueOf() } },
+            { key: '4', value: { max: moment('2018-08-04').valueOf() } },
+            { key: '5', value: { max: moment('2018-08-05').valueOf() } },
+            { key: '12', value: { max: moment('2018-08-08').valueOf() } },
+          ]
+        });
+      db.query
+        .withArgs('medic-client/visits_by_date')
+        .resolves({
+          rows: [
+            { key: moment('2018-08-01').valueOf(), value: '3' },
+            { key: moment('2018-08-03').valueOf(), value: '3' },
+            { key: moment('2018-08-04').valueOf(), value: '4' },
+            { key: moment('2018-08-05').valueOf(), value: '5' },
+            { key: moment('2018-08-08').valueOf(), value: '12' },
+            { key: moment('2018-08-10 23:59:00').valueOf(), value: '1' }, // count
+            { key: moment('2018-08-11 00:01:00').valueOf(), value: '1' }, // count
+            { key: moment('2018-08-11 12:00:00').valueOf(), value: '1' }, // dupe
+            { key: moment('2018-08-11 23:59:00').valueOf(), value: '1' }, // dupe
+            { key: moment('2018-08-12 00:01:00').valueOf(), value: '1' }, // count
+            { key: moment('2018-08-11 12:00:00').valueOf(), value: '2' }, // count
+            { key: moment('2018-08-11 20:00:00').valueOf(), value: '2' }, // dupe
           ]
         });
 
@@ -357,6 +404,88 @@ describe('Search service', function() {
           }
         ]);
       });
+    });
+
+    it('should not query visits_by_date when receiving extended results from SearchLib', () => {
+      searchStub.resolves({
+        results: ['1', '2', '3', '4'],
+        extendedResults: [
+          { key: '1', value: { max: moment('2018-08-10').valueOf() } },
+            { key: '2', value: { max: moment('2018-08-18').valueOf() } },
+            { key: '3', value: { max: moment('2018-07-13').valueOf() } },
+            { key: '4', value: { max: -1 } },
+            { key: '5', value: { max: moment('2018-07-21').valueOf() } },
+            { key: '6', value: { max: moment('2018-06-01').valueOf() } },
+            { key: '7', value: { max: moment('2018-07-29').valueOf() } },
+            { key: '8', value: { max: moment('2018-07-30').valueOf() } },
+          ]
+      });
+      GetDataRecords.resolves([{ _id: '1' }, { _id: '2' }, { _id: '3' }, { _id: '4' }]);
+      db.query
+        .withArgs('medic-client/visits_by_date')
+        .resolves({
+          rows: [
+            { key: moment('2018-08-01').valueOf(), value: '1' },
+            { key: moment('2018-08-02').valueOf(), value: '2' },
+            { key: moment('2018-08-04').valueOf(), value: '2' },
+            { key: moment('2018-08-04').valueOf(), value: '5' },
+            { key: moment('2018-08-05').valueOf(), value: '5' },
+            { key: moment('2018-08-08').valueOf(), value: '5' },
+            { key: moment('2018-08-10').valueOf(), value: '1' },
+            { key: moment('2018-08-10').valueOf(), value: '1' },
+            { key: moment('2018-08-12').valueOf(), value: '6' },
+            { key: moment('2018-08-13').valueOf(), value: '6' },
+            { key: moment('2018-08-16').valueOf(), value: '2' },
+            { key: moment('2018-08-18').valueOf(), value: '2' },
+            { key: moment('2018-08-18').valueOf(), value: '2' },
+          ]
+        });
+
+      return service('contacts', {}, {}, { displayLastVisitedDate: true, sortByLastVisitedDate: true })
+        .then(result => {
+          chai.expect(searchStub.callCount).to.equal(1);
+          chai.expect(searchStub.args[0])
+            .to.deep.equal(['contacts', {}, { limit: 50, skip: 0 }, { displayLastVisitedDate: true, sortByLastVisitedDate: true }]);
+          chai.expect(db.query.callCount).to.equal(1);
+          chai.expect(db.query.args[0]).to.deep.equal([
+            'medic-client/visits_by_date',
+            {
+              start_key: moment('2018-08-01').startOf('day').valueOf(),
+              end_key: moment('2018-08-01').endOf('month').valueOf()
+            }
+          ]);
+          2
+          chai.expect(result).to.deep.equal([
+            {
+              _id: '1',
+              lastVisitedDate: moment('2018-08-10 00:00:00').valueOf(),
+              visitCountGoal: undefined,
+              visitCount: 2,
+              sortByLastVisitedDate: true
+            },
+            {
+              _id: '2',
+              lastVisitedDate: moment('2018-08-18 00:00:00').valueOf(),
+              visitCountGoal: undefined,
+              visitCount: 4,
+              sortByLastVisitedDate: true
+            },
+            {
+              _id: '3',
+              lastVisitedDate: moment('2018-07-13 00:00:00').valueOf(),
+              visitCountGoal: undefined,
+              visitCount: 0,
+              sortByLastVisitedDate: true
+            },
+            {
+              _id: '4',
+              lastVisitedDate: -1,
+              visitCountGoal: undefined,
+              visitCount: 0,
+              sortByLastVisitedDate: true
+            }
+          ]);
+        });
     });
   });
 
@@ -396,13 +525,15 @@ describe('Search service', function() {
       GetDataRecords.withArgs(['1', '2', '3', '4']).resolves([
         { _id: '1' }, { _id: '2' }, { _id: '3' }, { _id: '4' }
       ]);
+
+      db.query.withArgs('medic-client/visits_by_date').resolves({ rows: []});
       db.query
         .withArgs('medic-client/contacts_by_last_visited')
-        .resolves({ rows :[
-          { key: '1', value: 1 },
-          { key: '2', value: 2 },
-          { key: '3', value: 3 },
-          { key: '4', value: 4 },
+        .resolves({ rows: [
+          { key: '1', value: { max: 1 } },
+          { key: '2', value: { max: 2 } },
+          { key: '3', value: { max: 3 } },
+          { key: '4', value: { max: 4 } },
         ]});
 
       const extensions = { displayLastVisitedDate: true };
@@ -410,9 +541,13 @@ describe('Search service', function() {
       return service('contacts', {}, {}, extensions, ['3', '4']).then(results => {
         chai.expect(GetDataRecords.callCount).to.equal(1);
         chai.expect(GetDataRecords.args[0][0]).to.deep.equal(['1', '2', '3', '4']);
-        chai.expect(db.query.callCount).to.equal(1);
-        chai.expect(db.query.args[0])
-          .to.deep.equal([ 'medic-client/contacts_by_last_visited', { reduce: false, keys: ['1', '2', '3', '4']} ]);
+        chai.expect(db.query.callCount).to.equal(2);
+        chai.expect(db.query.args[0]).to.deep.equal([
+          'medic-client/visits_by_date',
+          { start_key: moment().startOf('month').valueOf(), end_key: moment().endOf('month').valueOf() }
+        ]);
+        chai.expect(db.query.args[1])
+          .to.deep.equal([ 'medic-client/contacts_by_last_visited', { reduce: true, group: true } ]);
 
         chai.expect(results).to.deep.equal([
           { _id: '1', lastVisitedDate: 1, visitCount: 0, visitCountGoal: undefined, sortByLastVisitedDate: undefined },

--- a/webapp/tests/karma/unit/services/session.js
+++ b/webapp/tests/karma/unit/services/session.js
@@ -219,4 +219,25 @@ describe('Session service', function() {
     });
 
   });
+
+  describe('isDbAdmin', () => {
+    it('should return false if not logged in', () => {
+      ipCookie.returns({});
+      chai.expect(service.isDbAdmin()).to.equal(false);
+    });
+
+    it('returns true for _admin', () => {
+      ipCookie.returns({ roles: [ '_admin' ] });
+      chai.expect(service.isDbAdmin()).to.equal(true);
+      chai.expect(service.isDbAdmin({ roles: ['_admin', 'aaaa'] })).to.equal(true);
+    });
+
+    it('returns false for everyone else', () => {
+      ipCookie.returns({ roles: [ 'district_admin', 'some_other_role' ] });
+      chai.expect(service.isDbAdmin()).to.equal(false);
+      ipCookie.returns({ roles: [ 'national_admin', 'some_other_role' ] });
+      chai.expect(service.isDbAdmin()).to.equal(false);
+      chai.expect(service.isDbAdmin({ roles: ['role1', 'national_admin'] })).to.equal(false);
+    });
+  });
 });


### PR DESCRIPTION
# Description

Adds a new view that indexes home_visits by date, to use with a `start_key` + `end_key` query to count montly vists.
When sorting by last visited date, Search lib now returns the whole results pool, to avoid querying for `contacts_by_visited_date` twice.
DB Admins no longer default to UHC (it was impossible to load Muso contacts list as an admin, the `contacts_by_last_visited` had over 9MB and everything timed out before it was downloaded).

medic/medic-webapp#4981

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
