### PR TITLE
Exports function that returns CouchDB version

### DIFF
--- a/shared-libs/server-checks/package-lock.json
+++ b/shared-libs/server-checks/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@medic/server-checks",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/shared-libs/server-checks/package.json
+++ b/shared-libs/server-checks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medic/server-checks",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Server startup checks.",
   "main": "src/checks.js",
   "scripts": {

--- a/shared-libs/server-checks/src/checks.js
+++ b/shared-libs/server-checks/src/checks.js
@@ -56,15 +56,17 @@ const couchDbNoAdminPartyModeCheck = () => {
   });
 };
 
-const couchDbVersionCheck = (serverUrl) => {
+const getCouchDbVersion = (serverUrl) => {
   return new Promise((resolve, reject) => {
     request.get({ url: serverUrl, json: true }, (err, response, body) => {
-      if (err) {
-        return reject(err);
-      }
-      console.log(`CouchDB Version: ${body.version}`);
-      resolve(body.version);
+      return err ? reject(err) : resolve(body.version);
     });
+  });
+};
+
+const couchDbVersionCheck = (serverUrl) => {
+  return getCouchDbVersion(serverUrl).then(version => {
+    console.log(`CouchDB Version: ${version}`);
   });
 };
 
@@ -78,9 +80,9 @@ const check = (serverUrl) => {
 
 module.exports = {
   check: (serverUrl) => check(serverUrl),
-  getCouchDbVersion: (serverUrl) => couchDbVersionCheck(serverUrl),
+  getCouchDbVersion: (serverUrl) => getCouchDbVersion(serverUrl),
   _nodeVersionCheck: () => nodeVersionCheck(),
   _envVarsCheck: () => envVarsCheck(),
   _couchDbNoAdminPartyModeCheck: () => couchDbNoAdminPartyModeCheck(),
-
+  _couchDbVersionCheck: (serverUrl) => couchDbVersionCheck(serverUrl)
 };

--- a/shared-libs/server-checks/src/checks.js
+++ b/shared-libs/server-checks/src/checks.js
@@ -63,7 +63,7 @@ const couchDbVersionCheck = (serverUrl) => {
         return reject(err);
       }
       console.log(`CouchDB Version: ${body.version}`);
-      resolve();
+      resolve(body.version);
     });
   });
 };
@@ -78,8 +78,9 @@ const check = (serverUrl) => {
 
 module.exports = {
   check: (serverUrl) => check(serverUrl),
+  getCouchDbVersion: (serverUrl) => couchDbVersionCheck(serverUrl),
   _nodeVersionCheck: () => nodeVersionCheck(),
   _envVarsCheck: () => envVarsCheck(),
   _couchDbNoAdminPartyModeCheck: () => couchDbNoAdminPartyModeCheck(),
-  _couchDbVersionCheck: (serverUrl) => couchDbVersionCheck(serverUrl)
+
 };

--- a/shared-libs/server-checks/test/checks.js
+++ b/shared-libs/server-checks/test/checks.js
@@ -85,14 +85,15 @@ describe('Server Checks service', () => {
 
     it('couchdb valid version check', () => {
       sinon.stub(request, 'get').callsArgWith(1, null, null, {version: '2'});
-      return service._couchDbVersionCheck('something').then(() => {
+      return service.getCouchDbVersion('something').then(result => {
         chai.assert.equal(log(0), 'CouchDB Version: 2');
+        chai.assert.equal(result, '2');
       });
     });
 
     it('couchdb invalid version check', () => {
       sinon.stub(request, 'get').callsArgWith(1, 'error');
-      return service._couchDbVersionCheck('something').catch(err => {
+      return service.getCouchDbVersion('something').catch(err => {
         chai.assert.equal(err, 'error');
       });
     });

--- a/shared-libs/server-checks/test/checks.js
+++ b/shared-libs/server-checks/test/checks.js
@@ -1,8 +1,8 @@
 const chai = require('chai'),
-      sinon = require('sinon'),
-      service = require('../src/checks'),
-      http = require('http'),
-      request = require('request');
+    sinon = require('sinon'),
+    service = require('../src/checks'),
+    http = require('http'),
+    request = require('request');
 
 describe('Server Checks service', () => {
 

--- a/shared-libs/server-checks/test/checks.js
+++ b/shared-libs/server-checks/test/checks.js
@@ -1,8 +1,8 @@
 const chai = require('chai'),
-    sinon = require('sinon'),
-    service = require('../src/checks'),
-    http = require('http'),
-    request = require('request');
+      sinon = require('sinon'),
+      service = require('../src/checks'),
+      http = require('http'),
+      request = require('request');
 
 describe('Server Checks service', () => {
 
@@ -85,15 +85,14 @@ describe('Server Checks service', () => {
 
     it('couchdb valid version check', () => {
       sinon.stub(request, 'get').callsArgWith(1, null, null, {version: '2'});
-      return service.getCouchDbVersion('something').then(result => {
+      return service._couchDbVersionCheck('something').then(() => {
         chai.assert.equal(log(0), 'CouchDB Version: 2');
-        chai.assert.equal(result, '2');
       });
     });
 
     it('couchdb invalid version check', () => {
       sinon.stub(request, 'get').callsArgWith(1, 'error');
-      return service.getCouchDbVersion('something').catch(err => {
+      return service._couchDbVersionCheck('something').catch(err => {
         chai.assert.equal(err, 'error');
       });
     });
@@ -147,5 +146,28 @@ describe('Server Checks service', () => {
       });
     });
 
+  });
+
+  describe('getCouchDbVersion', () => {
+    it('should return couchdb version', () => {
+      sinon.stub(request, 'get').callsArgWith(1, null, null, { version: '2.2.0' });
+      return service.getCouchDbVersion('someURL').then(version => {
+        chai.expect(version).to.equal('2.2.0');
+        chai.expect(request.get.callCount).to.equal(1);
+        chai.expect(request.get.args[0][0]).to.deep.equal({ url: 'someURL', json: true });
+      });
+    });
+
+    it('should reject errors', () => {
+      sinon.stub(request, 'get').callsArgWith(1, 'someErr', null, null);
+      return service
+        .getCouchDbVersion('someOtherURL')
+        .then(() => chai.expect(false).to.equal('Should have thrown'))
+        .catch(err => {
+          chai.expect(err).to.equal('someErr');
+          chai.expect(request.get.callCount).to.equal(1);
+          chai.expect(request.get.args[0][0]).to.deep.equal({ url: 'someOtherURL', json: true });
+        });
+    });
   });
 });


### PR DESCRIPTION
# Description

ServerChecks shared lib now exports a function that returns the CouchDB version.

medic/medic-webapp#5076

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
