### PR TITLE
chore(#10374): stabilize search reports by case_id

### DIFF
--- a/tests/e2e/default-mobile/reports/search.wdio-spec.js
+++ b/tests/e2e/default-mobile/reports/search.wdio-spec.js
@@ -70,7 +70,7 @@ describe('Search Reports', () => {
 
     await reportsPage.openReport(hospitalReport.id);
     await reportsPage.clickOnCaseId();
-    await commonPage.waitForPageLoaded();
+    await commonPage.waitForLoaders();
     expect((await reportsPage.reportsListDetails()).length).to.equal(2);
     expect(await reportsPage.leftPanelSelectors.reportByUUID(hospitalReport.id).isDisplayed()).to.be.true;
     expect(await reportsPage.leftPanelSelectors.reportByUUID(healthCenterReport.id).isDisplayed()).to.be.true;


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

closes #10374

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10374-stabilize-search-reports-by-case-id/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10374-stabilize-search-reports-by-case-id/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10374-stabilize-search-reports-by-case-id/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

