### PR TITLE
chore(#10159): add _bulk_get benchmark to CouchDB scalability tests

### DIFF
--- a/tests/scalability/couchdb-benchmark/bulk_get.js
+++ b/tests/scalability/couchdb-benchmark/bulk_get.js
@@ -1,0 +1,39 @@
+const request = require('@medic/couch-request');
+const { performance } = require('perf_hooks');
+const utils = require('./utils');
+
+const docIds = [];
+
+const scenarios = [
+  { count: 100 },
+  { count: 1000 },
+  { count: 10000 },
+];
+
+const test = async (scenario) => {
+  const ids = docIds.slice(0, scenario.count);
+  const payload = ids.map(id => ({ id }));
+
+  const start = performance.now();
+  await request.post({ uri: `${utils.db}/_bulk_get`, body: { docs: payload } });
+  const end = performance.now();
+
+  return parseInt(end - start);
+};
+
+const getDocIds = async () => {
+  const maxDocs = Math.max(...scenarios.map(scenario => scenario.count));
+  const response = await request.get({ uri: `${utils.db}/_all_docs`, qs: { limit: maxDocs, skip: maxDocs * 10 } });
+  docIds.push(...response.rows.map(row => row.id));
+};
+
+module.exports = async () => {
+  await getDocIds();
+
+  const results = [];
+  for (const scenario of scenarios) {
+    const duration = await test(scenario);
+    results.push({ scenario, duration });
+  }
+  return results;
+};

--- a/tests/scalability/couchdb-benchmark/index.js
+++ b/tests/scalability/couchdb-benchmark/index.js
@@ -2,6 +2,7 @@ const { printResults, cleanFile, writeDbInfo } = require('./utils');
 
 const testChanges = require('./changes');
 const testAllDocs = require('./all_docs');
+const testBulkGet = require('./bulk_get');
 
 (async () => {
   await cleanFile();
@@ -9,8 +10,8 @@ const testAllDocs = require('./all_docs');
 
   await printResults('_changes', await testChanges());
   await printResults('_all_docs', await testAllDocs());
+  await printResults('_bulk_get', await testBulkGet());
 
-  // benchmark _bulk_get
   // benchmark db-doc get (with large attachments)
   // benchmark db-doc get (with large attachments got separately)
 })();


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->

closes #10159 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10159-_bulk_get-benchmark/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10159-_bulk_get-benchmark/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10159-_bulk_get-benchmark/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

