### PR TITLE
Mark message as errored if translation fails

### DIFF
--- a/ddocs/medic/_attachments/translations/messages-en.properties
+++ b/ddocs/medic/_attachments/translations/messages-en.properties
@@ -1183,3 +1183,4 @@ branding.favicon.field = Favicon
 branding.title.field = Title
 messages.errors.invalid = Invalid message:
 messages.errors.patient.missing = Patient not found
+messages.errors.message.empty = Message is empty

--- a/scripts/travis/couch-start
+++ b/scripts/travis/couch-start
@@ -6,7 +6,7 @@ if ! [[ "${USE_COUCHDB-}" = "true" ]]; then
 fi
 
 # start couchdb 2.x docker instance
-docker run -d -p 5984:5984 --name couch couchdb:2
+docker run -d -p 5984:5984 --name couch couchdb:2.2.0
 echo "Starting CouchDB 2.x"
 until nc -z localhost 5984; do sleep 1; done
 echo "CouchDB Started"

--- a/sentinel/tests/integration/schedules.js
+++ b/sentinel/tests/integration/schedules.js
@@ -256,7 +256,7 @@ describe('functional schedules', () => {
     sinon.stub(schedules, 'getScheduleConfig').returns({});
     sinon.stub(utils, 'getPatientContactUuid').callsArgWith(2, null, {_id: 'uuid'});
     sinon.stub(utils, 'getRegistrations').callsArgWithAsync(1, null, []);
-    sinon.stub(utils, 'translate').withArgs('thanks', 'en').returns('thanks');
+    sinon.stub(utils, 'translate').withArgs('thanks', 'en').returns('Thanks');
 
     const doc = {
       reported_date: moment().toISOString(),
@@ -275,7 +275,7 @@ describe('functional schedules', () => {
       testMessage(
           getMessage(doc, 0),
           '+5551596',
-          'thanks');
+          'Thanks');
     });
   });
 

--- a/sentinel/tests/unit/due_tasks.js
+++ b/sentinel/tests/unit/due_tasks.js
@@ -42,10 +42,12 @@ describe('due tasks', () => {
         {
           due: due,
           state: 'scheduled',
+          message: 'x'
         },
         {
           due: notDue,
           state: 'scheduled',
+          message: 'y'
         },
       ],
     };
@@ -96,10 +98,12 @@ describe('due tasks', () => {
         {
           due: due,
           state: 'scheduled',
+          message: 'x'
         },
         {
           due: notDue,
           state: 'scheduled',
+          message: 'y'
         },
       ],
     };
@@ -154,6 +158,7 @@ describe('due tasks', () => {
         {
           due: due,
           state: 'scheduled',
+          message: 'x'
         },
       ],
     };
@@ -162,6 +167,7 @@ describe('due tasks', () => {
         {
           due: due,
           state: 'scheduled',
+          message: 'y'
         },
       ],
     };

--- a/shared-libs/message-utils/src/index.js
+++ b/shared-libs/message-utils/src/index.js
@@ -225,6 +225,11 @@ exports.generate = function(config, translate, doc, content, recipient, extraCon
   };
 
   var message = exports.template(config, translate, doc, content, extraContext);
+  if (!message || (content.translationKey && message === content.translationKey)) {
+    result.error = 'messages.errors.message.empty';
+    return [ result ];
+  }
+
   var parsed = gsm(message);
   var max = config.multipart_sms_limit || 10;
 

--- a/webapp/tests/karma/unit/services/format-data-record.js
+++ b/webapp/tests/karma/unit/services/format-data-record.js
@@ -26,7 +26,7 @@ describe('FormatDataRecord service', () => {
 
   afterEach(() => sinon.restore());
 
-  it('generates cleared messages', done => {
+  it('errors messages when they fail to transate', done => {
     const doc = {
       from: '+123456',
       scheduled_tasks: [
@@ -48,7 +48,7 @@ describe('FormatDataRecord service', () => {
         chai.expect(row.messages.length).to.equal(1);
         const message = row.messages[0];
         chai.expect(message.to).to.equal('+123456');
-        chai.expect(message.message).to.equal('some.message');
+        chai.expect(message.error).to.equal('messages.errors.message.empty');
         done();
       })
       .catch(done);


### PR DESCRIPTION
# Description

Mark the message as errored when translation fails. Marking the message as errored will prevent it from being sent. 

<img width="753" alt="screen shot 2018-12-06 at 12 24 48 pm" src="https://user-images.githubusercontent.com/1445164/49600766-f43b6300-f951-11e8-9298-008976eabe54.png">


medic/medic-webapp#4598

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
