### PR TITLE
chore: fix deduplication unit tests to work on any date

### DIFF
--- a/webapp/tests/karma/ts/services/deduplicate.service.spec.ts
+++ b/webapp/tests/karma/ts/services/deduplicate.service.spec.ts
@@ -56,8 +56,10 @@ const SIBLINGS = [
 describe('Deduplicate', () => {
   let service;
   let telemetryService;
+  let clock;
 
   beforeEach(() => {
+    clock = sinon.useFakeTimers({ now: new Date('2025-11-11') });
     telemetryService = {
       record: sinon.stub(),
     };
@@ -78,7 +80,10 @@ describe('Deduplicate', () => {
     service = TestBed.inject(DeduplicateService);
   });
 
-  afterEach(() => sinon.restore());
+  afterEach(() => {
+    sinon.restore();
+    clock.restore();
+  });
 
   describe('getDuplicates', () => {
     it('should return duplicates based on default matching', () => {


### PR DESCRIPTION
As currently written, the test breaks between Jan 1 and Jan 31 because of how the default contact duplication logic treats contacts with a birth data _in the same year_ as duplicate.

This PR just updates the test code to force the "current" date not to change.

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [X] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [X] Tested: Unit and/or e2e where appropriate

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

