### PR TITLE
Fix execution of config.load when migration has not executed yet

### DIFF
--- a/api/src/config.js
+++ b/api/src/config.js
@@ -80,6 +80,8 @@ const loadTranslations = () => {
       return;
     }
     result.rows.forEach(row => {
+      // If the field generic does not exist then we assume that the translation document 
+      // has not been converted to the new format so we will use the field values
       const values = row.doc.generic ? Object.assign(row.doc.generic, row.doc.custom || {}) : row.doc.values;
       translationCache[row.doc.code] = translationUtils.loadTranslations(values);
     });

--- a/api/src/config.js
+++ b/api/src/config.js
@@ -80,7 +80,7 @@ const loadTranslations = () => {
       return;
     }
     result.rows.forEach(row => {
-      const values = Object.assign(row.doc.generic, row.doc.custom || {});
+      const values = row.doc.generic ? Object.assign(row.doc.generic, row.doc.custom || {}) : row.doc.values;
       translationCache[row.doc.code] = translationUtils.loadTranslations(values);
     });
   });


### PR DESCRIPTION
This is related to translations

# Description

These changes will ensure that as long as the migration has not been the executed to convert the translation format, `config.load()` can still execute loading the old format.

medic/medic-webapp#5062

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
