### PR TITLE
changes to which image and waiting for couchdb to be ready

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -493,8 +493,8 @@ module.exports = function(grunt) {
       },
       'setup-test-database': {
         cmd: [
-          `docker run -d -p 4984:5984 -p 4986:5986 --rm --name e2e-couchdb couchdb:2`,
-          'sh scripts/wait_for_couch.sh',
+          `docker run -d -p 4984:5984 -p 4986:5986 --rm --name e2e-couchdb --mount type=tmpfs,destination=/opt/couchdb/data couchdb:2`,
+          'sh scripts/e2e/wait_for_couch.sh 4984',
           `curl 'http://localhost:4984/_cluster_setup' -H 'Content-Type: application/json' --data-binary '{"action":"enable_single_node","username":"admin","password":"pass","bind_address":"0.0.0.0","port":5984,"singlenode":true}'`,
           'COUCH_URL=http://admin:pass@localhost:4984/medic COUCH_NODE_NAME=nonode@nohost grunt secure-couchdb', // yo dawg, I heard you like grunt...
           // Useful for debugging etc, as it allows you to use Fauxton easily
@@ -508,7 +508,7 @@ module.exports = function(grunt) {
         exitCodes: [0, 1] // 1 if e2e-couchdb doesn't exist, which is fine
       },
       'e2e-servers': {
-        cmd: 'node ./scripts/e2e-servers.js &'
+        cmd: 'node ./scripts/e2e/e2e-servers.js &'
       },
       bundlesize: {
         cmd: 'node ./node_modules/bundlesize/index.js',

--- a/scripts/e2e/e2e-servers.js
+++ b/scripts/e2e/e2e-servers.js
@@ -4,8 +4,8 @@ const fs = require('fs');
 const path = require('path');
 const { fork } = require('child_process');
 
-const constants = require('./../tests/constants');
-const utils = require('../tests/utils');
+const constants = require('../../tests/constants');
+const utils = require('../../tests/utils');
 
 // This is a dev dependency in the root package.json
 const express = require('express');

--- a/scripts/e2e/wait_for_couch.sh
+++ b/scripts/e2e/wait_for_couch.sh
@@ -1,0 +1,7 @@
+count=0
+echo `curl -o /dev/null -s -w "%{http_code}\n" http://localhost:$1`
+while [ `curl -o /dev/null -s -w "%{http_code}\n" http://localhost:$1` -ne 200 -a $count -lt 20 ]
+  do count=$((count+=1))
+  echo "waiting for couch to respond with 200 status code. Current count is $count" 
+  sleep 1 
+done

--- a/scripts/wait_for_couch.sh
+++ b/scripts/wait_for_couch.sh
@@ -1,6 +1,0 @@
-count=0
-while [ `curl -o /dev/null -s -w "%{http_code}\n" http://localhost:4984` -ne 200 -a $count -lt 20 ]
-  do count=$((count+=1))
-  echo "waiting for couch to respond with 200 status code. Current count is $count" 
-  sleep 1 
-done


### PR DESCRIPTION
using the 2.x.x official [couch image](https://hub.docker.com/_/couchdb) vs the [apache repo image](https://hub.docker.com/r/apache/couchdb), added bash script to check that couch is responding before trying to move on setting up, switch from semicolon to ampersand so if the setup fails it fails grunt 

# Description

[description]

medic/medic#[number]

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
