### PR TITLE
Hide delete button when the editing generic trans

### DIFF
--- a/admin/src/js/controllers/edit-translation.js
+++ b/admin/src/js/controllers/edit-translation.js
@@ -13,13 +13,14 @@ angular.module('controllers').controller('EditTranslationCtrl',
     $scope.editing = !!$scope.model.key;
     $scope.model.locales = _.pluck($scope.model.locales, 'doc');
     $scope.model.values = {};
+    $scope.is_custom = false;
 
     $scope.model.locales.forEach(function(locale) {
       const custom = locale.custom || {};
       const generic = locale.generic || {};
       var value = $scope.model.key ? custom[$scope.model.key] || generic[$scope.model.key] : null;
       $scope.model.values[locale.code] = value;
-      $scope.is_custom |= _.has(custom, $scope.model.key) 
+      $scope.is_custom = $scope.is_custom || _.has(custom, $scope.model.key);
     });
 
     var getUpdatedLocales = function() {

--- a/admin/src/js/controllers/edit-translation.js
+++ b/admin/src/js/controllers/edit-translation.js
@@ -13,14 +13,14 @@ angular.module('controllers').controller('EditTranslationCtrl',
     $scope.editing = !!$scope.model.key;
     $scope.model.locales = _.pluck($scope.model.locales, 'doc');
     $scope.model.values = {};
-    $scope.is_custom = false;
+    $scope.isCustom = false;
 
     $scope.model.locales.forEach(function(locale) {
       const custom = locale.custom || {};
       const generic = locale.generic || {};
       var value = $scope.model.key ? custom[$scope.model.key] || generic[$scope.model.key] : null;
       $scope.model.values[locale.code] = value;
-      $scope.is_custom = $scope.is_custom || _.has(custom, $scope.model.key);
+      $scope.isCustom = $scope.isCustom || _.has(custom, $scope.model.key);
     });
 
     var getUpdatedLocales = function() {

--- a/admin/src/js/controllers/edit-translation.js
+++ b/admin/src/js/controllers/edit-translation.js
@@ -19,6 +19,7 @@ angular.module('controllers').controller('EditTranslationCtrl',
       const generic = locale.generic || {};
       var value = $scope.model.key ? custom[$scope.model.key] || generic[$scope.model.key] : null;
       $scope.model.values[locale.code] = value;
+      $scope.is_custom |= _.has(custom, $scope.model.key) 
     });
 
     var getUpdatedLocales = function() {

--- a/admin/src/templates/edit_translation.html
+++ b/admin/src/templates/edit_translation.html
@@ -7,7 +7,7 @@
   on-cancel="cancel()"
   on-submit="submit()"
   on-delete="delete()"
-  show-delete="true"
+  show-delete="is_custom ? true : false"
 >
   <form action="" method="POST">
     <div class="form-group">

--- a/admin/src/templates/edit_translation.html
+++ b/admin/src/templates/edit_translation.html
@@ -7,7 +7,7 @@
   on-cancel="cancel()"
   on-submit="submit()"
   on-delete="delete()"
-  show-delete="is_custom ? true : false"
+  show-delete="isCustom"
 >
   <form action="" method="POST">
     <div class="form-group">


### PR DESCRIPTION
# Description

Hide the translation delete button when the user edits a generic translation. Only custom translations can be deleted.

medic/medic-webapp#3128

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
