### PR TITLE
Support binding to fields.patient_uuid

### DIFF
--- a/webapp/src/js/bootstrapper/purger.js
+++ b/webapp/src/js/bootstrapper/purger.js
@@ -192,7 +192,7 @@ module.exports = function(DB, initialReplication) {
     return doc && (
       doc.patient_id ||
       doc.place_id ||
-      (doc.fields && (doc.fields.patient_id || doc.fields.place_id))
+      (doc.fields && (doc.fields.patient_id || doc.fields.place_id || doc.fields.patient_uuid))
     );
   };
   var contactHasId = function(contact, id) {

--- a/webapp/src/js/services/rules-engine.js
+++ b/webapp/src/js/services/rules-engine.js
@@ -54,7 +54,7 @@ var nools = require('nools'),
         return doc && (
           doc.patient_id ||
           doc.place_id ||
-          (doc.fields && (doc.fields.patient_id || doc.fields.place_id))
+          (doc.fields && (doc.fields.patient_id || doc.fields.place_id || doc.fields.patient_uuid))
         );
       };
 


### PR DESCRIPTION
In some configurations the patient_id field holds the patient shortcode,
while the patient_uuid field holds the internal id.

For tasks and targets it's important that we know how to bind to the
UUID as well, because otherwise users may see bugs while offline. For
example, a task wouldn't close until the report that closes the task is
synced upwards, run through by Sentinel, and synced back down.

Less important for purging, but it's better that we keep the function
logic the same.