### PR TITLE
#4445 - Reduce time to render contacts list through live-list

### DIFF
--- a/webapp/src/js/controllers/contacts.js
+++ b/webapp/src/js/controllers/contacts.js
@@ -456,7 +456,10 @@ var _ = require('underscore'),
           limit,
           withIds,
           silent: true,
-          reuseExistingDom: true,
+
+          // The logic for updating Primary Contact changes is complex
+          // So redraw everything when a person changes
+          reuseExistingDom: change.doc.type !== 'person',
         });
       },
       filter: function(change) {

--- a/webapp/src/js/controllers/contacts.js
+++ b/webapp/src/js/controllers/contacts.js
@@ -431,8 +431,11 @@ var _ = require('underscore'),
         const limit = liveList.count();
         if (change.deleted && change.doc.type !== 'data_record') {
           liveList.remove(change.doc);
-        }        
-        liveList.invalidateCache(change.doc);
+        }
+        liveList.invalidateCache(change.doc._id);
+        if (change.doc.fields) {
+          liveList.invalidateCache(change.doc.fields.visited_contact_uuid);
+        }
 
         const withIds =
           isSortedByLastVisited() &&

--- a/webapp/src/js/controllers/contacts.js
+++ b/webapp/src/js/controllers/contacts.js
@@ -148,7 +148,7 @@ var _ = require('underscore'),
             contacts.length >= options.limit;
 
           const mergedList = options.paginating ?
-            _.uniq(contacts.concat(liveList.getList()), false, _.property('_id')) 
+            _.uniq(contacts.concat(liveList.getList()), false, _.property('_id'))
             : contacts;
           liveList.set(mergedList, !!options.reuseExistingDom);
 
@@ -438,7 +438,7 @@ var _ = require('underscore'),
         if (change.deleted && change.doc.type !== 'data_record') {
           liveList.remove(change.doc);
         }
-        
+
         if (change.doc) {
           liveList.invalidateCache(change.doc._id);
           if (change.doc.fields) {

--- a/webapp/src/js/controllers/contacts.js
+++ b/webapp/src/js/controllers/contacts.js
@@ -146,8 +146,7 @@ var _ = require('underscore'),
           $scope.moreItems = liveList.moreItems =
             contacts.length >= options.limit;
 
-          contacts.forEach(liveList.update);
-          liveList.refresh();
+          liveList.add(contacts);
           _initScroll();
           $scope.loading = false;
           $scope.appending = false;

--- a/webapp/src/js/controllers/contacts.js
+++ b/webapp/src/js/controllers/contacts.js
@@ -7,13 +7,11 @@ var _ = require('underscore'),
   var inboxControllers = angular.module('inboxControllers');
 
   inboxControllers.controller('ContactsCtrl', function(
-    $element,
     $log,
     $q,
     $scope,
     $state,
     $stateParams,
-    $timeout,
     $translate,
     Auth,
     Changes,
@@ -51,7 +49,11 @@ var _ = require('underscore'),
     var _initScroll = function() {
       scrollLoader.init(function() {
         if (!$scope.loading && $scope.moreItems) {
-          _query({ skip: true });
+          _query({
+            append: true,
+            limit: Math.floor(liveList.count() / 50 + 1) * 50,
+            reuseExistingDom: true,
+          });
         }
       });
     };
@@ -65,18 +67,15 @@ var _ = require('underscore'),
         $scope.error = false;
       }
 
-      if (options.skip) {
+      if (options.append) {
         $scope.appending = true;
-        options.skip = liveList.count();
       } else if (!options.silent) {
         liveList.set([]);
         additionalListItem = false;
       }
 
       if (additionalListItem) {
-        if (options.skip) {
-          options.skip -= 1;
-        } else {
+        if (!options.append) {
           options.limit -= 1;
         }
       }
@@ -146,7 +145,7 @@ var _ = require('underscore'),
           $scope.moreItems = liveList.moreItems =
             contacts.length >= options.limit;
 
-          liveList.add(contacts);
+          liveList.set(contacts, !!options.reuseExistingDom);
           _initScroll();
           $scope.loading = false;
           $scope.appending = false;

--- a/webapp/src/js/controllers/contacts.js
+++ b/webapp/src/js/controllers/contacts.js
@@ -428,6 +428,7 @@ var _ = require('underscore'),
     var changeListener = Changes({
       key: 'contacts-list',
       callback: function(change) {
+        const limit = liveList.count();
         if (change.deleted && change.doc.type !== 'data_record') {
           liveList.remove(change.doc);
         }        
@@ -438,7 +439,7 @@ var _ = require('underscore'),
           !!isRelevantVisitReport(change.doc) &&
           !change.deleted;
         return _query({
-          limit: liveList.count(),
+          limit,
           withIds,
           silent: true,
           reuseExistingDom: true,

--- a/webapp/src/js/controllers/contacts.js
+++ b/webapp/src/js/controllers/contacts.js
@@ -431,13 +431,19 @@ var _ = require('underscore'),
         var limit = liveList.count();
         if (change.deleted && change.doc.type !== 'data_record') {
           liveList.remove(change.doc);
-        }
+        }        
+        liveList.invalidateCache(change.doc);
 
         var withIds =
           isSortedByLastVisited() &&
           !!isRelevantVisitReport(change.doc) &&
           !change.deleted;
-        return _query({ limit: limit, silent: true, withIds: withIds });
+        return _query({
+          limit,
+          withIds,
+          silent: true,
+          reuseExistingDom: true,
+        });
       },
       filter: function(change) {
         return (

--- a/webapp/src/js/controllers/contacts.js
+++ b/webapp/src/js/controllers/contacts.js
@@ -446,11 +446,6 @@ var _ = require('underscore'),
           if (change.doc.fields) {
             liveList.invalidateCache(change.doc.fields.visited_contact_uuid);
           }
-
-          // Invalidate the parent to handle changing primary contacts
-          if (change.doc.type === 'person' && change.doc.parent) {
-            liveList.invalidateCache(change.doc.parent._id);
-          }
         }
 
         const withIds =

--- a/webapp/src/js/controllers/contacts.js
+++ b/webapp/src/js/controllers/contacts.js
@@ -76,7 +76,7 @@ var _ = require('underscore'),
 
       if (additionalListItem) {
         if (options.skip) {
-          options.skip -= 1;	
+          options.skip -= 1;
         } else {
           options.limit -= 1;
         }
@@ -441,8 +441,15 @@ var _ = require('underscore'),
 
         if (change.doc) {
           liveList.invalidateCache(change.doc._id);
+
+          // Invalidate the contact for changing reports with visited_contact_uuid
           if (change.doc.fields) {
             liveList.invalidateCache(change.doc.fields.visited_contact_uuid);
+          }
+
+          // Invalidate the parent to handle changing primary contacts
+          if (change.doc.parent) {
+            invalidateParents(change.doc.parent._id);
           }
         }
 

--- a/webapp/src/js/controllers/contacts.js
+++ b/webapp/src/js/controllers/contacts.js
@@ -428,18 +428,17 @@ var _ = require('underscore'),
     var changeListener = Changes({
       key: 'contacts-list',
       callback: function(change) {
-        var limit = liveList.count();
         if (change.deleted && change.doc.type !== 'data_record') {
           liveList.remove(change.doc);
         }        
         liveList.invalidateCache(change.doc);
 
-        var withIds =
+        const withIds =
           isSortedByLastVisited() &&
           !!isRelevantVisitReport(change.doc) &&
           !change.deleted;
         return _query({
-          limit,
+          limit: liveList.count(),
           withIds,
           silent: true,
           reuseExistingDom: true,

--- a/webapp/src/js/controllers/contacts.js
+++ b/webapp/src/js/controllers/contacts.js
@@ -459,7 +459,7 @@ var _ = require('underscore'),
 
           // The logic for updating Primary Contact changes is complex
           // So redraw everything when a person changes
-          reuseExistingDom: change.doc.type !== 'person',
+          reuseExistingDom: change.doc && change.doc.type !== 'person',
         });
       },
       filter: function(change) {

--- a/webapp/src/js/controllers/contacts.js
+++ b/webapp/src/js/controllers/contacts.js
@@ -448,8 +448,8 @@ var _ = require('underscore'),
           }
 
           // Invalidate the parent to handle changing primary contacts
-          if (change.doc.parent) {
-            invalidateParents(change.doc.parent._id);
+          if (change.doc.type === 'person' && change.doc.parent) {
+            liveList.invalidateCache(change.doc.parent._id);
           }
         }
 

--- a/webapp/src/js/services/live-list.js
+++ b/webapp/src/js/services/live-list.js
@@ -349,8 +349,9 @@ angular.module('inboxServices').factory('LiveList',
       }
 
       idx.lastUpdate = new Date();
-      idx.list = idx.list.concat(items).sort(idx.orderBy);
-      idx.dom = idx.list.reduce((agg, val) => {
+      idx.list = _.uniq(_.union(items, idx.list), false, _.property('_id'));
+      idx.list.sort(idx.orderBy);
+      idx.dom = items.reduce((agg, val) => {
         agg[val._id] = listItemFor(idx, val);
         return agg;
       }, idx.dom);

--- a/webapp/src/js/services/live-list.js
+++ b/webapp/src/js/services/live-list.js
@@ -404,13 +404,13 @@ angular.module('inboxServices').factory('LiveList',
       }
     }
 
-    function _invalidateCache(listName, item) {
+    function _invalidateCache(listName, id) {
       const idx = indexes[listName];
-      if (!idx || !idx.dom || !item || !item._id || !idx.dom[item._id]) {
+      if (!idx || !idx.dom || !id || !idx.dom[id]) {
         return;
       }
 
-      idx.dom[item._id].invalidateCache = true;
+      idx.dom[id].invalidateCache = true;
     }
 
     function _update(listName, updatedItem) {

--- a/webapp/src/js/services/live-list.js
+++ b/webapp/src/js/services/live-list.js
@@ -448,9 +448,7 @@ angular.module('inboxServices').factory('LiveList',
         delete idx.dom[removedItem._id];
 
         $(idx.selector).children().eq(removeIndex).remove();
-        if (removed.length) {
-          return removed[0];
-        }
+        return removed;
       }
     }
 

--- a/webapp/src/js/services/live-list.js
+++ b/webapp/src/js/services/live-list.js
@@ -452,12 +452,12 @@ angular.module('inboxServices').factory('LiveList',
         return;
       }
 
-      if (idx.dom[_id]) {
-        idx.dom[_id].addClass('selected');
-      }
-      
       if (previous && idx.dom[previous]) {
         idx.dom[previous].removeClass('selected');
+      }
+
+      if (idx.dom[_id]) {
+        idx.dom[_id].addClass('selected');
       }
     }
 

--- a/webapp/src/js/services/live-list.js
+++ b/webapp/src/js/services/live-list.js
@@ -471,8 +471,9 @@ angular.module('inboxServices').factory('LiveList',
 
       if (idx.dom[idx.selected]) {
         idx.dom[idx.selected].removeClass('selected');
-        delete idx.selected;
       }
+
+      delete idx.selected;
     }
 
     function _containsDeleteStub(listName, doc) {

--- a/webapp/src/js/services/live-list.js
+++ b/webapp/src/js/services/live-list.js
@@ -353,7 +353,8 @@ angular.module('inboxServices').factory('LiveList',
       idx.list = items.sort(idx.orderBy);
       idx.dom = items.reduce((agg, val) => {
         
-        const li = reuseExistingDom && idx.dom[val._id] ? idx.dom[val._id] : listItemFor(idx, val);
+        const useCache = reuseExistingDom && idx.dom[val._id] && !idx.dom[val._id].invalidateCache;
+        const li = useCache ? idx.dom[val._id] : listItemFor(idx, val);
         agg[val._id] = li;
         return agg;
       }, {});
@@ -400,6 +401,15 @@ angular.module('inboxServices').factory('LiveList',
               .before(li);
         }
       }
+    }
+
+    function _invalidateCache(listName, item) {
+      const idx = indexes[listName];
+      if (!idx || !idx.dom || !item || !item._id || !idx.dom[item._id]) {
+        return;
+      }
+
+      idx.dom[item._id].invalidateCache = true;
     }
 
     function _update(listName, updatedItem) {
@@ -529,6 +539,7 @@ angular.module('inboxServices').factory('LiveList',
 
       api[name] = {
         insert: _.partial(_insert, name),
+        invalidateCache: _.partial(_invalidateCache, name),
         update: _.partial(_update, name),
         remove: _.partial(_remove, name),
         getList: _.partial(_getList, name),

--- a/webapp/src/js/services/live-list.js
+++ b/webapp/src/js/services/live-list.js
@@ -351,9 +351,7 @@ angular.module('inboxServices').factory('LiveList',
       idx.lastUpdate = new Date();
       idx.list = idx.list.concat(items).sort(idx.orderBy);
       idx.dom = idx.list.reduce((agg, val) => {
-        if (!agg[val._id]) {
-          agg[val._id] = listItemFor(idx, val);
-        }
+        agg[val._id] = listItemFor(idx, val);
         return agg;
       }, idx.dom);
 

--- a/webapp/src/js/services/live-list.js
+++ b/webapp/src/js/services/live-list.js
@@ -351,14 +351,15 @@ angular.module('inboxServices').factory('LiveList',
 
       idx.lastUpdate = new Date();
       idx.list = items.sort(idx.orderBy);
-      idx.dom = items.reduce((agg, val) => {
-        
-        const useCache = reuseExistingDom && idx.dom[val._id] && !idx.dom[val._id].invalidateCache;
-        const li = useCache ? idx.dom[val._id] : listItemFor(idx, val);
-        agg[val._id] = li;
-        return agg;
-      }, {});
-
+      const newDom = {};
+      for (let i = 0; i < items.length; ++i) {
+        const item = items[i];
+        const useCache = reuseExistingDom && idx.dom[item._id] && !idx.dom[item._id].invalidateCache;
+        const li = useCache ? idx.dom[item._id] : listItemFor(idx, item);
+        newDom[item._id] = li;
+      }
+      idx.dom = newDom;
+      
       _refresh(listName);
     }
 

--- a/webapp/src/js/services/live-list.js
+++ b/webapp/src/js/services/live-list.js
@@ -444,12 +444,11 @@ angular.module('inboxServices').factory('LiveList',
 
     function _setSelected(listName, _id) {
       const idx = indexes[listName],
-            list = idx.list,
             previous = idx.selected;
 
       idx.selected = _id;
 
-      if (!list) {
+      if (!idx.list) {
         return;
       }
 

--- a/webapp/src/js/services/live-list.js
+++ b/webapp/src/js/services/live-list.js
@@ -503,7 +503,7 @@ angular.module('inboxServices').factory('LiveList',
     }
 
     function refreshAll() {
-      var i, now = new Date();
+      const now = new Date();
 
       _.forEach(indexes, function(idx, name) {
         // N.B. no need to update a list that's never been generated
@@ -512,7 +512,7 @@ angular.module('inboxServices').factory('LiveList',
           // instead of yesterday
           idx.list.forEach(item => {
             idx.dom[item._id] = listItemFor(idx, item);
-          })
+          });
 
           api[name].refresh();
           idx.lastUpdate = now;

--- a/webapp/tests/karma/unit/controllers/contacts.js
+++ b/webapp/tests/karma/unit/controllers/contacts.js
@@ -568,8 +568,9 @@ describe('Contacts controller', () => {
           scrollLoaderCallback();
           assert.deepEqual(searchService.args[1][2], { 
             reuseExistingDom: true,
-            append: true,
-            limit: 100
+            paginating: true,
+            limit: 50,
+            skip: 50,
           });
         });
     });
@@ -586,8 +587,9 @@ describe('Contacts controller', () => {
           scrollLoaderCallback();
           assert.deepEqual(searchService.args[1][2], {
             reuseExistingDom: true,
-            append: true,
-            limit: 100,
+            paginating: true,
+            limit: 50,
+            skip: 50,
           });
         });
     });
@@ -653,9 +655,10 @@ describe('Contacts controller', () => {
           //aand paginate the search results, also not skipping the extra place
           scrollLoaderCallback();
           assert.deepEqual(searchService.args[2][2], {
-            limit: 100,
-            append: true,
+            limit: 50,
+            paginating: true,
             reuseExistingDom: true,
+            skip: 50,
           });
         });
     });
@@ -672,43 +675,52 @@ describe('Contacts controller', () => {
           assert.equal(lhs.length, 50);
           scrollLoaderCallback();
           assert.deepEqual(searchService.args[1][2], {
-            limit: 100,
-            append: true,
+            limit: 50,
+            paginating: true,
             reuseExistingDom: true,
+            skip: 50,
           });
         });
     });
 
     it('when paginating, does not modify the skip when it finds homeplace on subsequent pages #4085', () => {
-      const searchResult = { _id: 'search-result' };
-      searchResults = Array(50).fill(searchResult);
+      const mockResults = (count, startAt = 0) => {
+        const result = [];
+        for (let i = startAt; i < startAt + count; i++) {
+          result.push({ _id: `search-result${i}` });
+        }
+        return result;
+      };
+      searchResults = mockResults(50);
 
       return createController()
         .getSetupPromiseForTesting({ scrollLoaderStub })
         .then(() => {
           const lhs = contactsLiveList.getList();
           assert.equal(lhs.length, 51);
-          searchResults = Array(99).fill(searchResult);
+          searchResults = mockResults(49, 50);
           searchResults.push(district);
           searchService.returns(Promise.resolve(searchResults));
           scrollLoaderCallback();
           assert.deepEqual(searchService.args[1][2], {
-            limit: 100,
-            append: true,
+            limit: 50,
+            paginating: true,
             reuseExistingDom: true,
+            skip: 50,
           });
           return Promise.resolve();
         })
         .then(() => {
           const lhs = contactsLiveList.getList();
           assert.equal(lhs.length, 100);
-          searchResults = Array(150).fill(searchResult);
+          searchResults = mockResults(50, 100);
           searchService.returns(Promise.resolve(searchResults));
           scrollLoaderCallback();
           assert.deepEqual(searchService.args[2][2], {
-            limit: 150,
-            append: true,
+            limit: 50,
+            paginating: true,
             reuseExistingDom: true,
+            skip: 100,
           });
           return Promise.resolve();
         })

--- a/webapp/tests/karma/unit/controllers/contacts.js
+++ b/webapp/tests/karma/unit/controllers/contacts.js
@@ -50,6 +50,7 @@ describe('Contacts controller', () => {
         refresh: sinon.stub(),
         count: () => elements.length,
         insert: e => elements.push(e),
+        invalidateCache: () => {},
         set: es => (elements = es),
         update: e => {
           if (e !== district || elements[0] !== district) {
@@ -607,6 +608,7 @@ describe('Contacts controller', () => {
           assert.equal(lhs.length, 10);
           assert.deepEqual(searchService.args[1][2], {
             limit: 10,
+            reuseExistingDom: true,
             silent: true,
             withIds: false,
           });
@@ -1134,7 +1136,7 @@ describe('Contacts controller', () => {
                     assert.deepEqual(searchService.args[i], [
                       'contacts',
                       { types: { selected: ['childType'] } },
-                      { limit: 5, withIds: false, silent: true },
+                      { limit: 5, withIds: false, silent: true, reuseExistingDom: true },
                       { displayLastVisitedDate: true, visitCountSettings: {} },
                       undefined,
                     ]);
@@ -1164,7 +1166,7 @@ describe('Contacts controller', () => {
                   assert.deepEqual(searchService.args[1], [
                     'contacts',
                     { types: { selected: ['childType'] } },
-                    { limit: 5, withIds: true, silent: true },
+                    { limit: 5, withIds: true, silent: true, reuseExistingDom: true },
                     {
                       displayLastVisitedDate: true,
                       visitCountSettings: {},
@@ -1177,7 +1179,7 @@ describe('Contacts controller', () => {
                     assert.deepEqual(searchService.args[i], [
                       'contacts',
                       { types: { selected: ['childType'] } },
-                      { limit: 5, withIds: false, silent: true },
+                      { limit: 5, withIds: false, silent: true, reuseExistingDom: true },
                       {
                         displayLastVisitedDate: true,
                         visitCountSettings: {},
@@ -1220,7 +1222,7 @@ describe('Contacts controller', () => {
                     assert.deepEqual(searchService.args[i], [
                       'contacts',
                       { types: { selected: ['childType'] } },
-                      { limit: 5, withIds: false, silent: true },
+                      { limit: 5, withIds: false, silent: true, reuseExistingDom: true },
                       { displayLastVisitedDate: true, visitCountSettings: {} },
                       undefined,
                     ]);
@@ -1249,7 +1251,7 @@ describe('Contacts controller', () => {
                   assert.deepEqual(searchService.args[1], [
                     'contacts',
                     { types: { selected: ['childType'] } },
-                    { limit: 5, withIds: true, silent: true },
+                    { limit: 5, withIds: true, silent: true, reuseExistingDom: true },
                     {
                       displayLastVisitedDate: true,
                       visitCountSettings: {},
@@ -1262,7 +1264,7 @@ describe('Contacts controller', () => {
                     assert.deepEqual(searchService.args[i], [
                       'contacts',
                       { types: { selected: ['childType'] } },
-                      { limit: 5, withIds: false, silent: true },
+                      { limit: 5, withIds: false, silent: true, reuseExistingDom: true },
                       {
                         displayLastVisitedDate: true,
                         visitCountSettings: {},
@@ -1305,7 +1307,7 @@ describe('Contacts controller', () => {
                     assert.deepEqual(searchService.args[i], [
                       'contacts',
                       { types: { selected: ['childType'] } },
-                      { limit: 5, withIds: false, silent: true },
+                      { limit: 5, withIds: false, silent: true, reuseExistingDom: true },
                       {},
                       undefined,
                     ]);
@@ -1344,7 +1346,7 @@ describe('Contacts controller', () => {
                     assert.deepEqual(searchService.args[2], [
                       'contacts',
                       { types: { selected: ['childType'] } },
-                      { limit: 5, withIds: false, silent: true },
+                      { limit: 5, withIds: false, silent: true, reuseExistingDom: true },
                       {},
                       undefined,
                     ]);

--- a/webapp/tests/karma/unit/controllers/contacts.js
+++ b/webapp/tests/karma/unit/controllers/contacts.js
@@ -608,9 +608,8 @@ describe('Contacts controller', () => {
           const lhs = contactsLiveList.getList();
           changesCallback({});
           assert.equal(lhs.length, 10);
-          assert.deepEqual(searchService.args[1][2], {
+          assert.deepInclude(searchService.args[1][2], {
             limit: 10,
-            reuseExistingDom: true,
             silent: true,
             withIds: false,
           });
@@ -1148,7 +1147,7 @@ describe('Contacts controller', () => {
                     assert.deepEqual(searchService.args[i], [
                       'contacts',
                       { types: { selected: ['childType'] } },
-                      { limit: 5, withIds: false, silent: true, reuseExistingDom: true },
+                      { limit: 5, withIds: false, silent: true, reuseExistingDom: i !== 5 },
                       { displayLastVisitedDate: true, visitCountSettings: {} },
                       undefined,
                     ]);
@@ -1191,7 +1190,7 @@ describe('Contacts controller', () => {
                     assert.deepEqual(searchService.args[i], [
                       'contacts',
                       { types: { selected: ['childType'] } },
-                      { limit: 5, withIds: false, silent: true, reuseExistingDom: true },
+                      { limit: 5, withIds: false, silent: true, reuseExistingDom: i !== 5 },
                       {
                         displayLastVisitedDate: true,
                         visitCountSettings: {},
@@ -1234,7 +1233,7 @@ describe('Contacts controller', () => {
                     assert.deepEqual(searchService.args[i], [
                       'contacts',
                       { types: { selected: ['childType'] } },
-                      { limit: 5, withIds: false, silent: true, reuseExistingDom: true },
+                      { limit: 5, withIds: false, silent: true, reuseExistingDom: i !== 5 },
                       { displayLastVisitedDate: true, visitCountSettings: {} },
                       undefined,
                     ]);
@@ -1276,7 +1275,7 @@ describe('Contacts controller', () => {
                     assert.deepEqual(searchService.args[i], [
                       'contacts',
                       { types: { selected: ['childType'] } },
-                      { limit: 5, withIds: false, silent: true, reuseExistingDom: true },
+                      { limit: 5, withIds: false, silent: true, reuseExistingDom: i !== 5 },
                       {
                         displayLastVisitedDate: true,
                         visitCountSettings: {},
@@ -1319,7 +1318,7 @@ describe('Contacts controller', () => {
                     assert.deepEqual(searchService.args[i], [
                       'contacts',
                       { types: { selected: ['childType'] } },
-                      { limit: 5, withIds: false, silent: true, reuseExistingDom: true },
+                      { limit: 5, withIds: false, silent: true, reuseExistingDom: i !== 5 },
                       {},
                       undefined,
                     ]);

--- a/webapp/tests/karma/unit/controllers/contacts.js
+++ b/webapp/tests/karma/unit/controllers/contacts.js
@@ -42,6 +42,11 @@ describe('Contacts controller', () => {
     deadList = () => {
       let elements = [];
 
+      const update = e => {
+        if (e !== district || elements[0] !== district) {
+          elements.push(e);
+        }
+      };
       return {
         getList: () => elements,
         initialised: sinon.stub(),
@@ -51,11 +56,8 @@ describe('Contacts controller', () => {
         count: () => elements.length,
         insert: e => elements.push(e),
         set: es => (elements = es),
-        update: e => {
-          if (e !== district || elements[0] !== district) {
-            elements.push(e);
-          }
-        },
+        update,
+        add: es => es.forEach(update),
         remove: () => {
           if (deadListFind()) {
             return elements.pop();

--- a/webapp/tests/karma/unit/controllers/contacts.js
+++ b/webapp/tests/karma/unit/controllers/contacts.js
@@ -42,11 +42,6 @@ describe('Contacts controller', () => {
     deadList = () => {
       let elements = [];
 
-      const update = e => {
-        if (e !== district || elements[0] !== district) {
-          elements.push(e);
-        }
-      };
       return {
         getList: () => elements,
         initialised: sinon.stub(),
@@ -56,8 +51,11 @@ describe('Contacts controller', () => {
         count: () => elements.length,
         insert: e => elements.push(e),
         set: es => (elements = es),
-        update,
-        add: es => es.forEach(update),
+        update: e => {
+          if (e !== district || elements[0] !== district) {
+            elements.push(e);
+          }
+        },
         remove: () => {
           if (deadListFind()) {
             return elements.pop();
@@ -567,8 +565,11 @@ describe('Contacts controller', () => {
           const lhs = contactsLiveList.getList();
           assert.equal(lhs.length, 50);
           scrollLoaderCallback();
-          assert.equal(searchService.args[1][2].skip, 50);
-          assert.equal(searchService.args[1][2].limit, 50);
+          assert.deepEqual(searchService.args[1][2], { 
+            reuseExistingDom: true,
+            append: true,
+            limit: 100
+          });
         });
     });
 
@@ -582,8 +583,11 @@ describe('Contacts controller', () => {
           const lhs = contactsLiveList.getList();
           assert.equal(lhs.length, 51);
           scrollLoaderCallback();
-          assert.equal(searchService.args[1][2].skip, 50);
-          assert.equal(searchService.args[1][2].limit, 50);
+          assert.deepEqual(searchService.args[1][2], {
+            reuseExistingDom: true,
+            append: true,
+            limit: 100,
+          });
         });
     });
 
@@ -601,8 +605,11 @@ describe('Contacts controller', () => {
           const lhs = contactsLiveList.getList();
           changesCallback({});
           assert.equal(lhs.length, 10);
-          assert.equal(searchService.args[1][2].limit, 10);
-          assert.equal(searchService.args[1][2].skip, undefined);
+          assert.deepEqual(searchService.args[1][2], {
+            limit: 10,
+            silent: true,
+            withIds: false,
+          });
         });
     });
 
@@ -635,8 +642,7 @@ describe('Contacts controller', () => {
           searchResults = Array(50).fill(searchResult);
           searchService.returns(Promise.resolve(searchResults));
           scope.search();
-          assert.equal(searchService.args[1][2].limit, 50);
-          assert.equal(searchService.args[1][2].skip, undefined);
+          assert.deepEqual(searchService.args[1][2], { limit: 50 });
           return Promise.resolve();
         })
         .then(() => {
@@ -644,8 +650,11 @@ describe('Contacts controller', () => {
           assert.equal(lhs.length, 50);
           //aand paginate the search results, also not skipping the extra place
           scrollLoaderCallback();
-          assert.equal(searchService.args[2][2].skip, 50);
-          assert.equal(searchService.args[2][2].limit, 50);
+          assert.deepEqual(searchService.args[2][2], {
+            limit: 100,
+            append: true,
+            reuseExistingDom: true,
+          });
         });
     });
 
@@ -660,8 +669,11 @@ describe('Contacts controller', () => {
           const lhs = contactsLiveList.getList();
           assert.equal(lhs.length, 50);
           scrollLoaderCallback();
-          assert.equal(searchService.args[1][2].skip, 50);
-          assert.equal(searchService.args[1][2].limit, 50);
+          assert.deepEqual(searchService.args[1][2], {
+            limit: 100,
+            append: true,
+            reuseExistingDom: true,
+          });
         });
     });
 
@@ -674,22 +686,28 @@ describe('Contacts controller', () => {
         .then(() => {
           const lhs = contactsLiveList.getList();
           assert.equal(lhs.length, 51);
-          searchResults = Array(49).fill(searchResult);
+          searchResults = Array(99).fill(searchResult);
           searchResults.push(district);
           searchService.returns(Promise.resolve(searchResults));
           scrollLoaderCallback();
-          assert.equal(searchService.args[1][2].skip, 50);
-          assert.equal(searchService.args[1][2].limit, 50);
+          assert.deepEqual(searchService.args[1][2], {
+            limit: 100,
+            append: true,
+            reuseExistingDom: true,
+          });
           return Promise.resolve();
         })
         .then(() => {
           const lhs = contactsLiveList.getList();
           assert.equal(lhs.length, 100);
-          searchResults = Array(50).fill(searchResult);
+          searchResults = Array(150).fill(searchResult);
           searchService.returns(Promise.resolve(searchResults));
           scrollLoaderCallback();
-          assert.equal(searchService.args[2][2].skip, 100);
-          assert.equal(searchService.args[2][2].limit, 50);
+          assert.deepEqual(searchService.args[2][2], {
+            limit: 150,
+            append: true,
+            reuseExistingDom: true,
+          });
           return Promise.resolve();
         })
         .then(() => {

--- a/webapp/tests/karma/unit/services/live-list.js
+++ b/webapp/tests/karma/unit/services/live-list.js
@@ -122,7 +122,6 @@ describe('LiveListSrv', function() {
 
     // then
     assert.deepEqual(_.keys(service.name), [
-      'add',
       'insert',
       'update',
       'remove',

--- a/webapp/tests/karma/unit/services/live-list.js
+++ b/webapp/tests/karma/unit/services/live-list.js
@@ -123,6 +123,7 @@ describe('LiveListSrv', function() {
     // then
     assert.deepEqual(_.keys(service.name), [
       'insert',
+      'invalidateCache',
       'update',
       'remove',
       'getList',

--- a/webapp/tests/karma/unit/services/live-list.js
+++ b/webapp/tests/karma/unit/services/live-list.js
@@ -122,6 +122,7 @@ describe('LiveListSrv', function() {
 
     // then
     assert.deepEqual(_.keys(service.name), [
+      'add',
       'insert',
       'update',
       'remove',


### PR DESCRIPTION
# Description

#4445

Performance optimizations for the Live-List class as-used in the contacts tab. 

Contact controller currently calls `livelist.update` once per list item and then `livelist.refresh` after all items are added. 

This change updates the interface `livelist.set` to avoid the incremental dom changes from `livelist.update` and then the full re-paint from `livelist.refresh`. The proposed change inserts the items each item into the model once, sorts the full list once, and then draws everything once. To avoid unnecessary scanning, update `livelist.dom` to a hashmap. `livelist.set()` accepts an optional flag `reuseExistingDom` which can avoid expensive calls to `listItemFor` when the contents of the DOM are being reused and not updated (eg. pagination). 

## Measurements
On my SM-G361H. Times are a measure of milliseconds spent in `live-list.js` functions.

Five samples of the time spent in Live-List drawing a full LHS contact list (40 contacts).

Sample | Proposed | Master
-- | -- | --
1 | 391 | 546
2 | 304 | 660
3 | 261 | 856
4 | 277 | 499
5 | 387 | 800
Mean | 324 | 660

Two hundred contacts, displayed over four paginated pages. Table shows the time to render each page in the LHS contact list while paginating.

Page | Proposed | Master
-- | -- | --
1 | 519 | 725
2 | 419 | 738
3 | 464 | 876
4 | 311 | 671
Mean | 428 | 752

## Testing
I'm testing the following scenarios:

* Create a new user as admin. Syncs to offline user's live-list. 
* Delete the user as admin. Syncs to offline user's live-list.
* Edit user as admin. Syncs to offline user's live-list.
* Edit user twice as offline user. Edits appear in live-list, no pagination.
* Proper pagination.
* Edit the home place as admin (doesn't update in offline user's live-list) 
* Paginate to nth page, then edit an element within that page.
* Search
* Update the name of a primary contact for clinic

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
