### PR TITLE
Don't forward seq_interval in upstream Changes requests

### DIFF
--- a/api/src/controllers/changes.js
+++ b/api/src/controllers/changes.js
@@ -170,7 +170,7 @@ const restartNormalFeed = feed => {
 
 const getChanges = feed => {
 
-  const options = _.pick(feed.req.query, 'since', 'style', 'conflicts', 'seq_interval');
+  const options = _.pick(feed.req.query, 'since', 'style', 'conflicts');
   options.doc_ids = feed.allowedDocIds;
   options.since = options.since || 0;
 

--- a/api/tests/mocha/controllers/changes.js
+++ b/api/tests/mocha/controllers/changes.js
@@ -288,8 +288,7 @@ describe('Changes controller', () => {
           since: '22',
           batch_size: 4,
           doc_ids: ['d1', 'd2', 'd3'],
-          conflicts: true,
-          seq_interval: false
+          conflicts: true
         });
       });
     });


### PR DESCRIPTION
# Description

Removes forwarding `seq_interval` request param from PouchDB replication requests. 

medic/medic-webapp#5235

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
