### PR TITLE
chore(#10483): fix datasource tests race condition with sentinel

### DIFF
--- a/tests/integration/shared-libs/cht-datasource/contact.spec.js
+++ b/tests/integration/shared-libs/cht-datasource/contact.spec.js
@@ -1,10 +1,10 @@
 const utils = require('@utils');
+const sentinelUtils = require('@utils/sentinel');
 const personFactory = require('@factories/cht/contacts/person');
 const placeFactory = require('@factories/cht/contacts/place');
 const userFactory = require('@factories/cht/users/users');
-const {getRemoteDataContext, Qualifier, Contact} = require('@medic/cht-datasource');
-const {expect} = require('chai');
-const {setAuth, removeAuth} = require('./auth');
+const { getRemoteDataContext, Qualifier, Contact } = require('@medic/cht-datasource');
+const { setAuth, removeAuth } = require('./auth');
 
 describe('cht-datasource Contact', () => {
   // NOTE: this is a common word added to contacts to fetch them
@@ -110,9 +110,12 @@ describe('cht-datasource Contact', () => {
   const expectedPlaces = [ place0, clinic1, clinic2 ];
   const expectedPlacesIds = expectedPlaces.map(place => place._id);
 
+  const excludedProperties = [ '_rev', 'reported_date', 'patient_id', 'place_id' ];
+
   before(async () => {
     setAuth();
     await utils.saveDocs(allDocItems);
+    await sentinelUtils.waitForSentinel();
     await utils.createUsers([ userNoPerms, offlineUser ]);
   });
 
@@ -129,17 +132,17 @@ describe('cht-datasource Contact', () => {
 
       it('returns the person contact matching the provided UUID', async () => {
         const person = await getContact(Qualifier.byUuid(patient._id));
-        expect(person).excluding([ '_rev', 'reported_date' ]).to.deep.equal(patient);
+        expect(person).excluding(excludedProperties).to.deep.equal(patient);
       });
 
       it('returns the place contact matching the provided UUID', async () => {
         const place = await getContact(Qualifier.byUuid(place0._id));
-        expect(place).excluding([ '_rev', 'reported_date' ]).to.deep.equal(place0);
+        expect(place).excluding(excludedProperties).to.deep.equal(place0);
       });
 
       it('returns the person contact with lineage when the withLineage query parameter is provided', async () => {
         const person = await getContactWithLineage(Qualifier.byUuid(patient._id));
-        expect(person).excludingEvery([ '_rev', 'reported_date' ]).to.deep.equal({
+        expect(person).excludingEvery(excludedProperties).to.deep.equal({
           ...patient, parent: {
             ...place0, contact: contact0, parent: {
               ...place1, contact: contact1, parent: {
@@ -152,7 +155,7 @@ describe('cht-datasource Contact', () => {
 
       it('returns the place contact with lineage when the withLineage query parameter is provided', async () => {
         const place = await getContactWithLineage(Qualifier.byUuid(place0._id));
-        expect(place).excludingEvery([ '_rev', 'reported_date' ]).to.deep.equal({
+        expect(place).excludingEvery(excludedProperties).to.deep.equal({
           ...place0, contact: contact0, parent: {
             ...place1, contact: contact1, parent: {
               ...place2, contact: contact2
@@ -253,7 +256,7 @@ describe('cht-datasource Contact', () => {
 
         const allData = [ ...firstPage.data, ...secondPage.data ];
 
-        expect(allData).excludingEvery([ '_rev', 'reported_date' ]).to.deep.equalInAnyOrder(expectedPlacesIds);
+        expect(allData).excludingEvery(excludedProperties).to.deep.equalInAnyOrder(expectedPlacesIds);
         expect(firstPage.data.length).to.be.equal(2);
         expect(secondPage.data.length).to.be.equal(1);
         expect(firstPage.cursor).to.be.equal('2');
@@ -269,7 +272,7 @@ describe('cht-datasource Contact', () => {
 
         const allData = [ ...firstPage.data, ...secondPage.data ];
 
-        expect(allData).excludingEvery([ '_rev', 'reported_date' ]).to.deep.equalInAnyOrder(expectedContactIds);
+        expect(allData).excludingEvery(excludedProperties).to.deep.equalInAnyOrder(expectedContactIds);
         expect(firstPage.data.length).to.be.equal(3);
         expect(secondPage.data.length).to.be.equal(3);
         expect(firstPage.cursor).to.not.equal(emptyNouveauCursor);
@@ -289,7 +292,7 @@ describe('cht-datasource Contact', () => {
 
         const allData = [ ...firstPage.data, ...secondPage.data ];
 
-        expect(allData).excludingEvery([ '_rev', 'reported_date' ]).to.deep.equalInAnyOrder(expectedContactIds);
+        expect(allData).excludingEvery(excludedProperties).to.deep.equalInAnyOrder(expectedContactIds);
         expect(firstPage.data.length).to.be.equal(2);
         expect(secondPage.data.length).to.be.equal(1);
         expect(firstPage.cursor).to.not.equal(emptyNouveauCursor);
@@ -387,7 +390,7 @@ describe('cht-datasource Contact', () => {
           docs.push(doc);
         }
 
-        expect(docs).excluding([ '_rev', 'reported_date' ]).to.deep.equalInAnyOrder(expectedPeopleIds);
+        expect(docs).excluding(excludedProperties).to.deep.equalInAnyOrder(expectedPeopleIds);
       });
     });
   });

--- a/tests/integration/shared-libs/cht-datasource/person.spec.js
+++ b/tests/integration/shared-libs/cht-datasource/person.spec.js
@@ -1,10 +1,10 @@
 const utils = require('@utils');
+const sentinelUtils = require('@utils/sentinel');
 const placeFactory = require('@factories/cht/contacts/place');
 const personFactory = require('@factories/cht/contacts/person');
 const { getRemoteDataContext, Person, Qualifier } = require('@medic/cht-datasource');
-const { expect } = require('chai');
 const userFactory = require('@factories/cht/users/users');
-const {setAuth, removeAuth} = require('./auth');
+const { setAuth, removeAuth } = require('./auth');
 
 describe('cht-datasource Person', () => {
   const contact0 = utils.deepFreeze(personFactory.build({ name: 'contact0', role: 'chw' }));
@@ -86,9 +86,12 @@ describe('cht-datasource Person', () => {
     }
   ];
 
+  const excludedProperties = [ '_rev', 'reported_date', 'patient_id', 'place_id' ];
+
   before(async () => {
     setAuth();
     await utils.saveDocs(allDocItems);
+    await sentinelUtils.waitForSentinel();
     await utils.createUsers([userNoPerms, offlineUser]);
   });
 
@@ -104,7 +107,7 @@ describe('cht-datasource Person', () => {
 
       it('returns the person matching the provided UUID', async () => {
         const person = await getPerson(Qualifier.byUuid(patient._id));
-        expect(person).excluding([ '_rev', 'reported_date' ]).to.deep.equal(patient);
+        expect(person).excluding(excludedProperties).to.deep.equal(patient);
       });
 
       it('returns null when no person is found for the UUID', async () => {
@@ -118,7 +121,7 @@ describe('cht-datasource Person', () => {
 
       it('returns the person with lineage', async () => {
         const person = await getPersonWithLineage(Qualifier.byUuid(patient._id));
-        expect(person).excludingEvery([ '_rev', 'reported_date' ]).to.deep.equal({
+        expect(person).excludingEvery(excludedProperties).to.deep.equal({
           ...patient,
           parent: {
             ...place0,
@@ -149,7 +152,7 @@ describe('cht-datasource Person', () => {
         const responsePeople = responsePage.data;
         const responseCursor = responsePage.cursor;
 
-        expect(responsePeople).excludingEvery([ '_rev', 'reported_date' ]).to.deep.equalInAnyOrder(expectedPeople);
+        expect(responsePeople).excludingEvery(excludedProperties).to.deep.equalInAnyOrder(expectedPeople);
         expect(responseCursor).to.be.equal(null);
       });
 
@@ -158,7 +161,7 @@ describe('cht-datasource Person', () => {
         const responsePeople = responsePage.data;
         const responseCursor = responsePage.cursor;
 
-        expect(responsePeople).excludingEvery([ '_rev', 'reported_date' ]).to.deep.equalInAnyOrder(expectedPeople);
+        expect(responsePeople).excludingEvery(excludedProperties).to.deep.equalInAnyOrder(expectedPeople);
         expect(responseCursor).to.be.equal('7');
       });
 
@@ -168,7 +171,7 @@ describe('cht-datasource Person', () => {
 
         const allPeople = [ ...firstPage.data, ...secondPage.data ];
 
-        expect(allPeople).excludingEvery([ '_rev', 'reported_date' ]).to.deep.equalInAnyOrder(expectedPeople);
+        expect(allPeople).excludingEvery(excludedProperties).to.deep.equalInAnyOrder(expectedPeople);
         expect(firstPage.data.length).to.be.equal(4);
         expect(secondPage.data.length).to.be.equal(3);
         expect(firstPage.cursor).to.be.equal('4');
@@ -204,7 +207,7 @@ describe('cht-datasource Person', () => {
           docs.push(doc);
         }
 
-        expect(docs).excluding([ '_rev', 'reported_date' ]).to.deep.equalInAnyOrder(expectedPeople);
+        expect(docs).excluding(excludedProperties).to.deep.equalInAnyOrder(expectedPeople);
       });
     });
   });

--- a/tests/integration/shared-libs/cht-datasource/place.spec.js
+++ b/tests/integration/shared-libs/cht-datasource/place.spec.js
@@ -1,10 +1,10 @@
 const utils = require('@utils');
+const sentinelUtils = require('@utils/sentinel');
 const placeFactory = require('@factories/cht/contacts/place');
 const personFactory = require('@factories/cht/contacts/person');
 const { getRemoteDataContext, Place, Qualifier } = require('@medic/cht-datasource');
-const { expect } = require('chai');
 const userFactory = require('@factories/cht/users/users');
-const {setAuth, removeAuth} = require('./auth');
+const { setAuth, removeAuth } = require('./auth');
 
 describe('cht-datasource Place', () => {
   const contact0 = utils.deepFreeze(personFactory.build({ name: 'contact0', role: 'chw' }));
@@ -75,9 +75,12 @@ describe('cht-datasource Place', () => {
   const dataContext = getRemoteDataContext(utils.getOrigin());
   const expectedPlaces = [place0, clinic1, clinic3];
 
+  const excludedProperties = [ '_rev', 'reported_date', 'patient_id', 'place_id' ];
+
   before(async () => {
     setAuth();
     await utils.saveDocs([contact0, contact1, contact2, place0, place1, place2, clinic1, clinic3, healthCenter2]);
+    await sentinelUtils.waitForSentinel();
     await utils.createUsers([userNoPerms, offlineUser]);
   });
 
@@ -93,7 +96,7 @@ describe('cht-datasource Place', () => {
 
       it('returns the place matching the provided UUID', async () => {
         const place = await getPlace(Qualifier.byUuid(place0._id));
-        expect(place).excluding([ '_rev', 'reported_date' ]).to.deep.equal(place0);
+        expect(place).excluding(excludedProperties).to.deep.equal(place0);
       });
 
       it('returns null when no place is found for the UUID', async () => {
@@ -107,7 +110,7 @@ describe('cht-datasource Place', () => {
 
       it('returns the place with lineage', async () => {
         const place = await getPlaceWithLineage(Qualifier.byUuid(place0._id));
-        expect(place).excludingEvery([ '_rev', 'reported_date' ]).to.deep.equal({
+        expect(place).excludingEvery(excludedProperties).to.deep.equal({
           ...place0,
           contact: contact0,
           parent: {
@@ -125,7 +128,7 @@ describe('cht-datasource Place', () => {
         'returns the place when the place has no primary contact',
         async () => {
           const place = await getPlaceWithLineage(Qualifier.byUuid(clinic3._id));
-          expect(place).excludingEvery([ '_rev', 'reported_date' ]).to.deep.equal({
+          expect(place).excludingEvery(excludedProperties).to.deep.equal({
             ...clinic3,
             contact: {},
             parent: {
@@ -144,7 +147,7 @@ describe('cht-datasource Place', () => {
         'returns the place when the place has no primary contact and parents',
         async () => {
           const place = await getPlaceWithLineage(Qualifier.byUuid(healthCenter2._id));
-          expect(place).excludingEvery([ '_rev', 'reported_date' ]).to.deep.equal({
+          expect(place).excludingEvery(excludedProperties).to.deep.equal({
             ...healthCenter2,
           });
         }
@@ -164,7 +167,7 @@ describe('cht-datasource Place', () => {
         const responsePlaces = responsePage.data;
         const responseCursor = responsePage.cursor;
 
-        expect(responsePlaces).excludingEvery([ '_rev', 'reported_date' ])
+        expect(responsePlaces).excludingEvery(excludedProperties)
           .to.deep.equalInAnyOrder(expectedPlaces);
         expect(responseCursor).to.be.equal(null);
       });
@@ -174,7 +177,7 @@ describe('cht-datasource Place', () => {
         const responsePlaces = responsePage.data;
         const responseCursor = responsePage.cursor;
 
-        expect(responsePlaces).excludingEvery([ '_rev', 'reported_date' ])
+        expect(responsePlaces).excludingEvery(excludedProperties)
           .to.deep.equalInAnyOrder(expectedPlaces);
         expect(responseCursor).to.be.equal('3');
       });
@@ -185,7 +188,7 @@ describe('cht-datasource Place', () => {
 
         const allPeople = [ ...firstPage.data, ...secondPage.data ];
 
-        expect(allPeople).excludingEvery([ '_rev', 'reported_date' ]).to.deep.equalInAnyOrder(expectedPlaces);
+        expect(allPeople).excludingEvery(excludedProperties).to.deep.equalInAnyOrder(expectedPlaces);
         expect(firstPage.data.length).to.be.equal(2);
         expect(secondPage.data.length).to.be.equal(1);
         expect(firstPage.cursor).to.be.equal('2');
@@ -221,7 +224,7 @@ describe('cht-datasource Place', () => {
           docs.push(doc);
         }
 
-        expect(docs).excluding([ '_rev', 'reported_date' ]).to.deep.equalInAnyOrder(expectedPlaces);
+        expect(docs).excluding(excludedProperties).to.deep.equalInAnyOrder(expectedPlaces);
       });
     });
   });


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

closes #10483

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10483-fix-datasource-e2e-tests/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10483-fix-datasource-e2e-tests/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10483-fix-datasource-e2e-tests/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

