### PR TITLE
(chore #8235): e2e test for sentinel transition error log

### DIFF
--- a/tests/integration/transitions/sentinel-transition-error-log.spec.js
+++ b/tests/integration/transitions/sentinel-transition-error-log.spec.js
@@ -1,0 +1,18 @@
+const utils = require('@utils');
+const { assert } = require('chai');
+
+describe('Sentinel Error Logs', async () => {
+  
+  it('logs an error if unknown transition, every 5 minutes', async () => {
+    const settings = {
+      transitions: {
+        test_transition: true
+      }
+    };
+
+    const collectLogs = await utils.collectSentinelLogs(/Unknown transition/);
+    await utils.updateSettings(settings, 'sentinel', false);
+    const logs = await collectLogs();
+    assert.exists(await logs.find(log => log.match(/Unknown transition "test_transition"/)));
+  });
+});

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -486,12 +486,14 @@ const deprecated = (name, replacement) => {
   }
 };
 
-const waitForSettingsUpdateLogs = (type) => {
+const waitForSettingsUpdateLogs = (type, updated) => {
   if (type === 'sentinel') {
     return module.exports.waitForSentinelLogs(/Reminder messages allowed between/);
   }
 
-  return module.exports.waitForApiLogs(/Settings updated/);
+  if(updated){
+    return module.exports.waitForApiLogs(/Settings updated/);
+  }
 };
 
 const killSpawnedProcess = (proc) => {
@@ -1117,10 +1119,10 @@ module.exports = {
    *                                       api logs, if value equals 'sentinel', will watch sentinel logs instead.
    * @return {Promise}        completion promise
    */
-  updateSettings: async (updates, ignoreReload) => {
+  updateSettings: async (updates, ignoreReload, updated = true) => {
     const watcher = ignoreReload &&
       Object.keys(updates).length &&
-      await waitForSettingsUpdateLogs(ignoreReload);
+      await waitForSettingsUpdateLogs(ignoreReload, updated);
     await updateSettings(updates);
     if (!ignoreReload) {
       return await refreshToGetNewSettings();


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

 e2e test for sentinel transition error log

medic/cht-core #8235 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8235-test-sentinel-transition-error-log/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8235-test-sentinel-transition-error-log/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8235-test-sentinel-transition-error-log/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

