### PR TITLE
Remove _purge e2e test for online users.

### DIFF
--- a/scripts/travis/couch-start
+++ b/scripts/travis/couch-start
@@ -6,7 +6,7 @@ if ! [[ "${USE_COUCHDB-}" = "true" ]]; then
 fi
 
 # start couchdb 2.x docker instance
-docker run -d -p 5984:5984 --name couch couchdb:2.2.0
+docker run -d -p 5984:5984 --name couch couchdb:2
 echo "Starting CouchDB 2.x"
 until nc -z localhost 5984; do sleep 1; done
 echo "CouchDB Started"

--- a/tests/e2e/api/routing.js
+++ b/tests/e2e/api/routing.js
@@ -567,12 +567,7 @@ describe('routing', () => {
               request
             )
           )
-          .catch(err => err),
-        utils
-          .requestOnTestDb(
-            _.extend({ path: '/_purge' }, onlineRequestOptions, request)
-          )
-          .catch(err => err),
+          .catch(err => err)
       ]).then(results => {
         expect(results[0].statusCode).toEqual(403);
         expect(results[0].responseBody.error).toEqual('forbidden');
@@ -582,8 +577,6 @@ describe('routing', () => {
 
         expect(results[2].statusCode).toEqual(403);
         expect(results[2].responseBody.error).toEqual('forbidden');
-
-        expect(results[3].responseBody.error).toEqual('not_implemented');
       });
     });
 


### PR DESCRIPTION
# Description

This test fails when running tests against Couch 2.3, since this endpoint has been finally implemented. 
Offline users are still blocked from accessing `_purge`. 

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
