### PR TITLE
Uses consistent naming for the App Settings console

### DIFF
--- a/webapp/src/templates/partials/header.html
+++ b/webapp/src/templates/partials/header.html
@@ -51,7 +51,7 @@
           <li role="presentation" mm-auth="can_configure" mm-auth-online="true">
             <a ng-href="{{adminUrl}}" role="menuitem" tabindex="-1" target="_blank" rel="noopener noreferrer">
               <i class="fa fa-fw fa-cog"></i>
-              <span translate>Configuration</span>
+              <span translate>admin.app.name</span>
             </a>
           </li>
           <li role="presentation" mm-auth="can_configure">


### PR DESCRIPTION
# Description

This change updates the webapp dropdown menu to use the same translation
key as and admin app uses so the naming will be consistent.

medic/medic-webapp#4960

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
