### PR TITLE
feat(#10317): support reporting periods in rules engine service

### DIFF
--- a/webapp/tests/karma/ts/services/rules-engine.service.spec.ts
+++ b/webapp/tests/karma/ts/services/rules-engine.service.spec.ts
@@ -1078,19 +1078,14 @@ describe('RulesEngineService', () => {
       expect(actual).to.deep.eq([]);
     });
 
-    it('should return zero values when target interval is not found', async () => {
+    it('should return empty array when target interval is not found', async () => {
       getTargetInterval.resolves(null);
       service = TestBed.inject(RulesEngineService);
 
       const actual = await service.fetchTargets(ReportingPeriod.PREVIOUS);
 
       expect(getTargetInterval.calledOnce).to.be.true;
-      expect(actual.length).to.eq(1);
-      expect(actual[0]).to.include({
-        id: 'target',
-        visible: true
-      });
-      expect(actual[0].value).to.deep.eq({ pass: 0, total: 0 });
+      expect(actual).to.deep.eq([]);
     });
 
     it('should handle errors and return empty array', async () => {
@@ -1159,12 +1154,10 @@ describe('RulesEngineService', () => {
 
       const actual = await service.fetchTargets(ReportingPeriod.PREVIOUS);
 
-      expect(actual.length).to.eq(2);
+      // Only returns targets that exist in the interval doc
+      expect(actual.length).to.eq(1);
       expect(actual[0]).to.include({ id: 'target' });
       expect(actual[0].value).to.deep.eq({ pass: 3, total: 7 });
-      // Second target not in interval doc, should have zero values
-      expect(actual[1]).to.include({ id: 'another-target' });
-      expect(actual[1].value).to.deep.eq({ pass: 0, total: 0, percent: 0 });
     });
   });
 });


### PR DESCRIPTION
# Description

Closes #10317

This pull request updates the rules engine service to support returning targets for the previous month.



# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

