### PR TITLE
fix(APIs): CORS misconfiguration for credentials transfer 

### DIFF
--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -144,17 +144,24 @@ app.use(prometheusMiddleware({
 // from different domains (e.g. localhost:5988 vs localhost:8080).  Adding the
 // --allow-cors commandline switch will enable this from within a web browser.
 if (process.argv.slice(2).includes('--allow-cors')) {
-  logger.warn('WARNING: allowing CORS requests to API!');
+  logger.warn('WARNING: allowing CORS requests to API! Only the following origins will be allowed:');
+  // Whitelist of allowed origins for CORS with credentials. Update as needed for your use-case.
+  const allowedOrigins = [
+    'http://localhost:8080',
+    'http://localhost:5988',
+    // add more origins as needed
+  ];
+  logger.warn(`CORS whitelist: ${allowedOrigins.join(', ')}`);
   app.use((req, res, next) => {
-    res.setHeader(
-      'Access-Control-Allow-Origin',
-      req.headers.origin || req.headers.host
-    );
+    const origin = req.headers.origin;
+    if (origin && allowedOrigins.includes(origin) && origin !== 'null') {
+      res.setHeader('Access-Control-Allow-Origin', origin);
+      res.setHeader('Access-Control-Allow-Credentials', 'true');
+    }
     res.setHeader(
       'Access-Control-Allow-Methods',
       'GET, POST, PUT, OPTIONS, HEAD, DELETE'
     );
-    res.setHeader('Access-Control-Allow-Credentials', 'true');
     next();
   });
 }


### PR DESCRIPTION


### Summary
A server can send the `"Access-Control-Allow-Credentials"` CORS header to control when a browser may send user credentials in Cross-Origin HTTP requests. when the `Access-Control-Allow-Credentials` header is `"true"`, the `Access-Control-Allow-Origin` header must have a value different from "*" in order to make browsers accept the header. Therefore, to allow multiple origins for Cross-Origin requests with credentials, the server must dynamically compute the value of the `"Access-Control-Allow-Origin"` header. Computing this header value from information in the request to the server can therefore potentially allow an attacker to control the origins that the browser sends credentials to.



### Description Of Changes
Fix this problem, we need to ensure that when `Access-Control-Allow-Credentials` is set to `'true'`, we do not blindly echo any requested origin. This is best accomplished by introducing a whitelist of allowed origins and only setting `Access-Control-Allow-Origin` if the requested origin is strictly present in the whitelist. This matches the secure pattern described in the provided background. The fix should be applied inside the middleware added in lines 148–159 within `api/src/routing.js`. We should define a static array or object of allowed origins, check if the value in `req.headers.origin` matches one, and only then set `Access-Control-Allow-Origin`. We must also ensure we never respond with `"null"` or `"*"`. We can keep the warning to further discourage unsafe usage.

To implement this, we need:
- An array or object (whitelist) of allowed origins.
- A sanitation/validation check in the middleware before setting the header.
- If the requested origin is not allowed, do not set `Access-Control-Allow-Origin` (or explicitly reject the request with a 403 error, though for compatibility we may prefer just skipping the header).

### References
[CORS, Access-Control-Allow-Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin)
[CORS, Access-Control-Allow-Credentials](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials)
[CORS Misconfigurations for Bitcoins and Bounties](http://blog.portswigger.net/2016/10/exploiting-cors-misconfigurations-for.html)
[CORS for developers, Advice for Resource Owners](https://w3c.github.io/webappsec-cors-for-developers/#resources)



# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

