### PR TITLE
Pretty error when grunting without COUCH_URL defined

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,6 +13,9 @@ const {
 const releaseName = TRAVIS_TAG || TRAVIS_BRANCH || 'local-development';
 
 const couchConfig = (() => {
+  if (!COUCH_URL) {
+    throw 'Required environment variable COUCH_URL is undefined. (eg. http://your:pass@localhost:5984/medic)';
+  }
   const parsedUrl = url.parse(COUCH_URL);
   if (!parsedUrl.auth) {
     throw 'COUCH_URL must contain admin authentication information';


### PR DESCRIPTION
COUCH_URL is now required for running `grunt`. As of https://github.com/medic/medic-webapp/commit/59a76afe830f3163ca0ce0c9f5ef7fb9c8445cd9.

Current error if COUCH_URL is undefined:
```
Loading "Gruntfile.js" tasks...ERROR
>> TypeError [ERR_INVALID_ARG_TYPE]: The "url" argument must be of type string. Received type undefined
```

Proposed error when COUCH_URL is undefined:
```
Loading "Gruntfile.js" tasks...ERROR
>> Required environment variable COUCH_URL is undefined. (eg. http://your:pass@localhost:5984/medic)
```