### PR TITLE
Shared getPatientId and getSubjectIds implementations.

### DIFF
--- a/shared-libs/registration-utils/package-lock.json
+++ b/shared-libs/registration-utils/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@medic/registration-utils",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/shared-libs/registration-utils/package-lock.json
+++ b/shared-libs/registration-utils/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@medic/registration-utils",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/shared-libs/registration-utils/package.json
+++ b/shared-libs/registration-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medic/registration-utils",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "main": "src/index.js",
   "scripts": {
     "test": "mocha ./test"

--- a/shared-libs/registration-utils/package.json
+++ b/shared-libs/registration-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medic/registration-utils",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "src/index.js",
   "scripts": {
     "test": "mocha ./test"

--- a/shared-libs/registration-utils/src/index.js
+++ b/shared-libs/registration-utils/src/index.js
@@ -1,4 +1,3 @@
-
 // returns the only continuous alphanumeric + dash + underscore sequence in lower case
 var normalizeFormCode = function(formCode) {
   var match = formCode.match(/^[^\w-]*([\w-]+)[^\w-]*$/);
@@ -46,3 +45,23 @@ exports.isValidRegistration = function(doc, settings) {
 };
 
 exports._normalizeFormCode = normalizeFormCode;
+
+var SUBJECT_PROPERTIES = ['_id', 'patient_id', 'place_id'];
+exports.getSubjectIds = function(contact) {
+  var subjectIds = [];
+  SUBJECT_PROPERTIES.forEach(function(prop) {
+    if (contact[prop]) {
+      subjectIds.push(contact[prop]);
+    }
+  });
+
+  return subjectIds;
+};
+
+exports.getPatientId = function(report) {
+  return report && (
+    report.patient_id ||
+    report.place_id ||
+    (report.fields && (report.fields.patient_id || report.fields.place_id || report.fields.patient_uuid))
+  );
+};

--- a/shared-libs/registration-utils/src/index.js
+++ b/shared-libs/registration-utils/src/index.js
@@ -46,10 +46,14 @@ exports.isValidRegistration = function(doc, settings) {
 
 exports._normalizeFormCode = normalizeFormCode;
 
-var SUBJECT_PROPERTIES = ['_id', 'patient_id', 'place_id'];
 exports.getSubjectIds = function(contact) {
   var subjectIds = [];
-  SUBJECT_PROPERTIES.forEach(function(prop) {
+
+  if (!contact) {
+    return subjectIds;
+  }
+
+  ['_id', 'patient_id', 'place_id'].forEach(function(prop) {
     if (contact[prop]) {
       subjectIds.push(contact[prop]);
     }

--- a/shared-libs/registration-utils/src/index.js
+++ b/shared-libs/registration-utils/src/index.js
@@ -46,6 +46,7 @@ exports.isValidRegistration = function(doc, settings) {
 
 exports._normalizeFormCode = normalizeFormCode;
 
+var SUBJECT_PROPERTIES = ['_id', 'patient_id', 'place_id'];
 exports.getSubjectIds = function(contact) {
   var subjectIds = [];
 
@@ -53,7 +54,7 @@ exports.getSubjectIds = function(contact) {
     return subjectIds;
   }
 
-  ['_id', 'patient_id', 'place_id'].forEach(function(prop) {
+  SUBJECT_PROPERTIES.forEach(function(prop) {
     if (contact[prop]) {
       subjectIds.push(contact[prop]);
     }

--- a/shared-libs/registration-utils/test/index.spec.js
+++ b/shared-libs/registration-utils/test/index.spec.js
@@ -215,4 +215,39 @@ describe('registrationUtils', () => {
       chai.expect(utils._normalizeFormCode('$%^&alpha1_-)(&^')).to.equal('alpha1_-');
     });
   });
+
+  describe('getSubjectIds', () => {
+    it('should return correct values', () => {
+      chai.expect(utils.getSubjectIds({})).to.deep.equal([]);
+      chai.expect(utils.getSubjectIds({ _id: 'a' })).to.deep.equal(['a']);
+      chai.expect(utils.getSubjectIds({ patient_id: 'b' })).to.deep.equal(['b']);
+      chai.expect(utils.getSubjectIds({ place_id: 'c' })).to.deep.equal(['c']);
+      chai.expect(utils.getSubjectIds({ _id: '' })).to.deep.equal([]);
+      chai.expect(utils.getSubjectIds({ patient_id: false })).to.deep.equal([]);
+      chai.expect(utils.getSubjectIds({ place_id: null })).to.deep.equal([]);
+      chai.expect(utils.getSubjectIds({ _id: 'a', patient_id: 'b' })).to.deep.equal(['a', 'b']);
+      chai.expect(utils.getSubjectIds({ _id: 'b', place_id: 'c' })).to.deep.equal(['b', 'c']);
+      chai.expect(utils.getSubjectIds({ _id: 'd', place_id: 'f', foo: 'bar' })).to.deep.equal(['d', 'f']);
+    });
+  });
+
+  describe('getPatientId', () => {
+    it('should return correct values', () => {
+      chai.expect(utils.getPatientId()).to.equal(undefined);
+      chai.expect(utils.getPatientId(false)).to.equal(false);
+      chai.expect(utils.getPatientId({})).to.equal(undefined);
+      chai.expect(utils.getPatientId({ patient_id: 'a' })).to.equal('a');
+      chai.expect(utils.getPatientId({ place_id: 'a' })).to.equal('a');
+      chai.expect(utils.getPatientId({ patient_id: 'a', place_id: 'b' })).to.equal('a');
+      chai.expect(utils.getPatientId({ patient_id: 'a', fields: {} })).to.equal('a');
+      chai.expect(utils.getPatientId({ patient_id: 'a', fields: { patient_id: 'b' } })).to.equal('a');
+      chai.expect(utils.getPatientId({ place_id: 'a', fields: { patient_id: 'b' } })).to.equal('a');
+      chai.expect(utils.getPatientId({ place_id: 'a', fields: { place_id: 'b' } })).to.equal('a');
+      chai.expect(utils.getPatientId({ fields: { place_id: 'b' } })).to.equal('b');
+      chai.expect(utils.getPatientId({ fields: { patient_id: 'b' } })).to.equal('b');
+      chai.expect(utils.getPatientId({ fields: { patient_uuid: 'b' } })).to.equal('b');
+      chai.expect(utils.getPatientId({ fields: { patient_id: 'a', patient_uuid: 'b' } })).to.equal('a');
+      chai.expect(utils.getPatientId({ fields: { place_id: 'a', patient_uuid: 'b' } })).to.equal('a');
+    });
+  });
 });

--- a/shared-libs/registration-utils/test/index.spec.js
+++ b/shared-libs/registration-utils/test/index.spec.js
@@ -218,6 +218,7 @@ describe('registrationUtils', () => {
 
   describe('getSubjectIds', () => {
     it('should return correct values', () => {
+      chai.expect(utils.getSubjectIds(false)).to.deep.equal([]);
       chai.expect(utils.getSubjectIds({})).to.deep.equal([]);
       chai.expect(utils.getSubjectIds({ _id: 'a' })).to.deep.equal(['a']);
       chai.expect(utils.getSubjectIds({ patient_id: 'b' })).to.deep.equal(['b']);


### PR DESCRIPTION
# Description

Adds getPatientId and getSubjectIds methods to @medic/registration-utils shared library.
To be used along with https://github.com/medic/medic-webapp/pull/5194

medic/medic-webapp#4885

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
