### PR TITLE
Don't forward seq_interval to CouchDB

### DIFF
--- a/api/src/controllers/changes.js
+++ b/api/src/controllers/changes.js
@@ -163,7 +163,7 @@ const restartNormalFeed = feed => {
 
 const getChanges = feed => {
   const options = { return_docs: true };
-  _.extend(options, _.pick(feed.req.query, 'since', 'style', 'conflicts', 'seq_interval'));
+  _.extend(options, _.pick(feed.req.query, 'since', 'style', 'conflicts'));
 
   // Prior to version 2.3.0, CouchDB had a bug where requesting _changes filtered by _doc_ids and using limit
   // would yield an incorrect `last_seq`, resulting in overall incomplete changes.

--- a/api/tests/mocha/controllers/changes.js
+++ b/api/tests/mocha/controllers/changes.js
@@ -320,7 +320,6 @@ describe('Changes controller', () => {
           batch_size: 4,
           doc_ids: ['d1', 'd2', 'd3'],
           conflicts: true,
-          seq_interval: false,
           return_docs: true,
         });
       });


### PR DESCRIPTION
# Description

Removes forwarding seq_interval request param from PouchDB replication requests.

medic/medic-webapp#5235

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
