### PR TITLE
CSP is blocking inline script on bootstrap retry button

### DIFF
--- a/webapp/src/js/bootstrapper/index.js
+++ b/webapp/src/js/bootstrapper/index.js
@@ -117,7 +117,8 @@
   var setUiError = function() {
     var errorMessage = translator.translate('ERROR_MESSAGE');
     var tryAgain = translator.translate('TRY_AGAIN');
-    $('.bootstrap-layer').html('<div><p>' + errorMessage + '</p><a class="btn btn-primary" href="#" onclick="window.location.reload(false);">' + tryAgain + '</a></div>');
+    $('.bootstrap-layer').html('<div><p>' + errorMessage + '</p><a id="btn-reload" class="btn btn-primary" href="#">' + tryAgain + '</a></div>');
+    $('#btn-reload').click(() => window.location.reload(false));
   };
 
   var getDdoc = function(localDb) {

--- a/webapp/tests/mocha/unit/bootstrapper.spec.js
+++ b/webapp/tests/mocha/unit/bootstrapper.spec.js
@@ -51,6 +51,7 @@ describe('bootstrapper', () => {
 
     $ = sinon.stub().returns({
       text: sinon.stub(),
+      click: sinon.stub(),
       html: sinon.stub()
     });
 


### PR DESCRIPTION
# Description

Navigate to webapp 3.4 (master)
Login as restricted user.
Go offline during initial replication.
Click "Try again"

Observed error: `Refused to execute inline event handler because it violates the following Content Security Policy directive: "script-src 'self' 'sha256-6i0jYw/zxQO6q9fIxqI++wftTrPWB3yxt4tQqy6By6k=' 'unsafe-eval'". Either the 'unsafe-inline' keyword, a hash ('sha256-...'), or a nonce ('nonce-...') is required to enable inline execution.`

This change should be merged into 3.4.

#5270

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
