### PR TITLE
4598 failed message translation no sent

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -13,9 +13,9 @@
       }
     },
     "@medic/message-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@medic/message-utils/-/message-utils-1.0.0.tgz",
-      "integrity": "sha512-HA1Ayq41eUXHgjBRz+EV1Ni+KF31SneEnsmHsSmXnTm/p6ciHTpIZlSKpHI2EnjpsEolQm1yEnmHjQtBHL8UDw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@medic/message-utils/-/message-utils-1.0.1.tgz",
+      "integrity": "sha512-bGIJz62ns9RDNhyDSQdyAvERI8pVHcTo8qOWsOxq7gVn7qOavSIMaYrhYro16lf7c7sOkwoXcALFyXt/e8mWzw==",
       "requires": {
         "underscore": "^1.9.1"
       }

--- a/admin/package.json
+++ b/admin/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@medic/lineage": "^1.0.0",
-    "@medic/message-utils": "^1.0.0",
+    "@medic/message-utils": "^1.0.1",
     "@medic/phone-number": "^1.0.0",
     "@medic/registration-utils": "^1.0.0",
     "angular": "^1.7.5",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -18,9 +18,9 @@
       }
     },
     "@medic/message-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@medic/message-utils/-/message-utils-1.0.0.tgz",
-      "integrity": "sha512-HA1Ayq41eUXHgjBRz+EV1Ni+KF31SneEnsmHsSmXnTm/p6ciHTpIZlSKpHI2EnjpsEolQm1yEnmHjQtBHL8UDw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@medic/message-utils/-/message-utils-1.0.1.tgz",
+      "integrity": "sha512-bGIJz62ns9RDNhyDSQdyAvERI8pVHcTo8qOWsOxq7gVn7qOavSIMaYrhYro16lf7c7sOkwoXcALFyXt/e8mWzw==",
       "requires": {
         "underscore": "^1.9.1"
       }

--- a/api/package.json
+++ b/api/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@medic/bulk-docs-utils": "^1.0.0",
     "@medic/lineage": "^1.0.0",
-    "@medic/message-utils": "^1.0.0",
+    "@medic/message-utils": "^1.0.1",
     "@medic/phone-number": "^1.0.0",
     "@medic/registration-utils": "^1.0.0",
     "@medic/search": "^1.1.0",

--- a/ddocs/medic/_attachments/translations/messages-en.properties
+++ b/ddocs/medic/_attachments/translations/messages-en.properties
@@ -1183,6 +1183,7 @@ branding.favicon.field = Favicon
 branding.title.field = Title
 messages.errors.invalid = Invalid message:
 messages.errors.patient.missing = Patient not found
+messages.errors.message.empty = Message is empty
 partner.tab.partners = Partners
 partner.name.field = Partner name
 partner.logo.field = Partner logo

--- a/sentinel/package-lock.json
+++ b/sentinel/package-lock.json
@@ -13,9 +13,9 @@
       }
     },
     "@medic/message-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@medic/message-utils/-/message-utils-1.0.0.tgz",
-      "integrity": "sha512-HA1Ayq41eUXHgjBRz+EV1Ni+KF31SneEnsmHsSmXnTm/p6ciHTpIZlSKpHI2EnjpsEolQm1yEnmHjQtBHL8UDw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@medic/message-utils/-/message-utils-1.0.1.tgz",
+      "integrity": "sha512-bGIJz62ns9RDNhyDSQdyAvERI8pVHcTo8qOWsOxq7gVn7qOavSIMaYrhYro16lf7c7sOkwoXcALFyXt/e8mWzw==",
       "requires": {
         "underscore": "^1.9.1"
       }

--- a/sentinel/package.json
+++ b/sentinel/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@medic/lineage": "^1.0.0",
-    "@medic/message-utils": "^1.0.0",
+    "@medic/message-utils": "^1.0.1",
     "@medic/phone-number": "^1.0.0",
     "@medic/registration-utils": "^1.0.0",
     "@medic/server-checks": "^1.0.0",

--- a/sentinel/tests/integration/schedules.js
+++ b/sentinel/tests/integration/schedules.js
@@ -256,7 +256,7 @@ describe('functional schedules', () => {
     sinon.stub(schedules, 'getScheduleConfig').returns({});
     sinon.stub(utils, 'getPatientContactUuid').callsArgWith(1, null, {_id: 'uuid'});
     sinon.stub(utils, 'getRegistrations').callsArgWithAsync(1, null, []);
-    sinon.stub(utils, 'translate').withArgs('thanks', 'en').returns('thanks');
+    sinon.stub(utils, 'translate').withArgs('thanks', 'en').returns('Thanks');
 
     const doc = {
       reported_date: moment().toISOString(),
@@ -275,7 +275,7 @@ describe('functional schedules', () => {
       testMessage(
           getMessage(doc, 0),
           '+5551596',
-          'thanks');
+          'Thanks');
     });
   });
 

--- a/sentinel/tests/unit/due_tasks.js
+++ b/sentinel/tests/unit/due_tasks.js
@@ -42,10 +42,12 @@ describe('due tasks', () => {
         {
           due: due,
           state: 'scheduled',
+          message: 'x'
         },
         {
           due: notDue,
           state: 'scheduled',
+          message: 'y'
         },
       ],
     };
@@ -96,10 +98,12 @@ describe('due tasks', () => {
         {
           due: due,
           state: 'scheduled',
+          message: 'x'
         },
         {
           due: notDue,
           state: 'scheduled',
+          message: 'y'
         },
       ],
     };
@@ -154,6 +158,7 @@ describe('due tasks', () => {
         {
           due: due,
           state: 'scheduled',
+          message: 'x'
         },
       ],
     };
@@ -162,6 +167,7 @@ describe('due tasks', () => {
         {
           due: due,
           state: 'scheduled',
+          message: 'y'
         },
       ],
     };

--- a/shared-libs/message-utils/src/index.js
+++ b/shared-libs/message-utils/src/index.js
@@ -229,7 +229,7 @@ exports.generate = function(config, translate, doc, content, recipient, extraCon
     result.error = 'messages.errors.message.empty';
     return [ result ];
   }
-  
+
   var parsed = gsm(message);
   var max = config.multipart_sms_limit || 10;
 

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -18,9 +18,9 @@
       }
     },
     "@medic/message-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@medic/message-utils/-/message-utils-1.0.0.tgz",
-      "integrity": "sha512-HA1Ayq41eUXHgjBRz+EV1Ni+KF31SneEnsmHsSmXnTm/p6ciHTpIZlSKpHI2EnjpsEolQm1yEnmHjQtBHL8UDw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@medic/message-utils/-/message-utils-1.0.1.tgz",
+      "integrity": "sha512-bGIJz62ns9RDNhyDSQdyAvERI8pVHcTo8qOWsOxq7gVn7qOavSIMaYrhYro16lf7c7sOkwoXcALFyXt/e8mWzw==",
       "requires": {
         "underscore": "^1.9.1"
       }

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@medic/bulk-docs-utils": "^1.0.0",
     "@medic/lineage": "^1.0.0",
-    "@medic/message-utils": "^1.0.0",
+    "@medic/message-utils": "^1.0.1",
     "@medic/phone-number": "^1.0.0",
     "@medic/registration-utils": "^1.0.0",
     "@medic/search": "^1.1.0",

--- a/webapp/tests/karma/unit/services/format-data-record.js
+++ b/webapp/tests/karma/unit/services/format-data-record.js
@@ -26,7 +26,7 @@ describe('FormatDataRecord service', () => {
 
   afterEach(() => sinon.restore());
 
-  it('generates cleared messages', done => {
+  it('errors messages when they fail to transate', done => {
     const doc = {
       from: '+123456',
       scheduled_tasks: [
@@ -48,7 +48,7 @@ describe('FormatDataRecord service', () => {
         chai.expect(row.messages.length).to.equal(1);
         const message = row.messages[0];
         chai.expect(message.to).to.equal('+123456');
-        chai.expect(message.message).to.equal('some.message');
+        chai.expect(message.error).to.equal('messages.errors.message.empty');
         done();
       })
       .catch(done);

--- a/webapp/tests/karma/unit/services/format-data-record.js
+++ b/webapp/tests/karma/unit/services/format-data-record.js
@@ -26,6 +26,34 @@ describe('FormatDataRecord service', () => {
 
   afterEach(() => sinon.restore());
 
+  it('generates cleared messages', done => {
+    const doc = {
+      from: '+123456',
+      scheduled_tasks: [
+        {
+          message: 'Some message',
+          state: 'cleared',
+          recipient: 'reporting_unit'
+        }
+      ]
+    };
+    const settings = {};
+    Settings.returns(Promise.resolve(settings));
+    Language.returns(Promise.resolve('en'));
+    service(doc)
+      .then(formatted => {
+        chai.expect(formatted.scheduled_tasks_by_group.length).to.equal(1);
+        chai.expect(formatted.scheduled_tasks_by_group[0].rows.length).to.equal(1);
+        const row = formatted.scheduled_tasks_by_group[0].rows[0];
+        chai.expect(row.messages.length).to.equal(1);
+        const message = row.messages[0];
+        chai.expect(message.to).to.equal('+123456');
+        chai.expect(message.message).to.equal('Some message');
+        done();
+      })
+      .catch(done);
+  });
+
   it('errors messages when they fail to transate', done => {
     const doc = {
       from: '+123456',


### PR DESCRIPTION
# Description

Mark the message as errored when translation fails. Marking the message as errored will prevent it from being sent.

<img width="753" alt="49600766-f43b6300-f951-11e8-9298-008976eabe54" src="https://user-images.githubusercontent.com/1445164/49660093-c61e5780-fa13-11e8-9e9e-f32d184652d3.png">


medic/medic-webapp#4598

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
