### PR TITLE
Add demo forms for muting and un-muting the different levels of hierarchy

### DIFF
--- a/demo-forms/muting-forms/mute_clinic.properties.json
+++ b/demo-forms/muting-forms/mute_clinic.properties.json
@@ -1,0 +1,8 @@
+{
+	"icon": "off",
+	"context": {
+		"person": false,
+		"place": true,
+		"expression": "!contact || (contact.type === 'clinic')"
+	}
+}

--- a/demo-forms/muting-forms/mute_clinic.xml
+++ b/demo-forms/muting-forms/mute_clinic.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <h:head>
+        <h:title>Mute clinic</h:title>
+        <model>
+            <instance>
+                <mute_clinic delimiter="#" id="mute_clinic" prefix="J1!mute_clinic!" version="2016-12-21">
+                    <inputs>
+                        <meta>
+                            <location>
+                                <lat/>
+                                <long/>
+                                <error/>
+                                <message/>
+                            </location>
+                        </meta>
+                        <source>user</source>
+                        <source_id/>
+                        <contact>
+                            <_id/>
+                            <name/>
+                            <parent>
+                                <contact>
+                                    <phone/>
+                                    <name/>
+                                </contact>
+                            </parent>
+                        </contact>
+                    </inputs>
+                    <place_id/>
+                    <place_name/>
+                    <chw_name/>
+                    <chw_phone/>
+                    <chw_sms/>
+                    <group_note>
+                        <pregnancy_note/>
+                        <send_note/>
+                        <chw_note/>
+                    </group_note>
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </mute_clinic>
+            </instance>
+            <instance id="contact-summary"/>
+            <bind nodeset="/mute_clinic/inputs" relevant="./source = 'user'"/>
+            <bind nodeset="/mute_clinic/inputs/source" type="string"/>
+            <bind nodeset="/mute_clinic/inputs/source_id" type="string"/>
+            <bind nodeset="/mute_clinic/inputs/contact/_id" type="db:clinic"/>
+            <bind nodeset="/mute_clinic/inputs/contact/name" type="string"/>
+            <bind nodeset="/mute_clinic/inputs/contact/parent/contact/phone" type="string"/>
+            <bind nodeset="/mute_clinic/inputs/contact/parent/contact/name" type="string"/>
+            <bind calculate="../inputs/contact/_id" nodeset="/mute_clinic/place_id" type="string"/>
+            <bind calculate="../inputs/contact/name" nodeset="/mute_clinic/place_name" type="string"/>
+            <bind calculate="../inputs/contact/parent/contact/name" nodeset="/mute_clinic/chw_name" type="string"/>
+            <bind calculate="../inputs/contact/parent/contact/phone" nodeset="/mute_clinic/chw_phone" type="string"/>
+            <bind calculate=" /mute_clinic/group_note/chw_note " nodeset="/mute_clinic/chw_sms" type="string"/>
+            <bind nodeset="/mute_clinic/group_note/pregnancy_note" readonly="true()" type="string"/>
+            <bind nodeset="/mute_clinic/group_note/send_note" required="true()" type="select1"/>
+            <bind nodeset="/mute_clinic/group_note/chw_note" relevant=" /mute_clinic/group_note/send_note  = 'yes'" type="string"/>
+            <bind calculate="concat('uuid:', uuid())" nodeset="/mute_clinic/meta/instanceID" readonly="true()" type="string"/>
+        </model>
+    </h:head>
+    <h:body class="pages">
+        <group appearance="field-list" ref="/mute_clinic/inputs">
+            <label>Clinic</label>
+            <input appearance="hidden" ref="/mute_clinic/inputs/source">
+                <label>Source</label>
+            </input>
+            <input appearance="hidden" ref="/mute_clinic/inputs/source_id">
+                <label>Source ID</label>
+            </input>
+            <group ref="/mute_clinic/inputs/contact">
+                <input appearance="db-object" ref="/mute_clinic/inputs/contact/_id">
+                    <label>What is the name of the Clinic?</label>
+                    <hint>Select a place from list</hint>
+                </input>
+                <input appearance="hidden" ref="/mute_clinic/inputs/contact/name">
+                    <label>Name</label>
+                </input>
+                <group ref="/mute_clinic/inputs/contact/parent">
+                    <group ref="/mute_clinic/inputs/contact/parent/contact">
+                        <input appearance="hidden" ref="/mute_clinic/inputs/contact/parent/contact/phone">
+                            <label>CHW Phone</label>
+                        </input>
+                        <input appearance="hidden" ref="/mute_clinic/inputs/contact/parent/contact/name">
+                            <label>CHW Name</label>
+                        </input>
+                    </group>
+                </group>
+            </group>
+        </group>
+        <group appearance="field-list" ref="/mute_clinic/group_note">
+            <label>Turning Muting ON</label>
+            <input ref="/mute_clinic/group_note/pregnancy_note">
+                <label>An SMS will automatically be sent to <output value=" /mute_clinic/chw_name "/> (<output value=" /mute_clinic/chw_phone "/>) to inform them that reminders are turned OFF for <output value=" /mute_clinic/place_name "/></label></input>
+            <select1 ref="/mute_clinic/group_note/send_note">
+                <label>Write additional info to send to the CHW?</label>
+                <item>
+                    <label>Yes</label>
+                    <value>yes</value>
+                </item>
+                <item>
+                    <label>No</label>
+                    <value>no</value>
+                </item>
+            </select1>
+            <input appearance="multiline" ref="/mute_clinic/group_note/chw_note">
+                <label>Enter short message to be sent</label>
+            </input>
+        </group>
+    </h:body>
+</h:html>

--- a/demo-forms/muting-forms/mute_district_hospital.properties.json
+++ b/demo-forms/muting-forms/mute_district_hospital.properties.json
@@ -1,0 +1,8 @@
+{
+	"icon": "off",
+	"context": {
+		"person": false,
+		"place": true,
+		"expression": "!contact || (contact.type === 'district_hospital')"
+	}
+}

--- a/demo-forms/muting-forms/mute_district_hospital.xml
+++ b/demo-forms/muting-forms/mute_district_hospital.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <h:head>
+        <h:title>Mute District Hospital</h:title>
+        <model>
+            <instance>
+                <mute_district_hospital delimiter="#" id="mute_district_hospital" prefix="J1!mute_district_hospital!" version="2016-12-21">
+                    <inputs>
+                        <meta>
+                            <location>
+                                <lat/>
+                                <long/>
+                                <error/>
+                                <message/>
+                            </location>
+                        </meta>
+                        <source>user</source>
+                        <source_id/>
+                        <contact>
+                            <_id/>
+                            <name/>
+                            <parent>
+                                <contact>
+                                    <phone/>
+                                    <name/>
+                                </contact>
+                            </parent>
+                        </contact>
+                    </inputs>
+                    <place_id/>
+                    <place_name/>
+                    <chw_name/>
+                    <chw_phone/>
+                    <chw_sms/>
+                    <group_note>
+                        <pregnancy_note/>
+                        <send_note/>
+                        <chw_note/>
+                    </group_note>
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </mute_district_hospital>
+            </instance>
+            <instance id="contact-summary"/>
+            <bind nodeset="/mute_district_hospital/inputs" relevant="./source = 'user'"/>
+            <bind nodeset="/mute_district_hospital/inputs/source" type="string"/>
+            <bind nodeset="/mute_district_hospital/inputs/source_id" type="string"/>
+            <bind nodeset="/mute_district_hospital/inputs/contact/_id" type="db:district_hospital"/>
+            <bind nodeset="/mute_district_hospital/inputs/contact/name" type="string"/>
+            <bind nodeset="/mute_district_hospital/inputs/contact/parent/contact/phone" type="string"/>
+            <bind nodeset="/mute_district_hospital/inputs/contact/parent/contact/name" type="string"/>
+            <bind calculate="../inputs/contact/_id" nodeset="/mute_district_hospital/place_id" type="string"/>
+            <bind calculate="../inputs/contact/name" nodeset="/mute_district_hospital/place_name" type="string"/>
+            <bind calculate="../inputs/contact/parent/contact/name" nodeset="/mute_district_hospital/chw_name" type="string"/>
+            <bind calculate="../inputs/contact/parent/contact/phone" nodeset="/mute_district_hospital/chw_phone" type="string"/>
+            <bind calculate=" /mute_district_hospital/group_note/chw_note " nodeset="/mute_district_hospital/chw_sms" type="string"/>
+            <bind nodeset="/mute_district_hospital/group_note/pregnancy_note" readonly="true()" type="string"/>
+            <bind nodeset="/mute_district_hospital/group_note/send_note" required="true()" type="select1"/>
+            <bind nodeset="/mute_district_hospital/group_note/chw_note" relevant=" /mute_district_hospital/group_note/send_note  = 'yes'" type="string"/>
+            <bind calculate="concat('uuid:', uuid())" nodeset="/mute_district_hospital/meta/instanceID" readonly="true()" type="string"/>
+        </model>
+    </h:head>
+    <h:body class="pages">
+        <group appearance="field-list" ref="/mute_district_hospital/inputs">
+            <label>Clinic</label>
+            <input appearance="hidden" ref="/mute_district_hospital/inputs/source">
+                <label>Source</label>
+            </input>
+            <input appearance="hidden" ref="/mute_district_hospital/inputs/source_id">
+                <label>Source ID</label>
+            </input>
+            <group ref="/mute_district_hospital/inputs/contact">
+                <input appearance="db-object" ref="/mute_district_hospital/inputs/contact/_id">
+                    <label>What is the name of the District Hospital?</label>
+                    <hint>Select a place from list</hint>
+                </input>
+                <input appearance="hidden" ref="/mute_district_hospital/inputs/contact/name">
+                    <label>Name</label>
+                </input>
+                <group ref="/mute_district_hospital/inputs/contact/parent">
+                    <group ref="/mute_district_hospital/inputs/contact/parent/contact">
+                        <input appearance="hidden" ref="/mute_district_hospital/inputs/contact/parent/contact/phone">
+                            <label>CHW Phone</label>
+                        </input>
+                        <input appearance="hidden" ref="/mute_district_hospital/inputs/contact/parent/contact/name">
+                            <label>CHW Name</label>
+                        </input>
+                    </group>
+                </group>
+            </group>
+        </group>
+        <group appearance="field-list" ref="/mute_district_hospital/group_note">
+            <label>Turning Muting ON</label>
+            <input ref="/mute_district_hospital/group_note/pregnancy_note">
+                <label>An SMS will automatically be sent to <output value=" /mute_district_hospital/chw_name "/> (<output value=" /mute_district_hospital/chw_phone "/>) to inform them that reminders are turned OFF for <output value=" /mute_district_hospital/place_name "/></label></input>
+            <select1 ref="/mute_district_hospital/group_note/send_note">
+                <label>Write additional info to send to the CHW?</label>
+                <item>
+                    <label>Yes</label>
+                    <value>yes</value>
+                </item>
+                <item>
+                    <label>No</label>
+                    <value>no</value>
+                </item>
+            </select1>
+            <input appearance="multiline" ref="/mute_district_hospital/group_note/chw_note">
+                <label>Enter short message to be sent</label>
+            </input>
+        </group>
+    </h:body>
+</h:html>

--- a/demo-forms/muting-forms/mute_health_center.properties.json
+++ b/demo-forms/muting-forms/mute_health_center.properties.json
@@ -1,0 +1,8 @@
+{
+	"icon": "off",
+	"context": {
+		"person": false,
+		"place": true,
+		"expression": "!contact || (contact.type === 'health_center')"
+	}
+}

--- a/demo-forms/muting-forms/mute_health_center.xml
+++ b/demo-forms/muting-forms/mute_health_center.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <h:head>
+        <h:title>Mute health center</h:title>
+        <model>
+            <instance>
+                <mute_health_center delimiter="#" id="mute_health_center" prefix="J1!mute_health_center!" version="2016-12-21">
+                    <inputs>
+                        <meta>
+                            <location>
+                                <lat/>
+                                <long/>
+                                <error/>
+                                <message/>
+                            </location>
+                        </meta>
+                        <source>user</source>
+                        <source_id/>
+                        <contact>
+                            <_id/>
+                            <name/>
+                            <parent>
+                                <contact>
+                                    <phone/>
+                                    <name/>
+                                </contact>
+                            </parent>
+                        </contact>
+                    </inputs>
+                    <place_id/>
+                    <place_name/>
+                    <chw_name/>
+                    <chw_phone/>
+                    <chw_sms/>
+                    <group_note>
+                        <pregnancy_note/>
+                        <send_note/>
+                        <chw_note/>
+                    </group_note>
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </mute_health_center>
+            </instance>
+            <instance id="contact-summary"/>
+            <bind nodeset="/mute_health_center/inputs" relevant="./source = 'user'"/>
+            <bind nodeset="/mute_health_center/inputs/source" type="string"/>
+            <bind nodeset="/mute_health_center/inputs/source_id" type="string"/>
+            <bind nodeset="/mute_health_center/inputs/contact/_id" type="db:health_center"/>
+            <bind nodeset="/mute_health_center/inputs/contact/name" type="string"/>
+            <bind nodeset="/mute_health_center/inputs/contact/parent/contact/phone" type="string"/>
+            <bind nodeset="/mute_health_center/inputs/contact/parent/contact/name" type="string"/>
+            <bind calculate="../inputs/contact/_id" nodeset="/mute_health_center/place_id" type="string"/>
+            <bind calculate="../inputs/contact/name" nodeset="/mute_health_center/place_name" type="string"/>
+            <bind calculate="../inputs/contact/parent/contact/name" nodeset="/mute_health_center/chw_name" type="string"/>
+            <bind calculate="../inputs/contact/parent/contact/phone" nodeset="/mute_health_center/chw_phone" type="string"/>
+            <bind calculate=" /mute_health_center/group_note/chw_note " nodeset="/mute_health_center/chw_sms" type="string"/>
+            <bind nodeset="/mute_health_center/group_note/pregnancy_note" readonly="true()" type="string"/>
+            <bind nodeset="/mute_health_center/group_note/send_note" required="true()" type="select1"/>
+            <bind nodeset="/mute_health_center/group_note/chw_note" relevant=" /mute_health_center/group_note/send_note  = 'yes'" type="string"/>
+            <bind calculate="concat('uuid:', uuid())" nodeset="/mute_health_center/meta/instanceID" readonly="true()" type="string"/>
+        </model>
+    </h:head>
+    <h:body class="pages">
+        <group appearance="field-list" ref="/mute_health_center/inputs">
+            <label>Clinic</label>
+            <input appearance="hidden" ref="/mute_health_center/inputs/source">
+                <label>Source</label>
+            </input>
+            <input appearance="hidden" ref="/mute_health_center/inputs/source_id">
+                <label>Source ID</label>
+            </input>
+            <group ref="/mute_health_center/inputs/contact">
+                <input appearance="db-object" ref="/mute_health_center/inputs/contact/_id">
+                    <label>What is the name of the Health Center?</label>
+                    <hint>Select a place from list</hint>
+                </input>
+                <input appearance="hidden" ref="/mute_health_center/inputs/contact/name">
+                    <label>Name</label>
+                </input>
+                <group ref="/mute_health_center/inputs/contact/parent">
+                    <group ref="/mute_health_center/inputs/contact/parent/contact">
+                        <input appearance="hidden" ref="/mute_health_center/inputs/contact/parent/contact/phone">
+                            <label>CHW Phone</label>
+                        </input>
+                        <input appearance="hidden" ref="/mute_health_center/inputs/contact/parent/contact/name">
+                            <label>CHW Name</label>
+                        </input>
+                    </group>
+                </group>
+            </group>
+        </group>
+        <group appearance="field-list" ref="/mute_health_center/group_note">
+            <label>Turning Muting ON</label>
+            <input ref="/mute_health_center/group_note/pregnancy_note">
+                <label>An SMS will automatically be sent to <output value=" /mute_health_center/chw_name "/> (<output value=" /mute_health_center/chw_phone "/>) to inform them that reminders are turned OFF for <output value=" /mute_health_center/place_name "/></label></input>
+            <select1 ref="/mute_health_center/group_note/send_note">
+                <label>Write additional info to send to the CHW?</label>
+                <item>
+                    <label>Yes</label>
+                    <value>yes</value>
+                </item>
+                <item>
+                    <label>No</label>
+                    <value>no</value>
+                </item>
+            </select1>
+            <input appearance="multiline" ref="/mute_health_center/group_note/chw_note">
+                <label>Enter short message to be sent</label>
+            </input>
+        </group>
+    </h:body>
+</h:html>

--- a/demo-forms/muting-forms/mute_person.properties.json
+++ b/demo-forms/muting-forms/mute_person.properties.json
@@ -1,0 +1,8 @@
+{
+	"icon": "off",
+	"context": {
+		"person": true,
+		"place": false,
+		"expression": "!contact || (contact.type === 'person')"
+	}
+}

--- a/demo-forms/muting-forms/mute_person.xml
+++ b/demo-forms/muting-forms/mute_person.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <h:head>
+    <h:title>Mute person</h:title>
+    <model>
+      <instance>
+        <mute_person delimiter="#" id="mute_person" prefix="J1!mute_person!" version="2016-12-21">
+          <inputs>
+            <meta>
+              <location>
+                <lat/>
+                <long/>
+                <error/>
+                <message/>
+              </location>
+            </meta>
+            <source>user</source>
+            <source_id/>
+            <contact>
+              <_id/>
+              <patient_id/>
+              <name/>
+              <date_of_birth/>
+              <sex/>
+              <parent>
+                <contact>
+                  <phone/>
+                  <name/>
+                </contact>
+              </parent>
+            </contact>
+          </inputs>
+          <patient_uuid/>
+          <patient_id/>
+          <patient_name/>
+          <chw_name/>
+          <chw_phone/>
+          <chw_sms/>
+          <group_note>
+            <pregnancy_note/>
+            <send_note/>
+            <chw_note/>
+          </group_note>
+          <meta>
+            <instanceID/>
+          </meta>
+        </mute_person>
+      </instance>
+      <instance id="contact-summary"/>
+      <bind nodeset="/mute_person/inputs" relevant="./source = 'user'"/>
+      <bind nodeset="/mute_person/inputs/source" type="string"/>
+      <bind nodeset="/mute_person/inputs/source_id" type="string"/>
+      <bind nodeset="/mute_person/inputs/contact/_id" type="db:person"/>
+      <bind nodeset="/mute_person/inputs/contact/patient_id" type="string"/>
+      <bind nodeset="/mute_person/inputs/contact/name" type="string"/>
+      <bind nodeset="/mute_person/inputs/contact/date_of_birth" type="string"/>
+      <bind nodeset="/mute_person/inputs/contact/sex" type="string"/>
+      <bind nodeset="/mute_person/inputs/contact/parent/contact/phone" type="string"/>
+      <bind nodeset="/mute_person/inputs/contact/parent/contact/name" type="string"/>
+      <bind calculate="../inputs/contact/_id" nodeset="/mute_person/patient_uuid" type="string"/>
+      <bind calculate="../inputs/contact/patient_id" nodeset="/mute_person/patient_id" type="string"/>
+      <bind calculate="../inputs/contact/name" nodeset="/mute_person/patient_name" type="string"/>
+      <bind calculate="../inputs/contact/parent/contact/name" nodeset="/mute_person/chw_name" type="string"/>
+      <bind calculate="../inputs/contact/parent/contact/phone" nodeset="/mute_person/chw_phone" type="string"/>
+      <bind calculate=" /mute_person/group_note/chw_note " nodeset="/mute_person/chw_sms" type="string"/>
+      <bind nodeset="/mute_person/group_note/pregnancy_note" readonly="true()" type="string"/>
+      <bind nodeset="/mute_person/group_note/send_note" required="true()" type="select1"/>
+      <bind nodeset="/mute_person/group_note/chw_note" relevant=" /mute_person/group_note/send_note  = 'yes'" type="string"/>
+      <bind calculate="concat('uuid:', uuid())" nodeset="/mute_person/meta/instanceID" readonly="true()" type="string"/>
+    </model>
+  </h:head>
+  <h:body class="pages">
+    <group appearance="field-list" ref="/mute_person/inputs">
+      <label>Patient</label>
+      <input appearance="hidden" ref="/mute_person/inputs/source">
+        <label>Source</label>
+      </input>
+      <input appearance="hidden" ref="/mute_person/inputs/source_id">
+        <label>Source ID</label>
+      </input>
+      <group ref="/mute_person/inputs/contact">
+        <input appearance="db-object" ref="/mute_person/inputs/contact/_id">
+          <label>What is the patient's name?</label>
+          <hint>Select a person from list</hint>
+        </input>
+        <input appearance="hidden" ref="/mute_person/inputs/contact/patient_id">
+          <label>Patient ID</label>
+        </input>
+        <input appearance="hidden" ref="/mute_person/inputs/contact/name">
+          <label>Name</label>
+        </input>
+        <input appearance="hidden" ref="/mute_person/inputs/contact/date_of_birth">
+          <label>Date of Birth</label>
+        </input>
+        <input appearance="hidden" ref="/mute_person/inputs/contact/sex">
+          <label>Sex</label>
+        </input>
+        <group ref="/mute_person/inputs/contact/parent">
+          <group ref="/mute_person/inputs/contact/parent/contact">
+            <input appearance="hidden" ref="/mute_person/inputs/contact/parent/contact/phone">
+              <label>CHW Phone</label>
+            </input>
+            <input appearance="hidden" ref="/mute_person/inputs/contact/parent/contact/name">
+              <label>CHW Name</label>
+            </input>
+          </group>
+        </group>
+      </group>
+    </group>
+    <group appearance="field-list" ref="/mute_person/group_note">
+      <label>Muting person</label>
+      <input ref="/mute_person/group_note/pregnancy_note">
+        <label>An SMS will automatically be sent to <output value=" /mute_person/chw_name "/> (<output value=" /mute_person/chw_phone "/>) to inform them that reminders are turned OFF for <output value=" /mute_person/patient_name "/></label></input>
+      <select1 ref="/mute_person/group_note/send_note">
+        <label>Write additional info to send to the CHW?</label>
+        <item>
+          <label>Yes</label>
+          <value>yes</value>
+        </item>
+        <item>
+          <label>No</label>
+          <value>no</value>
+        </item>
+      </select1>
+      <input appearance="multiline" ref="/mute_person/group_note/chw_note">
+        <label>Enter short message to be sent</label>
+      </input>
+    </group>
+  </h:body>
+</h:html>

--- a/demo-forms/muting-forms/unmute_clinic.properties.json
+++ b/demo-forms/muting-forms/unmute_clinic.properties.json
@@ -1,0 +1,8 @@
+{
+	"icon": "on",
+	"context": {
+		"person": false,
+		"place": true,
+		"expression": "!contact || (contact.type === 'clinic')"
+	}
+}

--- a/demo-forms/muting-forms/unmute_clinic.xml
+++ b/demo-forms/muting-forms/unmute_clinic.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <h:head>
+    <h:title>Unmute clinic</h:title>
+    <model>
+      <instance>
+        <unmute_clinic delimiter="#" id="unmute_clinic" prefix="J1!unmute_clinic!" version="2016-12-21">
+          <inputs>
+            <meta>
+              <location>
+                <lat/>
+                <long/>
+                <error/>
+                <message/>
+              </location>
+            </meta>
+            <source>user</source>
+            <source_id/>
+            <contact>
+              <_id/>
+              <name/>
+              <parent>
+                <contact>
+                  <phone/>
+                  <name/>
+                </contact>
+              </parent>
+            </contact>
+          </inputs>
+          <place_id/>
+          <place_name/>
+          <chw_name/>
+          <chw_phone/>
+          <chw_sms/>
+          <group_note>
+            <pregnancy_note/>
+            <send_note/>
+            <chw_note/>
+          </group_note>
+          <meta>
+            <instanceID/>
+          </meta>
+        </unmute_clinic>
+      </instance>
+      <instance id="contact-summary"/>
+      <bind nodeset="/unmute_clinic/inputs" relevant="./source = 'user'"/>
+      <bind nodeset="/unmute_clinic/inputs/source" type="string"/>
+      <bind nodeset="/unmute_clinic/inputs/source_id" type="string"/>
+      <bind nodeset="/unmute_clinic/inputs/contact/_id" type="db:clinic"/>
+      <bind nodeset="/unmute_clinic/inputs/contact/name" type="string"/>
+      <bind nodeset="/unmute_clinic/inputs/contact/parent/contact/phone" type="string"/>
+      <bind nodeset="/unmute_clinic/inputs/contact/parent/contact/name" type="string"/>
+      <bind calculate="../inputs/contact/_id" nodeset="/unmute_clinic/place_id" type="string"/>
+      <bind calculate="../inputs/contact/name" nodeset="/unmute_clinic/place_name" type="string"/>
+      <bind calculate="../inputs/contact/parent/contact/name" nodeset="/unmute_clinic/chw_name" type="string"/>
+      <bind calculate="../inputs/contact/parent/contact/phone" nodeset="/unmute_clinic/chw_phone" type="string"/>
+      <bind calculate=" /unmute_clinic/group_note/chw_note " nodeset="/unmute_clinic/chw_sms" type="string"/>
+      <bind nodeset="/unmute_clinic/group_note/pregnancy_note" readonly="true()" type="string"/>
+      <bind nodeset="/unmute_clinic/group_note/send_note" required="true()" type="select1"/>
+      <bind nodeset="/unmute_clinic/group_note/chw_note" relevant=" /unmute_clinic/group_note/send_note  = 'yes'" type="string"/>
+      <bind calculate="concat('uuid:', uuid())" nodeset="/unmute_clinic/meta/instanceID" readonly="true()" type="string"/>
+    </model>
+  </h:head>
+  <h:body class="pages">
+    <group appearance="field-list" ref="/unmute_clinic/inputs">
+      <label>Clinic</label>
+      <input appearance="hidden" ref="/unmute_clinic/inputs/source">
+        <label>Source</label>
+      </input>
+      <input appearance="hidden" ref="/unmute_clinic/inputs/source_id">
+        <label>Source ID</label>
+      </input>
+      <group ref="/unmute_clinic/inputs/contact">
+        <input appearance="db-object" ref="/unmute_clinic/inputs/contact/_id">
+          <label>What is the name of the Clinic?</label>
+          <hint>Select a place from list</hint>
+        </input>
+        <input appearance="hidden" ref="/unmute_clinic/inputs/contact/name">
+          <label>Name</label>
+        </input>
+        <group ref="/unmute_clinic/inputs/contact/parent">
+          <group ref="/unmute_clinic/inputs/contact/parent/contact">
+            <input appearance="hidden" ref="/unmute_clinic/inputs/contact/parent/contact/phone">
+              <label>CHW Phone</label>
+            </input>
+            <input appearance="hidden" ref="/unmute_clinic/inputs/contact/parent/contact/name">
+              <label>CHW Name</label>
+            </input>
+          </group>
+        </group>
+      </group>
+    </group>
+    <group appearance="field-list" ref="/unmute_clinic/group_note">
+      <label>Turning Muting OFF</label>
+      <input ref="/unmute_clinic/group_note/pregnancy_note">
+        <label>An SMS will automatically be sent to <output value=" /unmute_clinic/chw_name "/> (<output value=" /unmute_clinic/chw_phone "/>) to inform them that reminders are turned ON for <output value=" /unmute_clinic/place_name "/></label></input>
+      <select1 ref="/unmute_clinic/group_note/send_note">
+        <label>Write additional info to send to the CHW?</label>
+        <item>
+          <label>Yes</label>
+          <value>yes</value>
+        </item>
+        <item>
+          <label>No</label>
+          <value>no</value>
+        </item>
+      </select1>
+      <input appearance="multiline" ref="/unmute_clinic/group_note/chw_note">
+        <label>Enter short message to be sent</label>
+      </input>
+    </group>
+  </h:body>
+</h:html>

--- a/demo-forms/muting-forms/unmute_district_hospital.properties.json
+++ b/demo-forms/muting-forms/unmute_district_hospital.properties.json
@@ -1,0 +1,8 @@
+{
+	"icon": "on",
+	"context": {
+		"person": false,
+		"place": true,
+		"expression": "!contact || (contact.type === 'district_hospital')"
+	}
+}

--- a/demo-forms/muting-forms/unmute_district_hospital.xml
+++ b/demo-forms/muting-forms/unmute_district_hospital.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <h:head>
+    <h:title>Unmute district hospital</h:title>
+    <model>
+      <instance>
+        <unmute_district_hospital delimiter="#" id="unmute_district_hospital" prefix="J1!unmute_district_hospital!" version="2016-12-21">
+          <inputs>
+            <meta>
+              <location>
+                <lat/>
+                <long/>
+                <error/>
+                <message/>
+              </location>
+            </meta>
+            <source>user</source>
+            <source_id/>
+            <contact>
+              <_id/>
+              <name/>
+              <parent>
+                <contact>
+                  <phone/>
+                  <name/>
+                </contact>
+              </parent>
+            </contact>
+          </inputs>
+          <place_id/>
+          <place_name/>
+          <chw_name/>
+          <chw_phone/>
+          <chw_sms/>
+          <group_note>
+            <pregnancy_note/>
+            <send_note/>
+            <chw_note/>
+          </group_note>
+          <meta>
+            <instanceID/>
+          </meta>
+        </unmute_district_hospital>
+      </instance>
+      <instance id="contact-summary"/>
+      <bind nodeset="/unmute_district_hospital/inputs" relevant="./source = 'user'"/>
+      <bind nodeset="/unmute_district_hospital/inputs/source" type="string"/>
+      <bind nodeset="/unmute_district_hospital/inputs/source_id" type="string"/>
+      <bind nodeset="/unmute_district_hospital/inputs/contact/_id" type="db:district_hospital"/>
+      <bind nodeset="/unmute_district_hospital/inputs/contact/name" type="string"/>
+      <bind nodeset="/unmute_district_hospital/inputs/contact/parent/contact/phone" type="string"/>
+      <bind nodeset="/unmute_district_hospital/inputs/contact/parent/contact/name" type="string"/>
+      <bind calculate="../inputs/contact/_id" nodeset="/unmute_district_hospital/place_id" type="string"/>
+      <bind calculate="../inputs/contact/name" nodeset="/unmute_district_hospital/place_name" type="string"/>
+      <bind calculate="../inputs/contact/parent/contact/name" nodeset="/unmute_district_hospital/chw_name" type="string"/>
+      <bind calculate="../inputs/contact/parent/contact/phone" nodeset="/unmute_district_hospital/chw_phone" type="string"/>
+      <bind calculate=" /unmute_district_hospital/group_note/chw_note " nodeset="/unmute_district_hospital/chw_sms" type="string"/>
+      <bind nodeset="/unmute_district_hospital/group_note/pregnancy_note" readonly="true()" type="string"/>
+      <bind nodeset="/unmute_district_hospital/group_note/send_note" required="true()" type="select1"/>
+      <bind nodeset="/unmute_district_hospital/group_note/chw_note" relevant=" /unmute_district_hospital/group_note/send_note  = 'yes'" type="string"/>
+      <bind calculate="concat('uuid:', uuid())" nodeset="/unmute_district_hospital/meta/instanceID" readonly="true()" type="string"/>
+    </model>
+  </h:head>
+  <h:body class="pages">
+    <group appearance="field-list" ref="/unmute_district_hospital/inputs">
+      <label>Clinic</label>
+      <input appearance="hidden" ref="/unmute_district_hospital/inputs/source">
+        <label>Source</label>
+      </input>
+      <input appearance="hidden" ref="/unmute_district_hospital/inputs/source_id">
+        <label>Source ID</label>
+      </input>
+      <group ref="/unmute_district_hospital/inputs/contact">
+        <input appearance="db-object" ref="/unmute_district_hospital/inputs/contact/_id">
+          <label>What is the name of the Clinic?</label>
+          <hint>Select a place from list</hint>
+        </input>
+        <input appearance="hidden" ref="/unmute_district_hospital/inputs/contact/name">
+          <label>Name</label>
+        </input>
+        <group ref="/unmute_district_hospital/inputs/contact/parent">
+          <group ref="/unmute_district_hospital/inputs/contact/parent/contact">
+            <input appearance="hidden" ref="/unmute_district_hospital/inputs/contact/parent/contact/phone">
+              <label>CHW Phone</label>
+            </input>
+            <input appearance="hidden" ref="/unmute_district_hospital/inputs/contact/parent/contact/name">
+              <label>CHW Name</label>
+            </input>
+          </group>
+        </group>
+      </group>
+    </group>
+    <group appearance="field-list" ref="/unmute_district_hospital/group_note">
+      <label>Turning Muting OFF</label>
+      <input ref="/unmute_district_hospital/group_note/pregnancy_note">
+        <label>An SMS will automatically be sent to <output value=" /unmute_district_hospital/chw_name "/> (<output value=" /unmute_district_hospital/chw_phone "/>) to inform them that reminders are turned ON for <output value=" /unmute_district_hospital/place_name "/></label></input>
+      <select1 ref="/unmute_district_hospital/group_note/send_note">
+        <label>Write additional info to send to the CHW?</label>
+        <item>
+          <label>Yes</label>
+          <value>yes</value>
+        </item>
+        <item>
+          <label>No</label>
+          <value>no</value>
+        </item>
+      </select1>
+      <input appearance="multiline" ref="/unmute_district_hospital/group_note/chw_note">
+        <label>Enter short message to be sent</label>
+      </input>
+    </group>
+  </h:body>
+</h:html>

--- a/demo-forms/muting-forms/unmute_health_center.properties.json
+++ b/demo-forms/muting-forms/unmute_health_center.properties.json
@@ -1,0 +1,8 @@
+{
+	"icon": "on",
+	"context": {
+		"person": false,
+		"place": true,
+		"expression": "!contact || (contact.type === 'health_center')"
+	}
+}

--- a/demo-forms/muting-forms/unmute_health_center.xml
+++ b/demo-forms/muting-forms/unmute_health_center.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <h:head>
+    <h:title>Unmute health center</h:title>
+    <model>
+      <instance>
+        <unmute_health_center delimiter="#" id="unmute_health_center" prefix="J1!unmute_health_center!" version="2016-12-21">
+          <inputs>
+            <meta>
+              <location>
+                <lat/>
+                <long/>
+                <error/>
+                <message/>
+              </location>
+            </meta>
+            <source>user</source>
+            <source_id/>
+            <contact>
+              <_id/>
+              <name/>
+              <parent>
+                <contact>
+                  <phone/>
+                  <name/>
+                </contact>
+              </parent>
+            </contact>
+          </inputs>
+          <place_id/>
+          <place_name/>
+          <chw_name/>
+          <chw_phone/>
+          <chw_sms/>
+          <group_note>
+            <pregnancy_note/>
+            <send_note/>
+            <chw_note/>
+          </group_note>
+          <meta>
+            <instanceID/>
+          </meta>
+        </unmute_health_center>
+      </instance>
+      <instance id="contact-summary"/>
+      <bind nodeset="/unmute_health_center/inputs" relevant="./source = 'user'"/>
+      <bind nodeset="/unmute_health_center/inputs/source" type="string"/>
+      <bind nodeset="/unmute_health_center/inputs/source_id" type="string"/>
+      <bind nodeset="/unmute_health_center/inputs/contact/_id" type="db:health_center"/>
+      <bind nodeset="/unmute_health_center/inputs/contact/name" type="string"/>
+      <bind nodeset="/unmute_health_center/inputs/contact/parent/contact/phone" type="string"/>
+      <bind nodeset="/unmute_health_center/inputs/contact/parent/contact/name" type="string"/>
+      <bind calculate="../inputs/contact/_id" nodeset="/unmute_health_center/place_id" type="string"/>
+      <bind calculate="../inputs/contact/name" nodeset="/unmute_health_center/place_name" type="string"/>
+      <bind calculate="../inputs/contact/parent/contact/name" nodeset="/unmute_health_center/chw_name" type="string"/>
+      <bind calculate="../inputs/contact/parent/contact/phone" nodeset="/unmute_health_center/chw_phone" type="string"/>
+      <bind calculate=" /unmute_health_center/group_note/chw_note " nodeset="/unmute_health_center/chw_sms" type="string"/>
+      <bind nodeset="/unmute_health_center/group_note/pregnancy_note" readonly="true()" type="string"/>
+      <bind nodeset="/unmute_health_center/group_note/send_note" required="true()" type="select1"/>
+      <bind nodeset="/unmute_health_center/group_note/chw_note" relevant=" /unmute_health_center/group_note/send_note  = 'yes'" type="string"/>
+      <bind calculate="concat('uuid:', uuid())" nodeset="/unmute_health_center/meta/instanceID" readonly="true()" type="string"/>
+    </model>
+  </h:head>
+  <h:body class="pages">
+    <group appearance="field-list" ref="/unmute_health_center/inputs">
+      <label>Clinic</label>
+      <input appearance="hidden" ref="/unmute_health_center/inputs/source">
+        <label>Source</label>
+      </input>
+      <input appearance="hidden" ref="/unmute_health_center/inputs/source_id">
+        <label>Source ID</label>
+      </input>
+      <group ref="/unmute_health_center/inputs/contact">
+        <input appearance="db-object" ref="/unmute_health_center/inputs/contact/_id">
+          <label>What is the name of the Health Center?</label>
+          <hint>Select a place from list</hint>
+        </input>
+        <input appearance="hidden" ref="/unmute_health_center/inputs/contact/name">
+          <label>Name</label>
+        </input>
+        <group ref="/unmute_health_center/inputs/contact/parent">
+          <group ref="/unmute_health_center/inputs/contact/parent/contact">
+            <input appearance="hidden" ref="/unmute_health_center/inputs/contact/parent/contact/phone">
+              <label>CHW Phone</label>
+            </input>
+            <input appearance="hidden" ref="/unmute_health_center/inputs/contact/parent/contact/name">
+              <label>CHW Name</label>
+            </input>
+          </group>
+        </group>
+      </group>
+    </group>
+    <group appearance="field-list" ref="/unmute_health_center/group_note">
+      <label>Turning Muting OFF</label>
+      <input ref="/unmute_health_center/group_note/pregnancy_note">
+        <label>An SMS will automatically be sent to <output value=" /unmute_health_center/chw_name "/> (<output value=" /unmute_health_center/chw_phone "/>) to inform them that reminders are turned ON for <output value=" /unmute_health_center/place_name "/></label></input>
+      <select1 ref="/unmute_health_center/group_note/send_note">
+        <label>Write additional info to send to the CHW?</label>
+        <item>
+          <label>Yes</label>
+          <value>yes</value>
+        </item>
+        <item>
+          <label>No</label>
+          <value>no</value>
+        </item>
+      </select1>
+      <input appearance="multiline" ref="/unmute_health_center/group_note/chw_note">
+        <label>Enter short message to be sent</label>
+      </input>
+    </group>
+  </h:body>
+</h:html>

--- a/demo-forms/muting-forms/unmute_person.properties.json
+++ b/demo-forms/muting-forms/unmute_person.properties.json
@@ -1,0 +1,8 @@
+{
+	"icon": "on",
+	"context": {
+		"person": true,
+		"place": false,
+		"expression": "!contact || (contact.type === 'person')"
+	}
+}

--- a/demo-forms/muting-forms/unmute_person.xml
+++ b/demo-forms/muting-forms/unmute_person.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <h:head>
+    <h:title>Unmute person</h:title>
+    <model>
+      <instance>
+        <unmute_person delimiter="#" id="unmute_person" prefix="J1!unmute_person!" version="2016-12-21">
+          <inputs>
+            <meta>
+              <location>
+                <lat/>
+                <long/>
+                <error/>
+                <message/>
+              </location>
+            </meta>
+            <source>user</source>
+            <source_id/>
+            <contact>
+              <_id/>
+              <patient_id/>
+              <name/>
+              <date_of_birth/>
+              <sex/>
+              <parent>
+                <contact>
+                  <phone/>
+                  <name/>
+                </contact>
+              </parent>
+            </contact>
+          </inputs>
+          <patient_uuid/>
+          <patient_id/>
+          <patient_name/>
+          <chw_name/>
+          <chw_phone/>
+          <chw_sms/>
+          <group_note>
+            <pregnancy_note/>
+            <send_note/>
+            <chw_note/>
+          </group_note>
+          <meta>
+            <instanceID/>
+          </meta>
+        </unmute_person>
+      </instance>
+      <instance id="contact-summary"/>
+      <bind nodeset="/unmute_person/inputs" relevant="./source = 'user'"/>
+      <bind nodeset="/unmute_person/inputs/source" type="string"/>
+      <bind nodeset="/unmute_person/inputs/source_id" type="string"/>
+      <bind nodeset="/unmute_person/inputs/contact/_id" type="db:person"/>
+      <bind nodeset="/unmute_person/inputs/contact/patient_id" type="string"/>
+      <bind nodeset="/unmute_person/inputs/contact/name" type="string"/>
+      <bind nodeset="/unmute_person/inputs/contact/date_of_birth" type="string"/>
+      <bind nodeset="/unmute_person/inputs/contact/sex" type="string"/>
+      <bind nodeset="/unmute_person/inputs/contact/parent/contact/phone" type="string"/>
+      <bind nodeset="/unmute_person/inputs/contact/parent/contact/name" type="string"/>
+      <bind calculate="../inputs/contact/_id" nodeset="/unmute_person/patient_uuid" type="string"/>
+      <bind calculate="../inputs/contact/patient_id" nodeset="/unmute_person/patient_id" type="string"/>
+      <bind calculate="../inputs/contact/name" nodeset="/unmute_person/patient_name" type="string"/>
+      <bind calculate="../inputs/contact/parent/contact/name" nodeset="/unmute_person/chw_name" type="string"/>
+      <bind calculate="../inputs/contact/parent/contact/phone" nodeset="/unmute_person/chw_phone" type="string"/>
+      <bind calculate=" /unmute_person/group_note/chw_note " nodeset="/unmute_person/chw_sms" type="string"/>
+      <bind nodeset="/unmute_person/group_note/pregnancy_note" readonly="true()" type="string"/>
+      <bind nodeset="/unmute_person/group_note/send_note" required="true()" type="select1"/>
+      <bind nodeset="/unmute_person/group_note/chw_note" relevant=" /unmute_person/group_note/send_note  = 'yes'" type="string"/>
+      <bind calculate="concat('uuid:', uuid())" nodeset="/unmute_person/meta/instanceID" readonly="true()" type="string"/>
+    </model>
+  </h:head>
+  <h:body class="pages">
+    <group appearance="field-list" ref="/unmute_person/inputs">
+      <label>Patient</label>
+      <input appearance="hidden" ref="/unmute_person/inputs/source">
+        <label>Source</label>
+      </input>
+      <input appearance="hidden" ref="/unmute_person/inputs/source_id">
+        <label>Source ID</label>
+      </input>
+      <group ref="/unmute_person/inputs/contact">
+        <input appearance="db-object" ref="/unmute_person/inputs/contact/_id">
+          <label>What is the patient's name?</label>
+          <hint>Select a person from list</hint>
+        </input>
+        <input appearance="hidden" ref="/unmute_person/inputs/contact/patient_id">
+          <label>Patient ID</label>
+        </input>
+        <input appearance="hidden" ref="/unmute_person/inputs/contact/name">
+          <label>Name</label>
+        </input>
+        <input appearance="hidden" ref="/unmute_person/inputs/contact/date_of_birth">
+          <label>Date of Birth</label>
+        </input>
+        <input appearance="hidden" ref="/unmute_person/inputs/contact/sex">
+          <label>Sex</label>
+        </input>
+        <group ref="/unmute_person/inputs/contact/parent">
+          <group ref="/unmute_person/inputs/contact/parent/contact">
+            <input appearance="hidden" ref="/unmute_person/inputs/contact/parent/contact/phone">
+              <label>CHW Phone</label>
+            </input>
+            <input appearance="hidden" ref="/unmute_person/inputs/contact/parent/contact/name">
+              <label>CHW Name</label>
+            </input>
+          </group>
+        </group>
+      </group>
+    </group>
+    <group appearance="field-list" ref="/unmute_person/group_note">
+      <label>Unmute person</label>
+      <input ref="/unmute_person/group_note/pregnancy_note">
+        <label>An SMS will automatically be sent to <output value=" /unmute_person/chw_name "/> (<output value=" /unmute_person/chw_phone "/>) to inform them that reminders are turned ON for <output value=" /unmute_person/patient_name "/></label></input>
+      <select1 ref="/unmute_person/group_note/send_note">
+        <label>Write additional info to send to the CHW?</label>
+        <item>
+          <label>Yes</label>
+          <value>yes</value>
+        </item>
+        <item>
+          <label>No</label>
+          <value>no</value>
+        </item>
+      </select1>
+      <input appearance="multiline" ref="/unmute_person/group_note/chw_note">
+        <label>Enter short message to be sent</label>
+      </input>
+    </group>
+  </h:body>
+</h:html>


### PR DESCRIPTION
# Description

Sample forms that can be used for muting and un-muting at different levels of hierarchy. Very basic form.

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
