### PR TITLE
Ensures async tests run assertions

### DIFF
--- a/sentinel/tests/unit/pregnancy_registration.js
+++ b/sentinel/tests/unit/pregnancy_registration.js
@@ -134,7 +134,6 @@ describe('patient registration', () => {
       sinon.stub(utils, 'getClinicPhone').returns('somephone');
       sinon.stub(utils, 'getForm').returns({});
       assert(transition.filter(doc));
-
   });
 
   it('is id only', () => {
@@ -148,7 +147,6 @@ describe('patient registration', () => {
       assert.equal(transition.isIdOnly({
           getid: 'x'
       }), true);
-
   });
 
   it('setExpectedBirthDate sets lmp_date and expected_date to null when lmp 0', () => {
@@ -156,7 +154,6 @@ describe('patient registration', () => {
       transition.setExpectedBirthDate(doc);
       assert.equal(doc.lmp_date, null);
       assert.equal(doc.expected_date, null);
-
   });
 
   it('setExpectedBirthDate sets lmp_date and expected_date correctly for lmp: 10', () => {
@@ -168,8 +165,6 @@ describe('patient registration', () => {
       assert(doc.lmp_date);
       assert.equal(doc.lmp_date, start.clone().subtract(10, 'weeks').toISOString());
       assert.equal(doc.expected_date, start.clone().add(30, 'weeks').toISOString());
-
-
   });
 
   it('valid adds lmp_date and patient_id', () => {
@@ -191,12 +186,11 @@ describe('patient registration', () => {
           }
       };
 
-      transition.onMatch({ doc: doc }).then(function(changed) {
+      return transition.onMatch({ doc: doc }).then(function(changed) {
           assert.equal(changed, true);
           assert.equal(doc.lmp_date, start.toISOString());
           assert(doc.patient_id);
           assert.equal(doc.tasks, undefined);
-
       });
   });
 
@@ -213,11 +207,10 @@ describe('patient registration', () => {
           }
       };
 
-      transition.onMatch({ doc: doc }).then(function(changed) {
+      return transition.onMatch({ doc: doc }).then(function(changed) {
           assert.equal(changed, true);
           assert.equal(doc.errors.length, 1);
           assert.equal(doc.errors[0].message, 'messages.generic.registration_not_found');
-
       });
   });
 
@@ -234,10 +227,9 @@ describe('patient registration', () => {
           }
       };
 
-      transition.onMatch({ doc: doc }).then(function(changed) {
+      return transition.onMatch({ doc: doc }).then(function(changed) {
           assert.equal(changed, true);
           assert(!doc.errors);
-
       });
   });
 
@@ -259,12 +251,11 @@ describe('patient registration', () => {
           }
       };
 
-      transition.onMatch({ doc: doc }).then(function(changed) {
+      return transition.onMatch({ doc: doc }).then(function(changed) {
           assert.equal(changed, true);
           assert.equal(doc.lmp_date, null);
           assert(doc.patient_id);
           assert.equal(doc.tasks, undefined);
-
       });
   });
 
@@ -286,12 +277,10 @@ describe('patient registration', () => {
           getid: 'x'
       };
 
-      transition.onMatch({ doc: doc }).then(function(changed) {
+      return transition.onMatch({ doc: doc }).then(function(changed) {
           assert.equal(changed, true);
           assert.equal(doc.lmp_date, undefined);
           assert(doc.patient_id);
-
-
       });
   });
 
@@ -310,12 +299,11 @@ describe('patient registration', () => {
           getid: 'x'
       };
 
-      transition.onMatch({ doc: doc }).then(function(changed) {
+      return transition.onMatch({ doc: doc }).then(function(changed) {
           assert.equal(changed, true);
           assert.equal(doc.patient_id, undefined);
           assert(doc.tasks);
           assert.equal(getMessage(doc), 'Invalid patient name.');
-
       });
   });
 
@@ -330,12 +318,10 @@ describe('patient registration', () => {
           }
       };
 
-      transition.onMatch({ doc: doc }).then(function(changed) {
+      return transition.onMatch({ doc: doc }).then(function(changed) {
           assert.equal(changed, true);
           assert.equal(doc.patient_id, undefined);
           assert.equal(getMessage(doc), 'Invalid patient name.');
-
-
       });
   });
 
@@ -375,14 +361,19 @@ describe('patient registration', () => {
       });
   });
 
-  it('mismatched form returns false', () => {
+  it('mismatched form returns false', done => {
       const doc = {
           form: 'x',
           type: 'data_record'
       };
-      return transition.onMatch({ doc: doc }).catch(function() {
-
-      });
+      transition.onMatch({ doc: doc })
+        .then(() => {
+          done(new Error('Error should have been thrown'));
+        })
+        .catch(() => {
+          // expected
+          done();
+        });
   });
 
   it('missing all fields returns validation errors', () => {

--- a/sentinel/tests/unit/reminders.js
+++ b/sentinel/tests/unit/reminders.js
@@ -289,7 +289,7 @@ describe('reminders', () => {
           assert.equal(message.message, `hi ${year} ${week}`);
           assert.equal(task.form, 'XXX');
           assert.equal(task.ts, now.toISOString());
-          done()
+          done();
       });
   });
 

--- a/sentinel/tests/unit/transitions/update_scheduled_reports.js
+++ b/sentinel/tests/unit/transitions/update_scheduled_reports.js
@@ -180,7 +180,7 @@ describe('update_scheduled_reports', () => {
       });
     });
 
-    it('remove duplicates and replace with latest doc', done => {
+    it('remove duplicates and replace with latest doc', () => {
       sinon.stub(db.medic, 'view').callsArgWith(3, null, {
         // ascending records
         rows: [
@@ -228,7 +228,7 @@ describe('update_scheduled_reports', () => {
           reported_date: 200,
         },
       };
-      transition.onMatch(change).then(changed => {
+      return transition.onMatch(change).then(changed => {
         assert.equal(changed, true);
         assert.equal(bulkSave.callCount, 1);
         assert.equal(bulkSave.args[0][0].length, 2);
@@ -242,7 +242,6 @@ describe('update_scheduled_reports', () => {
             assert.equal(doc._deleted, true);
           }
         });
-        done();
       });
     });
   });


### PR DESCRIPTION
# Description

Asynchronous mocha tests must either take a callback parameter (usually called `done`) and execute that once the async code has completed, or return a promise. This fixes a bunch of places where this wasn't happening so the assertions were never actually running.

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
