### PR TITLE
build: add missing upload steps for extension libs, privacy policies and branding

### DIFF
--- a/scripts/build/build-config.sh
+++ b/scripts/build/build-config.sh
@@ -14,7 +14,10 @@ node ./node_modules/.bin/cht \
   upload-collect-forms \
   upload-contact-forms \
   upload-resources \
-  upload-custom-translations
+  upload-custom-translations \
+  upload-extension-libs \
+  upload-privacy-policies \
+  upload-branding
 
 echo "build-config: done"
 


### PR DESCRIPTION
## Overview
This PR fixes issue #10450 by adding missing upload steps in the build-config.sh script for extension libraries, privacy policies and branding assets. These steps were inadvertently omitted from the deployment process.

## Checklist
- [x] Code changes have been tested and verified
- [x] All relevant tests are passing
- [x] Documentation has been updated as needed

## Proof
The fix has been tested by running the build-config.sh script which now includes the missing upload steps:
- upload-extension-libs
- upload-privacy-policies 
- upload-branding

The deployment process now properly uploads all required assets as part of the configuration build.

Closes #10450