### PR TITLE
Don't write deploy_info if undefined

### DIFF
--- a/api/src/ddoc-extraction.js
+++ b/api/src/ddoc-extraction.js
@@ -120,7 +120,7 @@ const findUpdatedAppcache = ddoc => {
 
 const findUpdated = ddoc => {
   return Promise.all([
-    findUpdatedDdocs(ddoc.deploy_info),
+    findUpdatedDdocs(ddoc.deploy_info || null),
     findUpdatedAppcache(ddoc),
   ]).then(results => _.compact(_.flatten(results)));
 };

--- a/api/src/ddoc-extraction.js
+++ b/api/src/ddoc-extraction.js
@@ -52,7 +52,7 @@ const isUpdated = (newDdoc, deploy_info) => {
       newDdoc._rev = oldDdoc && oldDdoc._rev;
 
       // update the deploy info in the medic-client ddoc
-      if (newDdoc._id === CLIENT_DDOC_ID) {
+      if (newDdoc._id === CLIENT_DDOC_ID && (deploy_info || newDdoc.deploy_info)) {
         newDdoc.deploy_info = deploy_info;
       }
 
@@ -120,7 +120,7 @@ const findUpdatedAppcache = ddoc => {
 
 const findUpdated = ddoc => {
   return Promise.all([
-    findUpdatedDdocs(ddoc.deploy_info || null),
+    findUpdatedDdocs(ddoc.deploy_info),
     findUpdatedAppcache(ddoc),
   ]).then(results => _.compact(_.flatten(results)));
 };

--- a/api/tests/mocha/ddoc-extraction.js
+++ b/api/tests/mocha/ddoc-extraction.js
@@ -473,7 +473,7 @@ describe('DDoc extraction', () => {
     });
   });
 
-  it('defaults to null when no info in medic ddoc', () => {
+  it('defaults deploy_info to null #5109', () => {
     const get = sinon.stub(db.medic, 'get');
     const getAttachment = sinon.stub(db.medic, 'getAttachment');
 
@@ -527,7 +527,7 @@ describe('DDoc extraction', () => {
     });
   });
 
-  it('does not write client if both are null', () => {
+  it('does not write medic-client when no changes and existent and new deploy_info is null #5109', () => {
     const get = sinon.stub(db.medic, 'get');
     const getAttachment = sinon.stub(db.medic, 'getAttachment');
 

--- a/api/tests/mocha/ddoc-extraction.js
+++ b/api/tests/mocha/ddoc-extraction.js
@@ -473,4 +473,108 @@ describe('DDoc extraction', () => {
     });
   });
 
+  it('defaults to null when no info in medic ddoc', () => {
+    const get = sinon.stub(db.medic, 'get');
+    const getAttachment = sinon.stub(db.medic, 'getAttachment');
+
+    const attachment = { docs: [
+        { _id: '_design/medic-client', views: { doc_by_valid: { map: 'function() { return true; }' } } }
+      ] };
+    const ddoc = {
+      _id: '_design/medic',
+      _attachments: {
+        'manifest.appcache': {
+          content_type: 'text/cache-manifest',
+          revpos: 2730,
+          digest: 'md5-JRYByZdYixaFg3a4L6X0pw==',
+          length: 1224,
+          stub: true
+        }
+      }
+    };
+    const existingClient = {
+      _id: '_design/medic-client',
+      _rev: '2',
+      views: { doc_by_valid: { map: 'function() { return true; }' } }
+    };
+    const appcache = {
+      _id: 'appcache',
+      _rev: '5',
+      digest: 'md5-JRYByZdYixaFg3a4L6X0pw=='
+    };
+
+    const getDdoc = get.withArgs('_design/medic').resolves(ddoc);
+    const getDdocAttachment = getAttachment
+      .withArgs('_design/medic', 'ddocs/compiled.json')
+      .resolves(Buffer.from(JSON.stringify(attachment)));
+    const getAppcache = get.withArgs('appcache').resolves(appcache);
+    const getSettings = get.withArgs('settings').resolves({ });
+    const getClient = get.withArgs('_design/medic-client').resolves(existingClient);
+    const bulk = sinon.stub(db.medic, 'bulkDocs').resolves();
+
+    return ddocExtraction.run().then(() => {
+      getDdoc.callCount.should.equal(1);
+      getDdocAttachment.callCount.should.equal(1);
+      getAppcache.callCount.should.equal(1);
+      getSettings.callCount.should.equal(0);
+      getClient.callCount.should.equal(1);
+      bulk.callCount.should.equal(1);
+      const docs = bulk.args[0][0].docs;
+      chai.expect(docs.length).to.equal(1);
+      docs[0]._id.should.equal('_design/medic-client');
+      docs[0]._rev.should.equal('2');
+      chai.expect(docs[0].deploy_info).to.equal(null);
+    });
+  });
+
+  it('does not write client if both are null', () => {
+    const get = sinon.stub(db.medic, 'get');
+    const getAttachment = sinon.stub(db.medic, 'getAttachment');
+
+    const attachment = { docs: [
+        { _id: '_design/medic-client', views: { doc_by_valid: { map: 'function() { return true; }' } } }
+      ] };
+    const ddoc = {
+      _id: '_design/medic',
+      _attachments: {
+        'manifest.appcache': {
+          content_type: 'text/cache-manifest',
+          revpos: 2730,
+          digest: 'md5-JRYByZdYixaFg3a4L6X0pw==',
+          length: 1224,
+          stub: true
+        }
+      }
+    };
+    const existingClient = {
+      _id: '_design/medic-client',
+      _rev: '2',
+      deploy_info: null,
+      views: { doc_by_valid: { map: 'function() { return true; }' } }
+    };
+    const appcache = {
+      _id: 'appcache',
+      _rev: '5',
+      digest: 'md5-JRYByZdYixaFg3a4L6X0pw=='
+    };
+
+    const getDdoc = get.withArgs('_design/medic').resolves(ddoc);
+    const getDdocAttachment = getAttachment
+      .withArgs('_design/medic', 'ddocs/compiled.json')
+      .resolves(Buffer.from(JSON.stringify(attachment)));
+    const getAppcache = get.withArgs('appcache').resolves(appcache);
+    const getSettings = get.withArgs('settings').resolves({ });
+    const getClient = get.withArgs('_design/medic-client').resolves(existingClient);
+    const bulk = sinon.stub(db.medic, 'bulkDocs').resolves();
+
+    return ddocExtraction.run().then(() => {
+      getDdoc.callCount.should.equal(1);
+      getDdocAttachment.callCount.should.equal(1);
+      getAppcache.callCount.should.equal(1);
+      getSettings.callCount.should.equal(0);
+      getClient.callCount.should.equal(1);
+      bulk.callCount.should.equal(0);
+    });
+  });
+
 });


### PR DESCRIPTION
# Description

When doing a non-Horticulturalist deploy, `medic` ddoc lacks the `deploy_info` property which horti adds. 
As a result, ddoc extraction would update `medic-client` every time it ran (because `undefined` properties don't get saved in CouchDB). 
Fix: only copy `deploy_info` if either old or new value exist. 

This would not occur in production deployments which are handled by Horticulturalist. 

medic/medic-webapp#5109

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
