### PR TITLE
Changes outgoing messages so rows do not wrap

### DIFF
--- a/admin/src/css/configuration.less
+++ b/admin/src/css/configuration.less
@@ -112,14 +112,26 @@ dl.horizontal {
 }
 
 .message-queue {
+  table {
+    min-width: 100%;
+    margin-left: -15px;
+    margin-right: -15px;
+  }
+  td,
+  th {
+    padding: 5px;
+  }
+  relative-date,
+  table tbody td:first-child {
+    white-space: nowrap;
+  }
   .message-state {
-    display: flex;
+    display: block;
 
     &:before {
       font-family: 'FontAwesome';
-      font-size: 16px;
       margin-right: 10px;
-      display: block;
+      vertical-align: middle;
     }
     &.scheduled {
       &:before {
@@ -164,7 +176,6 @@ dl.horizontal {
         content: @failed-state-icon;
       }
     }
-
     &.delayed {
       color: @primary-color;
       font-weight: bold;

--- a/admin/src/css/configuration.less
+++ b/admin/src/css/configuration.less
@@ -119,7 +119,7 @@ dl.horizontal {
   }
   td,
   th {
-    padding: 5px;
+    padding: 5px 10px;
   }
   relative-date,
   table tbody td:first-child {

--- a/admin/src/templates/message_queue_tab.html
+++ b/admin/src/templates/message_queue_tab.html
@@ -1,56 +1,57 @@
 <p ng-show="error" class="alert alert-danger" role="alert" translate>admin.message.queue.error</p>
 
 <div class="container-fluid">
-  <div class="row flex-row selection-heading">
-    <div class="col col-fixed" translate>admin.message.queue.recipient</div>
-    <div class="col col-fixed" translate>admin.message.queue.created</div>
-    <div class="col col-grow" translate>admin.message.queue.message</div>
-    <div class="col col-fixed" translate>admin.message.queue.status</div>
-    <div class="col col-fixed" translate>admin.message.queue.due</div>
-    <div ng-if="displayLastUpdated" class="col col-fixed" translate>admin.message.queue.updated</div>
-  </div>
-</div>
-
-<div class="loader" ng-show="loading"></div>
-
-<div class="container-fluid">
-  <div class="row flex-row selection" ng-repeat="message in messages">
-
-    <div class="col col-fixed">{{message.recipient}}</div>
-
-    <div class="col col-fixed">
-      <relative-date date="message.record.reportedDate" date-format="dateFormat"></relative-date>
-      <div ng-if="message.link">
-        <a ng-href="{{basePath}}/#/reports/{{message.record.id}}" target="_blank" translate>
-          admin.message.queue.view.report
-        </a>
-      </div>
-    </div>
-
-    <div class="col col-grow">
-      <p ng-if="message.task"><strong>{{message.task}}</strong></p>
-      <span>{{message.content}}</span>
-      <div class="message-error" ng-if="message.error">
-        <span translate>messages.errors.invalid</span>
-        <span translate>{{message.error}}</span>
-      </div>
-    </div>
-
-    <div class="col col-fixed">
-      <span class="message-state {{message.state}}" ng-class="{ delayed: message.delayed, 'has-error': message.error }" translate>
-        {{'state.' + message.state}}
-      </span>
-    </div>
-
-    <div class="col col-fixed">
-      <relative-date date="message.due" date-format="dateFormat"></relative-date>
-    </div>
-
-    <div ng-if="displayLastUpdated" class="col col-fixed">
-      <relative-date date="message.stateHistory.timestamp" date-format="dateFormat"></relative-date>
-    </div>
-
-  </div>
+  <table>
+    <thead>
+      <tr class="row">
+        <th translate>admin.message.queue.recipient</th>
+        <th translate>admin.message.queue.created</th>
+        <th translate>admin.message.queue.message</th>
+        <th translate>admin.message.queue.status</th>
+        <th translate>admin.message.queue.due</th>
+        <th ng-if="displayLastUpdated" translate>admin.message.queue.updated</th>
+      </tr>
+    </thead>
+    <tbody ng-show="loading">
+      <tr>
+        <td colspan="{{ displayLastUpdated ? 6 : 5 }}">
+          <div class="loader"></div>
+        </td>
+      </tr>
+    </tbody>
+    <tbody>
+      <tr ng-repeat="message in messages" class="row">
+        <td>{{message.recipient}}</td>
+        <td>
+          <relative-date date="message.record.reportedDate" date-format="dateFormat"></relative-date>
+          <div>
+            <a ng-if="message.link" ng-href="{{basePath}}/#/reports/{{message.record.id}}" target="_blank" translate>
+              admin.message.queue.view.report
+            </a>
+          </div>
+        </td>
+        <td>
+          <p ng-if="message.task"><strong>{{message.task}}</strong></p>
+          <span>{{message.content}}</span>
+          <div class="message-error" ng-if="message.error">
+            <span translate>messages.errors.invalid</span>
+            <span translate>{{message.error}}</span>
+          </div>
+        </td>
+        <td>
+          <span class="message-state {{message.state}}" ng-class="{ delayed: message.delayed, 'has-error': message.error }" translate>
+            {{'state.' + message.state}}
+          </span>
+        </td>
+        <td>
+          <relative-date date="message.due" date-format="dateFormat"></relative-date>
+        </td>
+        <td ng-if="displayLastUpdated">
+          <relative-date date="message.stateHistory.timestamp" date-format="dateFormat"></relative-date>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </div>
 
 <mm-pagination></mm-pagination>


### PR DESCRIPTION
On smaller screens the outgoing messages table rows no longer wrap
so it's still readable.

medic/medic-webapp#5221

@dianabarsan Code review please!
@amandacilek Design review please! I've added screenshots to the original issue.

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
