### PR TITLE
Add "[webapp]" to slack notification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,6 +96,6 @@ notifications:
     rooms:
       - medic:SdzCLsD56UOr5U8ujzOCMDJd#development
     template:
-      - "<%{build_url}|%{author}'s build> %{result}. Commit: %{commit_message} (<%{compare_url}|compare>)"
+      - "[webapp] <%{build_url}|%{author}'s build> %{result}. Commit: %{commit_message} (<%{compare_url}|compare>)"
     on_success: change
     on_failure: always


### PR DESCRIPTION
This makes it clearer which repo a slack notification is generated for.