### PR TITLE
Adds muting history

### DIFF
--- a/sentinel/src/lib/infodoc.js
+++ b/sentinel/src/lib/infodoc.js
@@ -131,7 +131,7 @@ const bulkGet = changes => {
 const bulkUpdate = infoDocs => {
   const legacyDocs = [];
 
-  if (!infoDocs || !infoDocs.legacy) {
+  if (!infoDocs || !infoDocs.length) {
     return;
   }
 
@@ -145,7 +145,7 @@ const bulkUpdate = infoDocs => {
     doc.latest_replication_date = new Date();
   });
 
-  return db.medic.bulkDocs(infoDocs).then(() => {
+  return db.sentinel.bulkDocs(infoDocs).then(() => {
     if (legacyDocs.length) {
       return db.medic.bulkDocs(legacyDocs);
     }
@@ -158,5 +158,6 @@ module.exports = {
   updateTransition: (change, transition, ok) =>
     updateTransition(change, transition, ok),
   bulkGet: bulkGet,
-  bulkUpdate: bulkUpdate
+  bulkUpdate: bulkUpdate,
+  updateInfoDoc: updateInfoDoc
 };

--- a/sentinel/src/lib/infodoc.js
+++ b/sentinel/src/lib/infodoc.js
@@ -1,7 +1,9 @@
 const db = require('../db-pouch'),
-  logger = require('../lib/logger'),
-  infoDocId = id => id + '-info',
-  getDocId = infoDocId => infoDocId.slice(0, -5);
+  logger = require('../lib/logger');
+
+const infoDocId = id => id + '-info';
+
+const getDocId = infoDocId => infoDocId.slice(0, -5);
 
 const findInfoDoc = (database, change) => {
   return database.get(infoDocId(change.id)).catch(err => {
@@ -164,6 +166,5 @@ module.exports = {
   updateTransition: (change, transition, ok) =>
     updateTransition(change, transition, ok),
   bulkGet: bulkGet,
-  bulkUpdate: bulkUpdate,
-  updateInfoDoc: updateInfoDoc
+  bulkUpdate: bulkUpdate
 };

--- a/sentinel/src/lib/infodoc.js
+++ b/sentinel/src/lib/infodoc.js
@@ -1,6 +1,7 @@
 const db = require('../db-pouch'),
   logger = require('../lib/logger'),
-  infoDocId = id => id + '-info';
+  infoDocId = id => id + '-info',
+  getDocId = infoDocId => infoDocId.slice(0, -5);
 
 const findInfoDoc = (database, change) => {
   return database.get(infoDocId(change.id)).catch(err => {
@@ -9,6 +10,12 @@ const findInfoDoc = (database, change) => {
     }
     throw err;
   });
+};
+
+const findInfoDocs = (database, changes) => {
+  return database
+    .allDocs({ keys: changes.map(change => infoDocId(change.id)), include_docs: true })
+    .then(results => results.rows);
 };
 
 const getInfoDoc = change => {
@@ -89,9 +96,67 @@ const updateTransition = (change, transition, ok) => {
   });
 };
 
+const bulkGet = changes => {
+  const infoDocs = [];
+
+  if (!changes || !changes.length) {
+    return;
+  }
+
+  return findInfoDocs(db.sentinel, changes)
+    .then(result => {
+      const missing = [];
+      result.forEach(row => row.error ? missing.push({ id: getDocId(row.key) }) : infoDocs.push(row.doc));
+
+      if (!missing.length) {
+        return [];
+      }
+
+      return findInfoDocs(db.medic, missing);
+    })
+    .then(result => {
+      result.forEach(row => {
+        if (row.error) {
+          return infoDocs.push(createInfoDoc(getDocId(row.key), 'unknown'));
+        }
+
+        row.doc.legacy = true;
+        infoDocs.push(row.doc);
+      });
+
+      return infoDocs;
+    });
+};
+
+const bulkUpdate = infoDocs => {
+  const legacyDocs = [];
+
+  if (!infoDocs || !infoDocs.legacy) {
+    return;
+  }
+
+  infoDocs.forEach(doc => {
+    if (doc.legacy) {
+      delete doc.legacy;
+      legacyDocs.push(Object.assign({ _deleted: true }, doc));
+      delete doc._rev;
+    }
+
+    doc.latest_replication_date = new Date();
+  });
+
+  return db.medic.bulkDocs(infoDocs).then(() => {
+    if (legacyDocs.length) {
+      return db.medic.bulkDocs(legacyDocs);
+    }
+  });
+};
+
 module.exports = {
   get: change => getInfoDoc(change),
   delete: change => deleteInfoDoc(change),
   updateTransition: (change, transition, ok) =>
     updateTransition(change, transition, ok),
+  bulkGet: bulkGet,
+  bulkUpdate: bulkUpdate
 };

--- a/sentinel/src/lib/infodoc.js
+++ b/sentinel/src/lib/infodoc.js
@@ -107,7 +107,7 @@ const bulkGet = changes => {
     .then(result => {
       const missing = [];
       result.forEach(row => {
-        if (row.error) {
+        if (!row.doc) {
           missing.push({ id: getDocId(row.key) });
         } else {
           infoDocs.push(row.doc);
@@ -122,7 +122,7 @@ const bulkGet = changes => {
     })
     .then(result => {
       result.forEach(row => {
-        if (row.error) {
+        if (!row.doc) {
           infoDocs.push(createInfoDoc(getDocId(row.key), 'unknown'));
         } else {
           row.doc.legacy = true;

--- a/sentinel/src/lib/muting_utils.js
+++ b/sentinel/src/lib/muting_utils.js
@@ -2,7 +2,8 @@ const _ = require('underscore'),
       db = require('../db-pouch'),
       lineage = require('@shared-libs/lineage')(Promise, db.medic),
       utils = require('./utils'),
-      moment = require('moment');
+      moment = require('moment'),
+      infodoc = require('./infodoc');
 
 const SUBJECT_PROPERTIES = ['_id', 'patient_id', 'place_id'],
       BATCH_SIZE = 50;
@@ -46,19 +47,21 @@ const updateRegistration = (dataRecord, muted) => {
 };
 
 const updateContacts = (contacts, muted) => {
-  contacts = contacts.filter(contact => {
-    return Boolean(contact.muted) !== Boolean(muted) ? updateContact(contact, muted) : false;
-  });
-
   if (!contacts.length) {
-    return;
+    return Promise.resolve();
   }
+  contacts.forEach(contact => updateContact(contact, muted));
 
   return db.medic.bulkDocs(contacts);
 };
 
 const updateContact = (contact, muted) => {
-  contact.muted = muted;
+  if (muted) {
+    contact.muted = muted;
+  } else {
+    delete contact.muted;
+  }
+
   return contact;
 };
 
@@ -80,7 +83,7 @@ const updateRegistrations = (subjectIds, muted) => {
 
 const getSubjectIds = contact => _.values(_.pick(contact, SUBJECT_PROPERTIES));
 
-const getContactsAndSubjectIds = (contactIds) => {
+const getContactsAndSubjectIds = (contactIds, muted) => {
   return db.medic
     .allDocs({ keys: contactIds, include_docs: true })
     .then(result => {
@@ -88,7 +91,7 @@ const getContactsAndSubjectIds = (contactIds) => {
             subjectIds = [];
 
       result.rows.forEach(row => {
-        if (!row.doc) {
+        if (!row.doc || Boolean(row.doc.muted) === Boolean(muted)) {
           return;
         }
         contacts.push(row.doc);
@@ -99,8 +102,34 @@ const getContactsAndSubjectIds = (contactIds) => {
     });
 };
 
-const updateMuteState = (contact, muted) => {
-  const timestamp = moment().valueOf();
+const updateMutingHistories = (contacts, muted, reportId) => {
+  if (!contacts.length) {
+    return Promise.resolve();
+  }
+
+  return infodoc
+    .bulkGet(contacts.map(contact => ({ id: contact._id, doc: contact })))
+    .then(infoDocs => infoDocs.map(_.partial(addMutingHistory, _, muted, reportId)))
+    .then(infoDocs => infodoc.bulkUpdate(infoDocs));
+};
+
+const updateMutingHistory = (contact, muted, reportId) => {
+  return updateMutingHistories([contact], muted, reportId);
+};
+
+const addMutingHistory = (infoDoc, muted, reportId) => {
+  infoDoc.muting_history = infoDoc.muting_history || [];
+  infoDoc.muting_history.push({
+    muted: !!muted,
+    date: muted || moment(),
+    report_id: reportId
+  });
+
+  return infoDoc;
+};
+
+const updateMuteState = (contact, muted, reportId) => {
+  muted = muted && moment();
 
   let rootContactId;
   if (muted) {
@@ -122,10 +151,11 @@ const updateMuteState = (contact, muted) => {
     return batches
       .reduce((promise, batch) => {
         return promise
-          .then(() => getContactsAndSubjectIds(batch))
+          .then(() => getContactsAndSubjectIds(batch, muted))
           .then(result => Promise.all([
-            updateContacts(result.contacts, muted ? timestamp : false),
-            updateRegistrations(result.subjectIds, muted)
+            updateContacts(result.contacts, muted),
+            updateRegistrations(result.subjectIds, muted),
+            updateMutingHistories(result.contacts, muted, reportId)
           ]));
       }, Promise.resolve());
   });
@@ -166,7 +196,9 @@ module.exports = {
   isMutedInLineage: isMutedInLineage,
   unmuteMessages: unmuteMessages,
   muteUnsentMessages: muteUnsentMessages,
+  updateMutingHistory: updateMutingHistory,
   _getContactsAndSubjectIds: getContactsAndSubjectIds,
   _updateContacts: updateContacts,
+  _updateMuteHistories: updateMutingHistories,
   _lineage: lineage
 };

--- a/sentinel/src/lib/muting_utils.js
+++ b/sentinel/src/lib/muting_utils.js
@@ -50,8 +50,8 @@ const updateContacts = (contacts, muted) => {
   if (!contacts.length) {
     return Promise.resolve();
   }
-  contacts.forEach(contact => updateContact(contact, muted));
 
+  contacts.forEach(contact => updateContact(contact, muted));
   return db.medic.bulkDocs(contacts);
 };
 
@@ -109,7 +109,7 @@ const updateMutingHistories = (contacts, muted, reportId) => {
 
   return infodoc
     .bulkGet(contacts.map(contact => ({ id: contact._id, doc: contact })))
-    .then(infoDocs => infoDocs.map(_.partial(addMutingHistory, _, muted, reportId)))
+    .then(infoDocs => infoDocs.map(info => addMutingHistory(info, muted, reportId)))
     .then(infoDocs => infodoc.bulkUpdate(infoDocs));
 };
 
@@ -117,15 +117,15 @@ const updateMutingHistory = (contact, muted, reportId) => {
   return updateMutingHistories([contact], muted, reportId);
 };
 
-const addMutingHistory = (infoDoc, muted, reportId) => {
-  infoDoc.muting_history = infoDoc.muting_history || [];
-  infoDoc.muting_history.push({
+const addMutingHistory = (info, muted, reportId) => {
+  info.muting_history = info.muting_history || [];
+  info.muting_history.push({
     muted: !!muted,
     date: muted || moment(),
     report_id: reportId
   });
 
-  return infoDoc;
+  return info;
 };
 
 const updateMuteState = (contact, muted, reportId) => {

--- a/sentinel/src/lib/muting_utils.js
+++ b/sentinel/src/lib/muting_utils.js
@@ -114,7 +114,7 @@ const updateMutingHistories = (contacts, muted, reportId) => {
 };
 
 const updateMutingHistory = (contact, muted) => {
-  const mutedParentId = isMutedInLineage(contact, true);
+  const mutedParentId = isMutedInLineage(contact);
 
   return infodoc
     .bulkGet([{ id: mutedParentId }])
@@ -174,11 +174,11 @@ const updateMuteState = (contact, muted, reportId) => {
   });
 };
 
-const isMutedInLineage = (doc, returnId) => {
+const isMutedInLineage = doc => {
   let parent = doc && doc.parent;
   while (parent) {
     if (parent.muted) {
-      return returnId ? parent._id : true;
+      return parent._id;
     }
     parent = parent.parent;
   }

--- a/sentinel/src/transitions/muting.js
+++ b/sentinel/src/transitions/muting.js
@@ -71,9 +71,11 @@ module.exports = {
   onMatch: change => {
     if (change.doc.type !== 'data_record') {
       // process new contacts
-      mutingUtils.updateContact(change.doc, true);
+      const muted = new Date();
+      mutingUtils.updateContact(change.doc, muted);
       return mutingUtils
-        .updateRegistrations(mutingUtils.getSubjectIds(change.doc), true)
+        .updateRegistrations(mutingUtils.getSubjectIds(change.doc), muted)
+        .then(() => mutingUtils.updateMutingHistory(change.doc, muted))
         .then(() => true);
     }
 
@@ -98,7 +100,7 @@ module.exports = {
               return;
             }
 
-            return mutingUtils.updateMuteState(contact, muteState);
+            return mutingUtils.updateMuteState(contact, muteState, change.id);
           });
       })
       .then(changed => changed && module.exports._addMsg(getEventType(muteState), change.doc, targetContact))

--- a/sentinel/tests/unit/lib/infodoc.js
+++ b/sentinel/tests/unit/lib/infodoc.js
@@ -3,8 +3,15 @@ const assert = require('chai').assert,
   db = require('../../../src/db-pouch'),
   infodoc = require('../../../src/lib/infodoc');
 
+let clock;
+
 describe('infodoc', () => {
-  afterEach(() => sinon.restore());
+  afterEach(() => {
+    sinon.restore();
+    if (clock) {
+      clock.restore();
+    }
+  });
 
   it('gets infodoc from medic and moves it to sentinel', () => {
     const change = {id: 'messages-en'};
@@ -26,6 +33,174 @@ describe('infodoc', () => {
       assert.equal(updateSentinelInfo.args[0][0]._id, info._id);
       assert(!updateSentinelInfo.args[0][0]._rev);
       assert.deepEqual(updateSentinelInfo.args[0][0].transitions, []);
+    });
+  });
+
+  describe('bulkGet', () => {
+    it('should do nothing when parameter is empty', () => {
+      sinon.stub(db.sentinel, 'allDocs');
+      sinon.stub(db.medic, 'allDocs');
+
+      assert.equal(infodoc.bulkGet(), undefined);
+      assert.equal(infodoc.bulkGet(false), undefined);
+      assert.equal(infodoc.bulkGet([]), undefined);
+
+      assert.equal(db.sentinel.allDocs.callCount, 0);
+      assert.equal(db.medic.allDocs.callCount, 0);
+    });
+
+    it('should return infodocs when all are found in sentinel db', () => {
+      const changes = [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
+            infoDocs = [{ _id: 'a-info' }, { _id: 'b-info' }, { _id: 'c-info' }];
+
+      sinon.stub(db.sentinel, 'allDocs')
+        .resolves({ rows: infoDocs.map(doc => ({ key: doc._id, doc }))});
+      sinon.stub(db.medic, 'allDocs');
+
+      return infodoc.bulkGet(changes).then(result => {
+        assert.deepEqual(result, [
+          { _id: 'a-info' },
+          { _id: 'b-info' },
+          { _id: 'c-info' }
+        ]);
+
+        assert.equal(db.sentinel.allDocs.callCount, 1);
+        assert.deepEqual(db.sentinel.allDocs.args[0], [{ keys: ['a-info', 'b-info', 'c-info'], include_docs: true }]);
+        assert.equal(db.medic.allDocs.callCount, 0);
+      });
+    });
+
+    it('should return infodocs when all are found in medic db', () => {
+      const changes = [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
+            infoDocs = [{ _id: 'a-info', _rev: 'a-r' }, { _id: 'b-info', _rev: 'b-r' }, { _id: 'c-info', _rev: 'c-r' }];
+
+      sinon.stub(db.sentinel, 'allDocs')
+        .resolves({ rows: infoDocs.map(doc => ({ key: doc._id, error: 'not_found' }))});
+      sinon.stub(db.medic, 'allDocs')
+        .resolves({ rows: infoDocs.map(doc => ({ key: doc._id, doc }))});
+
+      return infodoc.bulkGet(changes).then(result => {
+        assert.deepEqual(result, [
+          { _id: 'a-info', _rev: 'a-r', legacy: true },
+          { _id: 'b-info', _rev: 'b-r', legacy: true },
+          { _id: 'c-info', _rev: 'c-r', legacy: true }
+        ]);
+
+        assert.equal(db.sentinel.allDocs.callCount, 1);
+        assert.deepEqual(db.sentinel.allDocs.args[0], [{ keys: ['a-info', 'b-info', 'c-info'], include_docs: true }]);
+        assert.equal(db.medic.allDocs.callCount, 1);
+        assert.deepEqual(db.medic.allDocs.args[0], [{ keys: ['a-info', 'b-info', 'c-info'], include_docs: true }]);
+      });
+    });
+
+    it('should generate infodocs when all are new', () => {
+      const changes = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+
+      sinon.stub(db.sentinel, 'allDocs')
+        .resolves({ rows: changes.map(doc => ({ key: `${doc.id}-info`, error: 'not_found' }))});
+      sinon.stub(db.medic, 'allDocs')
+        .resolves({ rows: changes.map(doc => ({ key: `${doc.id}-info`, error: 'not_found' }))});
+
+      return infodoc.bulkGet(changes).then(result => {
+        assert.deepEqual(result, [
+          { _id: 'a-info', type: 'info', doc_id: 'a', initial_replication_date: 'unknown'},
+          { _id: 'b-info', type: 'info', doc_id: 'b', initial_replication_date: 'unknown' },
+          { _id: 'c-info', type: 'info', doc_id: 'c', initial_replication_date: 'unknown' }
+        ]);
+
+        assert.equal(db.sentinel.allDocs.callCount, 1);
+        assert.deepEqual(db.sentinel.allDocs.args[0], [{ keys: ['a-info', 'b-info', 'c-info'], include_docs: true }]);
+        assert.equal(db.medic.allDocs.callCount, 1);
+        assert.deepEqual(db.medic.allDocs.args[0], [{ keys: ['a-info', 'b-info', 'c-info'], include_docs: true }]);
+      });
+    });
+
+    it('should work with a mix of all', () => {
+      const changes = [{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }, { id: 'e' }, { id: 'f' }];
+
+      sinon.stub(db.sentinel, 'allDocs')
+        .resolves({ rows: [
+            { key: 'a-info', id: 'a-info', doc: { _id: 'a-info', _rev: 'a-r', doc_id: 'a' } },
+            { key: 'b-info', error: 'not_found' },
+            { key: 'c-info', error: 'deleted' },
+            { key: 'd-info', id: 'd-info', doc: { _id: 'd-info', _rev: 'd-r', doc_id: 'd' } },
+            { key: 'e-info', error: 'deleted' },
+            { key: 'f-info', error: 'something' },
+          ]});
+      sinon.stub(db.medic, 'allDocs')
+        .resolves({ rows: [
+            { key: 'b-info', id: 'b-info', doc: { _id: 'b-info', _rev: 'b-r', doc_id: 'b' } },
+            { key: 'c-info', error: 'some error' },
+            { key: 'e-info', error: 'some error' },
+            { key: 'f-info', id: 'f-info', doc: { _id: 'f-info', _rev: 'f-r', doc_id: 'f' } },
+          ]});
+
+      return infodoc.bulkGet(changes).then(result => {
+        assert.deepEqual(result, [
+          { _id: 'a-info', _rev: 'a-r', doc_id: 'a' },
+          { _id: 'd-info', _rev: 'd-r', doc_id: 'd' },
+          { _id: 'b-info', _rev: 'b-r', doc_id: 'b', legacy: true },
+          { _id: 'c-info', doc_id: 'c', initial_replication_date: 'unknown', type: 'info' },
+          { _id: 'e-info', doc_id: 'e', initial_replication_date: 'unknown', type: 'info' },
+          { _id: 'f-info', _rev: 'f-r', doc_id: 'f', legacy: true },
+        ]);
+
+        assert.equal(db.sentinel.allDocs.callCount, 1);
+        assert.deepEqual(
+          db.sentinel.allDocs.args[0],
+          [{ keys: ['a-info', 'b-info', 'c-info', 'd-info', 'e-info', 'f-info'], include_docs: true } ]
+        );
+        assert.equal(db.medic.allDocs.callCount, 1);
+        assert.deepEqual(
+          db.medic.allDocs.args[0],
+          [{ keys: ['b-info', 'c-info', 'e-info', 'f-info'], include_docs: true }]
+        );
+      });
+    });
+
+    it('should throw sentinel all docs errors', () => {
+      sinon.stub(db.sentinel, 'allDocs').rejects({ some: 'error' });
+
+      return infodoc
+        .bulkGet([{ id: 'a' }])
+        .then(r => assert(r))
+        .catch(err => assert.deepEqual(err, { some: 'error' }));
+    });
+  });
+
+  describe('bulkUpdate', () => {
+    it('should do nothing when parameter is empty', () => {
+      sinon.stub(db.sentinel, 'bulkDocs');
+      sinon.stub(db.medic, 'bulkDocs');
+
+      assert.equal(infodoc.bulkGet(), undefined);
+      assert.equal(infodoc.bulkGet(false), undefined);
+      assert.equal(infodoc.bulkGet([]), undefined);
+
+      assert.equal(db.sentinel.bulkDocs.callCount, 0);
+      assert.equal(db.medic.bulkDocs.callCount, 0);
+    });
+
+    it('should save all docs when none are legacy', () => {
+      sinon.stub(db.sentinel, 'bulkDocs').resolves();
+      sinon.stub(db.medic, 'bulkDocs');
+      clock = sinon.useFakeTimers();
+
+      const infoDocs = [ { _id: 'a-info' }, { _id: 'b-info' }, { _id: 'c-info' }, { _id: 'd-info' } ];
+
+      return infodoc.bulkUpdate(infoDocs).then(() => {
+        assert.equal(db.sentinel.bulkDocs.callCount, 1);
+        assert.deepEqual(db.sentinel.bulkDocs.args[0], [[
+          { _id: 'a-info', latest_replication_date: new Date() },
+          { _id: 'b-info', latest_replication_date: new Date() },
+          { _id: 'x-info', latest_replication_date: new Date() }
+        ]]);
+        assert.equal(db.medic.bulkDocs.callCount, 0);
+      });
+    });
+
+    it('should delete legacy docs', () => {
+
     });
   });
 });

--- a/sentinel/tests/unit/lib/muting_utils.js
+++ b/sentinel/tests/unit/lib/muting_utils.js
@@ -1152,11 +1152,8 @@ describe('mutingUtils', () => {
   describe('isMutedInLineage', () => {
     it('should return false when no doc or no parent', () => {
       mutingUtils.isMutedInLineage().should.equal(false);
-      mutingUtils.isMutedInLineage(undefined, true).should.equal(false);
       mutingUtils.isMutedInLineage({}).should.equal(false);
-      mutingUtils.isMutedInLineage({}, true).should.equal(false);
       mutingUtils.isMutedInLineage({ parent: false }).should.equal(false);
-      mutingUtils.isMutedInLineage({ parent: false }, true).should.equal(false);
     });
 
     it('should return false when no parent is muted', () => {
@@ -1174,10 +1171,8 @@ describe('mutingUtils', () => {
       };
 
       mutingUtils.isMutedInLineage(doc).should.equal(false);
-      mutingUtils.isMutedInLineage(doc, true).should.equal(false);
       doc.muted = true;
       mutingUtils.isMutedInLineage(doc).should.equal(false);
-      mutingUtils.isMutedInLineage(doc, true).should.equal(false);
     });
 
     it('should return false when no parent is muted', () => {
@@ -1194,8 +1189,7 @@ describe('mutingUtils', () => {
           }
         }
       };
-      mutingUtils.isMutedInLineage(doc1).should.equal(true);
-      mutingUtils.isMutedInLineage(doc1, true).should.equal(2);
+      mutingUtils.isMutedInLineage(doc1).should.equal(2);
 
       const doc2 = {
         _id: 1,
@@ -1210,8 +1204,8 @@ describe('mutingUtils', () => {
           }
         }
       };
-      mutingUtils.isMutedInLineage(doc2).should.equal(true);
-      mutingUtils.isMutedInLineage(doc2, true).should.equal(4);
+
+      mutingUtils.isMutedInLineage(doc2).should.equal(4);
     });
   });
 

--- a/sentinel/tests/unit/lib/muting_utils.js
+++ b/sentinel/tests/unit/lib/muting_utils.js
@@ -419,12 +419,12 @@ describe('mutingUtils', () => {
 
         chai.expect(infodoc.bulkGet.callCount).to.equal(1);
         chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[
-          { id: 'my-place', doc: { _id: 'my-place', muted: moment(), place_id: 'my-place-id'} },
-          { id: 'my-place2', doc: { _id: 'my-place2', muted: moment() } },
-          { id: 'my-place3', doc: { _id: 'my-place3', place_id: 'place3', muted: moment() }},
-          { id: 'contact1', doc: { _id: 'contact1', patient_id: 'patient1', muted: moment() } },
-          { id: 'contact2', doc: { _id: 'contact2', patient_id: 'patient2', muted: moment() } },
-          { id: 'contact3', doc: { _id: 'contact3', patient_id: 'patient3', muted: moment() } }
+          { id: 'my-place' },
+          { id: 'my-place2' },
+          { id: 'my-place3' },
+          { id: 'contact1' },
+          { id: 'contact2' },
+          { id: 'contact3' }
         ]]);
         chai.expect(infodoc.bulkUpdate.callCount).to.equal(1);
       });
@@ -496,10 +496,10 @@ describe('mutingUtils', () => {
 
         chai.expect(infodoc.bulkGet.callCount).to.equal(1);
         chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[
-          { id: 'my-place', doc: { _id: 'my-place', place_id: 'my-place1' } },
-          { id: 'my-place2', doc: { _id: 'my-place2' } },
-          { id: 'my-place4', doc: { _id: 'my-place4' } },
-          { id: 'contact4', doc: { _id: 'contact4', patient_id: 'patient4' } }
+          { id: 'my-place' },
+          { id: 'my-place2' },
+          { id: 'my-place4' },
+          { id: 'contact4' }
         ]]);
         chai.expect(infodoc.bulkUpdate.callCount).to.equal(1);
       });
@@ -574,11 +574,11 @@ describe('mutingUtils', () => {
 
         chai.expect(infodoc.bulkGet.callCount).to.equal(1);
         chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[
-          { id: 'p2', doc: { _id: 'p2' } },
-          { id: 'p1', doc: { _id: 'p1' } },
-          { id: 'my-place', doc: { _id: 'my-place' } },
-          { id: 'contact1', doc: { _id: 'contact1', patient_id: 'patient1' } },
-          { id: 'contact2', doc: { _id: 'contact2', patient_id: 'patient2' } }
+          { id: 'p2' },
+          { id: 'p1' },
+          { id: 'my-place' },
+          { id: 'contact1' },
+          { id: 'contact2' }
         ]]);
         chai.expect(infodoc.bulkUpdate.callCount).to.equal(1);
       });
@@ -636,9 +636,7 @@ describe('mutingUtils', () => {
         ]]);
 
         chai.expect(infodoc.bulkGet.callCount).to.equal(1);
-        chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[
-          { id: 'contact', doc: { _id: 'contact', patient_id: 'patient', muted: moment() } }
-        ]]);
+        chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[ { id: 'contact' } ]]);
         chai.expect(infodoc.bulkUpdate.callCount).to.equal(1);
       });
     });
@@ -840,21 +838,21 @@ describe('mutingUtils', () => {
 
         chai.expect(infodoc.bulkGet.callCount).to.equal(3);
         chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[
-          { id: 'a', doc: { _id: 'a', muted: moment() } },
-          { id: 'b', doc: { _id: 'b', muted: moment() } },
-          { id: 'c', doc: { _id: 'c', muted: moment() } }
+          { id: 'a' },
+          { id: 'b' },
+          { id: 'c' }
         ]]);
 
         chai.expect(infodoc.bulkGet.args[1]).to.deep.equal([[
-          { id: 'd', doc: { _id: 'd', muted: moment() } },
-          { id: 'e', doc: { _id: 'e', muted: moment() } },
-          { id: 'f', doc: { _id: 'f', muted: moment() } }
+          { id: 'd' },
+          { id: 'e' },
+          { id: 'f' }
         ]]);
 
         chai.expect(infodoc.bulkGet.args[2]).to.deep.equal([[
-          { id: 'g', doc: { _id: 'g', muted: moment() } },
-          { id: 'h', doc: { _id: 'h', muted: moment() } },
-          { id: 'i', doc: { _id: 'i', muted: moment() } }
+          { id: 'g' },
+          { id: 'h' },
+          { id: 'i' }
         ]]);
         chai.expect(infodoc.bulkUpdate.callCount).to.equal(3);
       });
@@ -1154,8 +1152,11 @@ describe('mutingUtils', () => {
   describe('isMutedInLineage', () => {
     it('should return false when no doc or no parent', () => {
       mutingUtils.isMutedInLineage().should.equal(false);
+      mutingUtils.isMutedInLineage(undefined, true).should.equal(false);
       mutingUtils.isMutedInLineage({}).should.equal(false);
+      mutingUtils.isMutedInLineage({}, true).should.equal(false);
       mutingUtils.isMutedInLineage({ parent: false }).should.equal(false);
+      mutingUtils.isMutedInLineage({ parent: false }, true).should.equal(false);
     });
 
     it('should return false when no parent is muted', () => {
@@ -1173,8 +1174,10 @@ describe('mutingUtils', () => {
       };
 
       mutingUtils.isMutedInLineage(doc).should.equal(false);
+      mutingUtils.isMutedInLineage(doc, true).should.equal(false);
       doc.muted = true;
       mutingUtils.isMutedInLineage(doc).should.equal(false);
+      mutingUtils.isMutedInLineage(doc, true).should.equal(false);
     });
 
     it('should return false when no parent is muted', () => {
@@ -1192,6 +1195,7 @@ describe('mutingUtils', () => {
         }
       };
       mutingUtils.isMutedInLineage(doc1).should.equal(true);
+      mutingUtils.isMutedInLineage(doc1, true).should.equal(2);
 
       const doc2 = {
         _id: 1,
@@ -1206,7 +1210,7 @@ describe('mutingUtils', () => {
           }
         }
       };
-      mutingUtils.isMutedInLineage(doc2).should.equal(true);
+      mutingUtils.isMutedInLineage(doc2, true).should.equal(4);
     });
   });
 
@@ -1332,15 +1336,36 @@ describe('mutingUtils', () => {
         type: 'info',
         transitions: {}
       };
+      const parentInfo = {
+        _id: 'parent-info',
+        doc_id: 'parent',
+        type: 'info',
+        muting_history: [
+          { muted: true, report_id: 'report1' },
+          { muted: false, report_id: 'report2' },
+          { muted: true, report_id: 'report3' }
+        ]
+      };
+      const contact = {
+        _id: 'contact',
+        parent: {
+          _id: 'a',
+          parent: {
+            _id: 'parent',
+            muted: 'sometime this year'
+          }
+        }
+      };
 
-      infodoc.bulkGet.resolves([ info ]);
+      infodoc.bulkGet
+        .onCall(0).resolves([ parentInfo ])
+        .onCall(1).resolves([ info ]);
       infodoc.bulkUpdate.resolves();
 
-      return mutingUtils.updateMutingHistory({ _id: 'contact' }, moment(1234), 'report_id').then(() => {
-        chai.expect(infodoc.bulkGet.callCount).to.equal(1);
-        chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[
-          { id: 'contact', doc: { _id: 'contact' } }
-        ]]);
+      return mutingUtils.updateMutingHistory(contact, moment(1234)).then(() => {
+        chai.expect(infodoc.bulkGet.callCount).to.equal(2);
+        chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[ { id: 'parent' } ]]);
+        chai.expect(infodoc.bulkGet.args[1]).to.deep.equal([[ { id: 'contact' } ]]);
         chai.expect(infodoc.bulkUpdate.args[0]).to.deep.equal([[{
           _id: 'contact-info',
           doc_id: 'contact',
@@ -1349,7 +1374,7 @@ describe('mutingUtils', () => {
           muting_history: [{
             muted: true,
             date: moment(1234),
-            report_id: 'report_id'
+            report_id: 'report3'
           }]
         }]]);
       });
@@ -1369,15 +1394,40 @@ describe('mutingUtils', () => {
           }
         ]
       };
+      const parentInfo = {
+        _id: 'parent-info',
+        doc_id: 'parent',
+        type: 'info',
+        muting_history: [
+          { muted: true, report_id: 'report1' },
+          { muted: false, report_id: 'report2' },
+          { muted: true, report_id: 'report3' },
+          { muted: false, report_id: 'report4' }
+        ]
+      };
+      const contact = {
+        _id: 'contact',
+        parent: {
+          _id: 'a',
+          parent: {
+            _id: 'b',
+            parent: {
+              _id: 'parent',
+              muted: 'sometime this year'
+            }
+          }
+        }
+      };
 
-      infodoc.bulkGet.resolves([ info ]);
+      infodoc.bulkGet
+        .onCall(0).resolves([ parentInfo ])
+        .onCall(1).resolves([ info ]);
       infodoc.bulkUpdate.resolves();
 
-      return mutingUtils.updateMutingHistory({ _id: 'contact' }, false, 'report_id_2').then(() => {
-        chai.expect(infodoc.bulkGet.callCount).to.equal(1);
-        chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[
-          { id: 'contact', doc: { _id: 'contact' } }
-        ]]);
+      return mutingUtils.updateMutingHistory(contact, false).then(() => {
+        chai.expect(infodoc.bulkGet.callCount).to.equal(2);
+        chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[ { id: 'parent' } ]]);
+        chai.expect(infodoc.bulkGet.args[1]).to.deep.equal([[ { id: 'contact' } ]]);
         chai.expect(infodoc.bulkUpdate.args[0]).to.deep.equal([[{
           _id: 'contact-info',
           doc_id: 'contact',
@@ -1392,52 +1442,7 @@ describe('mutingUtils', () => {
             {
               muted: false,
               date: moment(),
-              report_id: 'report_id_2'
-            }
-          ]
-        }]]);
-      });
-    });
-
-    it('should work when report_id when not provided', () => {
-      const info = {
-        _id: 'id-info',
-        doc_id: 'id',
-        type: 'info',
-        transitions: {},
-        muting_history: [
-          {
-            muted: true,
-            date: 'some date',
-            report_id: 'report_id'
-          }
-        ]
-      };
-
-      infodoc.bulkGet.resolves([ info ]);
-      infodoc.bulkUpdate.resolves();
-
-      return mutingUtils.updateMutingHistory({ _id: 'id' }, false).then(() => {
-        chai.expect(infodoc.bulkGet.callCount).to.equal(1);
-        chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[
-          { id: 'id', doc: { _id: 'id' } }
-        ]]);
-        chai.expect(infodoc.bulkUpdate.callCount).to.equal(1);
-        chai.expect(infodoc.bulkUpdate.args[0]).to.deep.equal([[{
-          _id: 'id-info',
-          doc_id: 'id',
-          type: 'info',
-          transitions: {},
-          muting_history: [
-            {
-              muted: true,
-              date: 'some date',
-              report_id: 'report_id'
-            },
-            {
-              muted: false,
-              date: moment(),
-              report_id: undefined
+              report_id: 'report4'
             }
           ]
         }]]);
@@ -1445,14 +1450,21 @@ describe('mutingUtils', () => {
     });
 
     it('should save provided muted value when truthy', () => {
+      const contact = {
+        _id: 'a',
+        parent: {
+          _id: 'b',
+          muted: 'aaa'
+        }
+      };
+
       infodoc.bulkGet.resolves([{}]);
       infodoc.bulkUpdate.resolves();
 
-      return mutingUtils.updateMutingHistory({ _id: 'a' }, 'something').then(() => {
-        chai.expect(infodoc.bulkGet.callCount).to.equal(1);
-        chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[
-          { id: 'a', doc: { _id: 'a' } }
-        ]]);
+      return mutingUtils.updateMutingHistory(contact, 'something').then(() => {
+        chai.expect(infodoc.bulkGet.callCount).to.equal(2);
+        chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[ { id: 'b' } ]]);
+        chai.expect(infodoc.bulkGet.args[1]).to.deep.equal([[ { id: 'a' } ]]);
         chai.expect(infodoc.bulkUpdate.callCount).to.equal(1);
         chai.expect(infodoc.bulkUpdate.args[0]).to.deep.equal([[{
           muting_history: [
@@ -1467,14 +1479,21 @@ describe('mutingUtils', () => {
     });
 
     it('should save current date when falsy', () => {
+      const contact = {
+        _id: 'a',
+        parent: {
+          _id: 'b',
+          muted: 'aaa'
+        }
+      };
+
       infodoc.bulkGet.resolves([{}]);
       infodoc.bulkUpdate.resolves();
 
-      return mutingUtils.updateMutingHistory({ _id: 'a' }, undefined).then(() => {
-        chai.expect(infodoc.bulkGet.callCount).to.equal(1);
-        chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[
-          { id: 'a', doc: { _id: 'a' } }
-        ]]);
+      return mutingUtils.updateMutingHistory(contact, undefined).then(() => {
+        chai.expect(infodoc.bulkGet.callCount).to.equal(2);
+        chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[ { id: 'b' } ]]);
+        chai.expect(infodoc.bulkGet.args[1]).to.deep.equal([[ { id: 'a' } ]]);
         chai.expect(infodoc.bulkUpdate.callCount).to.equal(1);
         chai.expect(infodoc.bulkUpdate.args[0]).to.deep.equal([[{
           muting_history: [
@@ -1511,7 +1530,7 @@ describe('mutingUtils', () => {
         .then(() => chai.expect(false).to.equal('should have thrown'))
         .catch(err => {
           chai.expect(err).to.deep.equal({ some: 'error' });
-          chai.expect(infodoc.bulkGet.callCount).to.equal(1);
+          chai.expect(infodoc.bulkGet.callCount).to.equal(2);
           chai.expect(infodoc.bulkUpdate.callCount).to.equal(1);
         });
     });
@@ -1543,11 +1562,7 @@ describe('mutingUtils', () => {
 
       return mutingUtils._updateMuteHistories(contacts, moment(1234), 'reportId').then(() => {
         chai.expect(infodoc.bulkGet.callCount).to.equal(1);
-        chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[
-          { id: 'a', doc: { _id: 'a' } },
-          { id: 'b', doc: { _id: 'b' } },
-          { id: 'c', doc: { _id: 'c' } }
-        ]]);
+        chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[ { id: 'a' }, { id: 'b' }, { id: 'c' } ]]);
 
         chai.expect(infodoc.bulkUpdate.callCount).to.equal(1);
         chai.expect(infodoc.bulkUpdate.args[0]).to.deep.equal([[
@@ -1599,11 +1614,7 @@ describe('mutingUtils', () => {
 
       return mutingUtils._updateMuteHistories(contacts, false, 'reportId').then(() => {
         chai.expect(infodoc.bulkGet.callCount).to.equal(1);
-        chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[
-          { id: 'a', doc: { _id: 'a' } },
-          { id: 'b', doc: { _id: 'b' } },
-          { id: 'c', doc: { _id: 'c' } }
-        ]]);
+        chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[ { id: 'a' }, { id: 'b' }, { id: 'c' } ]]);
 
         chai.expect(infodoc.bulkUpdate.callCount).to.equal(1);
         chai.expect(infodoc.bulkUpdate.args[0]).to.deep.equal([[

--- a/sentinel/tests/unit/lib/muting_utils.js
+++ b/sentinel/tests/unit/lib/muting_utils.js
@@ -1231,8 +1231,12 @@ describe('mutingUtils', () => {
   });
 
   describe('updateContact', () => {
-    it('set muted to false', () => {
+    it('should remove muted property when unmuting', () => {
       chai.expect(mutingUtils.updateContact({}, false)).to.deep.equal({ });
+      chai.expect(mutingUtils.updateContact({ muted: 'something' }, false)).to.deep.equal({ });
+      chai
+        .expect(mutingUtils.updateContact({ _id: 'a', patient_id: 'b', muted: 'something' }, false))
+        .to.deep.equal({ _id: 'a', patient_id: 'b' });
     });
 
     it('set muted to received value', () => {

--- a/sentinel/tests/unit/lib/muting_utils.js
+++ b/sentinel/tests/unit/lib/muting_utils.js
@@ -1210,6 +1210,7 @@ describe('mutingUtils', () => {
           }
         }
       };
+      mutingUtils.isMutedInLineage(doc2).should.equal(true);
       mutingUtils.isMutedInLineage(doc2, true).should.equal(4);
     });
   });

--- a/sentinel/tests/unit/lib/muting_utils.js
+++ b/sentinel/tests/unit/lib/muting_utils.js
@@ -3,7 +3,8 @@ const mutingUtils = require('../../../src/lib/muting_utils'),
       chai = require('chai'),
       db = require('../../../src/db-pouch'),
       utils = require('../../../src/lib/utils'),
-      moment = require('moment');
+      moment = require('moment'),
+      infodoc = require('../../../src/lib/infodoc');
 
 let clock;
 
@@ -313,64 +314,22 @@ describe('mutingUtils', () => {
       });
     });
 
-    it('should update all contacts with unmuted state', () => {
+    it('should delete muted property when unmuting', () => {
       const contacts = [ { _id:  'a', muted: true }, { _id:  'b', muted: 123 }, { _id:  'c', muted: 'something' } ];
       db.medic.bulkDocs.resolves();
       return mutingUtils._updateContacts(contacts, false).then(() => {
         chai.expect(db.medic.bulkDocs.callCount).to.equal(1);
         chai.expect(db.medic.bulkDocs.args[0]).to.deep.equal([[
-          { _id:  'a', muted: false }, { _id:  'b', muted: false }, { _id:  'c', muted: false }
-        ]]);
-      });
-    });
-
-    it('should only update contacts with different muted state', () => {
-      const timestamp = 65000;
-      const contacts = [
-        { _id: 'a' },
-        { _id: 'b', muted: true },
-        { _id: 'c', muted: null },
-        { _id: 'd', muted: 0 },
-        { _id: 'f', muted: 12354 }
-      ];
-      db.medic.bulkDocs.resolves();
-      return mutingUtils._updateContacts(contacts, timestamp).then(() => {
-        chai.expect(db.medic.bulkDocs.callCount).to.equal(1);
-        chai.expect(db.medic.bulkDocs.args[0]).to.deep.equal([[
-          { _id:  'a', muted: timestamp },
-          { _id:  'c', muted: timestamp },
-          { _id:  'd', muted: timestamp }
-        ]]);
-      });
-    });
-
-    it('should only update contacts with different muted state', () => {
-      const contacts = [
-        { _id:  'a' },
-        { _id:  'b', muted: true },
-        { _id:  'c', muted: false },
-        { _id:  'd', muted: null },
-        { _id:  'e', muted: 123443 }
-      ];
-      db.medic.bulkDocs.resolves();
-      return mutingUtils._updateContacts(contacts, false).then(() => {
-        chai.expect(db.medic.bulkDocs.callCount).to.equal(1);
-        chai.expect(db.medic.bulkDocs.args[0]).to.deep.equal([[
-          { _id:  'b', muted: false },
-          { _id:  'e', muted: false },
+          { _id:  'a' }, { _id:  'b' }, { _id:  'c' }
         ]]);
       });
     });
 
     it('should not call bulkDocs if contacts are empty', () => {
-      chai.expect(mutingUtils._updateContacts([], true)).to.equal(undefined);
-      chai.expect(db.medic.bulkDocs.callCount).to.equal(0);
-    });
-
-    it('should not call bulkDocs if all contacts are in correct state', () => {
-      const contacts = [ { _id:  'a' }, { _id:  'b' }, { _id:  'c', muted: false } ];
-      chai.expect(mutingUtils._updateContacts(contacts, false)).to.equal(undefined);
-      chai.expect(db.medic.bulkDocs.callCount).to.equal(0);
+      return mutingUtils._updateContacts([], true).then(result => {
+        chai.expect(result).to.equal(undefined);
+        chai.expect(db.medic.bulkDocs.callCount).to.equal(0);
+      });
     });
 
     it('should throw bulkDocs errors', () => {
@@ -398,6 +357,9 @@ describe('mutingUtils', () => {
         muted: false,
         parent: { _id: 'p1', parent: { _id: 'p2' }}
       };
+
+      sinon.stub(infodoc, 'bulkGet').resolves([]);
+      sinon.stub(infodoc, 'bulkUpdate').resolves();
 
       const contacts = [
         { _id: 'my-place', muted: false, place_id: 'my-place-id'},
@@ -429,12 +391,12 @@ describe('mutingUtils', () => {
         chai.expect(!!result).to.equal(true);
         chai.expect(db.medic.bulkDocs.callCount).to.equal(1);
         chai.expect(db.medic.bulkDocs.args[0]).to.deep.equal([[
-          { _id: 'my-place', muted: timestamp, place_id: 'my-place-id'},
-          { _id: 'my-place2', muted: timestamp },
-          { _id: 'my-place3', place_id: 'place3', muted: timestamp },
-          { _id: 'contact1', patient_id: 'patient1', muted: timestamp },
-          { _id: 'contact2', patient_id: 'patient2', muted: timestamp },
-          { _id: 'contact3', patient_id: 'patient3', muted: timestamp }
+          { _id: 'my-place', muted: moment(), place_id: 'my-place-id'},
+          { _id: 'my-place2', muted: moment() },
+          { _id: 'my-place3', place_id: 'place3', muted: moment() },
+          { _id: 'contact1', patient_id: 'patient1', muted: moment() },
+          { _id: 'contact2', patient_id: 'patient2', muted: moment() },
+          { _id: 'contact3', patient_id: 'patient3', muted: moment() }
         ]]);
 
         chai.expect(db.medic.query.callCount).to.equal(1);
@@ -450,11 +412,21 @@ describe('mutingUtils', () => {
           db: db.medic,
           ids: [
             'my-place', 'my-place-id', 'my-place2', 'my-place3', 'place3',
-            'contact1', 'patient1', 'contact2', 'patient2', 'contact3', 'patient3',
-            'my-place4', 'contact4'
+            'contact1', 'patient1', 'contact2', 'patient2', 'contact3', 'patient3'
           ],
           registrations: true
         }]);
+
+        chai.expect(infodoc.bulkGet.callCount).to.equal(1);
+        chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[
+          { id: 'my-place', doc: { _id: 'my-place', muted: moment(), place_id: 'my-place-id'} },
+          { id: 'my-place2', doc: { _id: 'my-place2', muted: moment() } },
+          { id: 'my-place3', doc: { _id: 'my-place3', place_id: 'place3', muted: moment() }},
+          { id: 'contact1', doc: { _id: 'contact1', patient_id: 'patient1', muted: moment() } },
+          { id: 'contact2', doc: { _id: 'contact2', patient_id: 'patient2', muted: moment() } },
+          { id: 'contact3', doc: { _id: 'contact3', patient_id: 'patient3', muted: moment() } }
+        ]]);
+        chai.expect(infodoc.bulkUpdate.callCount).to.equal(1);
       });
     });
 
@@ -490,6 +462,8 @@ describe('mutingUtils', () => {
       db.medic.allDocs.resolves({ rows: contacts.map(doc => ({ id: doc._id, doc: doc }))});
       utils.getReportsBySubject.resolves([]);
       db.medic.bulkDocs.resolves();
+      sinon.stub(infodoc, 'bulkGet').resolves([]);
+      sinon.stub(infodoc, 'bulkUpdate').resolves();
 
       return mutingUtils.updateMuteState(hydratedContact, false).then(result => {
         chai.expect(!!result).to.equal(true);
@@ -498,19 +472,17 @@ describe('mutingUtils', () => {
         chai.expect(utils.getReportsBySubject.args[0]).to.deep.equal([{
           db: db.medic,
           ids: [
-            'my-place', 'my-place1', 'my-place2', 'my-place3',
-            'contact1', 'patient1', 'contact2', 'patient2',
-            'contact3', 'patient3', 'my-place4', 'contact4', 'patient4'
+            'my-place', 'my-place1', 'my-place2', 'my-place4', 'contact4', 'patient4'
           ],
           registrations: true
         }]);
 
         chai.expect(db.medic.bulkDocs.callCount).to.equal(1);
         chai.expect(db.medic.bulkDocs.args[0]).to.deep.equal([[
-          { _id: 'my-place', muted: false, place_id: 'my-place1' },
-          { _id: 'my-place2', muted: false },
-          { _id: 'my-place4', muted: false },
-          { _id: 'contact4', muted: false, patient_id: 'patient4' }
+          { _id: 'my-place', place_id: 'my-place1' },
+          { _id: 'my-place2' },
+          { _id: 'my-place4' },
+          { _id: 'contact4', patient_id: 'patient4' }
         ]]);
 
         chai.expect(db.medic.query.callCount).to.equal(1);
@@ -521,6 +493,15 @@ describe('mutingUtils', () => {
           keys: [ 'my-place', 'my-place2', 'my-place3', 'my-place4', 'contact1', 'contact2', 'contact3', 'contact4' ],
           include_docs: true
         }]);
+
+        chai.expect(infodoc.bulkGet.callCount).to.equal(1);
+        chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[
+          { id: 'my-place', doc: { _id: 'my-place', place_id: 'my-place1' } },
+          { id: 'my-place2', doc: { _id: 'my-place2' } },
+          { id: 'my-place4', doc: { _id: 'my-place4' } },
+          { id: 'contact4', doc: { _id: 'contact4', patient_id: 'patient4' } }
+        ]]);
+        chai.expect(infodoc.bulkUpdate.callCount).to.equal(1);
       });
     });
 
@@ -560,17 +541,19 @@ describe('mutingUtils', () => {
       db.medic.allDocs.resolves({ rows: contacts.map(doc => ({ id: doc._id, doc: doc }))});
       utils.getReportsBySubject.resolves([]);
       db.medic.bulkDocs.resolves();
+      sinon.stub(infodoc, 'bulkGet').resolves([]);
+      sinon.stub(infodoc, 'bulkUpdate').resolves();
 
       return mutingUtils.updateMuteState(hydratedPlace, false).then(result => {
         chai.expect(!!result).to.equal(true);
 
         chai.expect(db.medic.bulkDocs.callCount).to.equal(1);
         chai.expect(db.medic.bulkDocs.args[0]).to.deep.equal([[
-          { _id: 'p2', muted: false },
-          { _id: 'p1', muted: false },
-          { _id: 'my-place', muted: false },
-          { _id: 'contact1', muted: false, patient_id: 'patient1' },
-          { _id: 'contact2', muted: false, patient_id: 'patient2' }
+          { _id: 'p2' },
+          { _id: 'p1' },
+          { _id: 'my-place' },
+          { _id: 'contact1', patient_id: 'patient1' },
+          { _id: 'contact2', patient_id: 'patient2' }
         ]]);
 
         chai.expect(db.medic.query.callCount).to.equal(1);
@@ -588,6 +571,16 @@ describe('mutingUtils', () => {
           ids: [ 'p2', 'p1', 'my-place', 'contact1', 'patient1', 'contact2', 'patient2' ],
           registrations: true
         }]);
+
+        chai.expect(infodoc.bulkGet.callCount).to.equal(1);
+        chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[
+          { id: 'p2', doc: { _id: 'p2' } },
+          { id: 'p1', doc: { _id: 'p1' } },
+          { id: 'my-place', doc: { _id: 'my-place' } },
+          { id: 'contact1', doc: { _id: 'contact1', patient_id: 'patient1' } },
+          { id: 'contact2', doc: { _id: 'contact2', patient_id: 'patient2' } }
+        ]]);
+        chai.expect(infodoc.bulkUpdate.callCount).to.equal(1);
       });
     });
 
@@ -608,6 +601,8 @@ describe('mutingUtils', () => {
       ]);
       utils.setTasksStates.returns(true);
       db.medic.bulkDocs.resolves();
+      sinon.stub(infodoc, 'bulkGet').resolves([]);
+      sinon.stub(infodoc, 'bulkUpdate').resolves();
 
       return mutingUtils.updateMuteState(contact, true).then(result => {
         chai.expect(!!result).to.equal(true);
@@ -632,13 +627,19 @@ describe('mutingUtils', () => {
         chai.expect(db.medic.bulkDocs.args[0]).to.deep.equal([[{
           _id: 'contact',
           patient_id: 'patient',
-          muted: 100
+          muted: moment()
         }]]);
         chai.expect(db.medic.bulkDocs.args[1]).to.deep.equal([[
           { _id: 'r1' },
           { _id: 'r2' },
           { _id: 'r3' }
         ]]);
+
+        chai.expect(infodoc.bulkGet.callCount).to.equal(1);
+        chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[
+          { id: 'contact', doc: { _id: 'contact', patient_id: 'patient', muted: moment() } }
+        ]]);
+        chai.expect(infodoc.bulkUpdate.callCount).to.equal(1);
       });
     });
 
@@ -673,6 +674,44 @@ describe('mutingUtils', () => {
       db.medic.query.resolves({ rows: [{ id: 'contact' }] });
       db.medic.allDocs.resolves({ rows: [{ doc: { _id: 'contact' } }]});
       utils.getReportsBySubject.rejects({ some: 'error' });
+      sinon.stub(infodoc, 'bulkGet').resolves([]);
+      sinon.stub(infodoc, 'bulkUpdate').resolves();
+
+      return mutingUtils
+        .updateMuteState({ _id: 'contact' }, true)
+        .then(() => chai.expect(false).to.equal('Should have thrown'))
+        .catch(err => {
+          chai.expect(err).to.deep.equal({ some: 'error' });
+          chai.expect(db.medic.allDocs.callCount).to.equal(1);
+          chai.expect(db.medic.query.callCount).to.equal(1);
+          chai.expect(utils.getReportsBySubject.callCount).to.equal(1);
+        });
+    });
+
+    it('should throw infodoc.bulkGet errors', () => {
+      db.medic.query.resolves({ rows: [{ id: 'contact' }] });
+      db.medic.allDocs.resolves({ rows: [{ doc: { _id: 'contact' } }]});
+      utils.getReportsBySubject.resolves([]);
+      sinon.stub(infodoc, 'bulkGet').rejects({ some: 'error' });
+      sinon.stub(infodoc, 'bulkUpdate').resolves();
+
+      return mutingUtils
+        .updateMuteState({ _id: 'contact' }, true)
+        .then(() => chai.expect(false).to.equal('Should have thrown'))
+        .catch(err => {
+          chai.expect(err).to.deep.equal({ some: 'error' });
+          chai.expect(db.medic.allDocs.callCount).to.equal(1);
+          chai.expect(db.medic.query.callCount).to.equal(1);
+          chai.expect(utils.getReportsBySubject.callCount).to.equal(1);
+        });
+    });
+
+    it('should throw infodoc.bulkUpdate errors', () => {
+      db.medic.query.resolves({ rows: [{ id: 'contact' }] });
+      db.medic.allDocs.resolves({ rows: [{ doc: { _id: 'contact' } }]});
+      utils.getReportsBySubject.resolves([]);
+      sinon.stub(infodoc, 'bulkGet').resolves([]);
+      sinon.stub(infodoc, 'bulkUpdate').rejects({ some: 'error' });
 
       return mutingUtils
         .updateMuteState({ _id: 'contact' }, true)
@@ -698,10 +737,10 @@ describe('mutingUtils', () => {
       db.medic.allDocs
         .onCall(0)
         .resolves({ rows: [
-          { doc: { _id: 'a' }},
-          { doc: { _id: 'b' }},
-          { doc: { _id: 'c' }}
-        ]})
+            { doc: { _id: 'a' }},
+            { doc: { _id: 'b' }},
+            { doc: { _id: 'c' }}
+          ]})
         .onCall(1)
         .resolves({ rows: [
             { doc: { _id: 'd' }},
@@ -736,6 +775,8 @@ describe('mutingUtils', () => {
         ]);
 
       utils.setTasksStates.returns(true);
+      sinon.stub(infodoc, 'bulkGet').resolves([]);
+      sinon.stub(infodoc, 'bulkUpdate').resolves();
 
       return mutingUtils.updateMuteState({ _id: 'contact' }, true).then(result => {
         chai.expect(!!result).to.equal(true);
@@ -766,19 +807,19 @@ describe('mutingUtils', () => {
         chai.expect(requestedContacts).to.deep.equal(contactIds);
 
         chai.expect(db.medic.bulkDocs.args[0][0]).to.deep.equal([
-          { _id: 'a', muted: timestamp },
-          { _id: 'b', muted: timestamp },
-          { _id: 'c', muted: timestamp }
+          { _id: 'a', muted: moment() },
+          { _id: 'b', muted: moment() },
+          { _id: 'c', muted: moment() }
         ]);
         chai.expect(db.medic.bulkDocs.args[2][0]).to.deep.equal([
-          { _id: 'd', muted: timestamp },
-          { _id: 'e', muted: timestamp },
-          { _id: 'f', muted: timestamp }
+          { _id: 'd', muted: moment() },
+          { _id: 'e', muted: moment() },
+          { _id: 'f', muted: moment() }
         ]);
         chai.expect(db.medic.bulkDocs.args[4][0]).to.deep.equal([
-          { _id: 'g', muted: timestamp },
-          { _id: 'h', muted: timestamp },
-          { _id: 'i', muted: timestamp }
+          { _id: 'g', muted: moment() },
+          { _id: 'h', muted: moment() },
+          { _id: 'i', muted: moment() }
         ]);
 
         chai.expect(db.medic.bulkDocs.args[1][0]).to.deep.equal([
@@ -796,12 +837,30 @@ describe('mutingUtils', () => {
           { _id: 'r8' },
           { _id: 'r9' }
         ]);
+
+        chai.expect(infodoc.bulkGet.callCount).to.equal(3);
+        chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[
+          { id: 'a', doc: { _id: 'a', muted: moment() } },
+          { id: 'b', doc: { _id: 'b', muted: moment() } },
+          { id: 'c', doc: { _id: 'c', muted: moment() } }
+        ]]);
+
+        chai.expect(infodoc.bulkGet.args[1]).to.deep.equal([[
+          { id: 'd', doc: { _id: 'd', muted: moment() } },
+          { id: 'e', doc: { _id: 'e', muted: moment() } },
+          { id: 'f', doc: { _id: 'f', muted: moment() } }
+        ]]);
+
+        chai.expect(infodoc.bulkGet.args[2]).to.deep.equal([[
+          { id: 'g', doc: { _id: 'g', muted: moment() } },
+          { id: 'h', doc: { _id: 'h', muted: moment() } },
+          { id: 'i', doc: { _id: 'i', muted: moment() } }
+        ]]);
+        chai.expect(infodoc.bulkUpdate.callCount).to.equal(3);
       });
     });
 
     it('should throw an error when one of the batches fetching fails', () => {
-      const timestamp = 5000;
-      clock.tick(timestamp);
       const contactIds = Array.apply(null, Array(175)).map((x, i) => `contact${i}`);
       db.medic.query.resolves({ rows: contactIds.map(id => ({ id })) });
       db.medic.allDocs
@@ -835,6 +894,8 @@ describe('mutingUtils', () => {
         ]);
 
       utils.setTasksStates.returns(true);
+      sinon.stub(infodoc, 'bulkGet').resolves([]);
+      sinon.stub(infodoc, 'bulkUpdate').resolves();
 
       return mutingUtils
         .updateMuteState({ _id: 'contact' }, true)
@@ -845,6 +906,8 @@ describe('mutingUtils', () => {
           chai.expect(db.medic.allDocs.callCount).to.equal(3);
           chai.expect(utils.getReportsBySubject.callCount).to.equal(2);
           chai.expect(db.medic.bulkDocs.callCount).to.equal(4);
+          chai.expect(infodoc.bulkGet.callCount).to.equal(2);
+          chai.expect(infodoc.bulkUpdate.callCount).to.equal(2);
         });
     });
 
@@ -887,6 +950,8 @@ describe('mutingUtils', () => {
         ]);
 
       utils.setTasksStates.returns(true);
+      sinon.stub(infodoc, 'bulkGet').resolves([]);
+      sinon.stub(infodoc, 'bulkUpdate').resolves();
 
       return mutingUtils
         .updateMuteState({ _id: 'contact' }, true)
@@ -897,6 +962,112 @@ describe('mutingUtils', () => {
           chai.expect(db.medic.allDocs.callCount).to.equal(2);
           chai.expect(utils.getReportsBySubject.callCount).to.equal(2);
           chai.expect(db.medic.bulkDocs.callCount).to.equal(4);
+          chai.expect(infodoc.bulkGet.callCount).to.equal(2);
+          chai.expect(infodoc.bulkUpdate.callCount).to.equal(2);
+        });
+    });
+
+    it('should throw an error when one of the batches infodocs.bulkGet fails', () => {
+      const contactIds = Array.apply(null, Array(175)).map((x, i) => `contact${i}`);
+      db.medic.query.resolves({ rows: contactIds.map(id => ({ id })) });
+      db.medic.allDocs
+        .onCall(0)
+        .resolves({ rows: [
+            { doc: { _id: 'a' }},
+            { doc: { _id: 'b' }},
+            { doc: { _id: 'c' }}
+          ]})
+        .onCall(1)
+        .resolves({ rows: [
+            { doc: { _id: 'd' }},
+            { doc: { _id: 'e' }},
+            { doc: { _id: 'f' }}
+          ]});
+
+      db.medic.bulkDocs.resolves();
+      utils.getReportsBySubject
+        .onCall(0)
+        .resolves([
+          { _id: 'r1' },
+          { _id: 'r2' },
+          { _id: 'r3' },
+        ])
+        .onCall(1)
+        .resolves([
+          { _id: 'r4' },
+          { _id: 'r5' },
+          { _id: 'r6' },
+        ]);
+
+      utils.setTasksStates.returns(true);
+      sinon.stub(infodoc, 'bulkGet')
+        .onCall(0).resolves([])
+        .onCall(1).rejects({ some: 'error' });
+      sinon.stub(infodoc, 'bulkUpdate').resolves();
+
+      return mutingUtils
+        .updateMuteState({ _id: 'contact' }, true)
+        .then(() => chai.expect(true).to.equal('should have thrown'))
+        .catch(err => {
+          chai.expect(err).to.deep.equal({ some: 'error' });
+
+          chai.expect(db.medic.allDocs.callCount).to.equal(2);
+          chai.expect(utils.getReportsBySubject.callCount).to.equal(2);
+          chai.expect(db.medic.bulkDocs.callCount).to.equal(4);
+          chai.expect(infodoc.bulkGet.callCount).to.equal(2);
+          chai.expect(infodoc.bulkUpdate.callCount).to.equal(1);
+        });
+    });
+
+    it('should throw an error when one of the batches infodocs.bulkUpdate fails', () => {
+      const contactIds = Array.apply(null, Array(175)).map((x, i) => `contact${i}`);
+      db.medic.query.resolves({ rows: contactIds.map(id => ({ id })) });
+      db.medic.allDocs
+        .onCall(0)
+        .resolves({ rows: [
+            { doc: { _id: 'a' }},
+            { doc: { _id: 'b' }},
+            { doc: { _id: 'c' }}
+          ]})
+        .onCall(1)
+        .resolves({ rows: [
+            { doc: { _id: 'd' }},
+            { doc: { _id: 'e' }},
+            { doc: { _id: 'f' }}
+          ]});
+
+      db.medic.bulkDocs.resolves();
+      utils.getReportsBySubject
+        .onCall(0)
+        .resolves([
+          { _id: 'r1' },
+          { _id: 'r2' },
+          { _id: 'r3' },
+        ])
+        .onCall(1)
+        .resolves([
+          { _id: 'r4' },
+          { _id: 'r5' },
+          { _id: 'r6' },
+        ]);
+
+      utils.setTasksStates.returns(true);
+      sinon.stub(infodoc, 'bulkGet').resolves([]);
+      sinon.stub(infodoc, 'bulkUpdate')
+        .onCall(0).resolves()
+        .onCall(1).rejects({ some: 'error' });
+
+      return mutingUtils
+        .updateMuteState({ _id: 'contact' }, true)
+        .then(() => chai.expect(true).to.equal('should have thrown'))
+        .catch(err => {
+          chai.expect(err).to.deep.equal({ some: 'error' });
+
+          chai.expect(db.medic.allDocs.callCount).to.equal(2);
+          chai.expect(utils.getReportsBySubject.callCount).to.equal(2);
+          chai.expect(db.medic.bulkDocs.callCount).to.equal(4);
+          chai.expect(infodoc.bulkGet.callCount).to.equal(2);
+          chai.expect(infodoc.bulkUpdate.callCount).to.equal(2);
         });
     });
   });
@@ -911,7 +1082,7 @@ describe('mutingUtils', () => {
           { doc: { _id: '4', patient_id: 'patient_4' } }
         ]});
 
-      return mutingUtils._getContactsAndSubjectIds(ids).then(result => {
+      return mutingUtils._getContactsAndSubjectIds(ids, new Date()).then(result => {
         chai.expect(result.contacts).to.deep.equal([
           { _id: '1', place_id: 'place_1' },
           { _id: '2', patient_id: 'patient_2' },
@@ -935,6 +1106,48 @@ describe('mutingUtils', () => {
           chai.expect(db.medic.allDocs.callCount).to.equal(1);
           chai.expect(db.medic.allDocs.args[0]).to.deep.equal([{ keys: ['a'], include_docs: true }]);
         });
+    });
+
+    it('should only return contacts and subjects with different muted state', () => {
+      const ids = ['1', '2', '3', '4', '5', '6'];
+      db.medic.allDocs.resolves({ rows: [
+          { doc: { _id: '1', place_id: 'place_1' } },
+          { doc: { _id: '2', patient_id: 'patient_2', muted: true } },
+          { doc: { _id: '3', muted: null } },
+          { doc: { _id: '4', patient_id: 'patient_4', muted: 0 } },
+          { key: '5', error: 'not_found' },
+          { doc: { _id: '6', patient_id: 'patient_6', muted: 123 } }
+        ]});
+
+      return mutingUtils._getContactsAndSubjectIds(ids, new Date()).then(result => {
+        chai.expect(result.contacts).to.deep.equal([
+          { _id: '1', place_id: 'place_1' },
+          { _id: '3', muted: null },
+          { _id: '4', patient_id: 'patient_4', muted: 0 }
+        ]);
+        chai.expect(result.subjectIds).to.deep.equal(['1', 'place_1', '3', '4', 'patient_4']);
+      });
+    });
+
+    it('should only return contacts and subjects with different muted state', () => {
+      const ids = ['1', '2', '3', '4', '5', '6', '7'];
+      db.medic.allDocs.resolves({ rows: [
+          { doc: { _id: '1', place_id: 'place_1', muted: 1234 } },
+          { doc: { _id: '2', patient_id: 'patient_2', muted: false } },
+          { doc: { _id: '3', muted: null } },
+          { doc: { _id: '4', patient_id: 'patient_4', muted: 0 } },
+          { key: '5', error: 'not_found' },
+          { doc: { _id: '6', patient_id: 'patient_6' } },
+          { doc: { _id: '7', patient_id: 'patient_7', muted: true } },
+        ]});
+
+      return mutingUtils._getContactsAndSubjectIds(ids, false).then(result => {
+        chai.expect(result.contacts).to.deep.equal([
+          { _id: '1', place_id: 'place_1', muted: 1234 } ,
+          { _id: '7', patient_id: 'patient_7', muted: true }
+        ]);
+        chai.expect(result.subjectIds).to.deep.equal(['1', 'place_1', '7', 'patient_7']);
+      });
     });
   });
 
@@ -1014,7 +1227,7 @@ describe('mutingUtils', () => {
 
   describe('updateContact', () => {
     it('set muted to false', () => {
-      chai.expect(mutingUtils.updateContact({}, false)).to.deep.equal({ muted: false });
+      chai.expect(mutingUtils.updateContact({}, false)).to.deep.equal({ });
     });
 
     it('set muted to received value', () => {
@@ -1101,6 +1314,359 @@ describe('mutingUtils', () => {
       mutingUtils.unmuteMessages(unchangedDoc).should.equal(0);
       mutingUtils.unmuteMessages(changedDoc).should.equal(2);
       mutingUtils.unmuteMessages(changedDoc2).should.equal(4);
+    });
+  });
+
+  describe('updateMutingHistory', () => {
+    beforeEach(() => {
+      clock = sinon.useFakeTimers();
+      sinon.stub(infodoc, 'bulkGet');
+      sinon.stub(infodoc, 'bulkUpdate');
+    });
+    afterEach(() => clock.restore());
+
+    it('should add muting history property and push the current state', () => {
+      const info = {
+        _id: 'contact-info',
+        doc_id: 'contact',
+        type: 'info',
+        transitions: {}
+      };
+
+      infodoc.bulkGet.resolves([ info ]);
+      infodoc.bulkUpdate.resolves();
+
+      return mutingUtils.updateMutingHistory({ _id: 'contact' }, moment(1234), 'report_id').then(() => {
+        chai.expect(infodoc.bulkGet.callCount).to.equal(1);
+        chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[
+          { id: 'contact', doc: { _id: 'contact' } }
+        ]]);
+        chai.expect(infodoc.bulkUpdate.args[0]).to.deep.equal([[{
+          _id: 'contact-info',
+          doc_id: 'contact',
+          type: 'info',
+          transitions: {},
+          muting_history: [{
+            muted: true,
+            date: moment(1234),
+            report_id: 'report_id'
+          }]
+        }]]);
+      });
+    });
+
+    it('should add new entry in muting history with current state', () => {
+      const info = {
+        _id: 'contact-info',
+        doc_id: 'contact',
+        type: 'info',
+        transitions: {},
+        muting_history: [
+          {
+            muted: true,
+            date: 'some date',
+            report_id: 'report_id'
+          }
+        ]
+      };
+
+      infodoc.bulkGet.resolves([ info ]);
+      infodoc.bulkUpdate.resolves();
+
+      return mutingUtils.updateMutingHistory({ _id: 'contact' }, false, 'report_id_2').then(() => {
+        chai.expect(infodoc.bulkGet.callCount).to.equal(1);
+        chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[
+          { id: 'contact', doc: { _id: 'contact' } }
+        ]]);
+        chai.expect(infodoc.bulkUpdate.args[0]).to.deep.equal([[{
+          _id: 'contact-info',
+          doc_id: 'contact',
+          type: 'info',
+          transitions: {},
+          muting_history: [
+            {
+              muted: true,
+              date: 'some date',
+              report_id: 'report_id'
+            },
+            {
+              muted: false,
+              date: moment(),
+              report_id: 'report_id_2'
+            }
+          ]
+        }]]);
+      });
+    });
+
+    it('should work when report_id when not provided', () => {
+      const info = {
+        _id: 'id-info',
+        doc_id: 'id',
+        type: 'info',
+        transitions: {},
+        muting_history: [
+          {
+            muted: true,
+            date: 'some date',
+            report_id: 'report_id'
+          }
+        ]
+      };
+
+      infodoc.bulkGet.resolves([ info ]);
+      infodoc.bulkUpdate.resolves();
+
+      return mutingUtils.updateMutingHistory({ _id: 'id' }, false).then(() => {
+        chai.expect(infodoc.bulkGet.callCount).to.equal(1);
+        chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[
+          { id: 'id', doc: { _id: 'id' } }
+        ]]);
+        chai.expect(infodoc.bulkUpdate.callCount).to.equal(1);
+        chai.expect(infodoc.bulkUpdate.args[0]).to.deep.equal([[{
+          _id: 'id-info',
+          doc_id: 'id',
+          type: 'info',
+          transitions: {},
+          muting_history: [
+            {
+              muted: true,
+              date: 'some date',
+              report_id: 'report_id'
+            },
+            {
+              muted: false,
+              date: moment(),
+              report_id: undefined
+            }
+          ]
+        }]]);
+      });
+    });
+
+    it('should save provided muted value when truthy', () => {
+      infodoc.bulkGet.resolves([{}]);
+      infodoc.bulkUpdate.resolves();
+
+      return mutingUtils.updateMutingHistory({ _id: 'a' }, 'something').then(() => {
+        chai.expect(infodoc.bulkGet.callCount).to.equal(1);
+        chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[
+          { id: 'a', doc: { _id: 'a' } }
+        ]]);
+        chai.expect(infodoc.bulkUpdate.callCount).to.equal(1);
+        chai.expect(infodoc.bulkUpdate.args[0]).to.deep.equal([[{
+          muting_history: [
+            {
+              muted: true,
+              date: 'something',
+              report_id: undefined
+            }
+          ]
+        }]]);
+      });
+    });
+
+    it('should save current date when falsy', () => {
+      infodoc.bulkGet.resolves([{}]);
+      infodoc.bulkUpdate.resolves();
+
+      return mutingUtils.updateMutingHistory({ _id: 'a' }, undefined).then(() => {
+        chai.expect(infodoc.bulkGet.callCount).to.equal(1);
+        chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[
+          { id: 'a', doc: { _id: 'a' } }
+        ]]);
+        chai.expect(infodoc.bulkUpdate.callCount).to.equal(1);
+        chai.expect(infodoc.bulkUpdate.args[0]).to.deep.equal([[{
+          muting_history: [
+            {
+              muted: false,
+              date: moment(),
+              report_id: undefined
+            }
+          ]
+        }]]);
+      });
+    });
+
+    it('should throw infodoc.bulkGet errors', () => {
+      infodoc.bulkGet.rejects({ some: 'error' });
+      infodoc.bulkUpdate.resolves();
+
+      return mutingUtils
+        .updateMutingHistory({ _id: 'a' }, false)
+        .then(() => chai.expect(false).to.equal('should have thrown'))
+        .catch(err => {
+          chai.expect(err).to.deep.equal({ some: 'error' });
+          chai.expect(infodoc.bulkGet.callCount).to.equal(1);
+          chai.expect(infodoc.bulkUpdate.callCount).to.equal(0);
+        });
+    });
+
+    it('should throw infodoc.bulkGet errors', () => {
+      infodoc.bulkGet.resolves([{}]);
+      infodoc.bulkUpdate.rejects({ some: 'error' });
+
+      return mutingUtils
+        .updateMutingHistory({ _id: 'a' }, false)
+        .then(() => chai.expect(false).to.equal('should have thrown'))
+        .catch(err => {
+          chai.expect(err).to.deep.equal({ some: 'error' });
+          chai.expect(infodoc.bulkGet.callCount).to.equal(1);
+          chai.expect(infodoc.bulkUpdate.callCount).to.equal(1);
+        });
+    });
+  });
+
+  describe('updateMuteHistories', () => {
+    beforeEach(() => {
+      clock = sinon.useFakeTimers();
+      sinon.stub(infodoc, 'bulkGet');
+      sinon.stub(infodoc, 'bulkUpdate');
+    });
+    afterEach(() => clock.restore());
+
+    it('should do nothing if contacts list is empty', () => {
+      return mutingUtils._updateMuteHistories([]).then(() => {
+        chai.expect(infodoc.bulkGet.callCount).to.equal(0);
+        chai.expect(infodoc.bulkUpdate.callCount).to.equal(0);
+      });
+    });
+
+    it('should get all info docs and update them when muting', () => {
+      const contacts = [{ _id: 'a' }, { _id: 'b' }, { _id: 'c' }];
+      infodoc.bulkGet.resolves([
+        { _id: 'a-info', type: 'info', _rev: '1' },
+        { _id: 'b-info', type: 'info' },
+        { _id: 'c-info', type: 'info', _rev: '2', muting_history: [{ muted: true }, { muted: false }] }
+      ]);
+      infodoc.bulkUpdate.resolves();
+
+      return mutingUtils._updateMuteHistories(contacts, moment(1234), 'reportId').then(() => {
+        chai.expect(infodoc.bulkGet.callCount).to.equal(1);
+        chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[
+          { id: 'a', doc: { _id: 'a' } },
+          { id: 'b', doc: { _id: 'b' } },
+          { id: 'c', doc: { _id: 'c' } }
+        ]]);
+
+        chai.expect(infodoc.bulkUpdate.callCount).to.equal(1);
+        chai.expect(infodoc.bulkUpdate.args[0]).to.deep.equal([[
+          {
+            _id: 'a-info',
+            type: 'info',
+            _rev: '1',
+            muting_history: [{
+              muted: true,
+              date: moment(1234),
+              report_id: 'reportId'
+            }]
+          },
+          {
+            _id: 'b-info',
+            type: 'info',
+            muting_history: [{
+              muted: true,
+              date: moment(1234),
+              report_id: 'reportId'
+            }]
+          },
+          {
+            _id: 'c-info',
+            type: 'info',
+            _rev: '2',
+            muting_history: [
+              { muted: true },
+              { muted: false },
+              {
+                muted: true,
+                date: moment(1234),
+                report_id: 'reportId'
+              }
+            ]
+          }
+        ]]);
+      });
+    });
+
+    it('should get all info docs and update them when unmuting', () => {
+      const contacts = [{ _id: 'a' }, { _id: 'b' }, { _id: 'c' }];
+      infodoc.bulkGet.resolves([
+        { _id: 'a-info', type: 'info', _rev: '1' },
+        { _id: 'b-info', type: 'info' },
+        { _id: 'c-info', type: 'info', _rev: '2', muting_history: [{ muted: true }] }
+      ]);
+      infodoc.bulkUpdate.resolves();
+
+      return mutingUtils._updateMuteHistories(contacts, false, 'reportId').then(() => {
+        chai.expect(infodoc.bulkGet.callCount).to.equal(1);
+        chai.expect(infodoc.bulkGet.args[0]).to.deep.equal([[
+          { id: 'a', doc: { _id: 'a' } },
+          { id: 'b', doc: { _id: 'b' } },
+          { id: 'c', doc: { _id: 'c' } }
+        ]]);
+
+        chai.expect(infodoc.bulkUpdate.callCount).to.equal(1);
+        chai.expect(infodoc.bulkUpdate.args[0]).to.deep.equal([[
+          {
+            _id: 'a-info',
+            type: 'info',
+            _rev: '1',
+            muting_history: [{
+              muted: false,
+              date: moment(),
+              report_id: 'reportId'
+            }]
+          },
+          {
+            _id: 'b-info',
+            type: 'info',
+            muting_history: [{
+              muted: false,
+              date: moment(),
+              report_id: 'reportId'
+            }]
+          },
+          {
+            _id: 'c-info',
+            type: 'info',
+            _rev: '2',
+            muting_history: [
+              { muted: true },
+              {
+                muted: false,
+                date: moment(),
+                report_id: 'reportId'
+              }
+            ]
+          }
+        ]]);
+      });
+    });
+
+    it('should throw infodoc.bulkget errors', () => {
+      infodoc.bulkGet.rejects({ some: 'error' });
+
+      return mutingUtils
+        ._updateMuteHistories([{ _id: 'c' }])
+        .then(() => chai.expect(true).to.equal('should have thrown'))
+        .catch(err => {
+          chai.expect(err).to.deep.equal({ some: 'error' });
+          chai.expect(infodoc.bulkUpdate.callCount).to.equal(0);
+        });
+    });
+
+    it('should throw infodoc.bulkUpdate errors', () => {
+      infodoc.bulkGet.resolves([{ _id: 'a-info' }]);
+      infodoc.bulkUpdate.rejects({ some: 'error' });
+
+      return mutingUtils
+        ._updateMuteHistories([{ _id: 'a' }])
+        .then(() => chai.expect(true).to.equal('should have thrown'))
+        .catch(err => {
+          chai.expect(err).to.deep.equal({ some: 'error' });
+          chai.expect(infodoc.bulkGet.callCount).to.equal(1);
+          chai.expect(infodoc.bulkUpdate.callCount).to.equal(1);
+        });
     });
   });
 });

--- a/webapp/src/js/services/contact-muted.js
+++ b/webapp/src/js/services/contact-muted.js
@@ -12,19 +12,21 @@ angular.module('inboxServices').service('ContactMuted',
       }
 
       if (doc.muted) {
-        return true;
+        return doc.muted;
       }
 
       if (lineage) {
-        return _.some(lineage, function(parent) {
+        var mutedParent = _.find(lineage, function(parent) {
           return parent && parent.muted;
         });
+
+        return !!mutedParent && mutedParent.muted;
       }
 
       var parent = doc.parent;
       while (parent) {
         if (parent.muted) {
-          return true;
+          return parent.muted;
         }
         parent = parent.parent;
       }

--- a/webapp/tests/karma/unit/services/contact-muted.js
+++ b/webapp/tests/karma/unit/services/contact-muted.js
@@ -43,4 +43,14 @@ describe('ContactMuted service', function() {
     chai.expect(service({ parent: { parent: { muted: true, parent: { } } } })).to.equal(true);
     chai.expect(service({ parent: { parent: { parent: { parent: { muted: true } } } } })).to.equal(true);
   });
+
+  it('should return muted timestamp when contact is muted', () => {
+    chai.expect(service({ muted: 1234 })).to.equal(1234);
+    chai.expect(service({ muted: 'alpha' })).to.equal('alpha');
+  });
+
+  it('should return first muted parent timestamp', () => {
+    chai.expect(service({ parent: { muted: 1, parent: { muted: 2, parent: { muted: 3 } } } })).to.equal(1);
+    chai.expect(service({}, [{ muted: 1 }, { muted: 2 }, { muted: 3 }, {}])).to.equal(1);
+  });
 });


### PR DESCRIPTION
# Description

For analytics purposes, a contact's `muting_history` log is saved in the sentinel info doc. Each time the muted status is changed, an entry is added in the `muting_history` log, following this format: 
```
{ 
  muted: [true|false],
  date: '<muting/unmuting sentinel date, in ISO8601 format>',
  report_id: '<report that triggered muting/unmuting>'
}
```

For analytics purposes, the contact's `muted` property now contains a human readable date (in ISO8601 format). When unmuting, the property is removed altogether, avoiding having mixed data types for the same property. 

The `muted` field value (when existent) is exposed to ContactViewModel, instead of a Boolean `true`. 

medic/medic-webapp#4767

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
