### PR TITLE
Fixes Messages, Reports and LiveList memory leaks

### DIFF
--- a/webapp/src/js/controllers/contacts.js
+++ b/webapp/src/js/controllers/contacts.js
@@ -34,6 +34,8 @@ var _ = require('underscore'),
 
     var liveList = LiveList.contacts;
 
+    LiveList.$init($scope, 'contacts', 'contact-search');
+
     $scope.loading = true;
     $scope.selected = null;
     $scope.filters = {};
@@ -473,8 +475,7 @@ var _ = require('underscore'),
 
     $scope.$on('$destroy', function () {
       changeListener.unsubscribe();
-      LiveList.contacts.set([]);
-      LiveList['contact-search'].set([]);
+      LiveList.$reset('contacts', 'contact-search');
     });
 
     if ($stateParams.tour) {

--- a/webapp/src/js/controllers/contacts.js
+++ b/webapp/src/js/controllers/contacts.js
@@ -475,7 +475,9 @@ var _ = require('underscore'),
 
     $scope.$on('$destroy', function () {
       changeListener.unsubscribe();
-      LiveList.$reset('contacts', 'contact-search');
+      if (!$state.includes('contacts')) {
+        LiveList.$reset('contacts', 'contact-search');
+      }
     });
 
     if ($stateParams.tour) {

--- a/webapp/src/js/controllers/contacts.js
+++ b/webapp/src/js/controllers/contacts.js
@@ -471,7 +471,11 @@ var _ = require('underscore'),
       },
     });
 
-    $scope.$on('$destroy', changeListener.unsubscribe);
+    $scope.$on('$destroy', function () {
+      changeListener.unsubscribe();
+      LiveList.contacts.set([]);
+      LiveList['contact-search'].set([]);
+    });
 
     if ($stateParams.tour) {
       Tour.start($stateParams.tour);

--- a/webapp/src/js/controllers/contacts.js
+++ b/webapp/src/js/controllers/contacts.js
@@ -237,7 +237,9 @@ var _ = require('underscore'),
               $log.error('Error fetching relevant forms', err);
             }
             var showUnmuteModal = function(formId) {
-              return $scope.selected.doc.muted && !isUnmuteForm(results[4], formId);
+              return $scope.selected.doc &&
+                     $scope.selected.doc.muted &&
+                     !isUnmuteForm(results[4], formId);
             };
             var formSummaries =
               forms &&

--- a/webapp/src/js/controllers/messages-content.js
+++ b/webapp/src/js/controllers/messages-content.js
@@ -218,7 +218,11 @@ angular.module('inboxControllers').controller('MessagesContentCtrl',
       }
     });
 
-    $scope.$on('$destroy', changeListener.unsubscribe);
+    $scope.$on('$destroy', function() {
+      changeListener.unsubscribe();
+      $('body').off('focus', '#message-footer textarea');
+      $('body').off('blur', '#message-footer textarea');
+    });
 
     $('.tooltip').remove();
 

--- a/webapp/src/js/controllers/messages-content.js
+++ b/webapp/src/js/controllers/messages-content.js
@@ -220,8 +220,10 @@ angular.module('inboxControllers').controller('MessagesContentCtrl',
 
     $scope.$on('$destroy', function() {
       changeListener.unsubscribe();
-      $('body').off('focus', '#message-footer textarea');
-      $('body').off('blur', '#message-footer textarea');
+      if (!$state.includes('messages.detail')) {
+        $('body').off('focus', '#message-footer textarea');
+        $('body').off('blur', '#message-footer textarea');
+      }
     });
 
     $('.tooltip').remove();

--- a/webapp/src/js/controllers/reports.js
+++ b/webapp/src/js/controllers/reports.js
@@ -515,5 +515,10 @@ angular
       },
     });
 
-    $scope.$on('$destroy', changeListener.unsubscribe);
+    $scope.$on('$destroy', function() {
+      changeListener.unsubscribe();
+      SearchFilters.destroy();
+      LiveList.reports.set([]);
+      LiveList['report-search'].set([]);
+    });
   });

--- a/webapp/src/js/controllers/reports.js
+++ b/webapp/src/js/controllers/reports.js
@@ -36,6 +36,7 @@ angular
     $scope.verifyingReport = false;
 
     var liveList = LiveList.reports;
+    LiveList.$init($scope, 'reports', 'report-search');
 
     var updateLiveList = function(updated) {
       return AddReadStatus.reports(updated).then(function() {
@@ -518,7 +519,7 @@ angular
     $scope.$on('$destroy', function() {
       changeListener.unsubscribe();
       SearchFilters.destroy();
-      LiveList.reports.set([]);
-      LiveList['report-search'].set([]);
+      LiveList.$reset('reports', 'report-search');
+      $('.inbox').off('click', '#reports-list .content-row');
     });
   });

--- a/webapp/src/js/controllers/reports.js
+++ b/webapp/src/js/controllers/reports.js
@@ -518,8 +518,10 @@ angular
 
     $scope.$on('$destroy', function() {
       changeListener.unsubscribe();
-      SearchFilters.destroy();
-      LiveList.$reset('reports', 'report-search');
-      $('.inbox').off('click', '#reports-list .content-row');
+      if (!$state.includes('reports')) {
+        SearchFilters.destroy();
+        LiveList.$reset('reports', 'report-search');
+        $('.inbox').off('click', '#reports-list .content-row');
+      }
     });
   });

--- a/webapp/src/js/services/search-filters.js
+++ b/webapp/src/js/services/search-filters.js
@@ -218,6 +218,9 @@ var _ = require('underscore'),
           $('.filter.multidropdown:not(.no-reset)').each(function() {
             $(this).multiDropdown().reset();
           });
+        },
+        destroy: function() {
+          $('#date-filter').data('daterangepicker').remove();
         }
       };
     }

--- a/webapp/tests/karma/unit/controllers/contacts.js
+++ b/webapp/tests/karma/unit/controllers/contacts.js
@@ -32,7 +32,9 @@ describe('Contacts controller', () => {
     deadListContains,
     deadList,
     contactSummary,
-    isDbAdmin;
+    isDbAdmin,
+    liveListInit,
+    liveListReset;
 
   beforeEach(module('inboxApp'));
 
@@ -65,6 +67,7 @@ describe('Contacts controller', () => {
         },
         contains: deadListContains,
         containsDeleteStub: sinon.stub(),
+        setScope: sinon.stub()
       };
     };
 
@@ -130,6 +133,8 @@ describe('Contacts controller', () => {
     settings = sinon.stub().resolves({});
     auth = sinon.stub().rejects();
     isDbAdmin = sinon.stub();
+    liveListInit = sinon.stub();
+    liveListReset = sinon.stub();
 
     createController = () => {
       searchService = sinon.stub();
@@ -152,6 +157,8 @@ describe('Contacts controller', () => {
         LiveList: {
           contacts: contactsLiveList,
           'contact-search': contactSearchLiveList,
+          $init: liveListInit,
+          $reset: liveListReset
         },
         Search: searchService,
         SearchFilters: { freetext: sinon.stub(), reset: sinon.stub() },
@@ -183,6 +190,8 @@ describe('Contacts controller', () => {
           scope.setTitle.getCall(0).args[0],
           typeLabel + 'translated'
         );
+        assert(liveListInit.called);
+        assert.deepEqual(liveListInit.args[0], [scope, 'contacts', 'contact-search']);
       });
   });
 
@@ -1388,6 +1397,15 @@ describe('Contacts controller', () => {
             });
         });
       });
+    });
+  });
+
+  describe('destroy', () => {
+    it('should reset liveList when destroyed', () => {
+      createController();
+      scope.$destroy();
+      assert.equal(liveListReset.callCount, 1);
+      assert.deepEqual(liveListReset.args[0], ['contacts', 'contact-search']);
     });
   });
 });

--- a/webapp/tests/karma/unit/controllers/reports.js
+++ b/webapp/tests/karma/unit/controllers/reports.js
@@ -13,7 +13,8 @@ describe('ReportsCtrl controller', () => {
       Changes,
       FormatDataRecord,
       changesCallback,
-      changesFilter;
+      changesFilter,
+      searchFilters;
 
   beforeEach(module('inboxApp'));
 
@@ -35,13 +36,19 @@ describe('ReportsCtrl controller', () => {
     scope.setRightActionBar = sinon.stub();
     scope.setLeftActionBar = sinon.stub();
     scope.settingSelected = () => {};
-    LiveList = { reports: {
-      initialised: () => true,
-      setSelected: sinon.stub(),
-      containsDeleteStub: sinon.stub(),
-      remove: sinon.stub(),
-      count: sinon.stub()
-    }};
+    LiveList = {
+      reports: {
+        initialised: () => true,
+        setSelected: sinon.stub(),
+        containsDeleteStub: sinon.stub(),
+        remove: sinon.stub(),
+        count: sinon.stub(),
+        set: sinon.stub()
+      },
+      'report-search': {
+        set: sinon.stub()
+      }
+    };
     MarkRead = () => {};
     FormatDataRecord = data => {
       return {
@@ -65,6 +72,8 @@ describe('ReportsCtrl controller', () => {
     changesCallback = undefined;
     changesFilter = undefined;
 
+    searchFilters = { destroy: sinon.stub() };
+
     createController = () => {
       return $controller('ReportsCtrl', {
         '$scope': scope,
@@ -80,7 +89,7 @@ describe('ReportsCtrl controller', () => {
         'MessageState': {},
         'ReportViewModelGenerator': {},
         'Search': Search,
-        'SearchFilters': () => {},
+        'SearchFilters': searchFilters,
         'Settings': KarmaUtils.nullPromise(),
         'Tour': () => {},
         'UpdateFacility': {},

--- a/webapp/tests/karma/unit/controllers/reports.js
+++ b/webapp/tests/karma/unit/controllers/reports.js
@@ -14,7 +14,9 @@ describe('ReportsCtrl controller', () => {
       FormatDataRecord,
       changesCallback,
       changesFilter,
-      searchFilters;
+      searchFilters,
+      liveListInit,
+      liveListReset;
 
   beforeEach(module('inboxApp'));
 
@@ -36,6 +38,10 @@ describe('ReportsCtrl controller', () => {
     scope.setRightActionBar = sinon.stub();
     scope.setLeftActionBar = sinon.stub();
     scope.settingSelected = () => {};
+
+    liveListInit = sinon.stub();
+    liveListReset = sinon.stub();
+
     LiveList = {
       reports: {
         initialised: () => true,
@@ -47,7 +53,9 @@ describe('ReportsCtrl controller', () => {
       },
       'report-search': {
         set: sinon.stub()
-      }
+      },
+      $init: liveListInit,
+      $reset: liveListReset
     };
     MarkRead = () => {};
     FormatDataRecord = data => {
@@ -100,6 +108,8 @@ describe('ReportsCtrl controller', () => {
 
   it('set up controller', () => {
     createController();
+    chai.expect(liveListInit.called, true);
+    chai.expect(liveListInit.args[0]).to.deep.equal([scope, 'reports', 'report-search']);
   });
 
   it('when selecting a report, it sets the phone number in the actionbar', done => {
@@ -327,6 +337,16 @@ describe('ReportsCtrl controller', () => {
         chai.expect(LiveList.reports.remove.callCount).to.equal(0);
         chai.expect(Search.callCount).to.equal(1);
       });
+    });
+  });
+
+  describe('destroy', () => {
+    it('should reset liveList and destroy search filters when destroyed', () => {
+      createController();
+      scope.$destroy();
+      chai.expect(liveListReset.callCount).to.equal(1);
+      chai.expect(liveListReset.args[0]).to.deep.equal(['reports', 'report-search']);
+      chai.expect(searchFilters.destroy.callCount).to.equal(1);
     });
   });
 });

--- a/webapp/tests/karma/unit/services/live-list.js
+++ b/webapp/tests/karma/unit/services/live-list.js
@@ -64,8 +64,8 @@ describe('LiveListSrv', function() {
     assert.ok(service);
   });
 
-  it('should provide a single API method', function() {
-    assert.deepEqual(_.keys(service), ['$listFor']);
+  it('should provide correct API methods', function() {
+    assert.deepEqual(_.keys(service), ['$listFor', '$init', '$reset']);
   });
 
   describe('failures related to a missing piece of config', function() {
@@ -106,7 +106,7 @@ describe('LiveListSrv', function() {
     service.$listFor('name', config);
 
     // then
-    assert.deepEqual(_.keys(service), ['$listFor', 'name']);
+    assert.deepEqual(_.keys(service), ['$listFor', '$init', '$reset', 'name']);
   });
 
   it('should provide a defined set of functions on initialised lists', function() {
@@ -134,7 +134,8 @@ describe('LiveListSrv', function() {
       'initialised',
       'setSelected',
       'clearSelected',
-      'containsDeleteStub'
+      'containsDeleteStub',
+      'setScope'
     ]);
   });
 
@@ -540,6 +541,76 @@ describe('LiveListSrv', function() {
       const doc = { _id: 'a', _rev: 'b', _deleted: true };
       service.testing.set([{ _id: 'a' }]);
       assert.equal(service.testing.containsDeleteStub(doc), true);
+    });
+  });
+
+  describe('$init', () => {
+    it('should work when no params are set, with no lists and with missing lists', () => {
+      service.$init();
+      service.$init('foo');
+      service.$init('foo', 'bar');
+    });
+
+    it('should set the scope of all given existent lists', () => {
+      const scope = 'foo',
+            config = { listItem: sinon.stub(), orderBy: 'name', selector: 'list' };
+      service.$listFor('one', config);
+      service.$listFor('two', config);
+      service.$listFor('three', config);
+      sinon.spy(service.one, 'setScope');
+      sinon.spy(service.two, 'setScope');
+      sinon.spy(service.three, 'setScope');
+      service.$init(scope, 'one', 'two', 'three', 'four', 'five');
+      assert.equal(service.one.setScope.callCount, 1);
+      assert.deepEqual(service.one.setScope.args[0], [scope]);
+      assert.equal(service.two.setScope.callCount, 1);
+      assert.deepEqual(service.two.setScope.args[0], [scope]);
+      assert.equal(service.three.setScope.callCount, 1);
+      assert.deepEqual(service.three.setScope.args[0], [scope]);
+      assert.equal(service.four, undefined);
+      assert.equal(service.five, undefined);
+    });
+  });
+
+  describe('$reset', () => {
+    it('should work when no lists or with missing lists', () => {
+      service.$reset();
+      service.$reset('foo');
+      service.$reset('foo', 'bar');
+    });
+
+    it('should empty and reset scope of given existent lists', () => {
+      const scope = 'foo',
+            config = { listItem: sinon.stub(), orderBy: sinon.stub(), selector: 'list' };
+      service.$listFor('one', config);
+      service.$listFor('two', config);
+      service.$listFor('three', config);
+      service.one.setScope(scope);
+      service.one.set(['a', 'b', 'c']);
+      service.two.setScope(scope);
+      service.two.set(['1', '2', '3']);
+      service.three.setScope(scope);
+      service.three.set(['somewhere']);
+
+      sinon.spy(service.one, 'setScope');
+      sinon.spy(service.two, 'setScope');
+      sinon.spy(service.three, 'setScope');
+
+      service.$reset('one', 'two', 'three', 'four', 'five');
+      assert.deepEqual(service.one.getList(), []);
+      assert.equal(service.one.setScope.callCount, 1);
+      assert.deepEqual(service.one.setScope.args[0], []);
+
+      assert.deepEqual(service.two.getList(), []);
+      assert.equal(service.two.setScope.callCount, 1);
+      assert.deepEqual(service.two.setScope.args[0], []);
+
+      assert.deepEqual(service.three.getList(), []);
+      assert.equal(service.three.setScope.callCount, 1);
+      assert.deepEqual(service.three.setScope.args[0], []);
+
+      assert.equal(service.four, undefined);
+      assert.equal(service.five, undefined);
     });
   });
 


### PR DESCRIPTION
# Description

Changes Reports and Cotnacts LiveList to use child controller $scope instead of Inbox $scope, so the child scopes created by LiveList get destroyed when tabs are changed.
Clears jQuery event listeners in MessagesContentCtrl.
Removes Reports Filters DateTimePicker html when switching tabs. 

medic/medic-webapp#5050

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
