### PR TITLE
feat(#10225): support for centralized sms gateway of nepal (#10230)

### DIFF
--- a/api/src/services/messaging.js
+++ b/api/src/services/messaging.js
@@ -5,6 +5,7 @@ const logger = require('@medic/logger');
 const config = require('../config');
 const africasTalking = require('./africas-talking');
 const rapidPro = require('./rapidpro');
+const nepalDoITSMS = require('./nepal-doit-sms');
 const records = require('../services/records');
 const environment = require('@medic/environment');
 
@@ -14,6 +15,7 @@ const DB_CHECKING_INTERVAL = environment.isTesting ? 1000 : 1000 * 60;
 const SMS_SENDING_SERVICES = {
   'africas-talking': africasTalking,
   'rapidpro': rapidPro,
+  'nepal-doit-sms': nepalDoITSMS,
   // medic-gateway -- ignored because it's a pull not a push service
 };
 const DEFAULT_CONFIG = { outgoing_service: 'medic-gateway' };

--- a/api/src/services/nepal-doit-sms.js
+++ b/api/src/services/nepal-doit-sms.js
@@ -1,0 +1,175 @@
+const request = require('@medic/couch-request');
+const secureSettings = require('@medic/settings');
+const logger = require('@medic/logger');
+const config = require('../config');
+
+const BATCH_CONCURRENCY = 5;
+const STATUS_MAP = {
+  // success - based on API response status field
+  1: { success: true, state: 'sent', detail: 'Processed' },
+
+  // HTTP error status codes (from error object in catch block)
+  401: { success: false, state: 'failed', detail: 'InvalidCredentials' },
+  422: { success: false, state: 'failed', detail: 'UnprocessableContent' },
+  500: { success: false, state: 'failed', detail: 'InternalServerError', retry: true },
+};
+
+const getUrl = () => {
+  const settings = config.get('sms');
+
+  const url = settings?.nepal_doit_sms?.url;
+  if (!url) {
+    // invalid configuration - return null so callers can handle retry behavior
+    logger.error('No URL configured. Refer to the Nepal DoIT SMS configuration documentation.');
+    return null;
+  }
+  return url;
+};
+
+const getCredentials = () => {
+  return secureSettings.getCredentials('nepal_doit_sms:outgoing')
+    .then(apiKey => {
+      if (!apiKey) {
+        // no API key configured - return null so callers can handle retry behavior
+        logger.error('No API key configured. Refer to the Nepal DoIT SMS configuration documentation.');
+        return null;
+      }
+      return { apiKey };
+    });
+};
+
+const getStatus = response => {
+  // For API success response, check the status field
+  if (response && response.status !== undefined) {
+    return STATUS_MAP[response.status];
+  }
+  // For HTTP error status codes (in catch block)
+  if (response && response.statusCode !== undefined) {
+    return STATUS_MAP[response.statusCode];
+  }
+  return null;
+};
+
+const generateStateChange = (message, res) => {
+  if (!res) {
+    return;
+  }
+  const status = getStatus(res);
+  if (!status || status.retry) {
+    return;
+  }
+  return {
+    messageId: message.id,
+    state: status.state,
+    details: status.detail
+  };
+};
+
+const validateSuccessResponse = (result) => {
+  if (!result) {
+    logger.error(`No response received: %o`, result);
+    return false;
+  }
+
+  logger.debug(`SMS API Response: %o`, result);
+
+  const validResponse = getStatus(result);
+  if (!validResponse) {
+    logger.error(`SMS API returned status ${result.status}: %o`, result);
+    return false;
+  }
+
+  return true;
+};
+
+const sendMessage = async (credentials, message) => {
+  const url = getUrl();
+  if (!url) {
+    logger.error('No URL configured');
+    return; // retry later
+  }
+
+  logger.debug(`Sending message to "${url}"`);
+
+  // Strip the country code from recipient number
+  const recipientNumber = message.to.replace(/^\+977/, '');
+
+  try {
+    const result = await request.post({
+      url: url,
+      json: true,
+      body: {
+        mobile: recipientNumber,
+        message: message.content
+      },
+      headers: {
+        authorization: `Bearer ${credentials.apiKey}`,
+        accept: 'application/json'
+      }
+    });
+
+    if (!validateSuccessResponse(result)) {
+      return; // retry later
+    }
+
+    return generateStateChange(message, result);
+  } catch (err) {
+    // Handle HTTP errors (401, 422, 500, etc.)
+    logger.error(`SMS API error: ${err.message}`);
+
+    const errorStatus = getStatus(err);
+    if (errorStatus) {
+      // Known error status - generate appropriate state change
+      return generateStateChange(message, err);
+    }
+
+    // Unknown error - retry later
+    logger.error(`Unknown error sending SMS: %o`, err);
+    // implicit return undefined for retry
+  }
+};
+
+const processMessage = (credentials, message) => {
+  return sendMessage(credentials, message);
+};
+
+module.exports = {
+  /**
+   * Given an array of messages returns a promise which resolves an array
+   * of responses.
+   * @param messages An Array of objects with a `to` String and a `message` String.
+   * @return A Promise which resolves an Array of state change objects.
+   */
+  send: messages => {
+    // get the credentials every call so changes can be made without restarting api
+    return getCredentials().then(async credentials => {
+      if (!credentials) {
+        // No credentials configured - nothing to send, preserve retry semantics
+        return [];
+      }
+      const changes = [];
+      // Process messages in batches to limit concurrency
+      for (let i = 0; i < messages.length; i += BATCH_CONCURRENCY) {
+        const batch = messages.slice(i, i + BATCH_CONCURRENCY);
+
+        // Start batch in parallel
+        const results = await Promise.allSettled(
+          batch.map(message => processMessage(credentials, message))
+        );
+
+        // Collect successful state changes
+        results.forEach((result) => {
+          if (result.status === 'fulfilled' && result.value) {
+            changes.push(result.value);
+          } else if (result.status === 'rejected') {
+            logger.error('Error sending message in parallel batch: %o', result.reason);
+            // Rejected messages will be retried later (no state change)
+          }
+        });
+      }
+
+      return changes;
+    });
+  }
+
+};

--- a/api/tests/mocha/services/nepal-doit-sms.spec.js
+++ b/api/tests/mocha/services/nepal-doit-sms.spec.js
@@ -1,0 +1,246 @@
+const chai = require('chai');
+const sinon = require('sinon');
+const request = require('@medic/couch-request');
+const secureSettings = require('@medic/settings');
+const config = require('../../../src/config');
+const service = require('../../../src/services/nepal-doit-sms');
+
+const SUCCESS_RESPONSE = {
+  message: 'Success! SMS queued !',
+  status: 1,
+  ntc: 1,
+  ncell: 0,
+  invalid_number: []
+};
+
+const INVALID_CREDENTIALS_ERROR = {
+  statusCode: 401,
+  body: {
+    message: 'Invalid credentials',
+    error: 'Unauthorized'
+  },
+  message: '401 - {"message":"Invalid credentials","error":"Unauthorized"}'
+};
+
+const UNPROCESSABLE_CONTENT_ERROR = {
+  statusCode: 422,
+  body: {
+    message: 'The given data was invalid.',
+    errors: {
+      mobile: ['The mobile format is invalid.']
+    }
+  },
+  message: '422 - {"message":"The given data was invalid.","errors":{"mobile":["The mobile format is invalid."]}}'
+};
+
+const INTERNAL_SERVER_ERROR = {
+  statusCode: 500,
+  body: {
+    message: 'Internal server error',
+    error: 'Server Error'
+  },
+  message: '500 - {"message":"Internal server error","error":"Server Error"}'
+};
+
+describe('nepal doit sms service', () => {
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('send', () => {
+
+    it('fails early with bad config - no URL', () => {
+      sinon.stub(config, 'get').returns({});
+      sinon.stub(secureSettings, 'getCredentials').resolves('test-api-key');
+      const given = [ { id: 'a', to: '+9779876543210', content: 'hello' } ];
+      return service.send(given).then(actual => {
+        // When URL is missing, sendMessage fails and returns undefined, so no state changes
+        chai.expect(actual.length).to.equal(0);
+      });
+    });
+
+    it('fails early with bad config - no API key', () => {
+      sinon.stub(config, 'get').returns({
+        nepal_doit_sms: { url: 'https://api.example.com/sms' }
+      });
+      sinon.stub(secureSettings, 'getCredentials').resolves(null);
+      const given = [ { id: 'a', to: '+9779876543210', content: 'hello' } ];
+      return service.send(given).then(actual => {
+        // When API key is missing, getCredentials returns null and send() should return no changes
+        chai.expect(actual.length).to.equal(0);
+      });
+    });
+
+    it('forwards messages to API and strips country code for Nepal', () => {
+      sinon.stub(secureSettings, 'getCredentials').resolves('test-api-key');
+      sinon.stub(config, 'get').returns({
+        nepal_doit_sms: { url: 'https://api.example.com/sms' }
+      });
+      sinon.stub(request, 'post').resolves(SUCCESS_RESPONSE);
+      const given = [ { id: 'a', to: '+9779876543210', content: 'hello' } ];
+      return service.send(given).then(actual => {
+        chai.expect(actual).to.deep.equal([{
+          messageId: 'a',
+          state: 'sent',
+          details: 'Processed'
+        }]);
+        chai.expect(request.post.callCount).to.equal(1);
+        chai.expect(request.post.args[0][0].url).to.equal('https://api.example.com/sms');
+        chai.expect(request.post.args[0][0].json).to.equal(true);
+        chai.expect(request.post.args[0][0].body.mobile).to.equal('9876543210'); // country code stripped
+        chai.expect(request.post.args[0][0].body.message).to.equal('hello');
+        chai.expect(request.post.args[0][0].headers.authorization).to.equal('Bearer test-api-key');
+        chai.expect(request.post.args[0][0].headers.accept).to.equal('application/json');
+        chai.expect(config.get.callCount).to.equal(1);
+        chai.expect(config.get.args[0][0]).to.equal('sms');
+        chai.expect(secureSettings.getCredentials.callCount).to.equal(1);
+        chai.expect(secureSettings.getCredentials.args[0][0]).to.equal('nepal_doit_sms:outgoing');
+      });
+    });
+
+    it('handles phone numbers without country code', () => {
+      sinon.stub(secureSettings, 'getCredentials').resolves('test-api-key');
+      sinon.stub(config, 'get').returns({
+        nepal_doit_sms: { url: 'https://api.example.com/sms' }
+      });
+      sinon.stub(request, 'post').resolves(SUCCESS_RESPONSE);
+      const given = [ { id: 'a', to: '9876543210', content: 'hello' } ];
+      return service.send(given).then(actual => {
+        chai.expect(actual).to.deep.equal([{
+          messageId: 'a',
+          state: 'sent',
+          details: 'Processed'
+        }]);
+        chai.expect(request.post.args[0][0].body.mobile).to.equal('9876543210'); // unchanged
+      });
+    });
+
+    it('handles HTTP error responses appropriately', () => {
+      sinon.stub(secureSettings, 'getCredentials').resolves('test-api-key');
+      sinon.stub(config, 'get').returns({
+        nepal_doit_sms: { url: 'https://api.example.com/sms' }
+      });
+      sinon.stub(request, 'post')
+        .onCall(0).resolves(SUCCESS_RESPONSE) // success
+        .onCall(1).rejects(UNPROCESSABLE_CONTENT_ERROR) // fatal error
+        .onCall(2).rejects(INTERNAL_SERVER_ERROR); // temporary error - don't update state
+      const given = [
+        { id: 'a', to: '+9779876543210', content: 'hello' },
+        { id: 'b', to: '+97798765432111', content: 'hello' },
+        { id: 'c', to: '+9779876543212', content: 'hello' }
+      ];
+      return service.send(given).then(actual => {
+        chai.expect(request.post.callCount).to.equal(3);
+        chai.expect(actual).to.deep.equal([
+          {
+            messageId: 'a',
+            state: 'sent',
+            details: 'Processed'
+          },
+          {
+            messageId: 'b',
+            state: 'failed',
+            details: 'UnprocessableContent'
+          }
+          // Note: no entry for 'c' because 500 errors have retry: true flag
+        ]);
+      });
+    });
+
+    it('handles 401 unauthorized errors', () => {
+      sinon.stub(secureSettings, 'getCredentials').resolves('invalid-api-key');
+      sinon.stub(config, 'get').returns({
+        nepal_doit_sms: { url: 'https://api.example.com/sms' }
+      });
+      sinon.stub(request, 'post').rejects(INVALID_CREDENTIALS_ERROR);
+      const given = [ { id: 'a', to: '+9779876543210', content: 'hello' } ];
+      return service.send(given).then(actual => {
+        chai.expect(actual).to.deep.equal([{
+          messageId: 'a',
+          state: 'failed',
+          details: 'InvalidCredentials'
+        }]);
+        chai.expect(request.post.callCount).to.equal(1);
+      });
+    });
+
+    it('ignores unknown errors so they will be retried', () => {
+      sinon.stub(secureSettings, 'getCredentials').resolves('test-api-key');
+      sinon.stub(config, 'get').returns({
+        nepal_doit_sms: { url: 'https://api.example.com/sms' }
+      });
+      sinon.stub(request, 'post').rejects(new Error('Network timeout'));
+      const given = [ { id: 'a', to: '+9779876543210', content: 'hello' } ];
+      return service.send(given).then(actual => {
+        chai.expect(request.post.callCount).to.equal(1);
+        chai.expect(actual.length).to.equal(0);
+      });
+    });
+
+    it('ignores responses with invalid status so they will be retried', () => {
+      sinon.stub(secureSettings, 'getCredentials').resolves('test-api-key');
+      sinon.stub(config, 'get').returns({
+        nepal_doit_sms: { url: 'https://api.example.com/sms' }
+      });
+      sinon.stub(request, 'post').resolves({
+        message: 'Unknown status',
+        status: 999, // invalid status not in STATUS_MAP
+        ntc: 0,
+        ncell: 0,
+        invalid_number: []
+      });
+      const given = [ { id: 'a', to: '+9779876543210', content: 'hello' } ];
+      return service.send(given).then(actual => {
+        chai.expect(request.post.callCount).to.equal(1);
+        chai.expect(actual.length).to.equal(0);
+      });
+    });
+
+    it('handles empty response', () => {
+      sinon.stub(secureSettings, 'getCredentials').resolves('test-api-key');
+      sinon.stub(config, 'get').returns({
+        nepal_doit_sms: { url: 'https://api.example.com/sms' }
+      });
+      sinon.stub(request, 'post').resolves(null);
+      const given = [ { id: 'a', to: '+9779876543210', content: 'hello' } ];
+      return service.send(given).then(actual => {
+        chai.expect(request.post.callCount).to.equal(1);
+        chai.expect(actual.length).to.equal(0);
+      });
+    });
+
+    it('sends multiple messages sequentially', () => {
+      sinon.stub(secureSettings, 'getCredentials').resolves('test-api-key');
+      sinon.stub(config, 'get').returns({
+        nepal_doit_sms: { url: 'https://api.example.com/sms' }
+      });
+      sinon.stub(request, 'post').resolves(SUCCESS_RESPONSE);
+      const given = [
+        { id: 'a', to: '+9779876543210', content: 'hello' },
+        { id: 'b', to: '+9779876543211', content: 'world' }
+      ];
+      return service.send(given).then(actual => {
+        chai.expect(request.post.callCount).to.equal(2);
+        chai.expect(actual).to.deep.equal([
+          {
+            messageId: 'a',
+            state: 'sent',
+            details: 'Processed'
+          },
+          {
+            messageId: 'b',
+            state: 'sent',
+            details: 'Processed'
+          }
+        ]);
+        chai.expect(request.post.args[0][0].body.mobile).to.equal('9876543210');
+        chai.expect(request.post.args[0][0].body.message).to.equal('hello');
+        chai.expect(request.post.args[1][0].body.mobile).to.equal('9876543211');
+        chai.expect(request.post.args[1][0].body.message).to.equal('world');
+      });
+    });
+
+  });
+
+});


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

(cherry picked from commit 2b9065540a96ad7205a56913b7285123d6ee6ade)

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10225-for-4.x/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10225-for-4.x/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10225-for-4.x/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

