### PR TITLE
Contact RHS - Avoid primary contact lookup when redundant

### DIFF
--- a/webapp/src/js/services/contact-view-model-generator.js
+++ b/webapp/src/js/services/contact-view-model-generator.js
@@ -188,7 +188,7 @@ angular.module('inboxServices').factory('ContactViewModelGenerator',
             });
         });
     };
-    
+
     var loadChildren = function(model) {
       model.children = {};
       if (model.doc.type === 'person') {
@@ -239,7 +239,7 @@ angular.module('inboxServices').factory('ContactViewModelGenerator',
                     report.heading = getHeading(dataRecord);
                   }
                 });
-                
+
                 return reports;
               });
     };

--- a/webapp/src/js/services/contact-view-model-generator.js
+++ b/webapp/src/js/services/contact-view-model-generator.js
@@ -96,41 +96,51 @@ angular.module('inboxServices').factory('ContactViewModelGenerator',
       });
     };
 
-    var getPrimaryContact = function(doc) {
+    const getPrimaryContact = function(doc, children) {
       var contactId = doc && doc.contact && doc.contact._id;
       if (!contactId) {
         return $q.resolve();
       }
-      return DB().get(contactId).catch(function(err) {
-        if (err.status === 404 || err.error === 'not_found') {
-          return;
-        }
-        throw err;
-      });
+
+      const persons = children.persons || [];
+      const idx = _.findIndex(persons, person => person.doc._id === contactId);
+      if (idx !== -1) {
+        return $q.resolve({
+          idx,
+          doc: persons[idx].doc
+        });
+      }
+
+      // If the primary contact is not a child, fetch the document
+      return DB().get(contactId)
+        .then(doc => ({ idx, doc }))
+        .catch(function(err) {
+          if (err.status === 404 || err.error === 'not_found') {
+            return;
+          }
+          throw err;
+        });
     };
 
     var sortPrimaryContactToTop = function(model, children) {
-      return getPrimaryContact(model.doc)
-        .then(function(primaryContact) {
+      return getPrimaryContact(model.doc, children)
+        .then(function (primaryContact) {
           if (!primaryContact) {
             return;
           }
-          var newChild = {
-            id: primaryContact._id,
-            doc: primaryContact,
+          const newChild = {
+            id: primaryContact.doc._id,
+            doc: primaryContact.doc,
             isPrimaryContact: true
           };
           if (!children.persons) {
             children.persons = [ newChild ];
             return;
           }
-          var persons = children.persons;
+          const persons = children.persons;
           // remove existing child
-          var primaryContactIdx = _.findIndex(persons, function(child) {
-            return child.doc._id === primaryContact._id;
-          });
-          if (primaryContactIdx !== -1) {
-            persons.splice(primaryContactIdx, 1);
+          if (primaryContact.idx !== -1) {
+            persons.splice(primaryContact.idx, 1);
           }
           // push the primary contact on to the start of the array
           persons.unshift(newChild);
@@ -178,7 +188,7 @@ angular.module('inboxServices').factory('ContactViewModelGenerator',
             });
         });
     };
-
+    
     var loadChildren = function(model) {
       model.children = {};
       if (model.doc.type === 'person') {

--- a/webapp/tests/karma/unit/services/contact-view-model-generator.js
+++ b/webapp/tests/karma/unit/services/contact-view-model-generator.js
@@ -160,6 +160,16 @@ describe('ContactViewModelGenerator service', () => {
       });
     });
 
+    it('contact person loaded from children', () => {
+      return runPlaceTest([childContactPerson], []).then(model => {
+          assert.equal(dbGet.callCount, 0);
+          assert.equal(model.children.persons.length, 1);
+          const firstPerson = model.children.persons[0];
+          assert.deepEqual(firstPerson.doc, childContactPerson);
+          assert(firstPerson.isPrimaryContact, 'has isPrimaryContact flag');
+        });
+    });
+
     it('if no contact in parent, persons still get displayed', () => {
       delete doc.contact;
       return runPlaceTest([childPerson, childContactPerson]).then(model => {


### PR DESCRIPTION
# Description

This is a very minor performance tweak to avoid an unnecessary PouchDB.get() for a place's primary contact when the document is already in the place's children. In my limited exposure to project data, the primary contact is often a child of the place.

Looks like the in-memory lookup is ~0-1ms and PouchDB lookup ranges from 10-45ms. Not impressive... but I'm here cause it's on my list, and it doesn't add much compexity. Very open to just closing this as won't fix due to insufficient gains.

"The data fetched in right-panel step R6 was already fetched in step R4. Can we consolidate?" from #4445 

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
