### PR TITLE
chore(#10565): make api stability checks more robust

### DIFF
--- a/tests/integration/api/server.spec.js
+++ b/tests/integration/api/server.spec.js
@@ -184,7 +184,6 @@ describe('server', () => {
       await utils.stopHaproxy(); // this will also crash API
       await utils.startHaproxy();
       await utils.listenForApi();
-      await utils.delayPromise(1000);
 
       const forms = await utils.db.allDocs({
         start_key: 'form:',
@@ -207,7 +206,6 @@ describe('server', () => {
       await utils.stopApi();
       await utils.startHaproxy();
       await utils.startApi();
-      await utils.delayPromise(1000);
 
       await utils.request('/');
 
@@ -218,7 +216,6 @@ describe('server', () => {
       await utils.delayPromise(1000);
 
       await utils.listenForApi();
-      await utils.delayPromise(1000);
     });
 
     it('should work after restarting CouchDb @docker', async () => {
@@ -226,7 +223,6 @@ describe('server', () => {
       await utils.startCouchDb();
 
       await utils.listenForApi();
-      await utils.delayPromise(1000);
     });
   });
 

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -877,11 +877,18 @@ const getUserSettings = ({ contactId, name }) => {
 };
 
 const listenForApi = async () => {
-  let retryCount = 180;
+  const totalTries = 180; // 3 minutes
+  let retryCount = totalTries;
   do {
     try {
       console.log(`Checking API, retries left ${retryCount}`);
-      return await request({ path: '/api/info' });
+      await request({ path: '/api/info' });
+      if (retryCount < totalTries) {
+        // if api request failed at least once, make sure that it's stable
+        await delayPromise(1000);
+        await request({ path: '/api/info' });
+      }
+      return;
     } catch (err) {
       console.log('API check failed, trying again in 1 second');
       console.log(err.message);


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Adds an extra api check when expecting api to restart

closes #10565

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10565-fix-docker-test/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10565-fix-docker-test/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10565-fix-docker-test/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

