### PR TITLE
Show children / places / contacts as muted for muted parent.

### DIFF
--- a/webapp/src/templates/partials/contacts_content.html
+++ b/webapp/src/templates/partials/contacts_content.html
@@ -86,7 +86,7 @@
               heading="child.doc.name"
               summary="child.doc.title"
               primary-contact="child.isPrimaryContact"
-              is-muted="child.doc.muted && !selected.doc.muted"
+              is-muted="child.doc.muted"
               display-muted="true"
             />
           </ul>
@@ -98,7 +98,7 @@
               dob="child.doc.date_of_birth"
               primary-contact="child.isPrimaryContact"
               task-count="child.taskCount"
-              is-muted="child.doc.muted && !selected.doc.muted"
+              is-muted="child.doc.muted"
               display-muted="true"
             />
           </ul>
@@ -124,7 +124,7 @@
               route="'contacts'"
               heading="child.doc.name"
               summary="'contact.primary_contact_name' | translate:child.doc.contact"
-              is-muted="child.doc.muted && !selected.doc.muted"
+              is-muted="child.doc.muted"
               display-muted="true"
             />
           </ul>


### PR DESCRIPTION
# Description

Applies the muted styling to all children of muted parents.

medic/medic-webapp#4768

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
