### PR TITLE
Uses request-promise-native instead of request lib

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1741,6 +1741,24 @@
         "uuid": "^3.3.2"
       }
     },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "requires": {
+        "lodash": "^4.13.1"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+      "requires": {
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "^1.1.0",
+        "tough-cookie": ">=2.3.3"
+      }
+    },
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -1866,6 +1884,11 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "string-extended": {
       "version": "0.0.8",

--- a/api/package.json
+++ b/api/package.json
@@ -49,6 +49,7 @@
     "pouchdb-mapreduce": "^7.0.0",
     "properties": "^1.2.1",
     "request": "^2.88.0",
+    "request-promise-native": "^1.0.5",
     "semver": "^5.6.0",
     "simple-password-tester": "^1.0.0",
     "underscore": "^1.9.1",

--- a/api/src/auth.js
+++ b/api/src/auth.js
@@ -1,4 +1,4 @@
-var request = require('request'),
+var request = require('request-promise-native'),
     url = require('url'),
     _ = require('underscore'),
     db = require('./db-pouch'),
@@ -13,17 +13,10 @@ var get = (path, headers) => {
     host: dbUrl.host,
     pathname: path
   });
-  return new Promise((resolve, reject) => {
-    request.get({
-      url: fullUrl,
-      headers: headers,
-      json: true
-    }, (err, res, body) => {
-      if (err) {
-        return reject(err);
-      }
-      resolve(body);
-    });
+  return request.get({
+    url: fullUrl,
+    headers: headers,
+    json: true
   });
 };
 
@@ -115,26 +108,22 @@ module.exports = {
       });
   },
 
-  checkUrl: (req, callback) => {
+  checkUrl: req => {
     if (!req.params || !req.params.path) {
-      return callback(new Error('No path given'));
+      return Promise.reject(new Error('No path given'));
     }
     const dbUrl = url.parse(environment.serverUrl);
-    var fullUrl = url.format({
+    const fullUrl = url.format({
       protocol: dbUrl.protocol,
       host: dbUrl.host,
       pathname: req.params.path
     });
-    request.head({
+    return request.head({
       url: fullUrl,
       headers: req.headers,
-      json: true
-    }, (err, res) => {
-      if (err) {
-        return callback(err);
-      }
-      callback(null, res && { status: res.statusCode } );
-    });
+      resolveWithFullResponse: true
+    })
+      .then(res => res && res.statusCode);
   },
 
   /**
@@ -166,25 +155,22 @@ module.exports = {
    * Validates given Basic Auth credentials against the server
    *
    * @param      {Object}    Credentials object as created by basicAuthCredentials
-   * @param      {Function}  callback    returns the validated username or an
-   *                                     error if there was a problem
    */
-  validateBasicAuth: ({username, password}, callback) => {
+  validateBasicAuth: ({ username, password }) => {
     const authUrl = url.parse(process.env.COUCH_URL);
     delete authUrl.pathname;
     authUrl.auth = `${username}:${password}`;
 
-    request({ uri: url.format(authUrl), method: 'HEAD'}, (err, res) => {
-      if (err) {
-        return callback(err);
-      }
-
-      if (res.statusCode !== 200) {
-        return callback(Error(`Expected 200 got ${res.statusCode}`));
-      }
-
-      callback(null, username);
-    });
+    return request.head({
+      uri: url.format(authUrl),
+      resolveWithFullResponse: true
+    })
+      .then(res => {
+        if (res.statusCode !== 200) {
+          return Promise.reject(new Error(`Expected 200 got ${res.statusCode}`));
+        }
+        return username;
+      });
   },
 
   getUserSettings: userCtx => {

--- a/api/src/controllers/login.js
+++ b/api/src/controllers/login.js
@@ -2,7 +2,7 @@ const fs = require('fs'),
   { promisify } = require('util'),
   url = require('url'),
   path = require('path'),
-  request = require('request'),
+  request = require('request-promise-native'),
   _ = require('underscore'),
   auth = require('../auth'),
   environment = require('../environment'),
@@ -82,26 +82,16 @@ const getSessionCookie = res => {
 const createSession = req => {
   const user = req.body.user;
   const password = req.body.password;
-  return new Promise((resolve, reject) => {
-    request.post(
-      {
-        url: url.format({
-          protocol: environment.protocol,
-          hostname: environment.host,
-          port: environment.port,
-          pathname: '_session',
-        }),
-        json: true,
-        body: { name: user, password: password },
-        auth: { user: user, pass: password },
-      },
-      (err, sessionRes) => {
-        if (err) {
-          return reject(err);
-        }
-        resolve(sessionRes);
-      }
-    );
+  return request.post({
+    url: url.format({
+      protocol: environment.protocol,
+      hostname: environment.host,
+      port: environment.port,
+      pathname: '_session',
+    }),
+    json: true,
+    body: { name: user, password: password },
+    auth: { user: user, pass: password },
   });
 };
 

--- a/api/src/controllers/users.js
+++ b/api/src/controllers/users.js
@@ -29,19 +29,15 @@ const basicAuthValid = (credentials, username) => {
   if (!credentials) {
     return;
   }
-  return new Promise(resolve => {
-    auth.validateBasicAuth(credentials, err => {
-      if (err) {
-        logger.error(
-          `Invalid authorization attempt on /api/v1/users/${username}`
-        );
-        logger.error('%o',err);
-        resolve(false); // Incorrect basic auth
-      } else {
-        resolve(true); // Correct basic auth
-      }
+  return auth.validateBasicAuth(credentials)
+    .then(() => true) // Correct basic auth
+    .catch(err => {
+      logger.error(
+        `Invalid authorization attempt on /api/v1/users/${username}`
+      );
+      logger.error('%o', err);
+      return false; // Incorrect basic auth
     });
-  });
 };
 
 const isChangingPassword = req => Object.keys(req.body).includes('password');

--- a/api/src/migrations/add-national_admin-role.js
+++ b/api/src/migrations/add-national_admin-role.js
@@ -1,18 +1,15 @@
-const _ = require('underscore'),
-  request = require('request'),
-  url = require('url'),
-  series = require('async/series'),
-  { promisify } = require('util'),
-  environment = require('../environment'),
-  logger = require('../logger');
+const request = require('request-promise-native');
+const url = require('url');
+const environment = require('../environment');
+const logger = require('../logger');
 
 const DEFAULT_STRUCTURE = {
   names: [],
   roles: [],
 };
 
-const addRole = (dbname, role, callback) => {
-  request.get({
+const addRole = (dbname, role) => {
+  return request.get({
     url: url.format({
       protocol: environment.protocol,
       hostname: environment.host,
@@ -24,49 +21,41 @@ const addRole = (dbname, role, callback) => {
       pass: environment.password
     },
     json: true
-  }, (err, response, body) => {
-    if (err) {
-      return callback(err);
-    }
+  })
+    .then(body => {
+      // In CouchDB 1.x, if you have not written to the _security object before
+      // it is empty.
+      if (!body.admins) {
+        body.admins = DEFAULT_STRUCTURE;
+      }
 
-    // In CouchDB 1.x, if you have not written to the _security object before
-    // it is empty.
-    if (!body.admins) {
-      body.admins = DEFAULT_STRUCTURE;
-    }
-
-    if (!body.admins.roles.includes(role)) {
-      logger.info(`Adding ${role} role to ${dbname} admins`);
-      body.admins.roles.push(role);
-    }
-
-    request.put({
-      url: url.format({
-        protocol: environment.protocol,
-        hostname: environment.host,
-        port: environment.port,
-        pathname: `${dbname}/_security`,
-      }),
-      auth: {
-        user: environment.username,
-        pass: environment.password
-      },
-      json: true,
-      body: body
-    }, callback);
-  });
+      if (!body.admins.roles.includes(role)) {
+        logger.info(`Adding ${role} role to ${dbname} admins`);
+        body.admins.roles.push(role);
+      }
+      return request.put({
+        url: url.format({
+          protocol: environment.protocol,
+          hostname: environment.host,
+          port: environment.port,
+          pathname: `${dbname}/_security`,
+        }),
+        auth: {
+          user: environment.username,
+          pass: environment.password
+        },
+        json: true,
+        body: body
+      });
+    });
 };
 
 module.exports = {
   name: 'add-national_admin-role',
   created: new Date(2017, 3, 30),
-  run: promisify(callback => {
-    series(
-      [
-        _.partial(addRole, '_users', 'national_admin'),
-        _.partial(addRole, environment.db, 'national_admin'),
-      ],
-      callback
-    );
-  }),
+  run: () => {
+    return Promise.resolve()
+      .then(() => addRole('_users', 'national_admin'))
+      .then(() => addRole(environment.db, 'national_admin'));
+  }
 };

--- a/api/src/migrations/restrict-access-to-audit-db.js
+++ b/api/src/migrations/restrict-access-to-audit-db.js
@@ -1,14 +1,13 @@
-const request = require('request'),
+const request = require('request-promise-native'),
       url = require('url'),
-      {promisify} = require('util'),
       environment = require('../environment');
 
-const addMemberToDb = (callback) => {
+const addMemberToDb = () => {
   const securityObject = {
     admins: { names:[], roles: ['audit-writer'] },
     members: { names: [], roles:['audit-writer'] }
   };
-  request.put({
+  return request.put({
     url: url.format({
       protocol: environment.protocol,
       hostname: environment.host,
@@ -21,19 +20,16 @@ const addMemberToDb = (callback) => {
     },
     json: true,
     body: securityObject
-  }, callback);
+  });
 };
 
 module.exports = {
   name: 'restrict-access-to-audit-db',
   created: new Date(2017, 5, 8),
-  run: promisify(callback => {
-    addMemberToDb((err) => {
-      if (err) {
-        return callback(new Error('Failed to add member to audit db.' +
-          JSON.stringify(err, null, 2)));
-      }
-      callback();
+  run: () => {
+    return addMemberToDb().catch(err => {
+      return Promise.reject(new Error('Failed to add member to audit db.' +
+        JSON.stringify(err, null, 2)));
     });
-  })
+  }
 };

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -276,16 +276,17 @@ app.get('/api/info', function(req, res) {
 });
 
 app.get('/api/auth/:path', function(req, res) {
-  auth.checkUrl(req, function(err, output) {
-    if (err) {
-      return serverUtils.serverError(err, req, res);
-    }
-    if (output.status >= 400 && output.status < 500) {
-      res.status(403).send('Forbidden');
-    } else {
-      res.json(output);
-    }
-  });
+  auth.checkUrl(req)
+    .then(status => {
+      if (status && status >= 400 && status < 500) {
+        res.status(403).send('Forbidden');
+      } else {
+        res.json({ status: status });
+      }
+    })
+    .catch(err => {
+      serverUtils.serverError(err, req, res);
+    });
 });
 
 app.post('/api/v1/upgrade', jsonParser, upgrade.upgrade);

--- a/api/src/services/user-db.js
+++ b/api/src/services/user-db.js
@@ -1,4 +1,4 @@
-const request = require('request');
+const request = require('request-promise-native');
 const url = require('url');
 const db = require('../db-pouch');
 const environment = require('../environment');
@@ -29,29 +29,22 @@ const ddoc = {
 };
 
 const setSecurity = (dbName, username) => {
-  return new Promise((resolve, reject) => {
-    request.put({
-      url: url.format({
-        protocol: environment.protocol,
-        hostname: environment.host,
-        port: environment.port,
-        pathname: `${dbName}/_security`,
-      }),
-      auth: {
-        user: environment.username,
-        pass: environment.password
-      },
-      json: true,
-      body: {
-        admins: { names: [ username ], roles: [] },
-        members: { names: [ username ], roles: [] }
-      }
-    }, err => {
-      if (err) {
-        return reject(err);
-      }
-      resolve();
-    });
+  return request.put({
+    url: url.format({
+      protocol: environment.protocol,
+      hostname: environment.host,
+      port: environment.port,
+      pathname: `${dbName}/_security`,
+    }),
+    auth: {
+      user: environment.username,
+      pass: environment.password
+    },
+    json: true,
+    body: {
+      admins: { names: [ username ], roles: [] },
+      members: { names: [ username ], roles: [] }
+    }
   });
 };
 

--- a/api/tests/mocha/auth.spec.js
+++ b/api/tests/mocha/auth.spec.js
@@ -1,4 +1,4 @@
-const request = require('request'),
+const request = require('request-promise-native'),
       url = require('url'),
       chai = require('chai'),
       sinon = require('sinon'),
@@ -24,7 +24,7 @@ describe('Auth', () => {
 
     it('returns error when not logged in', () => {
       environment.serverUrl = 'http://abc.com';
-      const get = sinon.stub(request, 'get').callsArgWith(1, null, null);
+      const get = sinon.stub(request, 'get').resolves();
       return auth.check({ }).catch(err => {
         chai.expect(get.callCount).to.equal(1);
         chai.expect(get.args[0][0].url).to.equal('http://abc.com/_session');
@@ -35,7 +35,7 @@ describe('Auth', () => {
 
     it('returns error when no user context', () => {
       environment.serverUrl = 'http://abc.com';
-      const get = sinon.stub(request, 'get').callsArgWith(1, null, null, { roles: [] });
+      const get = sinon.stub(request, 'get').resolves({ roles: [] });
       return auth.check({ }).catch(err => {
         chai.expect(get.callCount).to.equal(1);
         chai.expect(err.message).to.equal('Not logged in');
@@ -45,7 +45,7 @@ describe('Auth', () => {
 
     it('returns error when request errors', () => {
       environment.serverUrl = 'http://abc.com';
-      const get = sinon.stub(request, 'get').callsArgWith(1, 'boom');
+      const get = sinon.stub(request, 'get').rejects('boom');
       return auth.check({ }).catch(err => {
         chai.expect(get.callCount).to.equal(1);
         chai.expect(get.args[0][0].url).to.equal('http://abc.com/_session');
@@ -58,7 +58,7 @@ describe('Auth', () => {
       environment.serverUrl = 'http://abc.com';
       const district = '123';
       const userCtx = { userCtx: { name: 'steve', roles: [ 'xyz' ] } };
-      const get = sinon.stub(request, 'get').callsArgWith(1, null, null, userCtx);
+      const get = sinon.stub(request, 'get').resolves(userCtx);
       sinon.stub(config, 'get').returns({ can_edit: ['abc'] });
       return auth.check({headers: []}, 'can_edit', district).catch(err => {
         chai.expect(get.callCount).to.equal(1);
@@ -71,7 +71,7 @@ describe('Auth', () => {
       environment.serverUrl = 'http://abc.com';
       const district = '123';
       const userCtx = { userCtx: { name: 'steve', roles: [ '_admin' ] } };
-      const get = sinon.stub(request, 'get').callsArgWith(1, null, null, userCtx);
+      const get = sinon.stub(request, 'get').resolves(userCtx);
       return auth.check({headers: []}, 'can_edit', district).then(ctx => {
         chai.expect(get.callCount).to.equal(1);
         chai.expect(ctx.user).to.equal('steve');
@@ -84,8 +84,8 @@ describe('Auth', () => {
       const district = '123';
       const userCtx = { userCtx: { name: 'steve', roles: [ 'xyz', 'district_admin' ] } };
       const get = sinon.stub(request, 'get');
-      get.onFirstCall().callsArgWith(1, null, null, userCtx);
-      get.onSecondCall().callsArgWith(1, null, null, { facility_id: district });
+      get.onFirstCall().resolves(userCtx);
+      get.onSecondCall().resolves({ facility_id: district });
       sinon.stub(config, 'get').returns({ can_edit: ['district_admin'] });
       return auth.check({headers: []}, 'can_edit', district).then(ctx => {
         chai.expect(get.callCount).to.equal(2);
@@ -99,8 +99,8 @@ describe('Auth', () => {
       const userCtx = { userCtx: { name: 'steve', roles: [ 'xyz', 'district_admin' ] } };
       sinon.stub(url, 'format').returns('http://abc.com');
       const get = sinon.stub(request, 'get');
-      get.onFirstCall().callsArgWith(1, null, null, userCtx);
-      get.onSecondCall().callsArgWith(1, null, null, { facility_id: '123' });
+      get.onFirstCall().resolves(userCtx);
+      get.onSecondCall().resolves({ facility_id: '123' });
       sinon.stub(config, 'get').returns({ can_edit: ['district_admin'] });
       return auth.check({headers: []}, 'can_edit', '789').catch(err => {
         chai.expect(get.callCount).to.equal(2);
@@ -115,8 +115,8 @@ describe('Auth', () => {
       const userCtx = { userCtx: { name: 'steve', roles: [ 'xyz', 'district_admin' ] } };
       sinon.stub(url, 'format').returns('http://abc.com');
       const get = sinon.stub(request, 'get');
-      get.onFirstCall().callsArgWith(1, null, null, userCtx);
-      get.onSecondCall().callsArgWith(1, null, null, { facility_id: district });
+      get.onFirstCall().resolves(userCtx);
+      get.onSecondCall().resolves({ facility_id: district });
       sinon.stub(config, 'get').returns({
         can_export_messages: ['district_admin'],
         can_export_contacts: ['district_admin'],
@@ -133,7 +133,7 @@ describe('Auth', () => {
       const district = '123';
       const userCtx = { userCtx: { name: 'steve', roles: [ 'xyz', 'district_admin' ] } };
       sinon.stub(url, 'format').returns('http://abc.com');
-      const get = sinon.stub(request, 'get').callsArgWith(1, null, null, userCtx);
+      const get = sinon.stub(request, 'get').resolves(userCtx);
       sinon.stub(config, 'get').returns({
         can_export_messages: ['district_admin'],
         can_export_server_logs: ['national_admin'],
@@ -149,18 +149,16 @@ describe('Auth', () => {
 
   describe('checkUrl', () => {
 
-    it('requests the given url and returns status', done => {
+    it('requests the given url and returns status', () => {
       environment.serverUrl = 'http://abc.com';
       const format = sinon.stub(url, 'format').returns('http://abc.com');
-      const head = sinon.stub(request, 'head').callsArgWith(1, null, { statusCode: 444 });
-      auth.checkUrl({ params: { path: '/home/screen' } }, (err, output) => {
-        chai.expect(err).to.equal(null);
+      const head = sinon.stub(request, 'head').resolves({ statusCode: 444 });
+      return auth.checkUrl({ params: { path: '/home/screen' } }).then(actual => {
         chai.expect(format.callCount).to.equal(1);
         chai.expect(format.args[0][0].pathname).to.equal('/home/screen');
         chai.expect(head.callCount).to.equal(1);
         chai.expect(head.args[0][0].url).to.equal('http://abc.com');
-        chai.expect(output.status).to.equal(444);
-        done();
+        chai.expect(actual).to.equal(444);
       });
     });
 

--- a/api/tests/mocha/controllers/login.spec.js
+++ b/api/tests/mocha/controllers/login.spec.js
@@ -5,7 +5,7 @@ const controller = require('../../../src/controllers/login'),
       db = require('../../../src/db-pouch').medic,
       sinon = require('sinon'),
       config = require('../../../src/config'),
-      request = require('request'),
+      request = require('request-promise-native'),
       fs = require('fs'),
       DB_NAME = 'lg',
       DDOC_NAME = 'medic';
@@ -168,7 +168,7 @@ describe('login controller', () => {
 
     it('returns errors from session create', () => {
       req.body = { user: 'sharon', password: 'p4ss' };
-      const post = sinon.stub(request, 'post').callsArgWith(1, 'boom');
+      const post = sinon.stub(request, 'post').rejects('boom');
       const status = sinon.stub(res, 'status').returns(res);
       const json = sinon.stub(res, 'json').returns(res);
       return controller.post(req, res).then(() => {
@@ -182,7 +182,7 @@ describe('login controller', () => {
 
     it('returns invalid credentials', () => {
       req.body = { user: 'sharon', password: 'p4ss' };
-      const post = sinon.stub(request, 'post').callsArgWith(1, null, { statusCode: 401 });
+      const post = sinon.stub(request, 'post').resolves({ statusCode: 401 });
       const status = sinon.stub(res, 'status').returns(res);
       const json = sinon.stub(res, 'json').returns(res);
       return controller.post(req, res).then(() => {
@@ -200,7 +200,7 @@ describe('login controller', () => {
         statusCode: 200,
         headers: { 'set-cookie': [ 'AuthSession=abc;' ] }
       };
-      const post = sinon.stub(request, 'post').callsArgWith(1, null, postResponse);
+      const post = sinon.stub(request, 'post').resolves(postResponse);
       const status = sinon.stub(res, 'status').returns(res);
       const json = sinon.stub(res, 'json').returns(res);
       const getUserCtx = sinon.stub(auth, 'getUserCtx').rejects('boom');
@@ -220,7 +220,7 @@ describe('login controller', () => {
         statusCode: 200,
         headers: { 'set-cookie': [ 'AuthSession=abc;' ] }
       };
-      const post = sinon.stub(request, 'post').callsArgWith(1, null, postResponse);
+      const post = sinon.stub(request, 'post').resolves(postResponse);
       const json = sinon.stub(res, 'json').returns(res);
       const cookie = sinon.stub(res, 'cookie').returns(res);
       const userCtx = { name: 'shazza', roles: [ 'project-stuff' ] };

--- a/api/tests/mocha/services/user-db.spec.js
+++ b/api/tests/mocha/services/user-db.spec.js
@@ -1,7 +1,7 @@
 const service = require('../../../src/services/user-db');
 const db = require('../../../src/db-pouch');
 const environment = require('../../../src/environment');
-const request = require('request');
+const request = require('request-promise-native');
 const chai = require('chai');
 const sinon = require('sinon');
 
@@ -45,7 +45,7 @@ describe('User DB service', () => {
       const create = sinon.stub(db, 'exists').resolves(false);
       const get = sinon.stub(db, 'get').resolves(userDb);
       const dbPut = sinon.stub(userDb, 'put').resolves();
-      const requestPut = sinon.stub(request, 'put').callsArgWith(1);
+      const requestPut = sinon.stub(request, 'put').resolves();
       environment.protocol = 'http:';
       environment.host = 'localhost';
       environment.port = '7357';


### PR DESCRIPTION
# Description

As requested (heh) replaces callback based `request` library with promise based `request-promise-native` throughout API.

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
