### PR TITLE
5277 - CSP connect-src still blocking upgrades via admin upgrade page

### DIFF
--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -41,7 +41,7 @@ const _ = require('underscore'),
   appcacheManifest = /\/manifest\.appcache$/,
   uuid = require('uuid'),
   compression = require('compression'),
-  BUILDS_DB = 'https://staging.dev.medicmobile.org/_couch/builds', // jshint ignore:line
+  BUILDS_DB = 'https://staging.dev.medicmobile.org/_couch/builds/', // jshint ignore:line
   app = express();
 
 // requires content-type application/json header

--- a/api/tests/mocha/routing.spec.js
+++ b/api/tests/mocha/routing.spec.js
@@ -16,6 +16,6 @@ describe('Routing', () => {
     const cspBuildDb = routing.__get__('BUILDS_DB');
     const actualBuildDb = adminUpgrade.__get__('BUILDS_DB');
     chai.expect(cspBuildDb).to.not.eq(undefined);
-    chai.expect(cspBuildDb).to.eq(actualBuildDb);
+    chai.expect(cspBuildDb).to.include(actualBuildDb);
   });
 });


### PR DESCRIPTION
# Description

Tweaking this fix. Tested e2e with a horti deployment via admin page upgrade page. Deployment didn't actually complete, but was able to kick off without error.
 
#5277

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
