### PR TITLE
chore: pin `regctl-installer` to a specific version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -400,7 +400,7 @@ jobs:
     steps:
     - name: Install regctl
       if: ${{ env.INTERNAL_CONTRIBUTOR }}
-      uses: regclient/actions/regctl-installer@main
+      uses: regclient/actions/regctl-installer@df29323daedc1f78ee74b261bd8d849327cb4ff0
 
     - name: Configure AWS credentials
       if: ${{ env.INTERNAL_CONTRIBUTOR }}


### PR DESCRIPTION
# Description

The latest version of the [`regctl` GitHub action](https://github.com/regclient/actions) seems to have an issue (at least with the way that we have been using it in our CI run.  

There is an [open PR](https://github.com/regclient/actions/pull/33) to fix the issue, but regardless it is a best practice that we should pin the version of `regctl-installer` so we do not hit this kind of problem randomly.  

The `regctl-installer` action is not versioned, so I have just pined to the latest commit has prior to the one that presumably caused the issue.  :+1: 





# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:jkuester-test/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:jkuester-test/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:jkuester-test/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

