### PR TITLE
Add ability to delete custom key from admin app

### DIFF
--- a/admin/src/css/theme.less
+++ b/admin/src/css/theme.less
@@ -145,7 +145,3 @@ ul {
 .btn-bottom-spacing  {
   margin-bottom: 5px;
 }
-.no-padding-horizontal {
-   padding-left: 0 !important;
-   padding-right: 0 !important;
-}

--- a/admin/src/css/theme.less
+++ b/admin/src/css/theme.less
@@ -145,3 +145,7 @@ ul {
 .btn-bottom-spacing  {
   margin-bottom: 5px;
 }
+.no-padding-horizontal {
+   padding-left: 0 !important;
+   padding-right: 0 !important;
+}

--- a/admin/src/js/controllers/edit-language.js
+++ b/admin/src/js/controllers/edit-language.js
@@ -30,7 +30,8 @@ angular.module('controllers').controller('EditLanguageCtrl',
 
     $scope.language = _.clone($scope.model) || {
       enabled: true,
-      values: {},
+      generic: {},
+      custom: {},
       type: 'translations'
     };
 

--- a/admin/src/js/controllers/edit-translation.js
+++ b/admin/src/js/controllers/edit-translation.js
@@ -15,7 +15,9 @@ angular.module('controllers').controller('EditTranslationCtrl',
     $scope.model.values = {};
 
     $scope.model.locales.forEach(function(locale) {
-      var value = $scope.model.key ? locale.custom[$scope.model.key] || locale.generic[$scope.model.key] : null;
+      const custom = locale.custom || {};
+      const generic = locale.generic || {};
+      var value = $scope.model.key ? custom[$scope.model.key] || generic[$scope.model.key] : null;
       $scope.model.values[locale.code] = value;
     });
 
@@ -29,6 +31,10 @@ angular.module('controllers').controller('EditTranslationCtrl',
           ($scope.editing && custom[$scope.model.key] && custom[$scope.model.key] !== newValue) ||
           ($scope.editing && !custom[$scope.model.key] && generic[$scope.model.key] && generic[$scope.model.key] !== newValue)
         ) {
+          if (!locale.custom) {
+            locale.custom = {};
+          }
+
           locale.custom[$scope.model.key] = newValue;
           return true;
         }

--- a/admin/src/js/controllers/edit-translation.js
+++ b/admin/src/js/controllers/edit-translation.js
@@ -15,18 +15,35 @@ angular.module('controllers').controller('EditTranslationCtrl',
     $scope.model.values = {};
 
     $scope.model.locales.forEach(function(locale) {
-      var value = $scope.model.key ? locale.values[$scope.model.key] : null;
+      var value = $scope.model.key ? locale.custom[$scope.model.key] || locale.generic[$scope.model.key] : null;
       $scope.model.values[locale.code] = value;
     });
 
     var getUpdatedLocales = function() {
       return _.filter($scope.model.locales, function(locale) {
         var newValue = $scope.model.values[locale.code];
+        const custom = locale.custom || {};
+        const generic = locale.generic || {};
         if (
           !$scope.editing ||
-          ($scope.editing && locale.values[$scope.model.key] !== newValue)
+          ($scope.editing && custom[$scope.model.key] && custom[$scope.model.key] !== newValue) ||
+          ($scope.editing && !custom[$scope.model.key] && generic[$scope.model.key] && generic[$scope.model.key] !== newValue)
         ) {
-          locale.values[$scope.model.key] = newValue;
+          locale.custom[$scope.model.key] = newValue;
+          return true;
+        }
+        return false;
+      });
+    };
+
+    var deleteKeyFromLocales = function() {
+      return _.filter($scope.model.locales, function(locale) {
+        const custom = locale.custom || {};
+        if (
+          !$scope.editing ||
+          ($scope.editing && custom[$scope.model.key])
+        ) {
+          delete locale.custom[$scope.model.key];
           return true;
         }
         return false;
@@ -53,6 +70,24 @@ angular.module('controllers').controller('EditTranslationCtrl',
 
     $scope.cancel = function() {
       $uibModalInstance.dismiss();
+    };
+
+    $scope.delete = function() {
+      $scope.setProcessing();
+      var updated = deleteKeyFromLocales();
+      if (!updated.length) {
+        $scope.setFinished();
+        $uibModalInstance.close();
+      } else {
+        DB().bulkDocs(updated)
+          .then(function() {
+            $scope.setFinished();
+            $uibModalInstance.close();
+          })
+          .catch(function(err) {
+            $scope.setError(err, 'Error updating settings');
+          });
+      }
     };
 
   }

--- a/admin/src/js/controllers/translation-languages.js
+++ b/admin/src/js/controllers/translation-languages.js
@@ -29,7 +29,7 @@ angular.module('controllers').controller('TranslationLanguagesCtrl',
         };
       }
 
-      result.missing = totalTranslations - Object.keys(doc.values).length;
+      result.missing = totalTranslations - Object.keys(Object.assign(doc.generic, doc.custom || {})).length;
 
       return result;
     };
@@ -43,7 +43,7 @@ angular.module('controllers').controller('TranslationLanguagesCtrl',
 
     var countTotalTranslations = function(rows) {
       var keys = rows.map(function(row) {
-        return row.doc.values ? Object.keys(row.doc.values) : [];
+        return row.doc.custom || row.doc.generic ? Object.keys(Object.assign(row.doc.generic, row.doc.custom || {})) : [];
       });
       keys = _.uniq(_.flatten(keys));
       return keys.length;

--- a/admin/src/js/directives/modal.js
+++ b/admin/src/js/directives/modal.js
@@ -32,14 +32,23 @@ angular.module('directives').directive('mmModal', function() {
       // string: (optional) the key to use for the cancel button (defaults to 'Cancel')
       cancelKey: '=',
 
+      // string: (optional) the key to use for the delete button (defaults to 'Delete')
+      deleteKey: '=',
+
       // function: to be called when dismissing the modal
       onCancel: '&',
 
       // function: to be called when submitting the modal
       onSubmit: '&',
 
+      // function: to be called when deleting the modal
+      onDelete: '&',
+
       // string: (optional) the expression which, if true, will disable the submit button
-      disableSubmit: '='
+      disableSubmit: '=',
+
+      // string: (optional) the expression which, if true, will show the delete button
+      showDelete: '='
     }
   };
 });

--- a/admin/src/js/services/properties.js
+++ b/admin/src/js/services/properties.js
@@ -13,9 +13,37 @@ angular.module('services').factory('ImportProperties',
         return;
       }
       var updated = false;
+      const generic = doc.generic || {};
+      const custom = doc.custom || {};
       Object.keys(parsed).forEach(function(key) {
-        if (doc.values[key] !== parsed[key]) {
-          doc.values[key] = parsed[key];
+        if (generic[key]) {
+          if (generic[key] === parsed[key]) {
+            if (custom[key]) {
+              delete doc.custom[key];
+              updated = true;
+            }
+          } else if (custom[key]) {
+            if (custom[key] !== parsed[key]) {
+              doc.custom[key] = parsed[key];
+              updated = true;
+            }
+          }  else {
+            if (!doc.custom) {
+              doc.custom = {};
+            }
+            doc.custom[key] = parsed[key];
+            updated = true;
+          }
+        } else if (custom[key]) {
+          if (custom[key] !== parsed[key]) {
+            doc.custom[key] = parsed[key];
+            updated = true;
+          }
+        } else {
+          if (!doc.custom) {
+            doc.custom = {};
+          }
+          doc.custom[key] = parsed[key];
           updated = true;
         }
       });
@@ -50,8 +78,9 @@ angular.module('services').factory('ExportProperties',
     'use strict';
     return function(settings, locale) {
       var stringifier = properties.createStringifier();
-      Object.keys(locale.values).forEach(function(key) {
-        stringifier.property({ key: key, value: locale.values[key] });
+      var values = Object.assign(locale.generic, locale.custom || {});
+      Object.keys(values).forEach(function(key) {
+        stringifier.property({ key: key, value: values[key] });
       });
       return properties.stringify(stringifier);
     };

--- a/admin/src/templates/edit_translation.html
+++ b/admin/src/templates/edit_translation.html
@@ -6,18 +6,13 @@
   submitting-key="'Submitting'"
   on-cancel="cancel()"
   on-submit="submit()"
+  on-delete="delete()"
+  show-delete="true"
 >
   <form action="" method="POST">
     <div class="form-group">
       <label translate>translation.key</label>
-      <div class="col-sm-11 no-padding-horizontal">
-        <input class="form-control" ng-model="model.key" ng-disabled="editing">
-      </div>
-      <div class="col-sm-1 no-padding-horizontal">
-        <button type="button" class="btn btn-link btn-danger" ng-click="delete()">
-            <i class="fa fa-trash-o"></i>
-          </button>
-      </div>
+      <input class="form-control" ng-model="model.key" ng-disabled="editing">
     </div>
     <div class="form-group" ng-repeat="locale in model.locales track by locale._id">
       <label>{{locale.name}}</label>

--- a/admin/src/templates/edit_translation.html
+++ b/admin/src/templates/edit_translation.html
@@ -12,7 +12,14 @@
   <form action="" method="POST">
     <div class="form-group">
       <label translate>translation.key</label>
-      <input class="form-control" ng-model="model.key" ng-disabled="editing">
+      <div class="col-sm-11 no-padding-horizontal">
+        <input class="form-control" ng-model="model.key" ng-disabled="editing">
+      </div>
+      <div class="col-sm-1 no-padding-horizontal">
+        <button type="button" class="btn btn-link btn-danger" ng-click="delete()">
+            <i class="fa fa-trash-o"></i>
+          </button>
+      </div>
     </div>
     <div class="form-group" ng-repeat="locale in model.locales track by locale._id">
       <label>{{locale.name}}</label>

--- a/admin/src/templates/edit_translation.html
+++ b/admin/src/templates/edit_translation.html
@@ -10,7 +10,14 @@
   <form action="" method="POST">
     <div class="form-group">
       <label translate>translation.key</label>
-      <input class="form-control" ng-model="model.key" ng-disabled="editing">
+      <div class="col-sm-11 no-padding-horizontal">
+        <input class="form-control" ng-model="model.key" ng-disabled="editing">
+      </div>
+      <div class="col-sm-1 no-padding-horizontal">
+        <button type="button" class="btn btn-link btn-danger" ng-click="delete()">
+            <i class="fa fa-trash-o"></i>
+          </button>
+      </div>
     </div>
     <div class="form-group" ng-repeat="locale in model.locales track by locale._id">
       <label>{{locale.name}}</label>

--- a/admin/src/templates/edit_translation.html
+++ b/admin/src/templates/edit_translation.html
@@ -12,14 +12,7 @@
   <form action="" method="POST">
     <div class="form-group">
       <label translate>translation.key</label>
-      <div class="col-sm-11 no-padding-horizontal">
-        <input class="form-control" ng-model="model.key" ng-disabled="editing">
-      </div>
-      <div class="col-sm-1 no-padding-horizontal">
-        <button type="button" class="btn btn-link btn-danger" ng-click="delete()">
-            <i class="fa fa-trash-o"></i>
-          </button>
-      </div>
+      <input class="form-control" ng-model="model.key" ng-disabled="editing">
     </div>
     <div class="form-group" ng-repeat="locale in model.locales track by locale._id">
       <label>{{locale.name}}</label>

--- a/admin/src/templates/modal.html
+++ b/admin/src/templates/modal.html
@@ -7,6 +7,7 @@
   <div class="modal-footer">
     <p class="note" ng-if="status.error" translate>{{status.error}}</p>
     <a class="btn cancel" ng-class="{ 'disabled': status.processing }" ng-click="onCancel()" translate>{{cancelKey || 'Cancel'}}</a>
+    <a class="btn btn-danger" ng-show="showDelete" ng-click="onDelete()"><i class="fa fa-trash-o"></i>&nbsp;<span translate>{{deleteKey || 'Delete'}}</span></a>
     <a class="btn submit" ng-class="{ 'btn-primary': !danger, 'btn-danger': danger, 'disabled': disableSubmit }" mm-enter="onSubmit()" ng-click="onSubmit()" ng-show="!status.processing" translate>{{submitKey}}</a>
     <a class="btn submit disabled" ng-class="{ 'btn-primary': !danger, 'btn-danger': danger }" ng-show="status.processing" translate>{{submittingKey || submitKey}}</a>
   </div>

--- a/admin/src/templates/modal.html
+++ b/admin/src/templates/modal.html
@@ -7,7 +7,7 @@
   <div class="modal-footer">
     <p class="note" ng-if="status.error" translate>{{status.error}}</p>
     <a class="btn cancel" ng-class="{ 'disabled': status.processing }" ng-click="onCancel()" translate>{{cancelKey || 'Cancel'}}</a>
-    <a class="btn btn-danger" ng-show="showDelete" ng-click="onDelete()"><i class="fa fa-trash-o"></i>&nbsp;<span translate>{{deleteKey || 'Delete'}}</span></a>
+    <a class="btn btn-danger pull-left" ng-show="showDelete" ng-click="onDelete()"><i class="fa fa-trash-o"></i>&nbsp;<span translate>{{deleteKey || 'Delete'}}</span></a>
     <a class="btn submit" ng-class="{ 'btn-primary': !danger, 'btn-danger': danger, 'disabled': disableSubmit }" mm-enter="onSubmit()" ng-click="onSubmit()" ng-show="!status.processing" translate>{{submitKey}}</a>
     <a class="btn submit disabled" ng-class="{ 'btn-primary': !danger, 'btn-danger': danger }" ng-show="status.processing" translate>{{submittingKey || submitKey}}</a>
   </div>

--- a/admin/tests/unit/controllers/edit-translation.js
+++ b/admin/tests/unit/controllers/edit-translation.js
@@ -40,16 +40,16 @@ describe('EditTranslationCtrl controller', function() {
     model = {
       key: 'title.key',
       locales: [
-        { doc: { code: 'en', values: { 'title.key': 'Welcome', 'bye': 'Goodbye' } } },
-        { doc: { code: 'fr', values: { 'title.key': 'Bonjour', 'bye': 'Au revoir' } } }
+        { doc: { code: 'en', generic: { 'title.key': 'Welcome', 'bye': 'Goodbye' } } },
+        { doc: { code: 'fr', generic: { 'title.key': 'Bonjour', 'bye': 'Au revoir' } } }
       ]
     };
     createController();
     chai.expect(scope.model.key).to.equal('title.key');
     chai.expect(scope.editing).to.equal(true);
     chai.expect(scope.model.locales).to.deep.equal([
-      { code: 'en', values: { 'title.key': 'Welcome', 'bye': 'Goodbye' } },
-      { code: 'fr', values: { 'title.key': 'Bonjour', 'bye': 'Au revoir' } }
+      { code: 'en', generic: { 'title.key': 'Welcome', 'bye': 'Goodbye' } },
+      { code: 'fr', generic: { 'title.key': 'Bonjour', 'bye': 'Au revoir' } }
     ]);
     chai.expect(scope.model.values).to.deep.equal({ en: 'Welcome', fr: 'Bonjour' });
   });
@@ -57,16 +57,16 @@ describe('EditTranslationCtrl controller', function() {
   it('render new', function() {
     model = {
       locales: [
-        { doc: { code: 'en', values: { 'title.key': 'Welcome', 'bye': 'Goodbye' } } },
-        { doc: { code: 'fr', values: { 'title.key': 'Bonjour', 'bye': 'Au revoir' } } }
+        { doc: { code: 'en', generic: { 'title.key': 'Welcome', 'bye': 'Goodbye' } } },
+        { doc: { code: 'fr', generic: { 'title.key': 'Bonjour', 'bye': 'Au revoir' } } }
       ]
     };
     createController();
     chai.expect(scope.model.key).to.equal(undefined);
     chai.expect(scope.editing).to.equal(false);
     chai.expect(scope.model.locales).to.deep.equal([
-      { code: 'en', values: { 'title.key': 'Welcome', 'bye': 'Goodbye' } },
-      { code: 'fr', values: { 'title.key': 'Bonjour', 'bye': 'Au revoir' } }
+      { code: 'en', generic: { 'title.key': 'Welcome', 'bye': 'Goodbye' } },
+      { code: 'fr', generic: { 'title.key': 'Bonjour', 'bye': 'Au revoir' } }
     ]);
     chai.expect(scope.model.values).to.deep.equal({ en: null, fr: null });
   });
@@ -75,9 +75,9 @@ describe('EditTranslationCtrl controller', function() {
     model = {
       key: 'title.key',
       locales: [
-        { doc: { code: 'en', values: { 'title.key': 'Welcome', 'bye': 'Goodbye' } } },
-        { doc: { code: 'fr', values: { 'title.key': 'Bonjour', 'bye': 'Au revoir' } } },
-        { doc: { code: 'es', values: { 'title.key': 'Hola', 'bye': 'Hasta luego' } } }
+        { doc: { code: 'en', generic: { 'title.key': 'Welcome', 'bye': 'Goodbye' } } },
+        { doc: { code: 'fr', generic: { 'title.key': 'Bonjour', 'bye': 'Au revoir' } } },
+        { doc: { code: 'es', generic: { 'title.key': 'Hola', 'bye': 'Hasta luego' } } }
       ]
     };
     bulkDocs.returns(Promise.resolve());
@@ -90,11 +90,11 @@ describe('EditTranslationCtrl controller', function() {
       var updated = bulkDocs.args[0][0];
       chai.expect(updated.length).to.equal(2); // spanish not saved as not updated
       chai.expect(updated[0].code).to.equal('en');
-      chai.expect(updated[0].values['title.key']).to.equal('Hello');
-      chai.expect(updated[0].values.bye).to.equal('Goodbye');
+      chai.expect(updated[0].custom['title.key']).to.equal('Hello');
+      chai.expect(updated[0].custom.bye).to.equal('Goodbye');
       chai.expect(updated[1].code).to.equal('fr');
-      chai.expect(updated[1].values['title.key']).to.equal('Bienvenue');
-      chai.expect(updated[1].values.bye).to.equal('Au revoir');
+      chai.expect(updated[1].custom['title.key']).to.equal('Bienvenue');
+      chai.expect(updated[1].custom.bye).to.equal('Au revoir');
       done();
     });
   });
@@ -102,9 +102,9 @@ describe('EditTranslationCtrl controller', function() {
   it('save new', function(done) {
     model = {
       locales: [
-        { doc: { code: 'en', newValue: 'a', values: { 'title.key': 'Welcome', 'bye': 'Goodbye' } } },
-        { doc: { code: 'fr', newValue: 'b', values: { 'title.key': 'Bonjour', 'bye': 'Au revoir' } } },
-        { doc: { code: 'es', newValue: '', values: { 'title.key': 'Hola', 'bye': 'Hasta luego' } } }
+        { doc: { code: 'en', newValue: 'a', generic: { 'title.key': 'Welcome', 'bye': 'Goodbye' } } },
+        { doc: { code: 'fr', newValue: 'b', generic: { 'title.key': 'Bonjour', 'bye': 'Au revoir' } } },
+        { doc: { code: 'es', newValue: '', generic: { 'title.key': 'Hola', 'bye': 'Hasta luego' } } }
       ]
     };
     bulkDocs.returns(Promise.resolve());
@@ -118,11 +118,11 @@ describe('EditTranslationCtrl controller', function() {
       var updated = bulkDocs.args[0][0];
       chai.expect(updated.length).to.equal(3);
       chai.expect(updated[0].code).to.equal('en');
-      chai.expect(updated[0].values.somethingelse).to.equal('a');
+      chai.expect(updated[0].custom.somethingelse).to.equal('a');
       chai.expect(updated[1].code).to.equal('fr');
-      chai.expect(updated[1].values.somethingelse).to.equal('b');
+      chai.expect(updated[1].custom.somethingelse).to.equal('b');
       chai.expect(updated[2].code).to.equal('es');
-      chai.expect(updated[2].values.somethingelse).to.equal(null);
+      chai.expect(updated[2].custom.somethingelse).to.equal(null);
       done();
     });
   });

--- a/admin/tests/unit/controllers/edit-translation.js
+++ b/admin/tests/unit/controllers/edit-translation.js
@@ -91,10 +91,8 @@ describe('EditTranslationCtrl controller', function() {
       chai.expect(updated.length).to.equal(2); // spanish not saved as not updated
       chai.expect(updated[0].code).to.equal('en');
       chai.expect(updated[0].custom['title.key']).to.equal('Hello');
-      chai.expect(updated[0].custom.bye).to.equal('Goodbye');
       chai.expect(updated[1].code).to.equal('fr');
       chai.expect(updated[1].custom['title.key']).to.equal('Bienvenue');
-      chai.expect(updated[1].custom.bye).to.equal('Au revoir');
       done();
     });
   });

--- a/admin/tests/unit/services/export-properties.js
+++ b/admin/tests/unit/services/export-properties.js
@@ -15,7 +15,7 @@ describe('ExportProperties service', function() {
 
     var doc = {
       code: 'en',
-      values: {
+      generic: {
         'Hello': 'Gidday',
         'Goodbye': 'See ya',
         'New thing': 'New'

--- a/admin/tests/unit/services/import-properties.js
+++ b/admin/tests/unit/services/import-properties.js
@@ -36,7 +36,7 @@ describe('ImportProperties service', function() {
                   'Goodbye = Au revoir';
     var doc = {
       code: 'fr',
-      values: {
+      generic: {
         'Hello': 'hello',
         'Goodbye': 'bye'
       }
@@ -53,7 +53,11 @@ describe('ImportProperties service', function() {
       .then(function() {
         chai.expect(put.args[0][0]).to.deep.equal({
           code: 'fr',
-          values: {
+          generic: {
+            'Hello': 'hello',
+            'Goodbye': 'bye'
+          },
+          custom: {
             'Hello': 'Bonjour',
             'Goodbye': 'Au revoir'
           }
@@ -68,7 +72,10 @@ describe('ImportProperties service', function() {
                   'Goodbye = Au revoir';
     var doc = {
       code: 'fr',
-      values: {
+      generic: {
+        'Hello': 'hello'
+      },
+      custom: {
         'Hello': 'hello'
       }
     };
@@ -86,7 +93,10 @@ describe('ImportProperties service', function() {
     return service(content, doc).then(function() {
       chai.expect(put.args[0][0]).to.deep.equal({
         code: 'fr',
-        values: {
+        generic: {
+          'Hello': 'hello'
+        },
+        custom: {
           'Hello': 'Bonjour',
           'Goodbye': 'Au revoir'
         }

--- a/api/src/config.js
+++ b/api/src/config.js
@@ -79,7 +79,7 @@ const loadTranslations = () => {
       return;
     }
     result.rows.forEach(row => {
-      translationCache[row.doc.code] = Object.assign(row.doc.custom || {}, row.doc.generic);
+      translationCache[row.doc.code] = Object.assign(row.doc.generic, row.doc.custom || {});
     });
   });
 };

--- a/sentinel/src/config.js
+++ b/sentinel/src/config.js
@@ -24,7 +24,7 @@ const loadTranslations = () => {
   return db.medic
     .query('medic-client/doc_by_type', options)
     .then(result => {
-      result.rows.forEach(row => (translations[row.doc.code] = Object.assign(row.doc.custom || {}, row.doc.generic)));
+      result.rows.forEach(row => (translations[row.doc.code] = Object.assign(row.doc.generic, row.doc.custom || {})));
     })
     .catch(err => {
       logger.error('Error loading translations - starting up anyway: %o', err);


### PR DESCRIPTION
# Description

Allows admin to delete translation keys from admin:
<img width="677" alt="screen shot 2018-11-26 at 2 13 26 pm" src="https://user-images.githubusercontent.com/1445164/49038112-023af800-f18a-11e8-8c28-8c6a1b70d30f.png">
Also, refactor translation related code to take into account new structure.

medic/medic-webapp#3128

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
