### PR TITLE
#5113 - Improved logging for E2E test failures due to api/sentinel startup

### DIFF
--- a/tests/base.conf.js
+++ b/tests/base.conf.js
@@ -34,7 +34,8 @@ class BaseConfig {
         browser.waitForAngularEnabled(false);
 
         if(options.manageServices) {
-          browser.driver.wait(serviceManager.startAll(), 60 * 1000, 'API and Sentinel should start within 60 seconds');
+          browser.driver.wait(serviceManager.startApi(), 60 * 1000, 'API failed to start within 60sec. Log at webapp/tests/logs/api.e2e.log. If stuck on the extract_user_settings migration check #5113.');
+          browser.driver.wait(serviceManager.startSentinel(), 60 * 1000, 'Sentinel failed to start within 60sec. Log at webapp/tests/logs/sentinel.e2e.log.');
           browser.driver.sleep(1); // block until previous command has completed
         }
 

--- a/tests/service-manager.js
+++ b/tests/service-manager.js
@@ -65,7 +65,7 @@ const startServer = (serviceName, startOutput, options={}) => {
 
 // start sentinel serially because it relies on api
 const startApi = () => startServer('api', 'Medic API listening on port');
-const startSentinel = () => startServer('sentinel', 'startup complete.', { logTimestamps:true });1
+const startSentinel = () => startServer('sentinel', 'startup complete.', { logTimestamps:true });
 const startAll = () => startApi.then(startSentinel);
 
 module.exports = {

--- a/tests/service-manager.js
+++ b/tests/service-manager.js
@@ -64,12 +64,15 @@ const startServer = (serviceName, startOutput, options={}) => {
 };
 
 // start sentinel serially because it relies on api
-const startAll = () => startServer('api', 'Medic API listening on port')
-           .then(() => startServer('sentinel', 'startup complete.', { logTimestamps:true }));
+const startApi = () => startServer('api', 'Medic API listening on port');
+const startSentinel = () => startServer('sentinel', 'startup complete.', { logTimestamps:true });1
+const startAll = () => startApi.then(startSentinel);
 
 module.exports = {
-  startAll: startAll,
-  stopAll: stopAll,
+  startApi,
+  startSentinel,
+  startAll,
+  stopAll,
 };
 
 // From orbit, just to be sure


### PR DESCRIPTION
# Description

Improved logging for E2E test failures due to api/sentinel startup issues.
medic/medic-webapp#5113

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
