### PR TITLE
[WIP] Lazy loading content in the contact's left panel

### DIFF
--- a/webapp/src/js/services/live-list.js
+++ b/webapp/src/js/services/live-list.js
@@ -72,6 +72,7 @@ angular.module('inboxServices').factory('LiveListConfig',
           scope.simprintsTier = contact.simprints && contact.simprints.tierNumber;
           scope.dod = contact.date_of_death;
           scope.muted = contact.muted;
+          scope.hydrating = contact.hydrating;
           if (contact.type !== 'person') {
             if (Number.isInteger(contact.lastVisitedDate) && contact.lastVisitedDate >= 0) {
               if (contact.lastVisitedDate === 0) {

--- a/webapp/src/templates/partials/content_row_list_item.html
+++ b/webapp/src/templates/partials/content_row_list_item.html
@@ -41,7 +41,7 @@ Places of interest
         </div>
       </div>
       <div class="summary">
-        <p class="{{overdue ? 'overdue' : ''}}">{{summary}}</p>
+        <p class="{{overdue ? 'overdue' : ''}} {{hydrating ? 'ng-hide' : ''}}">{{summary}}</p>
         <div class="status {{(valid && verified === undefined) ? 'ng-hide' : ''}}">
           <span class="verification-badge {{(valid && verified) ? 'verified' : 'error'}}" ng-bind-html="statusIcon | safeHtml"/>
         </div>


### PR DESCRIPTION
# Description

This change paints the "Contacts Panel" (left panel on the contact's tab) in two steps.  This results in increased perceived performance and can reduce the user's time to complete tasks. The user can interact with the page faster, while still getting the rich experiences which require longer load times.  

#4445

**The Downside** - This change requires the user to paint twice. Painting with Live-List is a costly operation, so the total time to the richer experience is regressed by this change (particularly when displayLastVisitedDates is false).  I'd say this is concerning and makes this a questionable win, particularly with #4998 in the pipe. We may want to consider performance optimizations to Live-List before considering this. 

The first paint triggers as soon as the contacts are fetched with no meta data (last visited date, primary contact, etc.). The second paint updates the existing page with the meta data after it is fetched.  

Related Changes - This can compliment both #4982 and #4998. Though #4998 reduces the time to fetch metadata and therefore reduces the upside of this change. 

An Edge Case - When the user selects to "sort by last visited," the content re-sorts on the second paint. This shuffle is likely confusing for users. Therefore, this lazy-loading experience is disabled when sorting by last visited date. 

The changes in GetDataSource and Search should scale to lazy loading content elsewhere (contacts-content panel, reports page, etc.) 

## Results 
All times in milliseconds.  
Times in format `x/y` - The `x` is time to first paint. The `y` is time to second paint.
Times are for heavy district admin user `adamayo` using muso-mali configurations.

### Performance for displayLastVisitedDates=true
Scenario | Trial 1 | Trial 2 | Trial 3 | Mean
-- | -- | -- | -- | --
SM-G903W master | 4562 | 3420 | 3595 | 3869
SM-G903W proposed | 741/4194 | 700/3814 | 715/3806 | 718/3938
SM-G361H master | 8145 | 7259 | 7245 | 7549
SM-G361H proposed | 1828/6937 | 1632/6426 | 1575/6642 | 1678/6668

### Performance for displayLastVisitedDates=false
Scenario | Trial 1 | Trial 2 | Trial 3 | Mean
-- | -- | -- | -- | --
SM-G903W master | 981 | 880 | 808 | 889
SM-G903W proposed | 829/1440 | 720/1345 | 669/1266 | 740/1350
SM-G361H master | 2005 | 1815 | 1907 | 1909
SM-G361H proposed | 1476/2795 | 1612/2818 | 1207/2318 | 1432/2643




# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
