### PR TITLE
Only replicate deletes if doc is still deleted

### DIFF
--- a/api/src/services/authorization.js
+++ b/api/src/services/authorization.js
@@ -207,10 +207,28 @@ const isSensitive = function(userCtx, subject, submitter, allowedSubmitter) {
 
 const getAllowedDocIds = (feed) => {
   return db.medic.query('medic/docs_by_replication_key', { keys: feed.subjectIds }).then(results => {
-    const validatedIds = ['_design/medic-client', 'org.couchdb.user:' + feed.userCtx.name];
+    const validatedIds = ['_design/medic-client', 'org.couchdb.user:' + feed.userCtx.name],
+          tombstoneIds = [];
+
     results.rows.forEach(row => {
-      if (!isSensitive(feed.userCtx, row.key, row.value.submitter, feed.subjectIds.indexOf(row.value.submitter) !== -1)) {
-        validatedIds.push(row.id);
+      if (isSensitive(feed.userCtx, row.key, row.value.submitter, feed.subjectIds.indexOf(row.value.submitter) !== -1)) {
+        return;
+      }
+
+      if (tombstoneUtils.isTombstoneId(row.id)) {
+        tombstoneIds.push(row.id);
+        return;
+      }
+
+      validatedIds.push(row.id);
+    });
+
+    // only include tombstones if the winning rev of the document is still deleted (if a doc appears in the view
+    // results, it means that the winning rev is not deleted and the tombstone doc should be skipped)
+    tombstoneIds.forEach(tombstoneId => {
+      const docId = tombstoneUtils.extractStub(tombstoneId).id;
+      if (!validatedIds.includes(docId)) {
+        validatedIds.push(tombstoneId);
       }
     });
 

--- a/api/src/services/authorization.js
+++ b/api/src/services/authorization.js
@@ -224,8 +224,8 @@ const getAllowedDocIds = (feed) => {
       validatedIds.push(row.id);
     });
 
-    // only include tombstones if the winning rev of the document is still deleted (if a doc appears in the view
-    // results, it means that the winning rev is not deleted and the tombstone doc should be skipped)
+    // only include tombstones if the winning rev of the document is deleted
+    // if a doc appears in the view results, it means that the winning rev is not deleted
     tombstoneIds.forEach(tombstoneId => {
       const docId = tombstoneUtils.extractStub(tombstoneId).id;
       if (!validatedIds.includes(docId)) {

--- a/api/src/services/authorization.js
+++ b/api/src/services/authorization.js
@@ -182,6 +182,7 @@ const getAuthorizationContext = (userCtx) => {
       }
     });
 
+    authorizationCtx.subjectIds = _.uniq(authorizationCtx.subjectIds);
     authorizationCtx.subjectIds.push(ALL_KEY);
     if (hasAccessToUnassignedDocs(userCtx)) {
       authorizationCtx.subjectIds.push(UNASSIGNED_KEY);

--- a/api/tests/mocha/services/authorization.spec.js
+++ b/api/tests/mocha/services/authorization.spec.js
@@ -200,6 +200,33 @@ describe('Authorization service', () => {
           ]);
         });
     });
+
+    it('should skip tombstones of documents that were re-added', () => {
+      const subjectIds = ['subject'];
+      db.medic.query
+        .withArgs('medic/docs_by_replication_key')
+        .resolves({ rows: [
+            { id: 'r1', key: 'subject', value: {} },
+            { id: 'r1_tombstone', key: 'subject', value: {} }, // skipped cause r1 winning is not deleted
+            { id: 'r2', key: 'subject', value: {} },
+            { id: 'r2_tombstone', key: 'subject', value: {} },  // skipped cause r2 winning is not deleted
+            { id: 'r3_tombstone', key: 'subject', value: {} },
+            { id: 'r4_tombstone', key: 'subject', value: {} },
+          ]});
+
+      tombstoneUtils.isTombstoneId.callsFake(id => id.indexOf('tombstone'));
+      tombstoneUtils.extractStub.callsFake(id => ({ id: id.replace('_tombstone', '') }));
+
+      return service
+        .getAllowedDocIds({ subjectIds, userCtx: { name: 'user', facility_id: 'facility_id', contact_id: 'contact_id' } })
+        .then(result => {
+          result.should.deep.equal([
+            '_design/medic-client', 'org.couchdb.user:user',
+            'r1', 'r2',
+            'r3_tombstone', 'r4_tombstone'
+          ]);
+        });
+    });
   });
 
   describe('getViewResults', () => {

--- a/tests/e2e/api/controllers/_changes.spec.js
+++ b/tests/e2e/api/controllers/_changes.spec.js
@@ -943,7 +943,7 @@ describe('changes handler', () => {
         });
     });
 
-    it('should returns the tombstone of a deleted doc', () => {
+    it('should return the tombstone of a deleted doc', () => {
       const contact = createSomeContacts(1, 'fixture:bobville')[0];
 
       return utils.saveDoc(contact)


### PR DESCRIPTION
# Description

When constructing the list of  `doc_ids` to request changes, check if an `_id` is present before adding it's tombstone. 

medic/medic-webapp#5186
# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
