### PR TITLE
5108 - "All reports synced" status doesn't update when there are new/edited docs

### DIFF
--- a/webapp/src/js/services/db-sync.js
+++ b/webapp/src/js/services/db-sync.js
@@ -168,6 +168,11 @@ angular
       },
 
       /**
+       * Boolean representing if sync is curently in progress
+       */
+      isSyncInProgress: () => inProgressSync,
+
+      /**
        * Set the current user's online status to control when replications will be attempted.
        *
        * @param newOnlineState {Boolean} The current online state of the user.

--- a/webapp/src/js/services/db.js
+++ b/webapp/src/js/services/db.js
@@ -1,3 +1,5 @@
+const _ = require('underscore');
+
 // Regex to test for characters that are invalid in db names
 // Only lowercase characters (a-z), digits (0-9), and any of the characters _, $, (, ), +, -, and / are allowed.
 // https://wiki.apache.org/couchdb/HTTP_database_API#Naming_and_Addressing
@@ -8,7 +10,7 @@ const META_DB_SUFFIX = 'meta';
 angular.module('inboxServices').factory('DB',
   function(
     $timeout,
-    $window,
+    $rootScope,
     Location,
     pouchDB,
     POUCHDB_OPTIONS,
@@ -55,6 +57,17 @@ angular.module('inboxServices').factory('DB',
       return clone;
     };
 
+    const emitEventOnWrite = function(pouchDb) {
+      const pouchDbWriteOperations = ['putAttachment', 'put', 'bulkDocs'];
+      pouchDbWriteOperations.forEach(function(operation) {
+        pouchDb[operation] = _.wrap(pouchDb[operation], function(original) {
+          const args = Array.from(arguments).splice(1);
+          $rootScope.$emit('dbWriteEvent', { operation, args });
+          return original.apply(pouchDb, args);
+        });
+      });
+    };
+
     const get = ({ remote=isOnlineOnly, meta=false }={}) => {
       if (!Session.userCtx()) {
         return Session.navigateToLogin();
@@ -62,6 +75,9 @@ angular.module('inboxServices').factory('DB',
       const name = getDbName(remote, meta);
       if (!cache[name]) {
         cache[name] = pouchDB(name, getParams(remote, meta));
+        if (!remote && !meta) {
+          emitEventOnWrite(cache[name]);
+        }
       }
       return cache[name];
     };

--- a/webapp/tests/karma/unit/services/db.js
+++ b/webapp/tests/karma/unit/services/db.js
@@ -7,6 +7,7 @@ describe('DB service', () => {
       userCtx,
       pouchDB,
       expected,
+      rootScope,
       isOnlineOnly;
 
   beforeEach(() => {
@@ -41,7 +42,8 @@ describe('DB service', () => {
       } );
       $provide.value('Location', Location);
     });
-    inject(($injector, $timeout) => {
+    inject(($injector, $timeout, _$rootScope_) => {
+      rootScope = _$rootScope_;
       getService = () => {
         // delay initialisation of the db service
         const service = $injector.get('DB');
@@ -66,22 +68,22 @@ describe('DB service', () => {
       // init
       const service = getService();
 
-      chai.expect(pouchDB.callCount).to.equal(2);
-      chai.expect(pouchDB.args[0][0]).to.equal('medicdb-user-johnny');
-      chai.expect(pouchDB.args[1][0]).to.equal('medicdb-user-johnny-meta');
+      expect(pouchDB.callCount).to.equal(2);
+      expect(pouchDB.args[0][0]).to.equal('medicdb-user-johnny');
+      expect(pouchDB.args[1][0]).to.equal('medicdb-user-johnny-meta');
 
       // get remote
       const actual = service({ remote: true });
-      chai.expect(actual.id).to.equal(expected.id);
-      chai.expect(pouchDB.callCount).to.equal(3);
-      chai.expect(pouchDB.args[2][0]).to.equal('ftp//myhost:21/medicdb');
-      chai.expect(pouchDB.args[2][1].skip_setup).to.equal(true);
+      expect(actual.id).to.equal(expected.id);
+      expect(pouchDB.callCount).to.equal(3);
+      expect(pouchDB.args[2][0]).to.equal('ftp//myhost:21/medicdb');
+      expect(pouchDB.args[2][1].skip_setup).to.equal(true);
 
       // get remote meta
       service({ remote: true, meta: true });
-      chai.expect(pouchDB.callCount).to.equal(4);
-      chai.expect(pouchDB.args[3][0]).to.equal('ftp//myhost:21/medicdb-user-johnny-meta');
-      chai.expect(pouchDB.args[3][1].skip_setup).to.equal(false);
+      expect(pouchDB.callCount).to.equal(4);
+      expect(pouchDB.args[3][0]).to.equal('ftp//myhost:21/medicdb-user-johnny-meta');
+      expect(pouchDB.args[3][1].skip_setup).to.equal(false);
     });
 
     it('caches pouchdb instances', () => {
@@ -93,19 +95,19 @@ describe('DB service', () => {
       // init
       const service = getService();
 
-      chai.expect(pouchDB.callCount).to.equal(2);
-      chai.expect(pouchDB.args[0][0]).to.equal('medicdb-user-johnny');
-      chai.expect(pouchDB.args[1][0]).to.equal('medicdb-user-johnny-meta');
+      expect(pouchDB.callCount).to.equal(2);
+      expect(pouchDB.args[0][0]).to.equal('medicdb-user-johnny');
+      expect(pouchDB.args[1][0]).to.equal('medicdb-user-johnny-meta');
 
       // get remote
       const actual1 = service({ remote: true });
-      chai.expect(actual1.id).to.equal(expected.id);
-      chai.expect(pouchDB.callCount).to.equal(3);
+      expect(actual1.id).to.equal(expected.id);
+      expect(pouchDB.callCount).to.equal(3);
 
       // get remote again
       const actual2 = service({ remote: true });
-      chai.expect(actual2.id).to.equal(expected.id);
-      chai.expect(pouchDB.callCount).to.equal(3);
+      expect(actual2.id).to.equal(expected.id);
+      expect(pouchDB.callCount).to.equal(3);
     });
 
     /**
@@ -121,20 +123,20 @@ describe('DB service', () => {
       // init
       const service = getService();
 
-      chai.expect(pouchDB.callCount).to.equal(2);
-      chai.expect(pouchDB.args[0][0]).to.equal('medicdb-user-johnny.<>^,?!');
-      chai.expect(pouchDB.args[1][0]).to.equal('medicdb-user-johnny.<>^,?!-meta');
+      expect(pouchDB.callCount).to.equal(2);
+      expect(pouchDB.args[0][0]).to.equal('medicdb-user-johnny.<>^,?!');
+      expect(pouchDB.args[1][0]).to.equal('medicdb-user-johnny.<>^,?!-meta');
 
       // get remote
       const actual = service({ remote: true });
-      chai.expect(actual.id).to.equal(expected.id);
-      chai.expect(pouchDB.callCount).to.equal(3);
-      chai.expect(pouchDB.args[2][0]).to.equal('ftp//myhost:21/medicdb');
+      expect(actual.id).to.equal(expected.id);
+      expect(pouchDB.callCount).to.equal(3);
+      expect(pouchDB.args[2][0]).to.equal('ftp//myhost:21/medicdb');
 
       // get remote meta
       service({ remote: true, meta: true });
-      chai.expect(pouchDB.callCount).to.equal(4);
-      chai.expect(pouchDB.args[3][0]).to.equal('ftp//myhost:21/medicdb-user-johnny(46)(60)(62)(94)(44)(63)(33)-meta');
+      expect(pouchDB.callCount).to.equal(4);
+      expect(pouchDB.args[3][0]).to.equal('ftp//myhost:21/medicdb-user-johnny(46)(60)(62)(94)(44)(63)(33)-meta');
     });
   });
 
@@ -148,18 +150,18 @@ describe('DB service', () => {
       // init
       const service = getService();
 
-      chai.expect(pouchDB.callCount).to.equal(2);
-      chai.expect(expected.viewCleanup.callCount).to.equal(2);
+      expect(pouchDB.callCount).to.equal(2);
+      expect(expected.viewCleanup.callCount).to.equal(2);
 
       // get local
       const actual = service();
-      chai.expect(pouchDB.callCount).to.equal(2);
-      chai.expect(actual.id).to.equal(expected.id);
-      chai.expect(pouchDB.args[0][0]).to.equal('medicdb-user-johnny');
-      chai.expect(pouchDB.args[0][1].auto_compaction).to.equal(true);
-      chai.expect(pouchDB.args[1][0]).to.equal('medicdb-user-johnny-meta');
-      chai.expect(pouchDB.args[1][1].auto_compaction).to.equal(true);
-      chai.expect(expected.viewCleanup.callCount).to.equal(2);
+      expect(pouchDB.callCount).to.equal(2);
+      expect(actual.id).to.equal(expected.id);
+      expect(pouchDB.args[0][0]).to.equal('medicdb-user-johnny');
+      expect(pouchDB.args[0][1].auto_compaction).to.equal(true);
+      expect(pouchDB.args[1][0]).to.equal('medicdb-user-johnny-meta');
+      expect(pouchDB.args[1][1].auto_compaction).to.equal(true);
+      expect(expected.viewCleanup.callCount).to.equal(2);
     });
 
     it('caches pouchdb instances', () => {
@@ -169,19 +171,19 @@ describe('DB service', () => {
 
       // init
       const service = getService();
-      chai.expect(pouchDB.callCount).to.equal(2);
+      expect(pouchDB.callCount).to.equal(2);
 
       // get local
       const actual1 = service();
-      chai.expect(pouchDB.callCount).to.equal(2);
-      chai.expect(actual1.id).to.equal(expected.id);
+      expect(pouchDB.callCount).to.equal(2);
+      expect(actual1.id).to.equal(expected.id);
 
       // get local again
       const actual2 = service();
-      chai.expect(pouchDB.callCount).to.equal(2);
-      chai.expect(actual2.id).to.equal(expected.id);
-      chai.expect(isOnlineOnly.callCount).to.equal(1);
-      chai.expect(userCtx.callCount).to.equal(8);
+      expect(pouchDB.callCount).to.equal(2);
+      expect(actual2.id).to.equal(expected.id);
+      expect(isOnlineOnly.callCount).to.equal(1);
+      expect(userCtx.callCount).to.equal(8);
     });
 
     it('returns remote for admin user', () => {
@@ -191,22 +193,46 @@ describe('DB service', () => {
 
       // init
       const service = getService();
-      chai.expect(pouchDB.callCount).to.equal(0);
-      chai.expect(expected.viewCleanup.callCount).to.equal(0);
+      expect(pouchDB.callCount).to.equal(0);
+      expect(expected.viewCleanup.callCount).to.equal(0);
 
       // get local returns remote
       const actual = service();
-      chai.expect(pouchDB.callCount).to.equal(1);
-      chai.expect(actual.id).to.equal(expected.id);
-      chai.expect(pouchDB.args[0][0]).to.equal('ftp//myhost:21/medicdb');
-      chai.expect(expected.viewCleanup.callCount).to.equal(0);
+      expect(pouchDB.callCount).to.equal(1);
+      expect(actual.id).to.equal(expected.id);
+      expect(pouchDB.args[0][0]).to.equal('ftp//myhost:21/medicdb');
+      expect(expected.viewCleanup.callCount).to.equal(0);
 
       // get locale  meta returns remote meta
       service({ meta: true });
-      chai.expect(pouchDB.callCount).to.equal(2);
-      chai.expect(pouchDB.args[1][0]).to.equal('ftp//myhost:21/medicdb-user-johnny-meta');
+      expect(pouchDB.callCount).to.equal(2);
+      expect(pouchDB.args[1][0]).to.equal('ftp//myhost:21/medicdb-user-johnny-meta');
     });
 
+    it('emits custom event on local write', done => {
+      isOnlineOnly.returns(false);
+      userCtx.returns({name: 'foo' });
+      Location.dbName = 'localwrite';
+
+      const expectedResult = 'derp';
+      const mockPut = sinon.spy(() => expectedResult); 
+      expected.put = mockPut;
+      pouchDB.returns(expected);
+      
+      const expectedArg1 = { foo: 'bar' };
+      const expectedArg2 = true;
+      const expectedArgs = [expectedArg1, expectedArg2];
+      rootScope.$on('dbWriteEvent', (e, actual) => {
+        expect(actual.args).to.deep.eq(expectedArgs);
+        expect(mockPut.callCount).to.eq(0); // put is called after the event
+        done();
+      });
+      const service = getService();
+      const db = service({ remote: false, meta: false });
+      const actualResult = db.put(expectedArg1, expectedArg2);
+      expect(actualResult).to.eq(expectedResult);
+      expect(mockPut.args[0]).to.deep.eq(expectedArgs);
+    });
   });
 
 });


### PR DESCRIPTION
# Description

This takes the concept described in #5108 and generalizes it so that any write to the local pouch is reflected in the user's sync status as "Reports to sync"

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
