### PR TITLE
 Increase migration stability 

### DIFF
--- a/api/src/migrations/fix-user-db-security.js
+++ b/api/src/migrations/fix-user-db-security.js
@@ -23,7 +23,7 @@ module.exports = {
                 resolve();
               });
             });
-          })
+          });
         }, Promise.resolve());
       })
       .then(() => callback())


### PR DESCRIPTION
I get errors pretty frequently when running this migration locally, to
do with CouchDB not being able to find shards. It seems to be that it's
smashing the user DB too much. This rewrite makes the writing part
syncronous.