### PR TITLE
Downgrade PouchDB to 6.4.3

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -301,6 +301,7 @@ module.exports = function(grunt) {
               'enketo-core/**',
               'font-awesome/**',
               'moment/**',
+              'pouchdb-browser/**',
             ],
             dest: 'webapp/node_modules_backup',
           },
@@ -430,6 +431,7 @@ module.exports = function(grunt) {
             'enketo-core',
             'font-awesome',
             'moment',
+            'pouchdb-browser',
           ];
           return modulesToPatch
             .map(function(module) {
@@ -492,6 +494,10 @@ module.exports = function(grunt) {
 
             // patch enketo to always mark the /inputs group as relevant
             'patch webapp/node_modules/enketo-core/src/js/Form.js < webapp/patches/enketo-inputs-always-relevant.patch',
+
+            // patch pouch to:
+            // * improve safari checks (https://github.com/medic/medic-webapp/issues/2797)
+            'patch webapp/node_modules/pouchdb-browser/lib/index.js < webapp/patches/pouchdb-browser.patch',
           ];
           return patches.join(' && ');
         },

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -46,8 +46,7 @@
     "partial-json-parser": "1.0.2",
     "phone-number": "file:../shared-libs/phone-number",
     "pojo2xml": "^1.7.1",
-    "pouchdb-browser": "^7.0.0",
-    "pouchdb-debug": "^7.0.0",
+    "pouchdb-browser": "^6.4.3",
     "search": "file:../shared-libs/search",
     "select2": "4.0.3",
     "simple-password-tester": "^1.0.0",
@@ -58,7 +57,7 @@
   "devDependencies": {},
   "resolutions": {
     "**/jquery": "3.2.x",
-    "**/pouchdb-browser": "^7.0.0",
+    "**/pouchdb-browser": "^6.4.3",
     "**/moment": "^2.22.2"
   }
 }

--- a/webapp/patches/pouchdb-browser.patch
+++ b/webapp/patches/pouchdb-browser.patch
@@ -1,0 +1,12 @@
+*** node_modules/pouchdb-browser/lib/index.js	2018-02-02 14:46:02.000000000 +0200
+--- pouchdb-browser-patched.js	2018-05-22 17:46:43.458259255 +0300
+***************
+*** 6503,6508 ****
+--- 6503,6509 ----
+    var isSafari = typeof openDatabase !== 'undefined' &&
+      /(Safari|iPhone|iPad|iPod)/.test(navigator.userAgent) &&
+      !/Chrome/.test(navigator.userAgent) &&
++     !/TECNO/.test(navigator.userAgent) && // MEDIC PATCH #2797
+      !/BlackBerry/.test(navigator.platform);
+
+    // Safari <10.1 does not meet our requirements for IDB support (#5572)

--- a/webapp/src/js/app.js
+++ b/webapp/src/js/app.js
@@ -1,5 +1,4 @@
 window.PouchDB = require('pouchdb-browser');
-window.PouchDB.plugin(require('pouchdb-debug'));
 window.$ = window.jQuery = require('jquery');
 window.d3 = require('d3');
 
@@ -91,14 +90,7 @@ _.templateSettings = {
   });
   var POUCHDB_OPTIONS = {
     local: { auto_compaction: true },
-    remote: {
-      skip_setup: true,
-      fetch: function(url, opts) {
-        opts.headers.set('Accept', 'application/json');
-        opts.credentials = 'same-origin';
-        return window.PouchDB.fetch(url, opts);
-      }
-    }
+    remote: { skip_setup: true, ajax: { timeout: 30000 }}
   };
   app.constant('POUCHDB_OPTIONS', POUCHDB_OPTIONS);
 

--- a/webapp/tests/karma/unit/services/db.js
+++ b/webapp/tests/karma/unit/services/db.js
@@ -55,7 +55,7 @@ describe('DB service', () => {
 
   describe('get remote', () => {
 
-    it('sets skip setup', () => {
+    it('sets ajax timeout', () => {
       isOnlineOnly.returns(false);
       Location.dbName = 'medicdb';
       Location.url = 'ftp//myhost:21/medicdb';
@@ -72,13 +72,13 @@ describe('DB service', () => {
       chai.expect(actual.id).to.equal(expected.id);
       chai.expect(pouchDB.callCount).to.equal(3);
       chai.expect(pouchDB.args[2][0]).to.equal('ftp//myhost:21/medicdb');
-      chai.expect(pouchDB.args[2][1].skip_setup).to.equal(true);
+      chai.expect(pouchDB.args[2][1]).to.deep.equal({ skip_setup: true, ajax: { timeout: 30000 } });
 
       // get remote meta
       service({ remote: true, meta: true });
       chai.expect(pouchDB.callCount).to.equal(4);
       chai.expect(pouchDB.args[3][0]).to.equal('ftp//myhost:21/medicdb-user-johnny-meta');
-      chai.expect(pouchDB.args[3][1].skip_setup).to.equal(false);
+      chai.expect(pouchDB.args[3][1]).to.deep.equal({ skip_setup: false, ajax: { timeout: 30000 } });
     });
 
     it('caches pouchdb instances', () => {
@@ -125,17 +125,19 @@ describe('DB service', () => {
       chai.expect(actual.id).to.equal(expected.id);
       chai.expect(pouchDB.callCount).to.equal(3);
       chai.expect(pouchDB.args[2][0]).to.equal('ftp//myhost:21/medicdb');
+      chai.expect(pouchDB.args[2][1]).to.deep.equal({ skip_setup: true, ajax: { timeout: 30000 } });
 
       // get remote meta
       service({ remote: true, meta: true });
       chai.expect(pouchDB.callCount).to.equal(4);
       chai.expect(pouchDB.args[3][0]).to.equal('ftp//myhost:21/medicdb-user-johnny(46)(60)(62)(94)(44)(63)(33)-meta');
+      chai.expect(pouchDB.args[3][1]).to.deep.equal({ skip_setup: false, ajax: { timeout: 30000 } });
     });
   });
 
   describe('get local', () => {
 
-    it('sets auto compaction', () => {
+    it('sets ajax timeout', () => {
       isOnlineOnly.returns(false);
       Location.dbName = 'medicdb';
       userCtx.returns({ name: 'johnny' });
@@ -193,12 +195,14 @@ describe('DB service', () => {
       chai.expect(pouchDB.callCount).to.equal(1);
       chai.expect(actual.id).to.equal(expected.id);
       chai.expect(pouchDB.args[0][0]).to.equal('ftp//myhost:21/medicdb');
+      chai.expect(pouchDB.args[0][1]).to.deep.equal({ skip_setup: true, ajax: { timeout: 30000 } });
       chai.expect(expected.viewCleanup.callCount).to.equal(0);
 
       // get locale  meta returns remote meta
       service({ meta: true });
       chai.expect(pouchDB.callCount).to.equal(2);
       chai.expect(pouchDB.args[1][0]).to.equal('ftp//myhost:21/medicdb-user-johnny-meta');
+      chai.expect(pouchDB.args[1][1]).to.deep.equal({ skip_setup: false, ajax: { timeout: 30000 } });
     });
 
   });

--- a/webapp/yarn.lock
+++ b/webapp/yarn.lock
@@ -1242,13 +1242,15 @@ pouchdb-binary-utils@6.4.3:
   dependencies:
     buffer-from "0.1.1"
 
-pouchdb-browser@^6.0.7, pouchdb-browser@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/pouchdb-browser/-/pouchdb-browser-7.0.0.tgz#d493fd738f21f7c91f17bbb7ee7ad97c2072e546"
+pouchdb-browser@^6.0.7, pouchdb-browser@^6.4.3:
+  version "6.4.3"
+  resolved "https://registry.yarnpkg.com/pouchdb-browser/-/pouchdb-browser-6.4.3.tgz#980de389abdb7850a8196525ca96c3b93d79b359"
   dependencies:
     argsarray "0.0.1"
+    debug "3.1.0"
     immediate "3.0.6"
     inherits "2.0.3"
+    lie "3.1.1"
     spark-md5 "3.0.0"
     uuid "3.2.1"
     vuvuzela "1.0.3"
@@ -1286,12 +1288,6 @@ pouchdb-core@^6.4.3:
 pouchdb-debug@6.4.3:
   version "6.4.3"
   resolved "https://registry.yarnpkg.com/pouchdb-debug/-/pouchdb-debug-6.4.3.tgz#d5ee0d0f638c455ef947fe6658030db1480c72c0"
-  dependencies:
-    debug "3.1.0"
-
-pouchdb-debug@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/pouchdb-debug/-/pouchdb-debug-7.0.0.tgz#db028678b952206ec64fd6fa76aa1dc62c0fe9a5"
   dependencies:
     debug "3.1.0"
 


### PR DESCRIPTION
# Description

Reverts change that upgrades PouchDB version from 6.4.3 to 7.0.0 in Webapp (API and Sentinel left unchanged). 

medic/medic-webapp#5257

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
