### PR TITLE
GH Actions: don't skip duplicate jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master
         with:
-          concurrent_skipping: 'same_content_newer'
+          skip_after_successful_duplicate: 'false'
           paths_ignore: '["**.md", "release-notes/**", "demo-forms/**"]'
 
   build:


### PR DESCRIPTION
# Description

The GH Action [fkirc/skip-duplicate-actions](https://github.com/marketplace/actions/skip-duplicate-actions) allows to skip jobs from changes that only affect "ignored" paths or "duplicated" jobs, but the last is undesired.

With the change provided even when merging to master the job won't be skipped, despite the content used may be the same used from the last job executed within the feature branch.
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
