### PR TITLE
#4713 - Replace appcache with a service worker cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist
 /build/
 config/standard/.gdrive.*.json
 config/*/backups/*
+api/src/extracted/**/*

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -43,6 +43,7 @@ module.exports = function(grunt) {
     replace: 'grunt-text-replace',
     uglify: 'grunt-contrib-uglify-es',
   });
+  require('./grunt.service-worker')(grunt);
   require('time-grunt')(grunt);
 
   // Project configuration
@@ -210,6 +211,7 @@ module.exports = function(grunt) {
         reporter: require('jshint-stylish'),
         ignores: [
           'webapp/src/js/modules/xpath-element-path.js',
+          'api/src/extracted/**/*',
           '**/node_modules/**',
           'sentinel/src/lib/pupil/**',
           'build/**',
@@ -266,6 +268,13 @@ module.exports = function(grunt) {
       dist: {
         src: 'build/ddocs/medic/_attachments/css/*.css',
       },
+    },
+    generateServiceWorker: {
+      config: {
+        rootUrl: '/medic/_design/medic/_rewrite/',
+        staticDirectoryPath: 'build/ddocs/medic/_attachments',
+        scriptOutputPath: 'build/ddocs/medic/_attachments/js/service-worker.js',
+      }
     },
     copy: {
       ddocs: {
@@ -536,7 +545,7 @@ module.exports = function(grunt) {
             // https://github.com/dangrossman/bootstrap-daterangepicker/pull/437
             'patch webapp/node_modules/bootstrap-daterangepicker/daterangepicker.js < webapp/patches/bootstrap-daterangepicker.patch',
 
-            // patch font-awesome to remove version attributes so appcache works
+            // patch font-awesome to remove version attributes
             // https://github.com/FortAwesome/Font-Awesome/issues/3286
             'patch webapp/node_modules/font-awesome/less/path.less < webapp/patches/font-awesome-remove-version-attribute.patch',
 
@@ -601,7 +610,7 @@ module.exports = function(grunt) {
         tasks: [
           'sass',
           'less:webapp',
-          'appcache',
+          'generateServiceWorker',
           'couch-compile:primary',
           'deploy',
         ],
@@ -611,7 +620,7 @@ module.exports = function(grunt) {
         tasks: [
           'browserify:webapp',
           'replace:update-app-constants',
-          'appcache',
+          'generateServiceWorker',
           'couch-compile:primary',
           'deploy',
         ],
@@ -623,7 +632,7 @@ module.exports = function(grunt) {
         ],
         tasks: [
           'ngtemplates:inboxApp',
-          'appcache',
+          'generateServiceWorker',
           'couch-compile:primary',
           'deploy',
         ],
@@ -632,7 +641,7 @@ module.exports = function(grunt) {
         files: 'webapp/src/templates/inbox.html',
         tasks: [
           'copy:inbox-file-attachment',
-          'appcache',
+          'generateServiceWorker',
           'couch-compile:primary',
           'deploy',
         ],
@@ -751,26 +760,6 @@ module.exports = function(grunt) {
             removeScriptTypeAttributes: true,
             removeStyleLinkTypeAttributes: true,
           },
-        },
-      },
-    },
-    appcache: {
-      options: {
-        basePath: 'build/ddocs/medic/_attachments',
-      },
-      inbox: {
-        dest: 'build/ddocs/medic/_attachments/manifest.appcache',
-        network: '*',
-        cache: {
-          patterns: [
-            'build/ddocs/medic/_attachments/manifest.json',
-            'build/ddocs/medic/_attachments/audio/**/*',
-            'build/ddocs/medic/_attachments/css/**/*',
-            'build/ddocs/medic/_attachments/fonts/**/*',
-            'build/ddocs/medic/_attachments/img/**/*',
-            'build/ddocs/medic/_attachments/js/**/*',
-            'build/ddocs/medic/_attachments/xslt/**/*',
-          ],
         },
       },
     },
@@ -927,7 +916,7 @@ module.exports = function(grunt) {
   grunt.registerTask('build-ddoc', 'Build the main ddoc', [
     'couch-compile:secondary',
     'copy:ddoc-attachments',
-    'appcache',
+    'generateServiceWorker',
     'couch-compile:primary',
   ]);
 

--- a/api/server.js
+++ b/api/server.js
@@ -12,6 +12,7 @@ serverChecks.check(environment.serverUrl).then(() => {
     config = require('./src/config'),
     migrations = require('./src/migrations'),
     ddocExtraction = require('./src/ddoc-extraction'),
+    resourceExtraction = require('./src/resource-extraction'),
     translations = require('./src/translations'),
     serverUtils = require('./src/server-utils'),
     apiPort = process.env.API_PORT || 5988;
@@ -20,6 +21,10 @@ serverChecks.check(environment.serverUrl).then(() => {
     .then(() => logger.info('Extracting ddoc…'))
     .then(ddocExtraction.run)
     .then(() => logger.info('DDoc extraction completed successfully'))
+
+    .then(() => logger.info('Extracting resources…'))
+    .then(resourceExtraction.run)
+    .then(() => logger.info('Extracting resources completed successfully'))
 
     .then(() => logger.info('Loading configuration…'))
     .then(config.load)

--- a/api/src/config.js
+++ b/api/src/config.js
@@ -1,6 +1,7 @@
 const _ = require('underscore'),
   db = require('./db-pouch'),
   ddocExtraction = require('./ddoc-extraction'),
+  resourceExtraction = require('./resource-extraction'),
   translations = require('./translations'),
   defaults = require('./config.default.json'),
   settingsService = require('./services/settings'),
@@ -141,6 +142,10 @@ module.exports = {
           });
           ddocExtraction.run().catch(err => {
             logger.error('Something went wrong trying to extract ddocs: %o', err);
+            process.exit(1);
+          });
+          resourceExtraction.run().catch(err => {
+            logger.error('Something went wrong trying to extract resources: %o', err);
             process.exit(1);
           });
           loadViewMaps();

--- a/api/src/resource-extraction.js
+++ b/api/src/resource-extraction.js
@@ -1,0 +1,49 @@
+/*
+Before Chrome 66, web requests from the service worker don't include credentials (cookies, basic auth, etc).
+This means service workers cannot cache any resource behind an authenticated endpoint.
+Therefore, we extract all cacheable resources into a folder and serve them as public static content.
+*/
+
+const
+  fs = require('fs'),
+  path = require('path'),
+  db = require('./db-pouch'),
+  logger = require('./logger'),
+  STATIC_RESOURCE_DESTINATION = path.resolve(`./src/extracted/`),
+  isAttachmentCacheable = name => name === 'manifest.json' || !!name.match(/(?:audio|css|fonts|templates|img|js|xslt)\/.*/);
+
+// Map of attachmentName -> attachmentDigest used to avoid extraction of unchanged documents
+let extractedDigests = {};
+
+const createFolderIfDne = x => !fs.existsSync(x) && fs.mkdirSync(x);
+
+const extractCacheableAttachments = () => {
+  createFolderIfDne(STATIC_RESOURCE_DESTINATION);
+  return db.medic
+    .get('_design/medic')
+    .then(ddoc => Promise.resolve(Object.keys(ddoc._attachments))
+      .then(attachmentNames => attachmentNames.filter(name => extractedDigests[name] !== ddoc._attachments[name].digest))
+      .then(attachmentNames => attachmentNames.filter(isAttachmentCacheable))
+      .then(requiredNames => Promise.all(requiredNames.map(required => extractAttachment(required))))
+      .then(attachmentNames => attachmentNames.forEach(name => extractedDigests[name] = ddoc._attachments[name].digest))
+    );
+};
+
+const extractAttachment = attachmentName => db.medic
+  .getAttachment('_design/medic', attachmentName)
+  .then(raw => new Promise((resolve, reject) => {
+    const outputPath = path.join(STATIC_RESOURCE_DESTINATION, attachmentName);
+    createFolderIfDne(path.dirname(outputPath));
+    fs.writeFile(outputPath, raw, err => {
+      logger.debug(`Extracted attachment ${outputPath}`);
+      if (err) {
+        return reject(err);
+      }
+      resolve(attachmentName);
+    });
+  }));
+
+module.exports = {
+  run: extractCacheableAttachments,
+  clearCache: () => extractedDigests = {},
+};

--- a/api/tests/mocha/config.js
+++ b/api/tests/mocha/config.js
@@ -3,6 +3,7 @@ const config = require('../../src/config'),
   db = require('../../src/db-pouch'),
   logger = require('../../src/logger'),
   ddocExtraction = require('../../src/ddoc-extraction'),
+  resourceExtraction = require('../../src/resource-extraction'),
   translations = require('../../src/translations'),
   settingsService = require('../../src/services/settings'),
   viewMapUtils = require('@medic/view-map-utils'),
@@ -22,6 +23,7 @@ describe('Config', () => {
     sinon.stub(db.medic, 'changes').returns({ on: on });
     sinon.stub(viewMapUtils, 'loadViewMaps');
     sinon.stub(ddocExtraction, 'run').resolves();
+    sinon.stub(resourceExtraction, 'run').resolves();
     sinon.stub(translations, 'run').resolves();
     sinon.stub(settingsService, 'get').resolves();
     sinon.stub(settingsService, 'update').resolves();
@@ -124,6 +126,7 @@ describe('Config', () => {
       changeCallback(change);
       chai.expect(translations.run.callCount).to.equal(1);
       chai.expect(ddocExtraction.run.callCount).to.equal(1);
+      chai.expect(resourceExtraction.run.callCount).to.equal(1);
       chai.expect(db.medic.get.callCount).to.equal(1);
       chai.expect(db.medic.get.args[0][0]).to.equal('_design/medic');
     });
@@ -135,6 +138,7 @@ describe('Config', () => {
       changeCallback(change);
       chai.expect(translations.run.callCount).to.equal(0);
       chai.expect(ddocExtraction.run.callCount).to.equal(0);
+      chai.expect(resourceExtraction.run.callCount).to.equal(0);
       chai.expect(db.medic.get.callCount).to.equal(0);
 
       chai.expect(db.medic.query.callCount).to.equal(1);

--- a/api/tests/mocha/ddoc-extraction.js
+++ b/api/tests/mocha/ddoc-extraction.js
@@ -23,8 +23,7 @@ describe('DDoc extraction', () => {
     const ddoc = {
       _id: '_design/medic',
       _attachments: {
-        'manifest.appcache': {
-          content_type: 'text/cache-manifest',
+        'js/service-worker.js': {
           revpos: 2730,
           digest: 'md5-JRYByZdYixaFg3a4L6X0pw==',
           length: 1224,
@@ -40,7 +39,7 @@ describe('DDoc extraction', () => {
     const getNew = get.withArgs('_design/new').rejects({ status: 404 });
     const getUpdated = get.withArgs('_design/updated').resolves({ _id: '_design/updated', _rev: '1', views: { doc_by_valed: { map: 'function() { return true; }' } } });
     const getUnchanged = get.withArgs('_design/unchanged').resolves({ _id: '_design/unchanged', _rev: '1', views: { doc_by_valid: { map: 'function() { return true; }' } } });
-    const getAppcache = get.withArgs('appcache').resolves({ digest: 'md5-JRYByZdYixaFg3a4L6X0pw==' });
+    const getSwMeta = get.withArgs('serviceWorkerMeta').resolves({ digest: 'md5-JRYByZdYixaFg3a4L6X0pw==' });
     const getSettings = get.withArgs('settings').resolves({ });
     const bulk = sinon.stub(db.medic, 'bulkDocs').resolves();
 
@@ -50,7 +49,7 @@ describe('DDoc extraction', () => {
       getNew.callCount.should.equal(1);
       getUpdated.callCount.should.equal(1);
       getUnchanged.callCount.should.equal(1);
-      getAppcache.callCount.should.equal(1);
+      getSwMeta.callCount.should.equal(1);
       getSettings.callCount.should.equal(0);
       bulk.callCount.should.equal(1);
       const docs = bulk.args[0][0].docs;
@@ -102,8 +101,7 @@ describe('DDoc extraction', () => {
     const ddoc = {
       _id: '_design/medic',
       _attachments: {
-        'manifest.appcache': {
-          content_type: 'text/cache-manifest',
+        'js/service-worker.js': {
           revpos: 2730,
           digest: 'md5-JRYByZdYixaFg3a4L6X0pw==',
           length: 1224,
@@ -156,7 +154,7 @@ describe('DDoc extraction', () => {
         }
       }
     });
-    const getAppcache = get.withArgs('appcache').resolves({ digest: 'md5-JRYByZdYixaFg3a4L6X0pw==' });
+    const getSwMeta = get.withArgs('serviceWorkerMeta').resolves({ digest: 'md5-JRYByZdYixaFg3a4L6X0pw==' });
     const getSettings = get.withArgs('settings').resolves({ });
     const bulk = sinon.stub(db.medic, 'bulkDocs').resolves();
 
@@ -165,7 +163,7 @@ describe('DDoc extraction', () => {
       getDdocAttachment.callCount.should.equal(1);
       getUpdated.callCount.should.equal(1);
       getUnchanged.callCount.should.equal(1);
-      getAppcache.callCount.should.equal(1);
+      getSwMeta.callCount.should.equal(1);
       getSettings.callCount.should.equal(0);
       bulk.callCount.should.equal(1);
       const docs = bulk.args[0][0].docs;
@@ -179,8 +177,7 @@ describe('DDoc extraction', () => {
     const ddoc = {
       _id: '_design/medic',
       _attachments: {
-        'manifest.appcache': {
-          content_type: 'text/cache-manifest',
+        'js/service-worker.js': {
           revpos: 2730,
           digest: 'md5-JRYByZdYixaFg3a4L6X0pw==',
           length: 1224,
@@ -194,12 +191,12 @@ describe('DDoc extraction', () => {
     const getDdocAttachment = getAttachment
       .withArgs('_design/medic', 'ddocs/compiled.json')
       .rejects({ status: 404 });
-    const getAppcache = get.withArgs('appcache').resolves({ digest: 'md5-JRYByZdYixaFg3a4L6X0pw==' });
+    const getSwMeta = get.withArgs('serviceWorkerMeta').resolves({ digest: 'md5-JRYByZdYixaFg3a4L6X0pw==' });
     const getSettings = get.withArgs('settings').resolves({ });
     return ddocExtraction.run().then(() => {
       getDdoc.callCount.should.equal(1);
       getDdocAttachment.callCount.should.equal(1);
-      getAppcache.callCount.should.equal(1);
+      getSwMeta.callCount.should.equal(1);
       getSettings.callCount.should.equal(0);
     });
   });
@@ -215,8 +212,7 @@ describe('DDoc extraction', () => {
       _id: '_design/medic',
       deploy_info: 1,
       _attachments: {
-        'manifest.appcache': {
-          content_type: 'text/cache-manifest',
+        'js/service-worker.js': {
           revpos: 2730,
           digest: 'md5-JRYByZdYixaFg3a4L6X0pw==',
           length: 1224,
@@ -235,7 +231,7 @@ describe('DDoc extraction', () => {
     const getDdocAttachment = getAttachment
       .withArgs('_design/medic', 'ddocs/compiled.json')
       .resolves(Buffer.from(JSON.stringify(attachment)));
-    const getAppcache = get.withArgs('appcache').rejects({ status: 404 });
+    const getSwMeta = get.withArgs('serviceWorkerMeta').rejects({ status: 404 });
     const getSettings = get.withArgs('settings').resolves({ });
     const getClient = get.withArgs('_design/medic-client').resolves(existingClient);
     const bulk = sinon.stub(db.medic, 'bulkDocs').resolves();
@@ -243,13 +239,13 @@ describe('DDoc extraction', () => {
     return ddocExtraction.run().then(() => {
       getDdoc.callCount.should.equal(1);
       getDdocAttachment.callCount.should.equal(1);
-      getAppcache.callCount.should.equal(1);
+      getSwMeta.callCount.should.equal(1);
       getSettings.callCount.should.equal(0);
       getClient.callCount.should.equal(1);
       bulk.callCount.should.equal(1);
       const docs = bulk.args[0][0].docs;
       chai.expect(docs.length).to.equal(1);
-      docs[0]._id.should.equal('appcache');
+      docs[0]._id.should.equal('serviceWorkerMeta');
       chai.expect(docs[0]._rev).to.equal(undefined);
       docs[0].digest.should.equal('md5-JRYByZdYixaFg3a4L6X0pw==');
     });
@@ -266,8 +262,7 @@ describe('DDoc extraction', () => {
       _id: '_design/medic',
       deploy_info: 1,
       _attachments: {
-        'manifest.appcache': {
-          content_type: 'text/cache-manifest',
+        'js/service-worker.js': {
           revpos: 2730,
           digest: 'md5-JRYByZdYixaFg3a4L6X0pw==',
           length: 1224,
@@ -291,7 +286,7 @@ describe('DDoc extraction', () => {
     const getDdocAttachment = getAttachment
       .withArgs('_design/medic', 'ddocs/compiled.json')
       .resolves(Buffer.from(JSON.stringify(attachment)));
-    const getAppcache = get.withArgs('appcache').resolves(appcache);
+    const getSwMeta = get.withArgs('serviceWorkerMeta').resolves(appcache);
     const getSettings = get.withArgs('settings').resolves({ });
     const getClient = get.withArgs('_design/medic-client').resolves(existingClient);
     const bulk = sinon.stub(db.medic, 'bulkDocs').resolves();
@@ -299,7 +294,7 @@ describe('DDoc extraction', () => {
     return ddocExtraction.run().then(() => {
       getDdoc.callCount.should.equal(1);
       getDdocAttachment.callCount.should.equal(1);
-      getAppcache.callCount.should.equal(1);
+      getSwMeta.callCount.should.equal(1);
       getSettings.callCount.should.equal(0);
       getClient.callCount.should.equal(1);
       bulk.callCount.should.equal(1);
@@ -322,8 +317,7 @@ describe('DDoc extraction', () => {
       _id: '_design/medic',
       deploy_info: { version: 2 },
       _attachments: {
-        'manifest.appcache': {
-          content_type: 'text/cache-manifest',
+        'js/service-worker.js': {
           revpos: 2730,
           digest: 'md5-JRYByZdYixaFg3a4L6X0pw==',
           length: 1224,
@@ -346,7 +340,7 @@ describe('DDoc extraction', () => {
     const getDdocAttachment = getAttachment
       .withArgs('_design/medic', 'ddocs/compiled.json')
       .resolves(Buffer.from(JSON.stringify(attachment)));
-    const getAppcache = get.withArgs('appcache').resolves(appcache);
+    const getSwMeta = get.withArgs('serviceWorkerMeta').resolves(appcache);
     const getSettings = get.withArgs('settings').resolves({ });
     const getClient = get.withArgs('_design/medic-client').resolves(existingClient);
     const bulk = sinon.stub(db.medic, 'bulkDocs').resolves();
@@ -354,7 +348,7 @@ describe('DDoc extraction', () => {
     return ddocExtraction.run().then(() => {
       getDdoc.callCount.should.equal(1);
       getDdocAttachment.callCount.should.equal(1);
-      getAppcache.callCount.should.equal(1);
+      getSwMeta.callCount.should.equal(1);
       getSettings.callCount.should.equal(0);
       getClient.callCount.should.equal(1);
       bulk.callCount.should.equal(1);
@@ -377,8 +371,7 @@ describe('DDoc extraction', () => {
       _id: '_design/medic',
       deploy_info: { version: 2 },
       _attachments: {
-        'manifest.appcache': {
-          content_type: 'text/cache-manifest',
+        'js/service-worker.js': {
           revpos: 2730,
           digest: 'md5-JRYByZdYixaFg3a4L6X0pw==',
           length: 1224,
@@ -402,7 +395,7 @@ describe('DDoc extraction', () => {
     const getDdocAttachment = getAttachment
       .withArgs('_design/medic', 'ddocs/compiled.json')
       .resolves(Buffer.from(JSON.stringify(attachment)));
-    const getAppcache = get.withArgs('appcache').resolves(appcache);
+    const getSwMeta = get.withArgs('serviceWorkerMeta').resolves(appcache);
     const getSettings = get.withArgs('settings').resolves({ });
     const getClient = get.withArgs('_design/medic-client').resolves(existingClient);
     const bulk = sinon.stub(db.medic, 'bulkDocs').resolves();
@@ -410,7 +403,7 @@ describe('DDoc extraction', () => {
     return ddocExtraction.run().then(() => {
       getDdoc.callCount.should.equal(1);
       getDdocAttachment.callCount.should.equal(1);
-      getAppcache.callCount.should.equal(1);
+      getSwMeta.callCount.should.equal(1);
       getSettings.callCount.should.equal(0);
       getClient.callCount.should.equal(1);
       bulk.callCount.should.equal(1);
@@ -433,8 +426,7 @@ describe('DDoc extraction', () => {
       _id: '_design/medic',
       deploy_info: { version: 2 },
       _attachments: {
-        'manifest.appcache': {
-          content_type: 'text/cache-manifest',
+        'js/service-worker.js': {
           revpos: 2730,
           digest: 'md5-JRYByZdYixaFg3a4L6X0pw==',
           length: 1224,
@@ -458,7 +450,7 @@ describe('DDoc extraction', () => {
     const getDdocAttachment = getAttachment
       .withArgs('_design/medic', 'ddocs/compiled.json')
       .resolves(Buffer.from(JSON.stringify(attachment)));
-    const getAppcache = get.withArgs('appcache').resolves(appcache);
+    const getSwMeta = get.withArgs('serviceWorkerMeta').resolves(appcache);
     const getSettings = get.withArgs('settings').resolves({ });
     const getClient = get.withArgs('_design/medic-client').resolves(existingClient);
     const bulk = sinon.stub(db.medic, 'bulkDocs').resolves();
@@ -466,7 +458,7 @@ describe('DDoc extraction', () => {
     return ddocExtraction.run().then(() => {
       getDdoc.callCount.should.equal(1);
       getDdocAttachment.callCount.should.equal(1);
-      getAppcache.callCount.should.equal(1);
+      getSwMeta.callCount.should.equal(1);
       getSettings.callCount.should.equal(0);
       getClient.callCount.should.equal(1);
       bulk.callCount.should.equal(0);
@@ -483,8 +475,7 @@ describe('DDoc extraction', () => {
     const ddoc = {
       _id: '_design/medic',
       _attachments: {
-        'manifest.appcache': {
-          content_type: 'text/cache-manifest',
+        'js/service-worker.js': {
           revpos: 2730,
           digest: 'md5-JRYByZdYixaFg3a4L6X0pw==',
           length: 1224,
@@ -507,7 +498,7 @@ describe('DDoc extraction', () => {
     const getDdocAttachment = getAttachment
       .withArgs('_design/medic', 'ddocs/compiled.json')
       .resolves(Buffer.from(JSON.stringify(attachment)));
-    const getAppcache = get.withArgs('appcache').resolves(appcache);
+    const getSwMeta = get.withArgs('serviceWorkerMeta').resolves(appcache);
     const getSettings = get.withArgs('settings').resolves({ });
     const getClient = get.withArgs('_design/medic-client').resolves(existingClient);
     const bulk = sinon.stub(db.medic, 'bulkDocs').resolves();
@@ -515,7 +506,7 @@ describe('DDoc extraction', () => {
     return ddocExtraction.run().then(() => {
       getDdoc.callCount.should.equal(1);
       getDdocAttachment.callCount.should.equal(1);
-      getAppcache.callCount.should.equal(1);
+      getSwMeta.callCount.should.equal(1);
       getSettings.callCount.should.equal(0);
       getClient.callCount.should.equal(1);
       bulk.callCount.should.equal(0);
@@ -533,8 +524,7 @@ describe('DDoc extraction', () => {
       _id: '_design/medic',
       deploy_info: 'something',
       _attachments: {
-        'manifest.appcache': {
-          content_type: 'text/cache-manifest',
+        'js/service-worker.js': {
           revpos: 2730,
           digest: 'md5-JRYByZdYixaFg3a4L6X0pw==',
           length: 1224,
@@ -557,7 +547,7 @@ describe('DDoc extraction', () => {
     const getDdocAttachment = getAttachment
       .withArgs('_design/medic', 'ddocs/compiled.json')
       .resolves(Buffer.from(JSON.stringify(attachment)));
-    const getAppcache = get.withArgs('appcache').resolves(appcache);
+    const getSwMeta = get.withArgs('serviceWorkerMeta').resolves(appcache);
     const getSettings = get.withArgs('settings').resolves({ });
     const getClient = get.withArgs('_design/medic-client').resolves(existingClient);
     const bulk = sinon.stub(db.medic, 'bulkDocs').resolves();
@@ -565,7 +555,7 @@ describe('DDoc extraction', () => {
     return ddocExtraction.run().then(() => {
       getDdoc.callCount.should.equal(1);
       getDdocAttachment.callCount.should.equal(1);
-      getAppcache.callCount.should.equal(1);
+      getSwMeta.callCount.should.equal(1);
       getSettings.callCount.should.equal(0);
       getClient.callCount.should.equal(1);
       bulk.callCount.should.equal(1);
@@ -587,8 +577,7 @@ describe('DDoc extraction', () => {
     const ddoc = {
       _id: '_design/medic',
       _attachments: {
-        'manifest.appcache': {
-          content_type: 'text/cache-manifest',
+        'js/service-worker.js': {
           revpos: 2730,
           digest: 'md5-JRYByZdYixaFg3a4L6X0pw==',
           length: 1224,
@@ -612,7 +601,7 @@ describe('DDoc extraction', () => {
     const getDdocAttachment = getAttachment
       .withArgs('_design/medic', 'ddocs/compiled.json')
       .resolves(Buffer.from(JSON.stringify(attachment)));
-    const getAppcache = get.withArgs('appcache').resolves(appcache);
+    const getSwMeta = get.withArgs('serviceWorkerMeta').resolves(appcache);
     const getSettings = get.withArgs('settings').resolves({ });
     const getClient = get.withArgs('_design/medic-client').resolves(existingClient);
     const bulk = sinon.stub(db.medic, 'bulkDocs').resolves();
@@ -620,7 +609,7 @@ describe('DDoc extraction', () => {
     return ddocExtraction.run().then(() => {
       getDdoc.callCount.should.equal(1);
       getDdocAttachment.callCount.should.equal(1);
-      getAppcache.callCount.should.equal(1);
+      getSwMeta.callCount.should.equal(1);
       getSettings.callCount.should.equal(0);
       getClient.callCount.should.equal(1);
       bulk.callCount.should.equal(1);

--- a/api/tests/mocha/resource-extraction.spec.js
+++ b/api/tests/mocha/resource-extraction.spec.js
@@ -1,0 +1,109 @@
+const rewire = require('rewire'),
+      resourceExtraction = rewire('../../src/resource-extraction'),
+      sinon = require('sinon'),
+      { expect } = require('chai'); // jshint ignore:line
+
+let fakeDdoc, mockFs, mockDb;
+resourceExtraction.__set__('logger', { debug: () => {} });
+function doMocking(overwrites = {}) {
+  const defaultAttachment = {
+    'js/service-worker.js': { digest: 'current' },
+  };
+
+  fakeDdoc = {
+    _id: '_design/medic',
+    _attachments: overwrites.attachments || defaultAttachment,
+  };
+
+  mockFs = {
+    existsSync: sinon.stub().returns(true),
+    writeFile: sinon.spy((a, b, callback) => callback()),
+  };
+  mockDb = {
+    medic: {
+      get: sinon.stub().resolves(fakeDdoc),
+      getAttachment: sinon.stub().resolves(overwrites.content),
+    },
+  };
+  resourceExtraction.__set__('fs', mockFs);
+  resourceExtraction.__set__('db', mockDb);
+  resourceExtraction.clearCache();
+}
+
+describe('Resource Extraction', () => {
+  it('attachments written to disk', done => {
+    const expected = { content: 'foo' };
+    doMocking(expected);
+    resourceExtraction.run().then(() => {
+      expect(mockFs.writeFile.callCount).to.eq(1);
+
+      const [actualOutputPath, actualContent] = mockFs.writeFile.args[0];
+      expect(actualOutputPath).to.include('src/extracted/js/service-worker.js');
+      expect(actualContent).to.include(expected.content);
+      done();
+    });
+  });
+
+  it('unchanged files get written once', done => {
+    const expected = { content: 'foo' };
+    doMocking(expected);
+    resourceExtraction.run()
+      .then(resourceExtraction.run)
+      .then(() => {
+        expect(mockFs.writeFile.callCount).to.eq(1);
+
+        const [actualOutputPath, actualContent] = mockFs.writeFile.args[0];
+        expect(actualOutputPath).to.include('src/extracted/js/service-worker.js');
+        expect(actualContent).to.include(expected.content);
+        done();
+      });
+  });
+
+  it('changed files get written again', done => {
+    const expected = { content: 'foo' };
+    doMocking(expected);
+    resourceExtraction.run()
+      .then(() => {
+        fakeDdoc._attachments['js/service-worker.js'].digest = 'update';
+        return resourceExtraction.run();
+      })
+      .then(() => {
+        expect(mockFs.writeFile.callCount).to.eq(2);
+
+        const [actualOutputPath, actualContent] = mockFs.writeFile.args[1];
+        expect(actualOutputPath).to.include('src/extracted/js/service-worker.js');
+        expect(actualContent).to.include(expected.content);
+        done();
+      });
+  });
+
+  it('non-cacheable attachments not written to disk', done => {
+    doMocking({ attachments: { 'skip/me.js': {} }});
+    resourceExtraction.run().then(() => {
+      expect(mockFs.writeFile.callCount).to.eq(0);
+      done();
+    });
+  });
+
+  it('isAttachmentCacheable filter properly for specific resources', () => {
+    const isAttachmentCacheable = resourceExtraction.__get__('isAttachmentCacheable');
+    expect(isAttachmentCacheable('audio/alert.mp3')).to.eq(true);
+    expect(isAttachmentCacheable('js/inbox.js')).to.eq(true);
+    expect(isAttachmentCacheable('manifest.json')).to.eq(true);
+    expect(isAttachmentCacheable('templates/inbox.html')).to.eq(true);
+
+    expect(isAttachmentCacheable('translations/messages-en.properties')).to.eq(false);
+  });
+
+  it('creates destination folder as necessary', done => {
+    doMocking();
+    mockFs.existsSync.returns(false);
+    mockFs.mkdirSync = sinon.stub().returns(true);
+    resourceExtraction.run().then(() => {
+      expect(mockFs.mkdirSync.callCount).to.eq(2);
+      expect(mockFs.mkdirSync.args[0][0]).to.include('src/extracted');
+      expect(mockFs.mkdirSync.args[1][0]).to.include('src/extracted/js');
+      done();
+    });
+  });
+});

--- a/ddocs/medic/rewrites.json
+++ b/ddocs/medic/rewrites.json
@@ -1,13 +1,4 @@
 [
-  {"from": "/css/*",              "to": "css/*"},
-  {"from": "/js/*",               "to": "js/*"},
-  {"from": "/audio/*",            "to": "audio/*"},
-  {"from": "/fonts/*",            "to": "fonts/*"},
-  {"from": "/img/*",              "to": "img/*"},
-  {"from": "/xslt/*",             "to": "xslt/*"},
-  {"from": "/manifest.appcache",  "to": "manifest.appcache"},
-  {"from": "/manifest.json",      "to": "manifest.json"},
-  {"from": "/templates/*",        "to": "templates/*"},
   {"from": "/",                   "to": "templates/inbox.html"},
   {"from": "#/*",                 "to": "templates/inbox.html"},
   {"from": "/#/*",                "to": "templates/inbox.html"}

--- a/ddocs/medic/validate_doc_update.js
+++ b/ddocs/medic/validate_doc_update.js
@@ -10,7 +10,7 @@
 function(newDoc, oldDoc, userCtx, secObj) {
 
   var ADMIN_ONLY_TYPES = [ 'form', 'translations' ],
-      ADMIN_ONLY_IDS = [ 'resources', 'appcache', 'zscore-charts', 'settings', 'branding', 'partners' ];
+      ADMIN_ONLY_IDS = [ 'resources', 'serviceWorkerMeta', 'zscore-charts', 'settings', 'branding', 'partners' ];
 
   var _err = function(msg) {
     throw({ forbidden: msg });

--- a/ddocs/medic/views/docs_by_replication_key/map.js
+++ b/ddocs/medic/views/docs_by_replication_key/map.js
@@ -6,7 +6,7 @@ function (doc) {
   if (doc._id === 'resources' ||
       doc._id === 'branding' ||
       doc._id === 'partners' ||
-      doc._id === 'appcache' ||
+      doc._id === 'serviceWorkerMeta' ||
       doc._id === 'zscore-charts' ||
       doc._id === 'settings' ||
       doc.type === 'form' ||

--- a/grunt.service-worker.js
+++ b/grunt.service-worker.js
@@ -1,0 +1,44 @@
+/*
+Note to Reviewer: I'm finding the 1000 line Gruntfile hard to parse. I easily get lost in the file's large indented blocks. 
+I can move this into that file, but what do you think of starting to chop up pieces of gruntfile into separate files?
+*/
+const swPrecache = require('sw-precache');
+const path = require('path');
+
+function registerServiceWorkerTasks(grunt) {
+  grunt.registerMultiTask('generateServiceWorker', function() {
+    const done = this.async();
+    const { staticDirectoryPath, rootUrl, scriptOutputPath } = this.data;
+    writeServiceWorkerFile(staticDirectoryPath, rootUrl, scriptOutputPath)
+      .then(done)
+      .catch(error => {
+        grunt.fail.warn(error);
+        done();
+      });
+  });
+};
+
+// Use the swPrecache library to generate a service-worker script
+function writeServiceWorkerFile(staticDirectoryPath, rootUrl, outputPath) {
+  const config = {
+    cacheId: 'cache',
+    claimsClient: true,
+    skipWaiting: true,
+    directoryIndex: false,
+    handleFetch: true,
+    staticFileGlobs: [
+      path.join(staticDirectoryPath, '{audio,css,fonts,img,js,xslt}', '*'),
+      path.join(staticDirectoryPath, 'manfiest.json'),
+    ],
+    dynamicUrlToDependencies: {
+      [rootUrl]: [path.join(staticDirectoryPath, 'templates', 'inbox.html')],
+    },
+    stripPrefixMulti: { [staticDirectoryPath]: '' },
+    maximumFileSizeToCacheInBytes: 1048576 * 20,
+    verbose: true,
+  };
+
+  return swPrecache.write(outputPath, config);
+}
+
+module.exports = registerServiceWorkerTasks;

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,22 +57,6 @@
       "integrity": "sha512-rI0LGoMiZGUM+tjDakQpwZOvcmQoubiJ7hxqrYU12VRxBuGGvOThxrBOU/QmJKlKg1WG6FMzuvcEyLffvVSsmw==",
       "dev": true
     },
-    "CSSselect": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
-      "integrity": "sha1-+Kt+H4QYzmPNput713ioXX7EkrI=",
-      "dev": true,
-      "requires": {
-        "CSSwhat": "0.4",
-        "domutils": "1.4"
-      }
-    },
-    "CSSwhat": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz",
-      "integrity": "sha1-hn2g/zn3eGEyQsRM/qg/CqTr35s=",
-      "dev": true
-    },
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
@@ -110,6 +94,23 @@
       "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
       "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
       "dev": true
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "requires": {
+        "acorn": "^3.0.4"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
     },
     "acorn-node": {
       "version": "1.6.2",
@@ -169,6 +170,12 @@
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
+    },
+    "ajv-keywords": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "dev": true
     },
     "align-text": {
       "version": "0.1.4",
@@ -243,6 +250,12 @@
           }
         }
       }
+    },
+    "ansi-escapes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+      "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -539,6 +552,44 @@
       "requires": {
         "follow-redirects": "^1.2.5",
         "is-buffer": "^1.1.5"
+      }
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "backo2": {
@@ -1223,10 +1274,25 @@
       "integrity": "sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg==",
       "dev": true
     },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "^0.2.0"
+      }
+    },
     "callsite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
       "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
+      "dev": true
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
     "camel-case": {
@@ -1334,32 +1400,17 @@
         "upper-case-first": "^1.1.0"
       }
     },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
+    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
-    },
-    "cheerio": {
-      "version": "0.18.0",
-      "resolved": "http://registry.npmjs.org/cheerio/-/cheerio-0.18.0.tgz",
-      "integrity": "sha1-ThwGN35yW3QOmW4N/sNThj3md/o=",
-      "dev": true,
-      "requires": {
-        "CSSselect": "~0.4.0",
-        "dom-serializer": "~0.0.0",
-        "entities": "~1.1.1",
-        "htmlparser2": "~3.8.1",
-        "lodash": "~2.4.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        }
-      }
     },
     "chokidar": {
       "version": "1.7.0",
@@ -1487,6 +1538,21 @@
       "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
       "dev": true
     },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
     "cliui": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
@@ -1516,6 +1582,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
       "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+      "dev": true
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
     "code-point-at": {
@@ -1987,6 +2059,12 @@
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true
     },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
     "defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
@@ -2166,6 +2244,15 @@
         "randombytes": "^2.0.0"
       }
     },
+    "doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
     "dom-serialize": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
@@ -2196,6 +2283,15 @@
         }
       }
     },
+    "dom-urls": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/dom-urls/-/dom-urls-1.1.0.tgz",
+      "integrity": "sha1-AB3fgWKM0ecGElxxdvU8zsVdkY4=",
+      "dev": true,
+      "requires": {
+        "urijs": "^1.16.1"
+      }
+    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
@@ -2212,15 +2308,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
       "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
-      "dev": true,
-      "requires": {
-        "domelementtype": "1"
-      }
-    },
-    "domutils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
-      "integrity": "sha1-CGVRN5bGswYDGFDhdVFrr4C3Km8=",
       "dev": true,
       "requires": {
         "domelementtype": "1"
@@ -2427,16 +2514,200 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "eslint": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.3.0",
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.1.0",
+        "concat-stream": "^1.6.0",
+        "cross-spawn": "^5.1.0",
+        "debug": "^3.1.0",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^3.7.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^3.5.4",
+        "esquery": "^1.0.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.0.1",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^3.0.6",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.9.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^1.0.1",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.3.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "4.0.2",
+        "text-table": "~0.2.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.12.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+          "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+          "dev": true
+        },
+        "progress": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+          "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
+    "eslint-scope": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+      "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "dev": true,
+      "requires": {
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.7.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "dev": true
+        }
+      }
+    },
     "esprima": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
       "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
       "dev": true
     },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
     "estree-walker": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.3.1.tgz",
       "integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
     "eventemitter2": {
@@ -2596,6 +2867,28 @@
         }
       }
     },
+    "external-editor": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "tmp": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "~1.0.2"
+          }
+        }
+      }
+    },
     "extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
@@ -2655,6 +2948,12 @@
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
     "faye-websocket": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
@@ -2692,6 +2991,16 @@
       "requires": {
         "escape-string-regexp": "^1.0.5",
         "object-assign": "^4.1.0"
+      }
+    },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "file-sync-cmp": {
@@ -2781,6 +3090,26 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
+        }
+      }
+    },
+    "flat-cache": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+      "dev": true,
+      "requires": {
+        "circular-json": "^0.3.1",
+        "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
+        "write": "^0.2.1"
+      },
+      "dependencies": {
+        "circular-json": {
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+          "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+          "dev": true
         }
       }
     },
@@ -3432,6 +3761,12 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
     "gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
@@ -3612,6 +3947,12 @@
         "ini": "^1.3.4"
       }
     },
+    "globals": {
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.9.0.tgz",
+      "integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg==",
+      "dev": true
+    },
     "globby": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
@@ -3742,15 +4083,6 @@
       "dev": true,
       "requires": {
         "html-minifier": "~2.1.2"
-      }
-    },
-    "grunt-appcache": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/grunt-appcache/-/grunt-appcache-0.2.0.tgz",
-      "integrity": "sha1-ebXyavRKaHvoS+d0OvtMSFiDPFk=",
-      "dev": true,
-      "requires": {
-        "cheerio": "~0.18.0"
       }
     },
     "grunt-browserify": {
@@ -4850,6 +5182,12 @@
       "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
       "dev": true
     },
+    "ignore": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "dev": true
+    },
     "ignore-by-default": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
@@ -4950,6 +5288,70 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
+        }
+      }
+    },
+    "inquirer": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.0.4",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rx-lite": "^4.0.8",
+        "rx-lite-aggregates": "^4.0.8",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
         }
       }
     },
@@ -5225,6 +5627,12 @@
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
     },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
     "is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
@@ -5235,6 +5643,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+      "dev": true
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
     "is-retry-allowed": {
@@ -5347,6 +5761,12 @@
       "integrity": "sha512-xcinL3AuDJk7VSzsHgb9DvvIXayBbadtMZ4HFPx8rUszbW1MuNMlwYVC4zzCZ6e1sqZpnNS5ZFYOhXqA39T7LQ==",
       "dev": true
     },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
     "js-yaml": {
       "version": "3.5.5",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
@@ -5457,6 +5877,12 @@
       "requires": {
         "jsonify": "~0.0.0"
       }
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -6153,6 +6579,16 @@
         }
       }
     },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
     "lie": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
@@ -6196,6 +6632,12 @@
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+      "dev": true
+    },
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
@@ -6212,6 +6654,12 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
+    },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
       "dev": true
     },
     "lodash.get": {
@@ -6231,6 +6679,25 @@
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
       "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
       "dev": true
+    },
+    "lodash.template": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+      "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "~3.0.0",
+        "lodash.templatesettings": "^4.0.0"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+      "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "~3.0.0"
+      }
     },
     "log-symbols": {
       "version": "1.0.2",
@@ -6611,6 +7078,12 @@
         "mime-db": "~1.37.0"
       }
     },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
+    },
     "mimic-response": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
@@ -6784,6 +7257,12 @@
       "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==",
       "dev": true
     },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "http://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
     "nan": {
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
@@ -6828,6 +7307,12 @@
           "dev": true
         }
       }
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
     },
     "ncname": {
       "version": "1.0.0",
@@ -7561,6 +8046,15 @@
         "wrappy": "1"
       }
     },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
+    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -7716,6 +8210,28 @@
             "y18n": "^3.2.1",
             "yargs-parser": "^2.4.1"
           }
+        }
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+          "dev": true
         }
       }
     },
@@ -8102,6 +8618,12 @@
         "irregular-plurals": "^1.0.0"
       }
     },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
+    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -8338,6 +8860,12 @@
           "dev": true
         }
       }
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
     },
     "prepend-http": {
       "version": "1.0.4",
@@ -9099,6 +9627,12 @@
         "safe-regex": "^1.1.0"
       }
     },
+    "regexpp": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+      "dev": true
+    },
     "registry-auth-token": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
@@ -9201,6 +9735,16 @@
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
+      }
+    },
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -9213,17 +9757,42 @@
       "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
       "dev": true
     },
+    "resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true
+    },
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
+    },
+    "rewire": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rewire/-/rewire-4.0.1.tgz",
+      "integrity": "sha512-+7RQ/BYwTieHVXetpKhT11UbfF6v1kGhKFrtZN7UDL2PybMsSt/rpLWeEUGF5Ndsl1D5BxiCB14VDJyoX+noYw==",
+      "dev": true,
+      "requires": {
+        "eslint": "^4.19.1"
+      }
     },
     "rfdc": {
       "version": "1.1.2",
@@ -9257,6 +9826,30 @@
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
+      }
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+      "dev": true
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "dev": true,
+      "requires": {
+        "rx-lite": "*"
       }
     },
     "safe-buffer": {
@@ -9502,6 +10095,12 @@
         "upper-case-first": "^1.1.2"
       }
     },
+    "serviceworker-cache-polyfill": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serviceworker-cache-polyfill/-/serviceworker-cache-polyfill-4.0.0.tgz",
+      "integrity": "sha1-3hnuc77yGrPAdAo3sz22JGS6ves=",
+      "dev": true
+    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -9640,6 +10239,23 @@
         "nise": "^1.4.6",
         "supports-color": "^5.5.0",
         "type-detect": "^4.0.8"
+      }
+    },
+    "slice-ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        }
       }
     },
     "snake-case": {
@@ -10190,6 +10806,42 @@
         "has-flag": "^3.0.0"
       }
     },
+    "sw-precache": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/sw-precache/-/sw-precache-5.2.1.tgz",
+      "integrity": "sha512-8FAy+BP/FXE+ILfiVTt+GQJ6UEf4CVHD9OfhzH0JX+3zoy2uFk7Vn9EfXASOtVmmIVbL3jE/W8Z66VgPSZcMhw==",
+      "dev": true,
+      "requires": {
+        "dom-urls": "^1.1.0",
+        "es6-promise": "^4.0.5",
+        "glob": "^7.1.1",
+        "lodash.defaults": "^4.2.0",
+        "lodash.template": "^4.4.0",
+        "meow": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "pretty-bytes": "^4.0.2",
+        "sw-toolbox": "^3.4.0",
+        "update-notifier": "^2.3.0"
+      },
+      "dependencies": {
+        "pretty-bytes": {
+          "version": "4.0.2",
+          "resolved": "http://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+          "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=",
+          "dev": true
+        }
+      }
+    },
+    "sw-toolbox": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/sw-toolbox/-/sw-toolbox-3.6.0.tgz",
+      "integrity": "sha1-Jt8dHHA0hljk3qKIQxkUm3sxg7U=",
+      "dev": true,
+      "requires": {
+        "path-to-regexp": "^1.0.1",
+        "serviceworker-cache-polyfill": "^4.0.0"
+      }
+    },
     "swap-case": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
@@ -10207,6 +10859,77 @@
       "dev": true,
       "requires": {
         "acorn-node": "^1.2.0"
+      }
+    },
+    "table": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.2.3",
+        "ajv-keywords": "^2.1.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
+        "slice-ansi": "1.0.0",
+        "string-width": "^2.1.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
       }
     },
     "tar": {
@@ -10562,6 +11285,15 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -10836,6 +11568,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/uri-path/-/uri-path-1.0.0.tgz",
       "integrity": "sha1-l0fwGDWJM8Md4PzP2C0TjmcmLjI=",
+      "dev": true
+    },
+    "urijs": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.1.tgz",
+      "integrity": "sha512-xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg==",
       "dev": true
     },
     "urix": {
@@ -11124,6 +11862,15 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     },
     "write-file-atomic": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "foreman": "^3.0.1",
     "grunt": "^1.0.3",
     "grunt-angular-templates": "^1.1.0",
-    "grunt-appcache": "^0.2.0",
     "grunt-browserify": "^5.3.0",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-cssmin": "^3.0.0",
@@ -62,8 +61,10 @@
     "pouchdb-core": "^7.0.0",
     "pouchdb-mapreduce": "^7.0.0",
     "protractor-jasmine2-screenshot-reporter": "^0.5.0",
+    "rewire": "^4.0.1",
     "semver": "^5.6.0",
     "sinon": "^7.1.1",
+    "sw-precache": "^5.2.1",
     "time-grunt": "^2.0.0",
     "underscore": "^1.9.1"
   },

--- a/tests/e2e/api/controllers/_changes.spec.js
+++ b/tests/e2e/api/controllers/_changes.spec.js
@@ -8,7 +8,7 @@ const _ = require('underscore'),
       semver = require('semver');
 
 const DEFAULT_EXPECTED = [
-  'appcache',
+  'serviceWorkerMeta',
   'settings',
   'resources',
   'branding',

--- a/tests/e2e/api/controllers/all-docs.spec.js
+++ b/tests/e2e/api/controllers/all-docs.spec.js
@@ -62,7 +62,7 @@ const restrictedKeys = [
 ];
 
 const unrestrictedKeys = [
-  'appcache',
+  'serviceWorkerMeta',
   'fixture:offline',
   'fixture:user:offline',
   'org.couchdb.user:offline',

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -155,7 +155,7 @@ const deleteAll = (except = []) => {
       ['translations', 'translations-backup', 'user-settings', 'info'].includes(
         doc.type
       ),
-    'appcache',
+    'serviceWorkerMeta',
     constants.USER_CONTACT_ID,
     'migration-log',
     'resources',

--- a/webapp/src/css/enketo/_fonts.scss
+++ b/webapp/src/css/enketo/_fonts.scss
@@ -1,8 +1,8 @@
 @font-face {
     font-family: 'enketo-icons';
-    src: url('../fonts/enketo-icons-v2.woff') format('woff'),
-        url('../fonts/enketo-icons-v2.ttf') format('truetype'),
-        url('../fonts/enketo-icons-v2.svg#enketo-icons') format('svg');
+    src: url('/fonts/enketo-icons-v2.woff') format('woff'),
+        url('/fonts/enketo-icons-v2.ttf') format('truetype'),
+        url('/fonts/enketo-icons-v2.svg#enketo-icons') format('svg');
     font-weight: normal;
     font-style: normal;
 }

--- a/webapp/src/css/font.less
+++ b/webapp/src/css/font.less
@@ -2,25 +2,25 @@
 
 @font-face {
   font-family: 'Noto';
-  src: url(../fonts/NotoSans-Regular.ttf) format("truetype");
+  src: url(/fonts/NotoSans-Regular.ttf) format("truetype");
   font-weight: normal;
   font-style: normal;
 }
 @font-face {
   font-family: 'Noto';
-  src: url(../fonts/NotoSans-Italic.ttf) format("truetype");
+  src: url(/fonts/NotoSans-Italic.ttf) format("truetype");
   font-weight: normal;
   font-style: italic;
 }
 @font-face {
   font-family: 'Noto';
-  src: url(../fonts/NotoSans-Bold.ttf) format("truetype");
+  src: url(/fonts/NotoSans-Bold.ttf) format("truetype");
   font-weight: bold;
   font-style: normal;
 }
 @font-face {
   font-family: 'Noto';
-  src: url(../fonts/NotoSans-BoldItalic.ttf) format("truetype");
+  src: url(/fonts/NotoSans-BoldItalic.ttf) format("truetype");
   font-weight: bold;
   font-style: italic;
 }

--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -1103,21 +1103,21 @@ a.fa:hover {
       padding-top: 100px;
     }
     .contact-pregnant {
-      background-image: url('../img/icon-pregnant.svg');
+      background-image: url('/img/icon-pregnant.svg');
       &.selected {
-        background-image: url('../img/icon-pregnant-selected.svg');
+        background-image: url('/img/icon-pregnant-selected.svg');
       }
     }
     .contact-chw {
-      background-image: url('../img/icon-chw.svg');
+      background-image: url('/img/icon-chw.svg');
       &.selected {
-        background-image: url('../img/icon-chw-selected.svg');
+        background-image: url('/img/icon-chw-selected.svg');
       }
     }
     .contact-nurse {
-      background-image: url('../img/icon-nurse.svg');
+      background-image: url('/img/icon-nurse.svg');
       &.selected {
-        background-image: url('../img/icon-nurse-selected.svg');
+        background-image: url('/img/icon-nurse-selected.svg');
       }
     }
   }

--- a/webapp/src/js/app.js
+++ b/webapp/src/js/app.js
@@ -147,7 +147,7 @@ _.templateSettings = {
       if (err.redirect) {
         window.location.href = err.redirect;
       } else {
-        console.error('Error fetching ddoc from remote server', err);
+        console.error('Error during bootstrapping', err);
         setTimeout(function() {
           // retry initial replication automatically after one minute
           window.location.reload(false);

--- a/webapp/src/js/bootstrapper/swRegister.js
+++ b/webapp/src/js/bootstrapper/swRegister.js
@@ -1,0 +1,43 @@
+/*
+Handles the initial registration of the service worker
+*/
+
+'use strict';
+
+function register(onInstalling) {
+  if (!window.navigator.serviceWorker) {
+    return Promise.reject(new Error('Service worker not supported'));
+  }
+
+  return new Promise(function (resolve, reject) {
+    window.navigator.serviceWorker.register('/service-worker.js')
+      .then(function(registration) {
+        // Do nothing if service worker is already up to date
+        if (!registration.installing) {
+          return resolve();
+        }
+
+        onInstalling();
+        registration.onupdatefound = function() {
+          const installingWorker = registration.installing;
+          installingWorker.onstatechange = function() {
+            switch (installingWorker.state) {
+              case 'activated':
+                resolve(installingWorker);
+                installingWorker.onstatechange = undefined;
+                break;
+              case 'redundant':
+                reject(new Error('Service worker labeled redundant'));
+                installingWorker.onstatechange = undefined;
+                break;
+              default:
+                console.debug(`Service worker state changed to ${installingWorker.state}`);
+            }
+          };
+        };
+      })
+      .catch(reject);
+  });
+}
+
+module.exports = register;

--- a/webapp/src/js/controllers/inbox.js
+++ b/webapp/src/js/controllers/inbox.js
@@ -41,6 +41,7 @@ var feedback = require('../modules/feedback'),
     SetLanguage,
     Settings,
     Snackbar,
+    UpdateServiceWorker,
     Telemetry,
     Tour,
     TranslateFrom,
@@ -78,7 +79,7 @@ var feedback = require('../modules/feedback'),
       // Disable debug for everything but localhost
       Debug.set(false);
     }
-    
+
     ResourceIcons.getAppTitle().then(title => {
       document.title = title;
     });
@@ -707,43 +708,24 @@ var feedback = require('../modules/feedback'),
       },
     });
 
-    if (window.applicationCache) {
-      window.applicationCache.addEventListener('updateready', showUpdateReady);
-      window.applicationCache.addEventListener('error', function(err) {
-        // TODO: once we trigger this work out what a 401 looks like and redirect
-        //       to the login page
-        $log.error('Application cache update error', err);
-      });
-      if (
-        window.applicationCache.status === window.applicationCache.UPDATEREADY
-      ) {
-        showUpdateReady();
-      }
-      Changes({
-        key: 'inbox-ddoc',
-        filter: function(change) {
-          return (
-            change.id === '_design/medic' ||
-            change.id === '_design/medic-client' ||
-            change.id === 'appcache' ||
-            change.id === 'settings'
-          );
-        },
-        callback: function() {
-          // if the manifest hasn't changed, prompt user to reload settings
-          window.applicationCache.addEventListener('noupdate', showUpdateReady);
-          // check if the manifest has changed. if it has, download and prompt
-          try {
-            window.applicationCache.update();
-          } catch (e) {
-            // chrome incognito mode active
-            $log.error('Error updating the appcache.', e);
-            showUpdateReady();
-          }
-        },
-      });
-    }
-
+    Changes({
+      key: 'inbox-ddoc',
+      filter: function(change) {
+        return (
+          change.id === '_design/medic' ||
+          change.id === '_design/medic-client' ||
+          change.id === 'serviceWorkerMeta' ||
+          change.id === 'settings'
+        );
+      },
+      callback: function(change) {
+        if (change.id === 'serviceWorkerMeta') {
+          UpdateServiceWorker(showUpdateReady);
+        } else {
+          showUpdateReady();
+        }
+      },
+    });
     RecurringProcessManager.startUpdateRelativeDate();
     $scope.$on('$destroy', function() {
       RecurringProcessManager.stopUpdateRelativeDate();

--- a/webapp/src/js/enketo/widgets/countdown-widget.js
+++ b/webapp/src/js/enketo/widgets/countdown-widget.js
@@ -113,7 +113,7 @@ function TimerAnimation(canvas, canvasW, canvasH, duration) {
         }
 
         function loadSound() {
-            return new Audio('./static/audio/alert.mp3');
+            return new Audio('/audio/alert.mp3');
         }
 
         return {

--- a/webapp/src/js/enketo/widgets/simprints.js
+++ b/webapp/src/js/enketo/widgets/simprints.js
@@ -52,7 +52,7 @@ define( function( require, exports, module ) {
         } );
 
         $translate( 'simprints.register' ).then( function( label ) {
-            $el.append( '<div><a class="btn btn-default simprints-register"><img src="img/simprints.png" width="20" height="20"/> ' + label + '</a></div>' );
+            $el.append( '<div><a class="btn btn-default simprints-register"><img src="/img/simprints.png" width="20" height="20"/> ' + label + '</a></div>' );
         } );
     };
 

--- a/webapp/src/js/services/db-sync.js
+++ b/webapp/src/js/services/db-sync.js
@@ -1,6 +1,6 @@
 var _ = require('underscore'),
   READ_ONLY_TYPES = ['form', 'translations'],
-  READ_ONLY_IDS = ['resources', 'branding', 'appcache', 'zscore-charts', 'settings', 'partners'],
+  READ_ONLY_IDS = ['resources', 'branding', 'serviceWorkerMeta', 'zscore-charts', 'settings', 'partners'],
   DDOC_PREFIX = ['_design/'],
   SYNC_INTERVAL = 5 * 60 * 1000, // 5 minutes
   META_SYNC_INTERVAL = 30 * 60 * 1000; // 30 minutes

--- a/webapp/src/js/services/index.js
+++ b/webapp/src/js/services/index.js
@@ -85,6 +85,7 @@
   require('./translation-null-interpolation');
   require('./unread-records');
   require('./update-facility');
+  require('./update-service-worker');
   require('./update-settings');
   require('./update-user');
   require('./user');

--- a/webapp/src/js/services/session.js
+++ b/webapp/src/js/services/session.js
@@ -28,22 +28,11 @@ var COOKIE_NAME = 'userCtx',
         return userCtxCookieValue;
       };
 
-      var waitForAppCache = function(callback) {
-        var appCache = $window.applicationCache;
-        if (appCache && appCache.status === appCache.DOWNLOADING) {
-          return appCache.addEventListener('updateready', callback);
-        }
-        callback();
-      };
-
       var navigateToLogin = function() {
         $log.warn('User must reauthenticate');
         ipCookie.remove(COOKIE_NAME, { path: '/' });
         userCtxCookieValue = undefined;
-        waitForAppCache(function() {
-          $window.location.href = '/' + Location.dbName + '/login' +
-            '?redirect=' + encodeURIComponent($window.location.href);
-        });
+        $window.location.href = `/${Location.dbName}/login?redirect=${encodeURIComponent($window.location.href)}`;
       };
 
       var logout = function() {

--- a/webapp/src/js/services/update-service-worker.js
+++ b/webapp/src/js/services/update-service-worker.js
@@ -1,0 +1,50 @@
+/*
+Handles service worker updates
+*/
+angular.module('inboxServices').factory('UpdateServiceWorker', function($window, $log, $timeout) {
+  'use strict';
+
+  const retryFailedUpdateAfterSec = 5 * 60;
+  let existingUpdateLoop;
+
+  function update(onSuccess) {
+    // This avoids multiple updates retrying in parallel
+    if (existingUpdateLoop) {
+      clearTimeout(existingUpdateLoop);
+      existingUpdateLoop = undefined;
+    }
+
+    $window.navigator.serviceWorker.getRegistrations()
+      .then(function(registrations) {
+        const registration = registrations && registrations.length && registrations[0];
+        if (!registration) {
+          $log.warn('Cannot update service worker - no active workers found');
+          return;
+        }
+
+        registration.onupdatefound = function() {
+          const installingWorker = registration.installing;
+          installingWorker.onstatechange = function() {
+            switch (installingWorker.state) {
+              case 'activated':
+                $log.info('New service worker activated');
+                registration.onupdatefound = undefined;
+                onSuccess();
+                break;
+              case 'redundant':
+                $log.warn(`Service worker failed to install or marked as redundant. Retrying install in ${retryFailedUpdateAfterSec}secs.`);
+                existingUpdateLoop = $timeout(() => update(onSuccess), retryFailedUpdateAfterSec * 1000);
+                registration.onupdatefound = undefined;
+                break;
+              default:
+                $log.debug(`Service worker state changed to ${installingWorker.state}!`);
+            }
+          };
+        };
+
+        registration.update();
+      });
+  }
+
+  return update;
+});

--- a/webapp/src/js/services/xslt.js
+++ b/webapp/src/js/services/xslt.js
@@ -2,14 +2,13 @@
 angular.module('inboxServices').service('XSLT',
   function(
     $http,
-    $q,
-    Location
+    $q
   ) {
 
     'use strict';
     'ngInject';
 
-    var staticRoot = Location.path + '/xslt/';
+    var staticRoot = '/xslt/';
     var processors = {};
     var xmlSerializer = new XMLSerializer();
 

--- a/webapp/src/templates/inbox.html
+++ b/webapp/src/templates/inbox.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 
-<html manifest="manifest.appcache">
+<html manifest="/empty.manifest">
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" type="text/css" href="css/inbox.css" />
+    <link rel="stylesheet" type="text/css" href="/css/inbox.css" />
     <link rel="shortcut icon" href="/favicon.ico">
-    <link rel="manifest" href="manifest.json">
+    <link rel="manifest" href="/manifest.json">
     <title id="app"></title>
     <script type="text/javascript">
       window.startupTimes = {};
@@ -33,8 +33,8 @@
       <span class="snackbar-content"></span>
     </div>
 
-    <script src="js/inbox.js" type="text/javascript"></script>
-    <script src="js/templates.js" type="text/javascript"></script>
+    <script src="/js/inbox.js" type="text/javascript"></script>
+    <script src="/js/templates.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/webapp/src/templates/modals/welcome.html
+++ b/webapp/src/templates/modals/welcome.html
@@ -16,6 +16,6 @@
     </div>
   </div>
   <div class="screenshot">
-    <img src="img/setup-wizard-demo.png" width="614" height="262" />
+    <img src="/img/setup-wizard-demo.png" width="614" height="262" />
   </div>
 </mm-modal>

--- a/webapp/src/templates/partials/filters/simprints.html
+++ b/webapp/src/templates/partials/filters/simprints.html
@@ -1,5 +1,5 @@
 <span class="simprints-filter" ng-show="simprintsEnabled">
   <a tabindex="-1" ng-click="simprintsIdentify()" translate-attr-title="simprints.search">
-    <img src="img/simprints.png" width="20" height="20"/>
+    <img src="/img/simprints.png" width="20" height="20"/>
   </a>
 </span>

--- a/webapp/tests/karma/unit/services/db-sync.js
+++ b/webapp/tests/karma/unit/services/db-sync.js
@@ -252,8 +252,8 @@ describe('DBSync service', () => {
       expect(actual).to.equal(false);
     });
 
-    it('does not replicate the appcache doc', () => {
-      const actual = filterFunction({ _id: 'appcache' });
+    it('does not replicate the serviceWorkerMeta doc', () => {
+      const actual = filterFunction({ _id: 'serviceWorkerMeta' });
       expect(actual).to.equal(false);
     });
 

--- a/webapp/tests/karma/unit/services/session.js
+++ b/webapp/tests/karma/unit/services/session.js
@@ -6,8 +6,6 @@ describe('Session service', function() {
       ipCookie,
       ipCookieRemove,
       location,
-      appCache,
-      appCacheListener,
       $httpBackend,
       Location;
 
@@ -15,15 +13,9 @@ describe('Session service', function() {
     module('inboxApp');
     ipCookie = sinon.stub();
     ipCookieRemove = sinon.stub();
-    appCacheListener = sinon.stub();
     ipCookie.remove = ipCookieRemove;
     Location = {};
     location = {};
-    appCache = {
-      DOWNLOADING: 3,
-      status: 0,
-      addEventListener: appCacheListener
-    };
     module(function ($provide) {
       $provide.factory('ipCookie', function() {
         return ipCookie;
@@ -33,7 +25,6 @@ describe('Session service', function() {
         return {
           angular: { callbacks: [] },
           location: location,
-          applicationCache: appCache
         };
       });
     });
@@ -44,7 +35,7 @@ describe('Session service', function() {
   });
 
   afterEach(function() {
-    KarmaUtils.restore(ipCookie, ipCookieRemove, appCacheListener);
+    KarmaUtils.restore(ipCookie, ipCookieRemove);
   });
 
   it('gets the user context', function(done) {
@@ -133,24 +124,6 @@ describe('Session service', function() {
     service.init();
     $httpBackend.flush();
     chai.expect(ipCookieRemove.callCount).to.equal(0);
-    done();
-  });
-
-  it('waits for app cache download before logging out', function(done) {
-    ipCookie.returns({});
-    location.href = 'CURRENT_URL';
-    Location.dbName = 'DB_NAME';
-    $httpBackend
-      .expect('DELETE', '/_session')
-      .respond(200);
-    appCache.status = 3;
-    service.init();
-    $httpBackend.flush();
-    appCacheListener.args[0][1](); // fire the appcache callback
-    chai.expect(appCacheListener.callCount).to.equal(1);
-    chai.expect(appCacheListener.args[0][0]).to.equal('updateready');
-    chai.expect(location.href).to.equal('/DB_NAME/login?redirect=CURRENT_URL');
-    chai.expect(ipCookieRemove.args[0][0]).to.equal('userCtx');
     done();
   });
 

--- a/webapp/tests/karma/unit/services/update-service-worker.js
+++ b/webapp/tests/karma/unit/services/update-service-worker.js
@@ -1,0 +1,109 @@
+describe('UpdateServiceWorker Service', () => {
+  'use strict';
+
+  let $timeout, service, fakeGetReg;
+
+  beforeEach(() => {
+    module('inboxApp');
+    
+    fakeGetReg = sinon.stub().resolves();
+    module($provide => {
+      $provide.value('$window', {
+        navigator: {
+          serviceWorker: {
+            getRegistrations: fakeGetReg, 
+          },
+        },
+      });
+    });
+    inject((_UpdateServiceWorker_, _$timeout_) => {
+      service = _UpdateServiceWorker_;
+      $timeout = _$timeout_;
+    });
+  });
+
+  afterEach(sinon.restore);
+
+  it('noop when there are no registered service workers', () => {
+    fakeGetReg.resolves([]);
+    const callback = sinon.stub();
+    service(callback);
+    expect(callback.called).to.eq(false);
+  });
+
+  it('service worker activation invokes callback', done => {
+    const registration = {
+      installing: { state: 'activated' },
+      update: sinon.stub(),
+    };
+    fakeGetReg.resolves([registration]);
+    const callback = sinon.stub();
+
+    service(callback);
+    executeSwLifecycle(registration, () => {
+      expect(registration.update.callCount).to.eq(1);
+      expect(callback.callCount).to.eq(1);
+      done();
+    });
+  });
+
+  it('service worker redundancy + retry invokes callback', done => {
+    const registration = {
+      installing: { state: 'redundant' },
+      update: sinon.stub(),
+    };
+    fakeGetReg.resolves([registration]);
+    const callback = sinon.stub();
+
+    service(callback);
+
+    executeSwLifecycle(registration, () => {
+      expect(registration.update.callCount).to.eq(1);
+      expect(callback.callCount).to.eq(0);
+
+      registration.installing.state = 'activated';
+      $timeout.flush(1000 * 60 * 10);
+
+      executeSwLifecycle(registration, () => {
+        expect(registration.update.callCount).to.eq(2);
+        expect(callback.callCount).to.eq(1);
+        done();
+      });
+    });
+  });
+
+  it('multiple redundant updates result in single retry', done => {
+    const registration = {
+      installing: { state: 'redundant' },
+      update: sinon.stub(),
+    };
+    fakeGetReg.resolves([registration]);
+    const callback = sinon.stub();
+
+    service(callback);
+    service(callback);
+    service(callback);
+
+    executeSwLifecycle(registration, () => {
+      expect(registration.update.callCount).to.eq(3);
+      expect(callback.callCount).to.eq(0);
+
+      registration.installing.state = 'activated';
+      $timeout.flush(1000 * 60 * 10);
+
+      executeSwLifecycle(registration, () => {
+        expect(registration.update.callCount).to.eq(4);
+        expect(callback.callCount).to.eq(1);
+        done();
+      });
+    });
+  });
+
+  function executeSwLifecycle(registration, callback) {
+    setTimeout(() => registration.onupdatefound(), 1);
+    setTimeout(() => {
+      registration.installing.onstatechange();
+      callback();
+    }, 2);
+  }
+});

--- a/webapp/tests/mocha/unit/swRegister.spec.js
+++ b/webapp/tests/mocha/unit/swRegister.spec.js
@@ -1,0 +1,91 @@
+const swRegister = require('../../../src/js/bootstrapper/swRegister'),
+      sinon = require('sinon'),
+      { expect } = require('chai');
+
+let fakeRegisterFunc;
+
+function executeSwLifecycle(registration) {
+  setTimeout(() => registration.onupdatefound(), 1);
+  setTimeout(() => registration.installing.onstatechange(), 2);
+}
+
+describe('Service worker registration (swRegister.js)', () => {
+  // ignore "Read Only" jshint error for overwriting `window`
+  // jshint -W020
+  beforeEach(() => {
+    fakeRegisterFunc = sinon.stub().resolves({
+      installing: 'something',
+    });
+
+    window = {
+      navigator: {
+        serviceWorker: {
+          register: fakeRegisterFunc,
+        },
+      },
+    };
+  });
+
+  it('resolves if already installed', done => {
+    fakeRegisterFunc.resolves({});
+    const callback = sinon.stub();
+    swRegister(callback).then(actual => {
+      expect(actual).to.eq(undefined);
+      expect(callback.called).to.eq(false);
+      done();
+    });
+  });
+
+  it('resolves on activation', done => {
+    const registration = {
+      installing: { state: 'activated' },
+    };
+    fakeRegisterFunc.resolves(registration);
+    
+    const callback = sinon.stub();
+    swRegister(callback).then(actual => {
+      expect(actual).to.be.an('object');
+      expect(callback.callCount).to.eq(1);
+      done();
+    });
+    executeSwLifecycle(registration);
+  });
+
+  it('rejects if service workers not supported', done => {
+    delete window.navigator.serviceWorker;
+    
+    const callback = sinon.stub();
+    swRegister(callback).catch(err => {
+      expect(callback.called).to.eq(false);
+      expect(err).to.include({ name: 'Error' });
+      expect(err.message).to.include('not supported');
+      done();
+    });
+  });
+
+  it('rejects on redundant', done => {
+    const registration = {
+      installing: { state: 'redundant' },
+    };
+    fakeRegisterFunc.resolves(registration);
+    
+    const callback = sinon.stub();
+    swRegister(callback).catch(err => {
+      expect(err).to.include({ name: 'Error' });
+      expect(err.message).to.include('redundant');
+      expect(callback.callCount).to.eq(1);
+      done();
+    });
+    executeSwLifecycle(registration);
+  });
+
+  it('rejects on error', done => {
+    fakeRegisterFunc.rejects('Error');
+    const callback = sinon.stub();
+    swRegister(callback).catch(err => {
+      expect(err).to.include({ name: 'Error' });
+      expect(callback.called).to.eq(false);
+      done();
+    });
+  });
+});

--- a/webapp/tests/mocha/unit/testingtests/protractor/utils.spec.js
+++ b/webapp/tests/mocha/unit/testingtests/protractor/utils.spec.js
@@ -14,7 +14,7 @@ describe('Protractor utils', () => {
       const request = sinon.stub(utils, 'request');
       request.onFirstCall().returns(Promise.resolve({rows: [
         {id: '_design/cats', doc: {_id: '_design/cats'}},
-        {id: 'appcache', doc: {_id: 'appcache'}},
+        {id: 'serviceWorkerMeta', doc: {_id: 'serviceWorkerMeta'}},
         {id: 'migration-log', doc: {_id: 'migration-log'}},
         {id: 'resources', doc: {_id: 'resources'}},
         {id: 'branding', doc: {_id: 'branding'}},

--- a/webapp/tests/mocha/unit/validate_doc_update.spec.js
+++ b/webapp/tests/mocha/unit/validate_doc_update.spec.js
@@ -68,8 +68,8 @@ describe('validate doc update', () => {
     done();
   });
 
-  it('only db and national admins are allowed change appcache doc', done => {
-    const doc = { _id: 'appcache' };
+  it('only db and national admins are allowed change serviceWorkerMeta doc', done => {
+    const doc = { _id: 'serviceWorkerMeta' };
     assert.isOk(allowedOnServer(userCtx({roles: [ '_admin' ]}), doc));
     assert.isOk(allowedOnServer(userCtx({roles: [ 'national_admin' ]}), doc));
     assert.deepEqual(allowedOnServer(userCtx({roles: [ ]}), doc), disallowed('You are not authorized to edit admin only docs'));


### PR DESCRIPTION
# Description 
This change replaces the underlying technology which allows the webapp to load while offline. This change removes the use of the legacy appcache and adds offline support via a PWA service worker. 
#4713

# Method
## Chrome 53 Constraint 
The technical approach taken in this proposed change is guided by a non-obvious constraint of service works in Chrome 53. Prior to Chrome 66, the web requests from the service worker don't include credentials (cookies, basic auth, etc). This means all resource we wish to cache must be accessible via unauthenticated endpoints. 

## Overview of my Approach

* **Service Worker Code** - I use the [swPrecache library from Google](https://github.com/GoogleChromeLabs/sw-precache#service-worker-precache) to generate the service worker script at build time. SwPrecache has been replaced by [Workbox](https://developers.google.com/web/tools/workbox/) which is Google's latest solution for generating service workers. Details as to why I'm using the legacy technology discussed in "swPrecache vs Workbox" below.  
* **New public endpoints** - When API starts, I extract all cacheable resources from _design/medic and write them to a new directory in `api/src/extracted`. So instead of serving resources through the authenticated endpoint `/medic/_design/medic/_rewrite/js/inbox.js`, the same resource is served from the public `/js/inbox.js`. 
* **Initial service worker installation** - I updated bootstrapper to handle the synchronous install of the service worker and show an error + reload action if precaching of any resource fails. (#3568) 
* **Triggering Updates** - A service worker update should be triggered when any resource in the cache changes (if not, you have to refresh twice to get a change). Since the `service-worker.js` generated at build time contains a hash of every cached resource, watching the script itself for changes is sufficient to detect when a cache update is necessary.  I re-use "ddoc extract" pattern to trigger the updates. 
* **Updating** - When the service worker updates, only the files which have changed are downloaded. If the service worker fails to download a required file for any reason (eg. connectivity), I retry on a timer every five minutes until it is successful. Only after the service worker updates is the user prompted to refresh. 
* **Scope** - A service worker can't have a "scope" broader than its own location. So although I serve the javascript from `/js/service-worker.js`, I create an alias at `/service-worker.js` to give it broad control to handle all caching concerns. 
* **Upgrading from AppCache to Service Workers** - If you login to current master (where resources are cached via appcache) and upgrade to this change - it is important to clear the old cache before caching anew. It is not possible to clear the appcache programmatically. I set `<html manifest="empty">` which requests an empty manifest and clears the cache. 
* **Rewire** - I've added a dependency on the rewire library for mocha testing. It's awesome and we should use it! 
 
## swPrecache vs Workbox 
It is worth checking out the [Support Details for swPrecache](https://github.com/GoogleChromeLabs/sw-precache#support). TLDR: "We would recommend Workbox for new projects" but "we’ll continue to support sw-precache". 
 
Workbox looks awesome. Most notably check out [enabling offline Google Analytics](https://developers.google.com/web/tools/workbox/modules/workbox-google-analytics). So why isn't this PR using Workbox? The short answer is we probably should – but this is a big PR and Workbox is going to complicate things.  
 
Here is why I'm using the swPrecache library: 
 
1. **The community support isn't perfect for either option** - Workbox 3 supports Chrome >51, but modern [Workbox 4 only supports Chrome >56](https://github.com/GoogleChrome/workbox/releases) so really both swPrecache and latests Workbox are [both not supporting us](https://www.youtube.com/watch?v=bVwh8PW6r88). 
1. **Partial Precache State** - SwPrecache is pretty much exactly what we want by default: it fails to install the service worker if any resource doesn't get precached and thus the possibility of a partial precached state. Workbox delivers a best effort precache and it isn't immediately obvious to me how to best avoid a partial precache state. 
1. **Dependent Scripts** - SwPrecache inlines all dependencies directly in the service worker so we just serve one script and we are done. Workbox has a modular build which deploys dependencies along-side your service worker (~20 files). A bit messy and not a perfect fit for our build script which ends up adding twenty more attachments to the database. A quick attempt to build only the required resources ended up with some dependencies being pulled from a cdn – which is problematic for projects using domain-based data contracts.  
 
All solvable problems, but a bit of untangling to do. Imo -- the best case would be using Workbox to output a script which does exactly what swPrecache is outputting now. I'm confident we can get there if we are interested in other features of Workbox *cough* - offline google analytics - *cough*. 
 
# Questions for Reviewer 

1. Let's discuss the general approach in this PR and maybe somebody can test a few scenarios on a device or two? If we like the result, maybe it is easier to carve this into chunks and review and submit in pieces. 
1. I just copied the list of resources to cache from appcache.manifest. We cache 29 files (some things which we maybe don't use). Maybe worth following up with an item to reduce how much we cache? 
1. The Application tab in devtools reports the disk use of appcache as 20.6MB and the same resources cached using service workers as 39.7MB. Unsure of the reason, but possible discussion point. 
1. It would be nice to get some guidance on exactly what horti scenarios would be good to test for this. 
1. Should we use the service worker to cache the favicon? 
1. Should we use the service worker to cache the login page? Even if you can't login, it's a better experience than seeing the non-localized white unbranded error page for login when offline. 
1. Upgrading from master to this change doesn't give the user the "Update" prompt because there is no change to a document being watched in master. Since this change won't be deployed atomically and will be instead packaged with other changes in v3.5 - I think that is safe. But we can consider tombstoning the legacy `appcache` document to make this change prompt an upgrade and also keep the database a bit cleaner. Looking for advice as I'm unsure how to best handle that. 
1. For performance reasons, we could consider making the service worker download and precache resources on the login page instead of after login. It is a one-line change which could benefit some users but possibly annoy others. 
1. Instead of using "ddoc-extraction," I considered calculating the hash of the service worker file at build-time and setting a single attribute on the medic-client ddoc. Think this would be cleaner? 
1. I put the core grunt logic into its own file instead of dumping it into the Gruntfile.js. I find that Gruntfile really hard to parse, and easily get lost in its large indentations. What do you think of starting to chop up that file into separate more manageable pieces (as done here)? 
1. Want to add a new UI state into the bootstrapper which says something like "Downloading App..." For the duration of the period in which we precache the service worker's resources? 
1. This change will block testing on insecure origins except localhost. This is pretty awkward for testing dev builds on a phone – I ran a DNS server + nginx proxy + vpn on my phone to work around it. This is likely something we should address in this change or shortly after. Looking to discuss the best approach. 
1. Is it safe the remove the write access controls to the deprecated appcache document in this change? 

# Scenarios I Tested

1. Incognito, login. Go offline. Refresh: user should get offline experience. 
1. Incognito, delete a required attachment, login: user should see an error dialog prompting to check connection. Rebuild and click retry: login should succeed and page should work offline. 
1. Incognito, login, update a css file, build, sync: user should see prompt to update. Update: user should see change in css appear. Network shows only the css file being updated. 
1. Incognito, login, update a css file, build, delete the css attachment in db, sync: user should see error in console and should not be prompted to update. Rebuild: after five minutes user should see prompt to update. Update: user should see change in css appear. 
1. If service-worker.js results in 404, then the app should not load and user should see error prompting to check connection. 
1. Incognito, login, update a css file, build, refresh without syncing: user should see prompt to update after refresh. Update: user should see change in css appear. 
1. Incognito, login to master (AppCache version). Rebuild to proposed change, sync. User should see prompt to update. 

# License
The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.