### PR TITLE
5082 - Make content-security-policy more strict

### DIFF
--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -115,9 +115,29 @@ app.use(
     // runs with a bunch of defaults: https://github.com/helmetjs/helmet
     hpkp: false, // explicitly block dangerous header
     contentSecurityPolicy: {
+      /* jshint ignore:start */
       directives: {
-        frameSrc: ['\'self\''] // prettier-ignore
+        defaultSrc: ["'none'"],
+        fontSrc: ["'self'"],
+        manifestSrc: ["'self'"],
+        connectSrc: ["'self'"],
+        formAction: ["'self'"],
+        imgSrc: [
+          "'self'",
+          'data:' // unsafe
+        ],
+        scriptSrc: [
+          "'self'",
+          "'sha256-6i0jYw/zxQO6q9fIxqI++wftTrPWB3yxt4tQqy6By6k='", // Explicitly allow the telemetry script setting startupTimes
+          "'unsafe-eval'" // AngularJS and several dependencies require this
+        ],
+        styleSrc: [
+          "'self'",
+          "'unsafe-inline'" // angular-ui-bootstrap
+        ],
       },
+      /* jshint ignore:end */
+      browserSniff: false,
     },
   })
 );

--- a/tests/e2e/content-security-policy.js
+++ b/tests/e2e/content-security-policy.js
@@ -1,0 +1,22 @@
+const utils = require('../utils');
+const { expect } = require('chai');
+
+describe('Content Security Policy', () => {
+  beforeEach(done => {
+    utils.resetBrowser();
+    done();
+  });
+
+  /*
+  If this test fails, you've probably changed the inline telemetry script
+  If the change is intentional, take the hash recommended in this error and replace the telemetry hash in the API helmet configuration
+  */
+  it('Telemetry script is not blocked by CSP', done => {
+    browser.manage()
+      .logs()
+      .get('browser').then(function(logEntries) {
+        logEntries.forEach(entry => expect(entry.message).to.not.include('Refused to execute inline script'));
+        done();
+      });
+  });
+});

--- a/webapp/src/templates/inbox.html
+++ b/webapp/src/templates/inbox.html
@@ -4,14 +4,14 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" type="text/css" href="css/inbox.css" />
-    <link rel="shortcut icon" href="/favicon.ico">
-    <link rel="manifest" href="manifest.json">
-    <title id="app"></title>
     <script type="text/javascript">
       window.startupTimes = {};
       window.startupTimes.start = performance.now();
     </script>
+    <link rel="stylesheet" type="text/css" href="css/inbox.css" />
+    <link rel="shortcut icon" href="/favicon.ico">
+    <link rel="manifest" href="manifest.json">
+    <title id="app"></title>
   </head>
   <body class="inbox {{currentTab}}" ng-controller="InboxCtrl" ng-class="{'show-content': showContent, 'bootstrapped': version && dbWarmedUp, 'select-mode': selectMode}">
 


### PR DESCRIPTION
# Description

I believe this is our most tightly constrained CSP without breaking anything. It requires a few "unsafe" configurations:

1. `imgSrc: data:` - "developers SHOULD NOT include either 'unsafe-inline', or data: as valid sources in their policies. Both enable XSS attacks by allowing code to be included directly in the document itself; they are best avoided completely." https://www.w3.org/TR/CSP3/#csp-directives
1. `scriptSrc: unsafe-eval` - We use `eval()` about 88 times and use `new Function()` about 17 times in inbox.js. "AngularJS makes use of this in the $parse service to provide a 30% increase in the speed of evaluating AngularJS expressions." https://docs.angularjs.org/api/ng/directive/ngCsp
1. `styleSrc: unsafe-inline` - Our dependency, `angular-ui-bootstrap` injects about 8 inline style blocks. Here is an example issue where they fix one of them https://github.com/angular-ui/bootstrap/issues/5470. The risks from unsafe css are reduced by fully constraining imgSrc (not done here) and by avoiding unsafe-eval (not done here).

#5082 

## Questions for Reviewer

1. I'm explicitly allowing the inline script for telemetry `window.startupTimes` - through a whitelisted hash. Another option would be to move that script into its own file and appcache it. As-is, if the content of this script ever changes, the corresponding hash will need to be updated. If we keep it as a hash, I'm unsure of the best method to keep the hash and script in sync (new test, calculate the hash in api, just pray, etc.). 
1. We may want to whitelist a hash for each of the eight style blocks from angular-ui-bootstrap instead of using`unsafe-inline` - I didn't do it because I'm not sure they are always the same for all browsers but they probably are and can follow-up if we close on that direction.

## Additional considerations

This change also makes the header larger. Including it on all resources (js, css, application/json, etc.) isn't required so one minor performance tweak we might consider here is setting it for `Accept: html` requests only. 

CSP also supports `report-uri` which can alert us when the security policy is violated (due to bugs or successful attacks). Might be worth opening an issue to enable this down the road.

## Testing

I went through some basic workflows in webapp + tried each actions in admin pages. In general though, this has risks of breaking edge-case functionalities or workflows I don't know about. Best to AT across all browsers as there are apparently some differences.

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
