### PR TITLE
Removes the linebreaks in status output

### DIFF
--- a/api/src/migrations/drop-audit-doc-index.js
+++ b/api/src/migrations/drop-audit-doc-index.js
@@ -102,15 +102,7 @@ var changeDocIdsBatch = function(skip, callback) {
       // we've reached the end of the database!
       return callback(null, null, false);
     }
-    logger.info(
-      `        Processing
-        ${skip} 
-         to  
-        (${skip + BATCH_SIZE}) 
-         docs of  
-        ${result.total_rows} 
-         total`
-    );
+    logger.info(`        Processing ${skip} to (${skip + BATCH_SIZE}) docs of ${result.total_rows} total`);
     var oldDocs = result.rows.filter(needsUpdate).map(function(row) {
       return row.doc;
     });

--- a/api/src/migrations/namespace-form-fields.js
+++ b/api/src/migrations/namespace-form-fields.js
@@ -63,15 +63,7 @@ var runBatch = function(batchSize, skip, callback) {
     if (err) {
       return callback(err);
     }
-    logger.info(
-      `        Processing 
-        ${skip} 
-         to  
-        (${skip + batchSize}) 
-         docs of  
-        ${result.total_rows} 
-        ' total`
-    );
+    logger.info(`        Processing ${skip} to (${skip + batchSize}) docs of ${result.total_rows} total`);
     var docs = _.uniq(_.pluck(result.rows, 'doc'));
 
     namespace(docs, function(err) {


### PR DESCRIPTION
# Description

These were added erroneously by prettier.

Split off from https://github.com/medic/medic-webapp/pull/5124

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
