### PR TITLE
5196 - Limit API startup to 120 seconds during E2E test runs

### DIFF
--- a/tests/base.conf.js
+++ b/tests/base.conf.js
@@ -30,7 +30,7 @@ class BaseConfig {
         jasmine.getEnv().addReporter(utils.reporter);
         browser.waitForAngularEnabled(false);
 
-        browser.driver.wait(listenForApi, 120 * 1000, 'API took too long to start up');
+        browser.driver.wait(listenForApi(), 120 * 1000, 'API took too long to start up');
         browser.driver.wait(setupSettings, 5 * 1000, 'Settings should be setup within 5 seconds');
         browser.driver.wait(utils.setUserContactDoc, 5 * 1000, 'User contact should be setup within 5 seconds');
         browser.driver.wait(setupUser, 5 * 1000, 'User should be setup within 5 seconds');


### PR DESCRIPTION
# Description

#5196

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
