### PR TITLE
Fix loading of Targets tab as admin

### DIFF
--- a/webapp/src/js/services/target-generator.js
+++ b/webapp/src/js/services/target-generator.js
@@ -113,7 +113,7 @@ var moment = require('moment'),
             })
             .catch(callback);
         } else {
-          callback();
+          callback(null, []);
         }
       };
     }

--- a/webapp/src/js/services/target-generator.js
+++ b/webapp/src/js/services/target-generator.js
@@ -93,7 +93,7 @@ var moment = require('moment'),
               // Clone the `userContact` object to prevent bad context
               // expressions from modifying it - this could leak into other
               // expressions.
-              var clone = JSON.parse(JSON.stringify(userContact));
+              var clone = userContact ? JSON.parse(JSON.stringify(userContact)) : {};
               return $parse(item.context)({ user: clone });
             }
             return true;
@@ -101,16 +101,20 @@ var moment = require('moment'),
         });
 
       return function(callback) {
-        init
-          .then(function() {
-            RulesEngine.listen('TargetGenerator', 'target', function(err, _targets) {
-              if (!err) {
-                _targets.forEach(mergeTarget);
-              }
-              callback(err, targets);
-            });
-          })
-          .catch(callback);
+        if (RulesEngine.enabled) {
+          init
+            .then(function() {
+              RulesEngine.listen('TargetGenerator', 'target', function(err, _targets) {
+                if (!err) {
+                  _targets.forEach(mergeTarget);
+                }
+                callback(err, targets);
+              });
+            })
+            .catch(callback);
+        } else {
+          callback();
+        }
       };
     }
   );

--- a/webapp/tests/karma/unit/services/target-generator.js
+++ b/webapp/tests/karma/unit/services/target-generator.js
@@ -51,7 +51,6 @@ describe('TargetGenerator service', function() {
   });
 
   it('returns empty array when no targets are configured', function(done) {
-    RulesEngine.enabled = false;
     Settings.returns(Promise.resolve({}));
     UserContact.returns(Promise.resolve());
     RulesEngine.listen.callsArgWith(2, null, []);

--- a/webapp/tests/karma/unit/services/target-generator.js
+++ b/webapp/tests/karma/unit/services/target-generator.js
@@ -13,6 +13,7 @@ describe('TargetGenerator service', function() {
     UserContact = sinon.stub();
     RulesEngine = {
       listen: sinon.stub(),
+      enabled: true
     };
     module('inboxApp');
     module(function ($provide) {
@@ -30,6 +31,16 @@ describe('TargetGenerator service', function() {
     KarmaUtils.restore(Settings, RulesEngine, UserContact);
   });
 
+  it('returns empty array when the rules engine is disabled', function(done) {
+    RulesEngine.enabled = false;
+    Settings.returns(Promise.resolve({}));
+    UserContact.returns(Promise.resolve());
+    injector.get('TargetGenerator')(function(err, actual) {
+      chai.expect(actual).to.deep.equal([]);
+      done();
+    });
+  });
+
   it('returns settings errors', function(done) {
     Settings.returns(Promise.reject('boom'));
     UserContact.returns(Promise.resolve());
@@ -40,6 +51,7 @@ describe('TargetGenerator service', function() {
   });
 
   it('returns empty array when no targets are configured', function(done) {
+    RulesEngine.enabled = false;
     Settings.returns(Promise.resolve({}));
     UserContact.returns(Promise.resolve());
     RulesEngine.listen.callsArgWith(2, null, []);


### PR DESCRIPTION
# Description

The problem is when you're admin you don't have a userContact so it's trying to stringify null which throws so we should wrap that in an if block.

For extra performance, skipping the TargetGenerator.init altogether if the RulesEngine is disabled because it's never going to get any targets emitted.

medic/medic-webapp#5071

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
