### PR TITLE
Clear offline schedules

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -29,9 +29,9 @@
       }
     },
     "@medic/registration-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@medic/registration-utils/-/registration-utils-1.0.0.tgz",
-      "integrity": "sha512-naViluib4Hh/VHpJ0CJQwnYQJSmciIc2coJukqOFCR37obeMapIca7ie+CD48izBjUDA/r+ZssQg2Yt3KCa9jQ=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@medic/registration-utils/-/registration-utils-1.1.0.tgz",
+      "integrity": "sha512-tOUfIHLtnap+JRo8LO20am4cBT57NnhnzG0MA7o+PYbq/liDtjJheNTKEKoOIzEYW/EDREjPJqiTgy7wGkTAOQ=="
     },
     "@uirouter/angularjs": {
       "version": "0.4.3",

--- a/admin/package.json
+++ b/admin/package.json
@@ -10,7 +10,7 @@
     "@medic/lineage": "^1.0.0",
     "@medic/message-utils": "^1.0.1",
     "@medic/phone-number": "^1.0.0",
-    "@medic/registration-utils": "^1.0.0",
+    "@medic/registration-utils": "^1.1.0",
     "angular": "^1.7.5",
     "angular-cookie": "^4.1.0",
     "angular-pouchdb": "^5.0.2",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -34,9 +34,9 @@
       }
     },
     "@medic/registration-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@medic/registration-utils/-/registration-utils-1.0.0.tgz",
-      "integrity": "sha512-naViluib4Hh/VHpJ0CJQwnYQJSmciIc2coJukqOFCR37obeMapIca7ie+CD48izBjUDA/r+ZssQg2Yt3KCa9jQ=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@medic/registration-utils/-/registration-utils-1.1.0.tgz",
+      "integrity": "sha512-tOUfIHLtnap+JRo8LO20am4cBT57NnhnzG0MA7o+PYbq/liDtjJheNTKEKoOIzEYW/EDREjPJqiTgy7wGkTAOQ=="
     },
     "@medic/search": {
       "version": "1.1.0",

--- a/api/package.json
+++ b/api/package.json
@@ -19,7 +19,7 @@
     "@medic/lineage": "^1.0.0",
     "@medic/message-utils": "^1.0.1",
     "@medic/phone-number": "^1.0.0",
-    "@medic/registration-utils": "^1.0.0",
+    "@medic/registration-utils": "^1.1.0",
     "@medic/search": "^1.1.0",
     "@medic/server-checks": "^1.0.1",
     "@medic/task-utils": "^1.0.0",

--- a/sentinel/package-lock.json
+++ b/sentinel/package-lock.json
@@ -29,9 +29,9 @@
       }
     },
     "@medic/registration-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@medic/registration-utils/-/registration-utils-1.0.0.tgz",
-      "integrity": "sha512-naViluib4Hh/VHpJ0CJQwnYQJSmciIc2coJukqOFCR37obeMapIca7ie+CD48izBjUDA/r+ZssQg2Yt3KCa9jQ=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@medic/registration-utils/-/registration-utils-1.1.0.tgz",
+      "integrity": "sha512-tOUfIHLtnap+JRo8LO20am4cBT57NnhnzG0MA7o+PYbq/liDtjJheNTKEKoOIzEYW/EDREjPJqiTgy7wGkTAOQ=="
     },
     "@medic/server-checks": {
       "version": "1.0.1",

--- a/sentinel/package.json
+++ b/sentinel/package.json
@@ -11,7 +11,7 @@
     "@medic/lineage": "^1.0.0",
     "@medic/message-utils": "^1.0.1",
     "@medic/phone-number": "^1.0.0",
-    "@medic/registration-utils": "^1.0.0",
+    "@medic/registration-utils": "^1.1.0",
     "@medic/server-checks": "^1.0.1",
     "@medic/task-utils": "^1.0.0",
     "@medic/tombstone-utils": "^1.0.0",

--- a/sentinel/src/lib/muting_utils.js
+++ b/sentinel/src/lib/muting_utils.js
@@ -1,12 +1,10 @@
-const _ = require('underscore'),
-      db = require('../db-pouch'),
+const db = require('../db-pouch'),
       lineage = require('@medic/lineage')(Promise, db.medic),
       utils = require('./utils'),
       moment = require('moment'),
       infodoc = require('./infodoc');
 
-const SUBJECT_PROPERTIES = ['_id', 'patient_id', 'place_id'],
-      BATCH_SIZE = 50;
+const BATCH_SIZE = 50;
 
 const getContact = doc => {
   const contactId = doc.fields &&
@@ -81,8 +79,6 @@ const updateRegistrations = (subjectIds, muted) => {
     });
 };
 
-const getSubjectIds = contact => _.values(_.pick(contact, SUBJECT_PROPERTIES));
-
 const getContactsAndSubjectIds = (contactIds, muted) => {
   return db.medic
     .allDocs({ keys: contactIds, include_docs: true })
@@ -95,7 +91,7 @@ const getContactsAndSubjectIds = (contactIds, muted) => {
           return;
         }
         contacts.push(row.doc);
-        subjectIds.push(...getSubjectIds(row.doc));
+        subjectIds.push(...utils.getSubjectIds(row.doc));
       });
 
       return { contacts, subjectIds };
@@ -205,7 +201,6 @@ module.exports = {
   updateContact: updateContact,
   getContact: getContact,
   updateRegistrations: updateRegistrations,
-  getSubjectIds: getSubjectIds,
   isMutedInLineage: isMutedInLineage,
   unmuteMessages: unmuteMessages,
   muteUnsentMessages: muteUnsentMessages,

--- a/sentinel/src/lib/utils.js
+++ b/sentinel/src/lib/utils.js
@@ -5,7 +5,8 @@ const _ = require('underscore'),
   config = require('../config'),
   taskUtils = require('@medic/task-utils'),
   registrationUtils = require('@medic/registration-utils'),
-  logger = require('./logger');
+  logger = require('./logger'),
+  SUBJECT_PROPERTIES = ['_id', 'patient_id', 'place_id'];
 
 /*
  * Get desired locale
@@ -312,4 +313,6 @@ module.exports = {
   },
   isNonEmptyString: expr => typeof expr === 'string' && expr.trim() !== '',
   evalExpression: (expr, context) => vm.runInNewContext(expr, context),
+
+  getSubjectIds: contact => _.values(_.pick(contact, SUBJECT_PROPERTIES))
 };

--- a/sentinel/src/lib/utils.js
+++ b/sentinel/src/lib/utils.js
@@ -5,8 +5,7 @@ const _ = require('underscore'),
   config = require('../config'),
   taskUtils = require('@medic/task-utils'),
   registrationUtils = require('@medic/registration-utils'),
-  logger = require('./logger'),
-  SUBJECT_PROPERTIES = ['_id', 'patient_id', 'place_id'];
+  logger = require('./logger');
 
 /*
  * Get desired locale
@@ -314,5 +313,5 @@ module.exports = {
   isNonEmptyString: expr => typeof expr === 'string' && expr.trim() !== '',
   evalExpression: (expr, context) => vm.runInNewContext(expr, context),
 
-  getSubjectIds: contact => _.values(_.pick(contact, SUBJECT_PROPERTIES))
+  getSubjectIds: contact => registrationUtils.getSubjectIds(contact)
 };

--- a/sentinel/src/transitions/accept_patient_reports.js
+++ b/sentinel/src/transitions/accept_patient_reports.js
@@ -209,7 +209,7 @@ const handleReport = (doc, config, callback) => {
         module.exports.silenceRegistrations(config, doc, registrations, callback);
       });
     })
-    .catch(err => callback(err));
+    .catch(callback);
 };
 
 module.exports = {

--- a/sentinel/src/transitions/accept_patient_reports.js
+++ b/sentinel/src/transitions/accept_patient_reports.js
@@ -197,7 +197,7 @@ const addMessagesToDoc = (doc, config, registrations) => {
 
 const handleReport = (doc, config, callback) => {
   utils
-    .getReportsBySubject({ ids: utils.getSubjectIds(doc.patient ), registrations: true })
+    .getReportsBySubject({ ids: utils.getSubjectIds(doc.patient), registrations: true })
     .then(registrations => {
       addMessagesToDoc(doc, config, registrations);
       addRegistrationToDoc(doc, registrations);

--- a/sentinel/src/transitions/accept_patient_reports.js
+++ b/sentinel/src/transitions/accept_patient_reports.js
@@ -126,16 +126,16 @@ const findValidRegistration = (doc, registrations) => {
             var nextTask = scheduled_tasks[j + 1] || { due: moment(visitReportedDate).add(1, 'd') };
             if (nextTask && moment(nextTask.due) > moment(visitReportedDate)) {
               // We loop through tasks. Once we find one that has either the status "delivered" or "sent" with
-              // a future task with a due date that is after the visit reported date then we have found the task 
+              // a future task with a due date that is after the visit reported date then we have found the task
               // linked to the visit. We always link if this is the last scheduled task delivered or sent.
               var taskIndex = _.findIndex(registration.scheduled_tasks, { due: task.due });
               registration.scheduled_tasks[taskIndex].report_uuid = doc._id;
               return registration;
             }
-          }          
+          }
         }
       }
-    } 
+    }
 };
 
 const addReportUUIDToRegistration = (doc, registrations, callback) => {
@@ -143,7 +143,7 @@ const addReportUUIDToRegistration = (doc, registrations, callback) => {
     if (validRegistration) {
       return db.medic.put(validRegistration, callback);
     }
-    
+
     callback();
 };
 
@@ -196,13 +196,9 @@ const addMessagesToDoc = (doc, config, registrations) => {
 };
 
 const handleReport = (doc, config, callback) => {
-  utils.getRegistrations(
-    { id: doc.fields.patient_id, },
-    (err, registrations) => {
-      if (err) {
-        return callback(err);
-      }
-
+  utils
+    .getReportsBySubject({ ids: utils.getSubjectIds(doc.patient ), registrations: true })
+    .then(registrations => {
       addMessagesToDoc(doc, config, registrations);
       addRegistrationToDoc(doc, registrations);
       addReportUUIDToRegistration(doc, registrations, err => {
@@ -212,8 +208,8 @@ const handleReport = (doc, config, callback) => {
 
         module.exports.silenceRegistrations(config, doc, registrations, callback);
       });
-    }
-  );
+    })
+    .catch(err => callback(err));
 };
 
 module.exports = {

--- a/sentinel/src/transitions/muting.js
+++ b/sentinel/src/transitions/muting.js
@@ -74,7 +74,7 @@ module.exports = {
       const muted = new Date();
       mutingUtils.updateContact(change.doc, muted);
       return mutingUtils
-        .updateRegistrations(mutingUtils.getSubjectIds(change.doc), muted)
+        .updateRegistrations(utils.getSubjectIds(change.doc), muted)
         .then(() => mutingUtils.updateMutingHistory(change.doc, muted))
         .then(() => true);
     }

--- a/sentinel/src/transitions/registration.js
+++ b/sentinel/src/transitions/registration.js
@@ -386,21 +386,20 @@ module.exports = {
         silence_for: null,
       };
 
-      utils.getRegistrations(
-        { id: options.doc.fields && options.doc.fields.patient_id, },
-        (err, registrations) => {
-          if (err) {
-            return cb(err);
-          }
-
+      utils
+        .getReportsBySubject({
+          ids: utils.getSubjectIds(options.doc.patient),
+          registrations: true
+        })
+        .then(registrations => {
           acceptPatientReports.silenceRegistrations(
             config,
             options.doc,
             registrations,
             cb
           );
-        }
-      );
+        })
+        .catch(cb);
     },
   },
   addMessages: (config, doc, callback) => {

--- a/sentinel/tests/unit/lib/muting_utils.js
+++ b/sentinel/tests/unit/lib/muting_utils.js
@@ -1205,21 +1205,6 @@ describe('mutingUtils', () => {
     });
   });
 
-  describe('getSubjectIds', () => {
-    it('should return correct values', () => {
-      chai.expect(mutingUtils.getSubjectIds({})).to.deep.equal([]);
-      chai.expect(mutingUtils.getSubjectIds({ _id: 'a' })).to.deep.equal(['a']);
-      chai.expect(mutingUtils.getSubjectIds({ patient_id: 'b' })).to.deep.equal(['b']);
-      chai.expect(mutingUtils.getSubjectIds({ place_id: 'c' })).to.deep.equal(['c']);
-      chai.expect(mutingUtils.getSubjectIds({ _id: '' })).to.deep.equal(['']);
-      chai.expect(mutingUtils.getSubjectIds({ patient_id: false })).to.deep.equal([false]);
-      chai.expect(mutingUtils.getSubjectIds({ place_id: null })).to.deep.equal([null]);
-      chai.expect(mutingUtils.getSubjectIds({ _id: 'a', patient_id: 'b' })).to.deep.equal(['a', 'b']);
-      chai.expect(mutingUtils.getSubjectIds({ _id: 'b', place_id: 'c' })).to.deep.equal(['b', 'c']);
-      chai.expect(mutingUtils.getSubjectIds({ _id: 'd', place_id: 'f', foo: 'bar' })).to.deep.equal(['d', 'f']);
-    });
-  });
-
   describe('updateContact', () => {
     it('should remove muted property when unmuting', () => {
       chai.expect(mutingUtils.updateContact({}, false)).to.deep.equal({ });

--- a/sentinel/tests/unit/lib/utils.js
+++ b/sentinel/tests/unit/lib/utils.js
@@ -291,4 +291,19 @@ describe('utils util', () => {
       taskUtils.setTaskState.callCount.should.equal(6);
     });
   });
+
+  describe('getSubjectIds', () => {
+    it('should return correct values', () => {
+      utils.getSubjectIds({}).should.deep.equal([]);
+      utils.getSubjectIds({ _id: 'a' }).should.deep.equal(['a']);
+      utils.getSubjectIds({ patient_id: 'b' }).should.deep.equal(['b']);
+      utils.getSubjectIds({ place_id: 'c' }).should.deep.equal(['c']);
+      utils.getSubjectIds({ _id: '' }).should.deep.equal(['']);
+      utils.getSubjectIds({ patient_id: false }).should.deep.equal([false]);
+      utils.getSubjectIds({ place_id: null }).should.deep.equal([null]);
+      utils.getSubjectIds({ _id: 'a', patient_id: 'b' }).should.deep.equal(['a', 'b']);
+      utils.getSubjectIds({ _id: 'b', place_id: 'c' }).should.deep.equal(['b', 'c']);
+      utils.getSubjectIds({ _id: 'd', place_id: 'f', foo: 'bar' }).should.deep.equal(['d', 'f']);
+    });
+  });
 });

--- a/sentinel/tests/unit/lib/utils.js
+++ b/sentinel/tests/unit/lib/utils.js
@@ -293,17 +293,11 @@ describe('utils util', () => {
   });
 
   describe('getSubjectIds', () => {
-    it('should return correct values', () => {
-      utils.getSubjectIds({}).should.deep.equal([]);
-      utils.getSubjectIds({ _id: 'a' }).should.deep.equal(['a']);
-      utils.getSubjectIds({ patient_id: 'b' }).should.deep.equal(['b']);
-      utils.getSubjectIds({ place_id: 'c' }).should.deep.equal(['c']);
-      utils.getSubjectIds({ _id: '' }).should.deep.equal(['']);
-      utils.getSubjectIds({ patient_id: false }).should.deep.equal([false]);
-      utils.getSubjectIds({ place_id: null }).should.deep.equal([null]);
-      utils.getSubjectIds({ _id: 'a', patient_id: 'b' }).should.deep.equal(['a', 'b']);
-      utils.getSubjectIds({ _id: 'b', place_id: 'c' }).should.deep.equal(['b', 'c']);
-      utils.getSubjectIds({ _id: 'd', place_id: 'f', foo: 'bar' }).should.deep.equal(['d', 'f']);
+    it('should call registration_utils method', () => {
+      sinon.stub(registrationUtils, 'getSubjectIds').returns(['a', 'b']);
+      utils.getSubjectIds({ _id: 'a' }).should.deep.equal(['a', 'b']);
+      registrationUtils.getSubjectIds.callCount.should.equal(1);
+      registrationUtils.getSubjectIds.args[0].should.deep.equal([{ _id: 'a' }]);
     });
   });
 });

--- a/sentinel/tests/unit/transitions/accept_patient_reports.js
+++ b/sentinel/tests/unit/transitions/accept_patient_reports.js
@@ -349,6 +349,18 @@ describe('accept_patient_reports', () => {
       });
     });
 
+
+    it('should catch utils.getReportsBySubject errors', done => {
+      sinon.stub(utils, 'getReportsBySubject').rejects({ some: 'error' });
+      sinon.stub(utils, 'getSubjectIds').returns(['a', 'b']);
+
+      transition._handleReport({}, {}, (err, complete) => {
+        (!!complete).should.equal(false);
+        err.should.deep.equal({ some: 'error' });
+        utils.getReportsBySubject.callCount.should.equal(1);
+        done();
+      });
+    });
   });
 
   describe('silenceReminders', () => {

--- a/sentinel/tests/unit/transitions/accept_patient_reports.js
+++ b/sentinel/tests/unit/transitions/accept_patient_reports.js
@@ -273,9 +273,8 @@ describe('accept_patient_reports', () => {
           ],
         },
       ];
-      sinon
-        .stub(utils, 'getRegistrations')
-        .callsArgWith(1, null, registrations);
+
+      sinon.stub(utils, 'getReportsBySubject').resolves(registrations);
       transition._handleReport(doc, config, (err, complete) => {
         complete.should.equal(true);
         putRegistration.callCount.should.equal(1);
@@ -338,9 +337,7 @@ describe('accept_patient_reports', () => {
           ],
         },
       ];
-      sinon
-        .stub(utils, 'getRegistrations')
-        .callsArgWith(1, null, registrations);
+      sinon.stub(utils, 'getReportsBySubject').resolves(registrations);
       transition._handleReport(doc, config, (err, complete) => {
         complete.should.equal(true);
         putRegistration.callCount.should.equal(1);

--- a/sentinel/tests/unit/transitions/accept_patient_reports.js
+++ b/sentinel/tests/unit/transitions/accept_patient_reports.js
@@ -227,7 +227,7 @@ describe('accept_patient_reports', () => {
         done();
       });
     });
-    
+
     it('adds report_uuid property', done => {
       const putRegistration = sinon.stub(db.medic, 'put');
       putRegistration.callsArg(1);

--- a/sentinel/tests/unit/transitions/accept_patient_reports.js
+++ b/sentinel/tests/unit/transitions/accept_patient_reports.js
@@ -96,7 +96,7 @@ describe('accept_patient_reports', () => {
         (typeof doc.errors).should.equal('undefined');
         (typeof doc.tasks).should.equal('undefined');
         utils.getReportsBySubject.callCount.should.equal(1);
-        utils.getReportsBySubject.args[0].should.deep.equal([{ db: db.medic, ids: ['x', 'y'], registrations: true }]);
+        utils.getReportsBySubject.args[0].should.deep.equal([{ ids: ['x', 'y'], registrations: true }]);
         utils.getSubjectIds.callCount.should.equal(1);
         utils.getSubjectIds.args[0].should.deep.equal([doc.patient]);
         done();
@@ -195,35 +195,6 @@ describe('accept_patient_reports', () => {
       transition._handleReport(doc, config, (err, complete) => {
         complete.should.equal(true);
         doc.registration_id.should.equal(registrations[1]._id);
-        done();
-      });
-    });
-
-    it('should call utils.getRegistrations with correct DB (#4962)', done => {
-      const doc = {
-        fields: { patient_id: 'x' },
-        from: '+123',
-      };
-      sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, []);
-
-      const config = {
-        messages: [
-          {
-            event_type: 'registration_not_found',
-            message: [
-              {
-                content: 'not found {{patient_id}}',
-                locale: 'en',
-              },
-            ],
-            recipient: 'reporting_unit',
-          },
-        ],
-      };
-
-      transition._handleReport(doc, config, () => {
-        utils.getRegistrations.callCount.should.equal(1);
-        utils.getRegistrations.args[0][0].should.deep.equal({ id: 'x' });
         done();
       });
     });

--- a/sentinel/tests/unit/transitions/accept_patient_reports.js
+++ b/sentinel/tests/unit/transitions/accept_patient_reports.js
@@ -153,7 +153,6 @@ describe('accept_patient_reports', () => {
         { _id: 'c' }, // should be silenced
       ];
       sinon.stub(utils, 'getReportsBySubject').resolves(registrations);
-
       transition._handleReport(doc, config, (err, complete) => {
         complete.should.equal(true);
         transition._silenceReminders.callCount.should.equal(2);
@@ -173,7 +172,6 @@ describe('accept_patient_reports', () => {
         { _id: 'a', reported_date: '2017-02-05T09:23:07.853Z' },
       ];
       sinon.stub(utils, 'getReportsBySubject').resolves(registrations);
-
       transition._handleReport(doc, config, (err, complete) => {
         complete.should.equal(true);
         doc.registration_id.should.equal(registrations[0]._id);
@@ -191,7 +189,6 @@ describe('accept_patient_reports', () => {
         { _id: 'b', reported_date: '2016-02-05T09:23:07.853Z' },
       ];
       sinon.stub(utils, 'getReportsBySubject').resolves(registrations);
-
       transition._handleReport(doc, config, (err, complete) => {
         complete.should.equal(true);
         doc.registration_id.should.equal(registrations[1]._id);
@@ -244,7 +241,6 @@ describe('accept_patient_reports', () => {
           ],
         },
       ];
-
       sinon.stub(utils, 'getReportsBySubject').resolves(registrations);
       transition._handleReport(doc, config, (err, complete) => {
         complete.should.equal(true);
@@ -316,7 +312,6 @@ describe('accept_patient_reports', () => {
         done();
       });
     });
-
 
     it('should catch utils.getReportsBySubject errors', done => {
       sinon.stub(utils, 'getReportsBySubject').rejects({ some: 'error' });

--- a/sentinel/tests/unit/transitions/muting.js
+++ b/sentinel/tests/unit/transitions/muting.js
@@ -3,7 +3,8 @@ const sinon = require('sinon'),
       chai = require('chai'),
       transitionUtils = require('../../../src/transitions/utils'),
       mutingUtils = require('../../../src/lib/muting_utils'),
-      transition = require('../../../src/transitions/muting');
+      transition = require('../../../src/transitions/muting'),
+      utils = require('../../../src/lib/utils');
 
 describe('Muting transition', () => {
   afterEach(() => sinon.restore());
@@ -13,11 +14,12 @@ describe('Muting transition', () => {
 
     sinon.stub(mutingUtils, 'isMutedInLineage');
     sinon.stub(mutingUtils, 'updateContact');
-    sinon.stub(mutingUtils, 'getSubjectIds');
     sinon.stub(mutingUtils, 'updateRegistrations');
     sinon.stub(mutingUtils, 'updateMuteState');
     sinon.stub(mutingUtils, 'getContact');
     sinon.stub(mutingUtils, 'updateMutingHistory');
+
+    sinon.stub(utils, 'getSubjectIds');
   });
 
   describe('init', () => {
@@ -111,15 +113,15 @@ describe('Muting transition', () => {
       it('should update the contact', () => {
         const doc = { _id: 'id', type: 'person', patient_id: 'patient' };
         mutingUtils.updateRegistrations.resolves();
-        mutingUtils.getSubjectIds.returns(['id', 'patient']);
+        utils.getSubjectIds.returns(['id', 'patient']);
         mutingUtils.updateMutingHistory.resolves();
 
         return transition.onMatch({ doc }).then(result => {
           chai.expect(result).to.equal(true);
           chai.expect(mutingUtils.updateContact.callCount).to.equal(1);
           chai.expect(mutingUtils.updateContact.args[0]).to.deep.equal([doc, new Date()]);
-          chai.expect(mutingUtils.getSubjectIds.callCount).to.equal(1);
-          chai.expect(mutingUtils.getSubjectIds.args[0]).to.deep.equal([doc]);
+          chai.expect(utils.getSubjectIds.callCount).to.equal(1);
+          chai.expect(utils.getSubjectIds.args[0]).to.deep.equal([doc]);
           chai.expect(mutingUtils.updateRegistrations.callCount).to.equal(1);
           chai.expect(mutingUtils.updateRegistrations.args[0]).to.deep.equal([['id', 'patient'], new Date()]);
           chai.expect(mutingUtils.updateMutingHistory.callCount).to.equal(1);
@@ -130,7 +132,7 @@ describe('Muting transition', () => {
       it('should throw updateRegistrations errors', () => {
         const doc = { _id: 'id', type: 'person', patient_id: 'patient' };
         mutingUtils.updateRegistrations.rejects({ some: 'error' });
-        mutingUtils.getSubjectIds.returns(['id', 'patient']);
+        utils.getSubjectIds.returns(['id', 'patient']);
         mutingUtils.updateMutingHistory.resolves();
 
         return transition
@@ -139,9 +141,9 @@ describe('Muting transition', () => {
           .catch(err => {
             chai.expect(err).to.deep.equal({ some: 'error' });
             chai.expect(mutingUtils.updateContact.callCount).to.equal(1);
+            chai.expect(utils.getSubjectIds.callCount).to.equal(1);
+            chai.expect(utils.getSubjectIds.args[0]).to.deep.equal([doc]);
             chai.expect(mutingUtils.updateContact.args[0]).to.deep.equal([doc, new Date()]);
-            chai.expect(mutingUtils.getSubjectIds.callCount).to.equal(1);
-            chai.expect(mutingUtils.getSubjectIds.args[0]).to.deep.equal([doc]);
             chai.expect(mutingUtils.updateRegistrations.callCount).to.equal(1);
             chai.expect(mutingUtils.updateRegistrations.args[0]).to.deep.equal([['id', 'patient'], new Date()]);
             chai.expect(mutingUtils.updateMutingHistory.callCount).to.equal(0);
@@ -151,7 +153,7 @@ describe('Muting transition', () => {
       it('should throw updateMutingHistory errors', () => {
         const doc = { _id: 'id', type: 'person', patient_id: 'patient' };
         mutingUtils.updateRegistrations.resolves();
-        mutingUtils.getSubjectIds.returns(['id', 'patient']);
+        utils.getSubjectIds.returns(['id', 'patient']);
         mutingUtils.updateMutingHistory.rejects({ some: 'error' });
 
         return transition
@@ -161,8 +163,8 @@ describe('Muting transition', () => {
             chai.expect(err).to.deep.equal({ some: 'error' });
             chai.expect(mutingUtils.updateContact.callCount).to.equal(1);
             chai.expect(mutingUtils.updateContact.args[0]).to.deep.equal([doc, new Date()]);
-            chai.expect(mutingUtils.getSubjectIds.callCount).to.equal(1);
-            chai.expect(mutingUtils.getSubjectIds.args[0]).to.deep.equal([doc]);
+            chai.expect(utils.getSubjectIds.callCount).to.equal(1);
+            chai.expect(utils.getSubjectIds.args[0]).to.deep.equal([doc]);
             chai.expect(mutingUtils.updateRegistrations.callCount).to.equal(1);
             chai.expect(mutingUtils.updateRegistrations.args[0]).to.deep.equal([['id', 'patient'], new Date()]);
             chai.expect(mutingUtils.updateMutingHistory.callCount).to.equal(1);

--- a/sentinel/tests/unit/transitions/registration.js
+++ b/sentinel/tests/unit/transitions/registration.js
@@ -923,7 +923,6 @@ describe('registration', () => {
         utils.getSubjectIds.args[0].should.deep.equal([doc.patient]);
         utils.getReportsBySubject.callCount.should.equal(1);
         utils.getReportsBySubject.args[0].should.deep.equal([ {
-          db: dbPouch.medic,
           ids: ['uuid', 'patient_id'],
           registrations: true
         } ]);

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -34,9 +34,9 @@
       }
     },
     "@medic/registration-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@medic/registration-utils/-/registration-utils-1.0.0.tgz",
-      "integrity": "sha512-naViluib4Hh/VHpJ0CJQwnYQJSmciIc2coJukqOFCR37obeMapIca7ie+CD48izBjUDA/r+ZssQg2Yt3KCa9jQ=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@medic/registration-utils/-/registration-utils-1.1.0.tgz",
+      "integrity": "sha512-tOUfIHLtnap+JRo8LO20am4cBT57NnhnzG0MA7o+PYbq/liDtjJheNTKEKoOIzEYW/EDREjPJqiTgy7wGkTAOQ=="
     },
     "@medic/search": {
       "version": "1.1.0",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -16,7 +16,7 @@
     "@medic/lineage": "^1.0.0",
     "@medic/message-utils": "^1.0.1",
     "@medic/phone-number": "^1.0.0",
-    "@medic/registration-utils": "^1.0.0",
+    "@medic/registration-utils": "^1.1.0",
     "@medic/search": "^1.1.0",
     "@medic/task-utils": "^1.0.0",
     "@medic/translation-utils": "^1.0.1",

--- a/webapp/src/js/bootstrapper/purger.js
+++ b/webapp/src/js/bootstrapper/purger.js
@@ -1,4 +1,5 @@
-const utils = require('./utils');
+const utils = require('./utils'),
+      registrationUtils = require('@medic/registration-utils');
 
 const LAST_PURGED_DATE_KEY = 'medic-last-purge-date';
 const LAST_REPLICATED_SEQ_KEY = 'medic-last-replicated-seq';
@@ -184,23 +185,12 @@ module.exports = function(DB, initialReplication) {
     }
   };
 
-  // Copied and slightly modified from the rules-service:
-  // https://github.com/medic/medic-webapp/blob/master/webapp/src/js/services/rules-engine.js#L52-L67
-  // We want to be consistent with rules
   var getContactId = function(doc) {
     // get the associated patient or place id to group reports by
-    return doc && (
-      doc.patient_id ||
-      doc.place_id ||
-      (doc.fields && (doc.fields.patient_id || doc.fields.place_id || doc.fields.patient_uuid))
-    );
+    return registrationUtils.getPatientId(doc);
   };
   var contactHasId = function(contact, id) {
-    return contact && (
-      contact._id === id ||
-      contact.patient_id === id ||
-      contact.place_id === id
-    );
+    return registrationUtils.getSubjectIds(contact).includes(id);
   };
 
   const reportsByContact = () => {

--- a/webapp/src/js/services/contact-view-model-generator.js
+++ b/webapp/src/js/services/contact-view-model-generator.js
@@ -1,4 +1,5 @@
-var _ = require('underscore');
+var _ = require('underscore'),
+    registrationUtils = require('@medic/registration-utils');
 
 /**
  * Hydrates the given contact by uuid and creates a model which
@@ -234,14 +235,9 @@ angular.module('inboxServices').factory('ContactViewModelGenerator',
     var getReports = function(contactDocs) {
       var subjectIds = [];
       contactDocs.forEach(function(doc) {
-        subjectIds.push(doc._id);
-        if (doc.patient_id) {
-          subjectIds.push(doc.patient_id);
-        }
-        if (doc.place_id) {
-          subjectIds.push(doc.place_id);
-        }
+        subjectIds.push(registrationUtils.getSubjectIds(doc));
       });
+      subjectIds = _.flatten(subjectIds);
       return Search('reports', { subjectIds: subjectIds }, { include_docs: true })
         .then(function(reports) {
           reports.forEach(function(report) {

--- a/webapp/src/js/services/rules-engine.js
+++ b/webapp/src/js/services/rules-engine.js
@@ -3,7 +3,8 @@ var nools = require('nools'),
     nootils = require('medic-nootils'),
     FIRST_RUN_COMPLETE_TYPE = '_complete',
     // number of weeks before reported date to assume for start of pregnancy
-    KNOWN_TYPES = [ FIRST_RUN_COMPLETE_TYPE, 'task', 'target' ];
+    KNOWN_TYPES = [ FIRST_RUN_COMPLETE_TYPE, 'task', 'target' ],
+    registrationUtils = require('@medic/registration-utils');
 
 (function () {
 
@@ -51,19 +52,11 @@ var nools = require('nools'),
 
       var getContactId = function(doc) {
         // get the associated patient or place id to group reports by
-        return doc && (
-          doc.patient_id ||
-          doc.place_id ||
-          (doc.fields && (doc.fields.patient_id || doc.fields.place_id || doc.fields.patient_uuid))
-        );
+        return registrationUtils.getPatientId(doc);
       };
 
       var contactHasId = function(contact, id) {
-        return contact && (
-          contact._id === id ||
-          contact.patient_id === id ||
-          contact.place_id === id
-        );
+        return registrationUtils.getSubjectIds(contact).includes(id);
       };
 
       var deriveFacts = function(dataRecords, contacts) {


### PR DESCRIPTION
# Description

When clearing schedules, either by `registration` transition or `accept_patient_reports` transition, switches from matching `patient_id` only (via `utils.getRegistrations`) to matching `_id`, `patient_id` and `place_id` (via `utils.getReportsBySubject`).
This allows clearing schedules for patients that were created while offline. 

medic/medic-webapp#4885

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
