### PR TITLE
Serves new appcache from old location

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,6 +10,18 @@ const {
   TRAVIS_BUILD_NUMBER
 } = process.env;
 
+const APPCACHE_OPTIONS = {
+  patterns: [
+    'build/ddocs/medic/_attachments/manifest.json',
+    'build/ddocs/medic/_attachments/audio/**/*',
+    'build/ddocs/medic/_attachments/css/**/*',
+    'build/ddocs/medic/_attachments/fonts/**/*',
+    'build/ddocs/medic/_attachments/img/**/*',
+    'build/ddocs/medic/_attachments/js/**/*',
+    'build/ddocs/medic/_attachments/xslt/**/*',
+  ],
+};
+
 const releaseName = TRAVIS_TAG || TRAVIS_BRANCH || 'local-development';
 
 const couchConfig = (() => {
@@ -776,18 +788,14 @@ module.exports = function(grunt) {
       inbox: {
         dest: 'build/ddocs/medic/_attachments/manifest.appcache',
         network: '*',
-        cache: {
-          patterns: [
-            'build/ddocs/medic/_attachments/manifest.json',
-            'build/ddocs/medic/_attachments/audio/**/*',
-            'build/ddocs/medic/_attachments/css/**/*',
-            'build/ddocs/medic/_attachments/fonts/**/*',
-            'build/ddocs/medic/_attachments/img/**/*',
-            'build/ddocs/medic/_attachments/js/**/*',
-            'build/ddocs/medic/_attachments/xslt/**/*',
-          ],
-        },
+        cache: APPCACHE_OPTIONS,
       },
+      obsolete: {
+        dest: 'build/ddocs/medic/_attachments/static/dist/manifest.appcache',
+        network: '*',
+        baseUrl: '../../',
+        cache: APPCACHE_OPTIONS,
+      }
     },
     sass: {
       options: {

--- a/ddocs/medic/rewrites.json
+++ b/ddocs/medic/rewrites.json
@@ -6,6 +6,7 @@
   {"from": "/img/*",              "to": "img/*"},
   {"from": "/xslt/*",             "to": "xslt/*"},
   {"from": "/manifest.appcache",  "to": "manifest.appcache"},
+  {"from": "/static/dist/manifest.appcache",  "to": "static/dist/manifest.appcache"},
   {"from": "/manifest.json",      "to": "manifest.json"},
   {"from": "/templates/*",        "to": "templates/*"},
   {"from": "/",                   "to": "templates/inbox.html"},

--- a/webapp/src/js/controllers/inbox.js
+++ b/webapp/src/js/controllers/inbox.js
@@ -713,7 +713,8 @@ var feedback = require('../modules/feedback'),
         $log.error('Application cache update error', err);
       });
       if (
-        $window.applicationCache.status === $window.applicationCache.UPDATEREADY
+        $window.applicationCache.status === $window.applicationCache.UPDATEREADY ||
+        $window.applicationCache.status === $window.applicationCache.UNCACHED
       ) {
         showUpdateReady();
       }


### PR DESCRIPTION
# Description

When users upgrade from 2.x their old appcache needs to be
updated with new files. This change ensures the appcache is
available at the old location as well as the new location.

This is not a long term solution but will do until we
migrate to using service worker caching instead.

medic/medic-webapp#5247

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
