### PR TITLE
Replaced Google Groups with Slack for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ At Medic Mobile we welcome and appreciate community contributions.
 
 ### Communication
 
-If you have an idea or a question we'd love to hear from you! The easiest ways to get in touch are by raising issues in the [medic-webapp Github repo](https://github.com/medic/medic-webapp/issues) or by messaging our [Google Group](https://groups.google.com/forum/#!forum/medic-developers).
+If you have an idea or a question we'd love to hear from you! The easiest way to get in touch is by raising issues in the [medic-webapp Github repo](https://github.com/medic/medic-webapp/issues). You can also reach out on our community Slack channel. You can request access via [this _Community Health Toolkit_ page](https://communityhealthtoolkit.org/slack).
 
 ### Submitting code
 


### PR DESCRIPTION
# Description

Remove Google Groups for contributors and added link to CHT page where they can request access to Slack

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
