### PR TITLE
Mark message that is empty or fails translation as errored

### DIFF
--- a/shared-libs/message-utils/package-lock.json
+++ b/shared-libs/message-utils/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@medic/message-utils",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/shared-libs/message-utils/package.json
+++ b/shared-libs/message-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medic/message-utils",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "src/index.js",
   "scripts": {
     "test": "mocha ./test"

--- a/shared-libs/message-utils/src/index.js
+++ b/shared-libs/message-utils/src/index.js
@@ -225,6 +225,11 @@ exports.generate = function(config, translate, doc, content, recipient, extraCon
   };
 
   var message = exports.template(config, translate, doc, content, extraContext);
+  if (!message || (content.translationKey && message === content.translationKey)) {
+    result.error = 'messages.errors.message.empty';
+    return [ result ];
+  }
+  
   var parsed = gsm(message);
   var max = config.multipart_sms_limit || 10;
 


### PR DESCRIPTION
# Description

This PR is needed to publish the shared-libs/message-utils change that is required by https://github.com/medic/medic-webapp/pull/5081
Travis fails because it uses the published package

medic/medic-webapp#4598

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
