### PR TITLE
chore: update release templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/z_release_feature.md
+++ b/.github/ISSUE_TEMPLATE/z_release_feature.md
@@ -7,20 +7,19 @@ assignees: ''
 
 ---
 
-When development is ready to begin on a [Feature Release](https://docs.communityhealthtoolkit.org/core/releases/feature_releases/#release-names), an engineer should be nominated as a Release Engineer. They will be responsible for making sure the following tasks are followed, though not necessarily doing the work themselves.
+When development is ready to begin on a [Feature Release](https://docs.communityhealthtoolkit.org/core/releases/feature_releases/#release-names), a maintainer should be nominated as a Release Manager. They will be responsible for making sure the following tasks are followed, though not necessarily doing the work themselves.
 
 # Planning
 
-- [ ] Create a GH Milestone for the release.
+- [ ] Create a GH Milestone for the release and add this issue to it.
 - [ ] Add all the issues to be worked on to the Milestone.
 - [ ] Have an actual named deployment and specific end user that will be testing this Feature Release. They need to test in production, on the latest version. No speculative Feature Releases.
-- [ ] Assign an engineer as Release Engineer for this release.
+- [ ] Assign a maintainer as Release Manager for this release.
 
 # Development
 
 - [ ] Create a new release branch in `cht-core` from the most recent release and call it  `<major>.<minor>.<patch>-FR-<FEATURE-NAME>`. If latest is `3.15.0` and the feature is to "allow movies to be uploaded", call it `3.15.0-FR-movie-upload`. Done before the release so all PRs can be set to merge to this branch, and not to `master`.
 - [ ] Set the version number in `package.json` and `package-lock.json` and submit a PR. The easiest way to do this is to use `npm --no-git-tag-version version <feature-release>`.
-- [ ] Ensure QA is briefed and is partnering with the Engineers and any involved CHT Community members to ensure early and often checks of the feature are on track to be of production quality from the start.
 
 # Releasing
 

--- a/.github/ISSUE_TEMPLATE/z_release_major.md
+++ b/.github/ISSUE_TEMPLATE/z_release_major.md
@@ -9,19 +9,21 @@ assignees: ''
 
 # Planning - CHT Community 
 
-- [ ] Create a GH Milestone for the release. We use [semver](http://semver.org) so if there are breaking changes increment the major, otherwise if there are new features increment the minor, otherwise increment the service pack. Breaking changes in our case relate to updated software requirements (egs: CouchDB, node, minimum browser versions), broken backwards compatibility in an api, or a major visual update that requires user retraining.
+- [ ] Create a GH Milestone for the release and add this issue to it. We use [semver](http://semver.org) so if there are breaking changes increment the major, otherwise if there are new features increment the minor, otherwise increment the service pack. Breaking changes for the CHT relate to updated software requirements (for example: CouchDB, node, minimum browser versions), broken backwards compatibility in an API, or a major visual update that requires user retraining.
 - [ ] Add all the issues to be worked on to the Milestone. Ideally each minor release will have one or two features, a handful of improvements, and plenty of bug fixes.
-- [ ] Identify any features and improvements in the release that need end-user documentation (beyond eng team documentation improvements) and create corresponding issues in the cht-docs repo.
-- [ ] Assign an engineer as Release Engineer for this release.
+- [ ] Ensure that all issues are labelled correctly, particularly "UI/UX" and "Breaking change" labelled issues, if any. 
+- [ ] Ensure that "Regressions" are labelled with "Affects: <version>" labels. The "Affects" label is used in a link in the Known Issues section of the release notes of that version so it has to match exactly. To make sure the label is correct go to the [release notes](https://docs.communityhealthtoolkit.org/core/releases/#release-notes) and ensure the issue is listed.
+- [ ] Identify any features and improvements in the release that need end-user documentation (beyond technical documentation improvements) and create corresponding issues in the cht-docs repo.
+- [ ] Assign a maintainer as Release Manager for this release.
 
-# Development - Release Engineer
+# Development - Release Manager
 
-When development is ready to begin one of the engineers should be nominated as a Release Engineer. They will be responsible for making sure the following tasks are completed though not necessarily completing them.
+When development is ready to begin one of the maintainers should be nominated as a Release Manager. They will be responsible for making sure the following tasks are completed though not necessarily completing them.
 
 - [ ] Checkout to a new `<issue>-update-version` branch (eg: `1234-update-version`) and set the version number in the `package.json` and `package-lock.json`. The easiest way to do this is to use `npm --no-git-tag-version version <major|minor>`. Once the version is updated, submit a PR to `master` branch.
 - [ ] Ensure that issues associated with commits merged to `master` since the last release are closed and mapped to the milestone.
 
-# Releasing - Release Engineer
+# Releasing - Release Manager
 
 Once the PR has been merged into `master`, and the `master` branch has the new version number, then the release process can start:
 
@@ -47,6 +49,6 @@ If all is good, then in 24h, I will start the release. Thanks!
 - [ ] Once you publish the release, confirm the release build completes successfully and the new release is available on the [market](https://staging.dev.medicmobile.org/_couch/builds_4/_design/builds/_view/releases). Make sure that the document has new entry with `id: medic:medic:<major>.<minor>.<patch>`
 - [ ] Upgrade the [demo](https://demo-cht.dev.medicmobile.org/) instance to the newly released version.
 - [ ] Use cht-conf to upload the configuration from the `cht-core/config/demo` folder to the `demo-cht.dev` server.
-- [ ] Announce the release on the [CHT forum](https://forum.communityhealthtoolkit.org/c/product/releases/26), under the "Product - Releases" category using this [template](https://forum.communityhealthtoolkit.org/new-topic?title=Announcing%20the%20release%20of%20%3Cmajor%3E.%3Cminor%3E.%3Cpatch%3E%20of%20the%20CHT%20Core%20Framework&body=%2AWe%27re%20excited%20to%20announce%20the%20release%20of%20%7B%7Bversion%7D%7D%20of%20CHT%20Core%20Framework%2A%0A%0ASee%20below%20for%20some%20highlights%2C%20read%20the%20%5Brelease%20notes%5D%28PASTE_RELEASE_NOTES_URL_HERE%29%20for%20full%20details.%0A%0AFollowing%20the%20CHT%27s%20support%20policy%2C%20versions%20%7B%7Bversions%7D%7D%20are%20no%20longer%20supported.%20Projects%20running%20these%20versions%20should%20start%20planning%20to%20upgrade%20in%20the%20near%20future.%20For%20more%20details%20read%20the%20CHT%20%5Bsoftware%20support%20documentation%5D%28https%3A%2F%2Fdocs.communityhealthtoolkit.org%2Fcore%2Freleases%2F%23supported-versions%29.%0A%0A%23%23%20%7B%7Bversion%7D%7D%20Highlights%0A%0A%23%23%3A%20%5B%7B%7BHighlight%201%20Title%7D%7D%5D%28PASTE_URL_TO_SECTION_HERE%29%0A%0ADescription%20of%20highlight%20section%0A%0A%23%23%3A%20%5B%7B%7BHighlight%202%20Title%7D%7D%5D%28PASTE_URL_TO%20SECTION_HERE%29%0A%0ADescription%20of%20highlight%20section%0A%0A%23%23%3A%20%5BAnd%20more...%5D%28PASTE_URL_TO_SECTION_HERE%29%0A%0AWe%E2%80%99ve%20also%20implemented%20loads%20of%20other%20improvements%20and%20fixed%20a%20heap%20of%20bugs.&category=releases).
+- [ ] Announce the release on the [CHT Forum](https://forum.communityhealthtoolkit.org/c/product/releases/26), under the "Announcements - Releases" category using this [template](https://forum.communityhealthtoolkit.org/new-topic?title=Announcing%20the%20release%20of%20%3Cmajor%3E.%3Cminor%3E.%3Cpatch%3E%20of%20the%20CHT%20Core%20Framework&body=%2AWe%27re%20excited%20to%20announce%20the%20release%20of%20%7B%7Bversion%7D%7D%20of%20CHT%20Core%20Framework%2A%0A%0ASee%20below%20for%20some%20highlights%2C%20read%20the%20%5Brelease%20notes%5D%28PASTE_RELEASE_NOTES_URL_HERE%29%20for%20full%20details.%0A%0AFollowing%20the%20CHT%27s%20support%20policy%2C%20versions%20%7B%7Bversions%7D%7D%20are%20no%20longer%20supported.%20Projects%20running%20these%20versions%20should%20start%20planning%20to%20upgrade%20in%20the%20near%20future.%20For%20more%20details%20read%20the%20CHT%20%5Bsoftware%20support%20documentation%5D%28https%3A%2F%2Fdocs.communityhealthtoolkit.org%2Fcore%2Freleases%2F%23supported-versions%29.%0A%0A%23%23%20%7B%7Bversion%7D%7D%20Highlights%0A%0A%23%23%3A%20%5B%7B%7BHighlight%201%20Title%7D%7D%5D%28PASTE_URL_TO_SECTION_HERE%29%0A%0ADescription%20of%20highlight%20section%0A%0A%23%23%3A%20%5B%7B%7BHighlight%202%20Title%7D%7D%5D%28PASTE_URL_TO%20SECTION_HERE%29%0A%0ADescription%20of%20highlight%20section%0A%0A%23%23%3A%20%5BAnd%20more...%5D%28PASTE_URL_TO_SECTION_HERE%29%0A%0AWe%E2%80%99ve%20also%20implemented%20loads%20of%20other%20improvements%20and%20fixed%20a%20heap%20of%20bugs.&category=releases).
 - [ ] Go over the list of commits and individually notify contributing / interested community members about the release. 
 - [ ] Mark this issue "done" and close the Milestone.

--- a/.github/ISSUE_TEMPLATE/z_release_patch.md
+++ b/.github/ISSUE_TEMPLATE/z_release_patch.md
@@ -9,19 +9,19 @@ assignees: ''
 
 # Planning - CHT Community 
 
-- [ ] Create an GH Milestone and add this issue to it.
+- [ ] Create an GH Milestone for the release and add this issue to it.
 - [ ] Add all the issues to be worked on to the Milestone.
 - [ ] Ensure that all issues are labelled correctly, particularly ensure that "Regressions" are labelled with "Affects: <version>" labels. The "Affects" label is used in a link in the Known Issues section of the release notes of that version so it has to match exactly. To make sure the label is correct go to the [release notes](https://docs.communityhealthtoolkit.org/core/releases/#release-notes) and ensure the issue is listed.
 
-# Development - Release Engineer
+# Development - Release Manager
 
-When development is ready to begin one of the engineers should be nominated as a Release Engineer. They will be responsible for making sure the following tasks are completed though not necessarily completing them.
+When development is ready to begin one of the maintainers should be nominated as a Release Manager. They will be responsible for making sure the following tasks are completed though not necessarily completing them.
 
 - [ ] Set the version number in `package.json` and `package-lock.json` and submit a PR to the release branch. The easiest way to do this is to use `npm --no-git-tag-version version patch`.
 - [ ] Ensure that issues from merged commits are closed and mapped to a milestone.
-- [ ] Write an update in the #stewardship-team Slack channel summarising development and identifying any blockers (the [milestone-status](https://github.com/medic/support-scripts/tree/master/milestone-status) script can be used to get a breakdown of the issues). The Release Engineer is to update this every week until the version is released.
+- [ ] Write an update in the #stewardship-team Slack channel summarising development and identifying any blockers (the [milestone-status](https://github.com/medic/support-scripts/tree/master/milestone-status) script can be used to get a breakdown of the issues). The Release Manager is to update this every week until the version is released.
 
-# Releasing - Release Engineer
+# Releasing - Release Manager
 
 Once all issues have been merged into `master` then the release process can start:
 
@@ -37,7 +37,7 @@ Once all issues have been merged into `master` then the release process can star
 - [ ] Create a [new release](https://github.com/medic/cht-core/releases/new) in GitHub, with the naming convention `<major>.<minor>.<patch>`, from the release branch created above as the target branch. Click on the "Choose a tag" dropdown and create a tag for the release with the naming convention `<major>.<minor>.<patch>`. Add a link to the release notes page in the description of the release.
 - [ ] Once you publish the release, confirm the release build completes successfully and the new release is available on the [market](https://staging.dev.medicmobile.org/_couch/builds_4/_design/builds/_view/releases). Make sure that the document has new entry with `id: medic:medic:<major>.<minor>.<patch>`
 - [ ] Upgrade the [demo](https://demo-cht.dev.medicmobile.org/) instance to the newly released version.
-- [ ] Announce the release on the [CHT forum](https://forum.communityhealthtoolkit.org/), under the "Product - Releases" category using this [template](https://forum.communityhealthtoolkit.org/new-topic?title=Announcing%20the%20release%20of%20%3Cmajor%3E.%3Cminor%3E.%3Cpatch%3E%20of%20the%20CHT%20Core%20Framework&body=%2AAnnouncing%20the%20release%20of%20%7B%7Bversion%7D%7D%20of%20%7B%7Bproduct%7D%7D%2A%0AThis%20release%20fixes%20%7B%7Bnumber%20of%20bugs%7D%7D.%20Read%20the%20%5Brelease%20notes%5D%28%7B%7Burl%7D%7D%29%20for%20full%20details.&category=releases).
+- [ ] Announce the release on the [CHT Forum](https://forum.communityhealthtoolkit.org/), under the "Announcements - Releases" category using this [template](https://forum.communityhealthtoolkit.org/new-topic?title=Announcing%20the%20release%20of%20%3Cmajor%3E.%3Cminor%3E.%3Cpatch%3E%20of%20the%20CHT%20Core%20Framework&body=%2AAnnouncing%20the%20release%20of%20%7B%7Bversion%7D%7D%20of%20%7B%7Bproduct%7D%7D%2A%0AThis%20release%20fixes%20%7B%7Bnumber%20of%20bugs%7D%7D.%20Read%20the%20%5Brelease%20notes%5D%28%7B%7Burl%7D%7D%29%20for%20full%20details.&category=releases).
 - [ ] Go over the list of commits and individually notify contributing / interested community members about the release.
 - [ ] Go to the [Issues tab](https://github.com/medic/cht-core/issues) and filter the issues with `is:issue label:"Affects: 4.x.x" ` , replace `4.x.x` with the previous version number. Add any open "known issues" from the prior release that were not fixed in this release. Done by adding the correct `Affects: 4.x.x` label.
 - [ ] Mark this issue "done" and close the Milestone.


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->
Update release templates to insist on issue labelling. 

<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:release-template-tweaks/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:release-template-tweaks/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:release-template-tweaks/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

