### PR TITLE
fix(#10495): adds docs_by_replication_key to monitoring

### DIFF
--- a/api/src/services/monitoring.js
+++ b/api/src/services/monitoring.js
@@ -31,6 +31,7 @@ const NOUVEAU_INDEXES_TO_MONITOR = {
     'medic': [
       'contacts_by_freetext',
       'reports_by_freetext',
+      'docs_by_replication_key'
     ],
   },
   sentinel: {},

--- a/api/tests/mocha/services/monitoring.spec.js
+++ b/api/tests/mocha/services/monitoring.spec.js
@@ -177,6 +177,16 @@ const NOUVEAU_INDEX_INFO_BY_DDOC = {
         signature: '46de1dfc576838494f798264571dc59658db7ea164915dd459a7752c31591ae6',
       },
     },
+    'docs_by_replication_key': {
+      name: '_design/medic/docs_by_replication_key',
+      search_index: { 
+        update_seq: 1263237,
+        purge_seq: 0,
+        num_docs: 1261007,
+        disk_size: 218427370,
+        signature: '779b1288c85ec5019d5d6a86124b99c12aa729b5edc2d145ff0d09d10cd0f3fb' 
+      }
+    }
   },
 };
 
@@ -327,6 +337,11 @@ describe('Monitoring service', () => {
               name: 'medic/reports_by_freetext',
               doc_count: 183741,
             },
+            {
+              file_size: 218427370,
+              name: 'medic/docs_by_replication_key',
+              doc_count: 1261007,
+            },
           ],
         },
         sentinel: {
@@ -400,6 +415,10 @@ describe('Monitoring service', () => {
           json: true,
           url: `${environment.serverUrl}/${environment.db}/_design/medic/_nouveau_info/reports_by_freetext`,
         }],
+        [{
+          json: true,
+          url: `${environment.serverUrl}/${environment.db}/_design/medic/_nouveau_info/docs_by_replication_key`,
+        }],
         [{ json: true, url: `${environment.serverUrl}/${environment.db}/_design/medic-sms/_info` }],
         [{ json: true, url: `${environment.serverUrl}/${environment.db}-sentinel/_design/sentinel/_info` }],
         [{ json: true, url: `${environment.serverUrl}/${environment.db}-users-meta/_design/users-meta/_info` }],
@@ -457,6 +476,11 @@ describe('Monitoring service', () => {
               file_size: 157258510,
               name: 'medic/reports_by_freetext',
               doc_count: 183741,
+            },
+            {
+              file_size: 218427370,
+              name: 'medic/docs_by_replication_key',
+              doc_count: 1261007,
             },
           ],
         },
@@ -557,6 +581,10 @@ describe('Monitoring service', () => {
         [{
           json: true,
           url: `${environment.serverUrl}/${environment.db}/_design/medic/_nouveau_info/reports_by_freetext`,
+        }],
+        [{
+          json: true,
+          url: `${environment.serverUrl}/${environment.db}/_design/medic/_nouveau_info/docs_by_replication_key`,
         }],
         [{ json: true, url: `${environment.serverUrl}/${environment.db}/_design/medic-sms/_info` }],
         [{ json: true, url: `${environment.serverUrl}/${environment.db}-sentinel/_design/sentinel/_info` }],
@@ -676,6 +704,10 @@ describe('Monitoring service', () => {
         [{
           json: true,
           url: `${environment.serverUrl}/${environment.db}/_design/medic/_nouveau_info/reports_by_freetext`,
+        }],
+        [{
+          json: true,
+          url: `${environment.serverUrl}/${environment.db}/_design/medic/_nouveau_info/docs_by_replication_key`,
         }],
         [{ json: true, url: `${environment.serverUrl}/${environment.db}/_design/medic-sms/_info` }],
         [{ json: true, url: `${environment.serverUrl}/${environment.db}-sentinel/_design/sentinel/_info` }],
@@ -810,6 +842,10 @@ describe('Monitoring service', () => {
         [{
           json: true,
           url: `${environment.serverUrl}/${environment.db}/_design/medic/_nouveau_info/reports_by_freetext`,
+        }],
+        [{
+          json: true,
+          url: `${environment.serverUrl}/${environment.db}/_design/medic/_nouveau_info/docs_by_replication_key`,
         }],
         [{ json: true, url: `${environment.serverUrl}/${environment.db}/_design/medic-sms/_info` }],
         [{ json: true, url: `${environment.serverUrl}/${environment.db}-sentinel/_design/sentinel/_info` }],

--- a/tests/integration/api/controllers/monitoring.spec.js
+++ b/tests/integration/api/controllers/monitoring.spec.js
@@ -1,6 +1,3 @@
-const chai = require('chai');
-const chaiExclude = require('chai-exclude');
-chai.use(chaiExclude);
 const utils = require('@utils');
 const sentinelUtils = require('@utils/sentinel');
 
@@ -18,7 +15,7 @@ const VIEW_INDEXES_BY_DB = {
 };
 
 const NOUVEAU_INDEXES_BY_DB = {
-  'medic-test': ['medic/contacts_by_freetext', 'medic/reports_by_freetext'],
+  'medic-test': ['medic/contacts_by_freetext', 'medic/reports_by_freetext', 'medic/docs_by_replication_key'],
 };
 
 const getAppVersion = async () => {
@@ -87,7 +84,10 @@ const assertIndeterminateFields = (result) => {
 };
 
 describe('monitoring', () => {
-  beforeEach(() => sentinelUtils.waitForSentinel());
+  beforeEach(async () => {
+    await utils.waitForIndexes();
+    await sentinelUtils.waitForSentinel();
+  });
   afterEach(() => utils.revertDb([], true));
 
   describe('v1', () => {

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -1641,6 +1641,16 @@ const escapeBranchName = (branch) => branch?.replace(/[^A-Za-z0-9.-]/g, '-');
 const toggleSentinelTransitions = () => sendSignal('sentinel', 'USR1');
 const runSentinelTasks = () => sendSignal('sentinel', 'USR2');
 
+const waitForIndexes = async () => {
+  let indexes = [];
+  do {
+    indexes = await request({ path: '/_active_tasks' });
+    if (indexes.length) {
+      await delayPromise(500);
+    }
+  } while (indexes.length);
+};
+
 module.exports = {
   db,
   sentinelDb,
@@ -1724,4 +1734,5 @@ module.exports = {
   runCommand,
   deletePurgeDbs,
   saveLogs,
+  waitForIndexes,
 };


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Stabilizes the monitoring e2e tests

closes #10495 
closes #10499

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10495-wait-for-indexes/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10495-wait-for-indexes/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10495-wait-for-indexes/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

