### PR TITLE
5234 - Guard against bad HTTP codes in error reporting

### DIFF
--- a/api/src/server-utils.js
+++ b/api/src/server-utils.js
@@ -53,7 +53,7 @@ module.exports = {
       return module.exports.serverError(err, req, res);
     }
     // https://github.com/nodejs/node/issues/9027
-    let code = err.code || err.statusCode || 500;
+    let code = err.code || err.statusCode || err.status || 500;
     if (!Number.isInteger(code)) {
       logger.warn(`Non-numeric error code: ${code}`);
       code = 500;

--- a/api/src/server-utils.js
+++ b/api/src/server-utils.js
@@ -52,7 +52,12 @@ module.exports = {
     if (typeof err === 'string') {
       return module.exports.serverError(err, req, res);
     }
-    var code = err.code || err.statusCode || err.status || 500;
+    // https://github.com/nodejs/node/issues/9027
+    let code = err.code || err.statusCode || 500;
+    if (typeof code !== 'number') {
+      console.warn('Non-numeric error code: ' + code);
+      code = 502;
+    }
     if (code === 401) {
       return module.exports.notLoggedIn(req, res, showPrompt);
     }

--- a/api/src/server-utils.js
+++ b/api/src/server-utils.js
@@ -54,8 +54,8 @@ module.exports = {
     }
     // https://github.com/nodejs/node/issues/9027
     let code = err.code || err.statusCode || 500;
-    if (typeof code !== 'number') {
-      console.warn('Non-numeric error code: ' + code);
+    if (!Number.isInteger(code)) {
+      logger.warn(`Non-numeric error code: ${code}`);
       code = 502;
     }
     if (code === 401) {

--- a/api/src/server-utils.js
+++ b/api/src/server-utils.js
@@ -56,7 +56,7 @@ module.exports = {
     let code = err.code || err.statusCode || 500;
     if (!Number.isInteger(code)) {
       logger.warn(`Non-numeric error code: ${code}`);
-      code = 502;
+      code = 500;
     }
     if (code === 401) {
       return module.exports.notLoggedIn(req, res, showPrompt);

--- a/api/tests/mocha/server-utils.spec.js
+++ b/api/tests/mocha/server-utils.spec.js
@@ -83,6 +83,20 @@ describe('Server utils', () => {
     chai.expect(end.args[0][0]).to.equal('Server error');
   });
 
+  it('error 500 for any non-numeric error code', () => {
+    const writeHead = sinon.stub(res, 'writeHead');
+    serverUtils.error({ code: '100' }, req, res);
+    chai.expect(writeHead.callCount).to.eq(1);
+    chai.expect(writeHead.args[0][0]).to.eq(500);
+  });
+
+  it('error 500 for unparseable non-numeric error code', () => {
+    const writeHead = sinon.stub(res, 'writeHead');
+    serverUtils.error({ code: 'foo' }, req, res);
+    chai.expect(writeHead.callCount).to.eq(1);
+    chai.expect(writeHead.args[0][0]).to.eq(500);
+  });
+
   it('notLoggedIn redirects to login page for human user', () => {
     const redirect = sinon.stub(res, 'redirect');
     req.url = 'someurl';

--- a/tests/e2e/api/controllers/users.js
+++ b/tests/e2e/api/controllers/users.js
@@ -157,7 +157,7 @@ describe('Users API', () => {
       })
       .then(() => fail('You should get an error in this situation'))
       .catch(err => {
-        expect(err.responseBody).toBe('not logged in');
+        expect(err.responseBody).toBe('Server error');
       }));
 
     it('Allows for users to modify themselves with a cookie', () =>

--- a/tests/e2e/api/controllers/users.js
+++ b/tests/e2e/api/controllers/users.js
@@ -157,7 +157,7 @@ describe('Users API', () => {
       })
       .then(() => fail('You should get an error in this situation'))
       .catch(err => {
-        expect(err.responseBody).toBe('Server error');
+        expect(err.responseBody).toBe('not logged in');
       }));
 
     it('Allows for users to modify themselves with a cookie', () =>


### PR DESCRIPTION
# Description

#5234 

Just pushing the buttons described by this issue. Please double check the expected behavior of this change via the unit tests. Confirm you expect these scenarios to result in error code `500` or aspects of the code make be think they should be `502`/`100` respectively?

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
