### PR TITLE
Fixes bug where no permissions were checked in admin permissions page.

### DIFF
--- a/admin/src/templates/authorization_permissions.html
+++ b/admin/src/templates/authorization_permissions.html
@@ -9,7 +9,7 @@
         <ul>
           <li ng-repeat="role in permission.roles" class="checkbox">
             <label>
-              <input type="checkbox" ng-model="role.value"/>
+              <input type="checkbox" ng-model="role.enabled"/>
               <span translate>{{roles[role.name].name}}</span>
             </label>
           </li>


### PR DESCRIPTION
# Description

Updates `authorization_permissions` admin template to use new property `enabled` (instead of `value`) for existent permissions.

medic/medic-webapp#3762

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
