### PR TITLE
chore(#10382): fix duplicate contacts e2e test

### DIFF
--- a/tests/e2e/default/contacts/duplicate-contacts.wdio-spec.js
+++ b/tests/e2e/default/contacts/duplicate-contacts.wdio-spec.js
@@ -11,8 +11,7 @@ const contactsPage = require('@page-objects/default/contacts/contacts.wdio.page'
 const { getTelemetryDbName, destroyDbInBrowser, getTelemetryFromBrowser } = require('@utils/telemetry');
 const { USERNAME } = require('@constants');
 
-// skipped due to https://github.com/medic/cht-core/issues/10382
-describe.skip('Duplicate contact detection', () => {
+describe('Duplicate contact detection', () => {
   const CREATED_ON = '4 Apr, 2025';
   const TELEMETRY_DB_NAME= getTelemetryDbName(USERNAME, new Date());
   const CREATE_PERSON_FORM_ID = 'form:contact:person:create';

--- a/tests/page-objects/default/contacts/contacts.wdio.page.js
+++ b/tests/page-objects/default/contacts/contacts.wdio.page.js
@@ -236,7 +236,7 @@ const addPerson = async (
   await commonEnketoPage.setDateValue('Age', dobValue);
   await commonEnketoPage.setInputValue('External ID', externalIDValue);
   await commonEnketoPage.setTextareaValue('Notes', notesValue);
-  await genericForm.submitForm();
+  await genericForm.submitForm({ waitForPageLoaded: waitForComplete });
   if (waitForSentinel) {
     await sentinelUtils.waitForSentinel();
   }


### PR DESCRIPTION
# Description

Updates the contact page test util to not wait for the submission of the person form to succeed when `waitForComplete` is false.

Closes https://github.com/medic/cht-core/issues/10382

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [X] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [X] Tested: Unit and/or e2e where appropriate

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

