### PR TITLE
5228 - Jasmine e2e test report is always empty

### DIFF
--- a/tests/base.conf.js
+++ b/tests/base.conf.js
@@ -26,6 +26,11 @@ class BaseConfig {
           utils.reporter.beforeLaunch(resolve);
         });
       },
+      afterLaunch: function(exitCode) {
+        return new Promise(function(resolve) {
+          utils.reporter.afterLaunch(resolve.bind(this, exitCode));
+        });
+      },
       onPrepare: () => {
         jasmine.getEnv().addReporter(utils.reporter);
         browser.waitForAngularEnabled(false);


### PR DESCRIPTION
# Description

Run e2e tests. 
Browse to tests/results/report.html to view report

Expected: Report
Obsereved: Empty report

#5228

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
