### PR TITLE
chore(#10261): bump nginx upload limit

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,5 +1,5 @@
 # base build
-FROM nginx:1.25.1-alpine AS base_nginx
+FROM nginx:1.29.4-alpine AS base_nginx
 RUN apk add --update --no-cache \
     curl \
     socat \

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -7,12 +7,12 @@ events {
 
 http {
     include       /etc/nginx/mime.types;
-    default_type  application/octet-stream;
+    default_type  application/json;
 
     sendfile              on;
     keepalive_timeout     3600;
     proxy_read_timeout    3600;
-    client_max_body_size  32M;
+    client_max_body_size  1G;
     server_tokens         off;
 
     map $http_accept $error_extension {

--- a/nginx/tests/integration/ssl_install.spec.js
+++ b/nginx/tests/integration/ssl_install.spec.js
@@ -109,7 +109,7 @@ EOF_DELIMITER`;
     console.log(`Tearing down ${CHT_NGINX_SERVICE_NAME} service...`);
     await new Promise((resolve) => {
       exec(
-        `docker compose -f "${COMPOSE_FILE_PATH}" down -v --remove-orphans`,
+        `docker compose -f "${COMPOSE_FILE_PATH}" down -v --remove-orphans -t 0`,
         (error, stdout, stderr) => { // -v to remove volumes
           if (error) {
             console.error(`docker compose down failed during cleanup: ${stderr}`);


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

also updates nginx version. 

closes #10261 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10261-bump-nginx-upload-limit-for-non-json/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10261-bump-nginx-upload-limit-for-non-json/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10261-bump-nginx-upload-limit-for-non-json/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

