### PR TITLE
Accommodate to having scheduled messages about deleted patients

### DIFF
--- a/admin/src/css/configuration.less
+++ b/admin/src/css/configuration.less
@@ -121,8 +121,14 @@ dl.horizontal {
       margin-right: 10px;
       display: block;
     }
-    &.scheduled:before {
-      content: @scheduled-state-icon;
+    &.scheduled {
+      &:before {
+        content: @scheduled-state-icon;
+      }
+      &.has-error {
+        color: @error-color;
+        font-weight: bold;
+      }
     }
     &.muted:before {
       content: @muted-state-icon;
@@ -161,11 +167,6 @@ dl.horizontal {
 
     &.delayed {
       color: @primary-color;
-      font-weight: bold;
-    }
-
-    &.invalid {
-      color: @error-color;
       font-weight: bold;
     }
   }

--- a/admin/src/css/configuration.less
+++ b/admin/src/css/configuration.less
@@ -163,6 +163,24 @@ dl.horizontal {
       color: @primary-color;
       font-weight: bold;
     }
+
+    &.invalid {
+      color: @error-color;
+      font-weight: bold;
+    }
+  }
+
+  .task-error {
+    color: @failed-state-color;
+    font-size: @font-small;
+
+    &:before {
+      font-family: FontAwesome;
+      font-size: @font-small;
+      margin-right: 5px;
+      vertical-align: middle;
+      content: @failed-state-icon;
+    }
   }
 
   .pagination {

--- a/admin/src/css/configuration.less
+++ b/admin/src/css/configuration.less
@@ -170,15 +170,14 @@ dl.horizontal {
     }
   }
 
-  .task-error {
+  .message-error {
     color: @failed-state-color;
     font-size: @font-small;
 
     &:before {
       font-family: FontAwesome;
-      font-size: @font-small;
       margin-right: 5px;
-      vertical-align: middle;
+      vertical-align: baseline;
       content: @failed-state-icon;
     }
   }

--- a/admin/src/css/configuration.less
+++ b/admin/src/css/configuration.less
@@ -171,18 +171,6 @@ dl.horizontal {
     }
   }
 
-  .message-error {
-    color: @failed-state-color;
-    font-size: @font-small;
-
-    &:before {
-      font-family: FontAwesome;
-      margin-right: 5px;
-      vertical-align: baseline;
-      content: @failed-state-icon;
-    }
-  }
-
   .pagination {
     .fa {
       line-height: inherit;

--- a/admin/src/css/main.less
+++ b/admin/src/css/main.less
@@ -3,6 +3,7 @@
 @import "admin/node_modules/font-awesome/less/font-awesome";
 @import "webapp/src/css/variables";
 @import "webapp/src/css/font";
+@import "webapp/src/css/messages";
 
 @import "theme";
 @import "configuration";

--- a/admin/src/js/services/message-queue.js
+++ b/admin/src/js/services/message-queue.js
@@ -222,7 +222,8 @@ angular.module('services').factory('MessageQueue',
           stateHistory: message.task.state_history,
           content: message.sms.message,
           due: message.due,
-          link: !!message.doc.form
+          link: !!message.doc.form,
+          error: message.sms.error || false
         };
       });
     };

--- a/admin/src/templates/message_queue_tab.html
+++ b/admin/src/templates/message_queue_tab.html
@@ -29,11 +29,11 @@
 
     <div class="col col-grow">
       <p ng-if="message.task"><strong>{{message.task}}</strong></p>
-      <p class="task-error" ng-if="message.error">
+      <span>{{message.content}}</span>
+      <div class="message-error" ng-if="message.error">
         <span translate>messages.errors.invalid</span>
         <span translate>{{message.error}}</span>
-      </p>
-      <span>{{message.content}}</span>
+      </div>
     </div>
 
     <div class="col col-fixed">

--- a/admin/src/templates/message_queue_tab.html
+++ b/admin/src/templates/message_queue_tab.html
@@ -37,7 +37,7 @@
     </div>
 
     <div class="col col-fixed">
-      <span class="message-state {{message.state}}" ng-class="{ delayed: message.delayed, invalid: message.error }" translate>
+      <span class="message-state {{message.state}}" ng-class="{ delayed: message.delayed, 'has-error': message.error }" translate>
         {{'state.' + message.state}}
       </span>
     </div>

--- a/admin/src/templates/message_queue_tab.html
+++ b/admin/src/templates/message_queue_tab.html
@@ -29,11 +29,15 @@
 
     <div class="col col-grow">
       <p ng-if="message.task"><strong>{{message.task}}</strong></p>
+      <p class="task-error" ng-if="message.error">
+        <span translate>messages.errors.invalid</span>
+        <span translate>{{message.error}}</span>
+      </p>
       <span>{{message.content}}</span>
     </div>
 
     <div class="col col-fixed">
-      <span class="message-state {{message.state}}" ng-class="{ delayed: message.delayed }" translate>
+      <span class="message-state {{message.state}}" ng-class="{ delayed: message.delayed, invalid: message.error }" translate>
         {{'state.' + message.state}}
       </span>
     </div>

--- a/ddocs/medic/_attachments/translations/messages-en.properties
+++ b/ddocs/medic/_attachments/translations/messages-en.properties
@@ -1178,3 +1178,5 @@ contact.muted.modal.text = This contact is currently muted. You may proceed, but
 branding.logo.field = Logo
 branding.favicon.field = Favicon
 branding.title.field = Title
+messages.errors.invalid = Invalid message:
+messages.errors.patient.missing = Patient not found

--- a/sentinel/src/schedule/due_tasks.js
+++ b/sentinel/src/schedule/due_tasks.js
@@ -86,7 +86,7 @@ module.exports = {
                           context
                         );
 
-                        if (!messageUtils.getError(messages)) {
+                        if (!messageUtils.hasError(messages)) {
                           task.messages = messages;
                         }
                       }

--- a/sentinel/src/schedule/due_tasks.js
+++ b/sentinel/src/schedule/due_tasks.js
@@ -93,7 +93,7 @@ module.exports = {
                         }
                       }
 
-                      // only update tasks
+                      // only update task states when messages exist
                       if (task.messages) {
                         updatedTasks = true;
                         utils.setTaskState(task, 'pending');

--- a/sentinel/src/schedule/due_tasks.js
+++ b/sentinel/src/schedule/due_tasks.js
@@ -67,7 +67,7 @@ module.exports = {
                   if (err) {
                     return cb(err);
                   }
-                  var changedTasks = false;
+                  var updatedTasks = false;
                   // set task to pending for gateway to pick up
                   doc.scheduled_tasks.forEach(task => {
                     if (task.due === obj.key) {
@@ -86,19 +86,22 @@ module.exports = {
                           context
                         );
 
+                        // generated messages could have errors, such messages should not be saved
+                        // an example invalid message would be generated when a registration was missing the patient
                         if (!messageUtils.hasError(messages)) {
                           task.messages = messages;
                         }
                       }
 
+                      // only update tasks
                       if (task.messages) {
-                        changedTasks = true;
+                        updatedTasks = true;
                         utils.setTaskState(task, 'pending');
                       }
                     }
                   });
 
-                  if (!changedTasks) {
+                  if (!updatedTasks) {
                     return cb();
                   }
 

--- a/shared-libs/message-utils/src/index.js
+++ b/shared-libs/message-utils/src/index.js
@@ -271,7 +271,7 @@ exports.template = function(config, translate, doc, content, extraContext) {
   return render(config, template, context, locale);
 };
 
-exports.getError = function(messages) {
+exports.hasError = function(messages) {
   return messages && messages[0] && messages[0].error;
 };
 

--- a/shared-libs/message-utils/src/index.js
+++ b/shared-libs/message-utils/src/index.js
@@ -237,6 +237,14 @@ exports.generate = function(config, translate, doc, content, recipient, extraCon
     result.original_message = message;
   }
 
+  var isMissingPatient = extraContext &&
+                         !extraContext.patient &&
+                         extraContext.registrations &&
+                         extraContext.registrations.length;
+  if (isMissingPatient) {
+    result.error = 'messages.errors.patient.missing';
+  }
+
   return [ result ];
 };
 
@@ -261,6 +269,10 @@ exports.template = function(config, translate, doc, content, extraContext) {
   }
   var context = extendedTemplateContext(doc, extraContext);
   return render(config, template, context, locale);
+};
+
+exports.getError = function(messages) {
+  return messages && messages[0] && messages[0].error;
 };
 
 exports._getRecipient = getRecipient;

--- a/shared-libs/message-utils/src/index.js
+++ b/shared-libs/message-utils/src/index.js
@@ -157,13 +157,6 @@ var extendedTemplateContext = function(doc, extras) {
     _.defaults(templateContext, extractTemplateContext(extras.registrations[0]));
   }
 
-  if (!extras.patient && extras.registrations && extras.registrations.length) {
-    // If you're providing registrations to the template context you need to
-    // provide the patient contact document as well. Patients can be
-    // "registered" through the UI, only creating a patient and no registration report
-    throw Error('Cannot provide registrations to template context without a patient');
-  }
-
   return templateContext;
 };
 

--- a/shared-libs/message-utils/test/index.js
+++ b/shared-libs/message-utils/test/index.js
@@ -390,6 +390,50 @@ describe('messageUtils', () => {
 
     });
 
+    describe('errors', () => {
+      it('should add an error when registrations are provided without a patient', () => {
+        const config = {},
+              translate = null,
+              doc = {},
+              content = { message: 'sms' },
+              recipient = '1234',
+              context = { registrations: [{ _id: 'a' }] };
+
+        const messages = utils.generate(config, translate, doc, content, recipient, context);
+        expect(messages[0].message).to.equal('sms');
+        expect(messages[0].to).to.equal('1234');
+        expect(messages[0].error).to.equal('messages.errors.patient.missing');
+      });
+
+      it('should not add an error when no patient and no registrations are provided', () => {
+        const config = {},
+              translate = null,
+              doc = {},
+              content = { message: 'sms' },
+              recipient = '1234',
+              context = { registrations: false };
+
+        const messages = utils.generate(config, translate, doc, content, recipient, context);
+        expect(messages[0].message).to.equal('sms');
+        expect(messages[0].to).to.equal('1234');
+        expect(messages[0].error).to.equal(undefined);
+      });
+
+      it('should not add an error when patient is provided', () => {
+        const config = {},
+              translate = null,
+              doc = {},
+              content = { message: 'sms' },
+              recipient = '1234',
+              context = { patient: { name: 'a' } };
+
+        const messages = utils.generate(config, translate, doc, content, recipient, context);
+        expect(messages[0].message).to.equal('sms');
+        expect(messages[0].to).to.equal('1234');
+        expect(messages[0].error).to.equal(undefined);
+      });
+    });
+
   });
 
   describe('template', () => {
@@ -613,4 +657,18 @@ describe('messageUtils', () => {
 
   });
 
+  describe('getError', () => {
+    it('should work with incorrect param', () => {
+      expect(utils.getError()).to.equal(undefined);
+      expect(utils.getError(false)).to.equal(false);
+      expect(utils.getError({})).to.equal(undefined);
+      expect(utils.getError([])).to.equal(undefined);
+    });
+
+    it('should return correct result', () => {
+      expect(utils.getError([{ a: 1 }])).to.equal(undefined);
+      expect(utils.getError([{ error: false }])).to.equal(false);
+      expect(utils.getError([{ error: 'something' }])).to.equal('something');
+    });
+  });
 });

--- a/shared-libs/message-utils/test/index.js
+++ b/shared-libs/message-utils/test/index.js
@@ -165,6 +165,12 @@ describe('messageUtils', () => {
       const actual = utils._extendedTemplateContext(doc, { patient: patient, registrations: registrations });
       actual.name.should.equal('doug');
     });
+
+    it('should allow registrations without a patient', () => {
+      const extras = { registrations: [{ patient_name: 'clone' }] };
+      const result = utils._extendedTemplateContext({}, extras);
+      result.patient_name.should.equal('clone');
+    });
   });
 
   describe('generate', () => {

--- a/shared-libs/message-utils/test/index.js
+++ b/shared-libs/message-utils/test/index.js
@@ -657,18 +657,18 @@ describe('messageUtils', () => {
 
   });
 
-  describe('getError', () => {
+  describe('hasError', () => {
     it('should work with incorrect param', () => {
-      expect(utils.getError()).to.equal(undefined);
-      expect(utils.getError(false)).to.equal(false);
-      expect(utils.getError({})).to.equal(undefined);
-      expect(utils.getError([])).to.equal(undefined);
+      expect(utils.hasError()).to.equal(undefined);
+      expect(utils.hasError(false)).to.equal(false);
+      expect(utils.hasError({})).to.equal(undefined);
+      expect(utils.hasError([])).to.equal(undefined);
     });
 
     it('should return correct result', () => {
-      expect(utils.getError([{ a: 1 }])).to.equal(undefined);
-      expect(utils.getError([{ error: false }])).to.equal(false);
-      expect(utils.getError([{ error: 'something' }])).to.equal('something');
+      expect(utils.hasError([{ a: 1 }])).to.equal(undefined);
+      expect(utils.hasError([{ error: false }])).to.equal(false);
+      expect(utils.hasError([{ error: 'something' }])).to.equal('something');
     });
   });
 });

--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -658,8 +658,8 @@ body {
     }
   }
 
-  &.error {
-    .state {
+  &.has-error {
+    .state.scheduled {
       color: @failed-state-color;
       &:before {
         color: @failed-state-color;

--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -19,6 +19,7 @@
 @import 'content-list';
 
 @import 'enketo/medic';
+@import 'messages';
 
 .container-fluid {
   overflow: hidden;
@@ -658,12 +659,10 @@ body {
     }
   }
 
-  &.has-error {
-    .state.scheduled {
+  &.has-error .state.scheduled {
+    &,
+    &:before {
       color: @failed-state-color;
-      &:before {
-        color: @failed-state-color;
-      }
     }
   }
 }
@@ -812,18 +811,6 @@ a.fa:hover {
       margin-top: 10px;
       &:first-child {
         margin-top: 0;
-      }
-
-      .message-error {
-        color: @failed-state-color;
-        font-size: @font-small;
-
-        &:before {
-          font-family: FontAwesome;
-          margin-right: 5px;
-          vertical-align: baseline;
-          content: @failed-state-icon;
-        }
       }
     }
   }

--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -657,6 +657,15 @@ body {
       color: @failed-state-color;
     }
   }
+
+  &.error {
+    .state {
+      color: @failed-state-color;
+      &:before {
+        color: @failed-state-color;
+      }
+    }
+  }
 }
 
 .item-content {
@@ -805,15 +814,14 @@ a.fa:hover {
         margin-top: 0;
       }
 
-      .error {
+      .message-error {
         color: @failed-state-color;
         font-size: @font-small;
 
         &:before {
           font-family: FontAwesome;
-          font-size: @font-small;
           margin-right: 5px;
-          vertical-align: middle;
+          vertical-align: baseline;
           content: @failed-state-icon;
         }
       }

--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -804,6 +804,19 @@ a.fa:hover {
       &:first-child {
         margin-top: 0;
       }
+
+      .error {
+        color: @failed-state-color;
+        font-size: @font-small;
+
+        &:before {
+          font-family: FontAwesome;
+          font-size: @font-small;
+          margin-right: 5px;
+          vertical-align: middle;
+          content: @failed-state-icon;
+        }
+      }
     }
   }
 }

--- a/webapp/src/css/messages.less
+++ b/webapp/src/css/messages.less
@@ -1,0 +1,11 @@
+.message-error {
+  color: @failed-state-color;
+  font-size: @font-small;
+
+  &:before {
+    font-family: FontAwesome;
+    margin-right: 5px;
+    vertical-align: baseline;
+    content: @failed-state-icon;
+  }
+}

--- a/webapp/src/js/services/format-data-record.js
+++ b/webapp/src/js/services/format-data-record.js
@@ -467,6 +467,10 @@ angular
               t.recipient,
               context
             );
+
+            if (messages.hasError(copy.messages)) {
+              copy.error = true;
+            }
           }
 
           // timestamp is used for sorting in the frontend

--- a/webapp/src/templates/partials/reports_content.html
+++ b/webapp/src/templates/partials/reports_content.html
@@ -123,7 +123,7 @@
                       </div>
                     </li>
                   </ul>
-                  <span class="task-state {{ task.error ? 'error' : ''}}" ng-bind-html="task | state"></span>
+                  <span class="task-state {{ task.error ? 'has-error' : ''}}" ng-bind-html="task | state"></span>
                 </li>
                 <li class="clear"></li>
               </ul>

--- a/webapp/src/templates/partials/reports_content.html
+++ b/webapp/src/templates/partials/reports_content.html
@@ -116,7 +116,12 @@
                 <li ng-repeat="task in group.rows | orderBy:'timestamp'">
                   <ul>
                     <li ng-repeat="message in task.messages">
+                      <p class="error" ng-if="message.error">
+                        <span translate>messages.errors.invalid</span>
+                        <span translate>{{message.error}}</span>
+                      </p>
                       <p>{{message.message}}</p>
+
                     </li>
                   </ul>
                   <span class="task-state" ng-bind-html="task | state"></span>

--- a/webapp/src/templates/partials/reports_content.html
+++ b/webapp/src/templates/partials/reports_content.html
@@ -116,15 +116,14 @@
                 <li ng-repeat="task in group.rows | orderBy:'timestamp'">
                   <ul>
                     <li ng-repeat="message in task.messages">
-                      <p class="error" ng-if="message.error">
+                      <p>{{message.message}}</p>
+                      <div class="message-error" ng-if="message.error">
                         <span translate>messages.errors.invalid</span>
                         <span translate>{{message.error}}</span>
-                      </p>
-                      <p>{{message.message}}</p>
-
+                      </div>
                     </li>
                   </ul>
-                  <span class="task-state" ng-bind-html="task | state"></span>
+                  <span class="task-state {{ task.error ? 'error' : ''}}" ng-bind-html="task | state"></span>
                 </li>
                 <li class="clear"></li>
               </ul>


### PR DESCRIPTION
# Description

Updates `message-utils` shared library to not throw an error when registrations are provided without a patient, rather mark the resulted message with a translatable error. 
Updates Sentinel's `due_tasks` to not save such invalid/errored messages, also not updating task statuses either in such cases.
Updates Webapp Reports Content view and Admin Message Queue to clearly display such invalid scheduled messages - displaying the message error along with the generated content.

medic/medic-webapp#649
medic/medic-webapp#5019

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
