### PR TITLE
chore(#medic/cht-docs/issues/2107): restore volume binding script

### DIFF
--- a/scripts/medic-eks-get-volume-binding.sh
+++ b/scripts/medic-eks-get-volume-binding.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$#" -ne 2 ]; then
+if [[ "$#" -ne 2 ]]; then
     echo "Usage: $0 <namespace> <deployment>"
     exit 1
 fi
@@ -12,7 +12,7 @@ get_pv_details() {
     local pvc_name=$1
     local pv_name
     pv_name=$(kubectl get pvc -n "$NAMESPACE" "$pvc_name" -o jsonpath='{.spec.volumeName}' 2>/dev/null)
-    if [ -n "$pv_name" ]; then
+    if [[ -n "$pv_name" ]]; then
         kubectl get pv "$pv_name" -o json 2>/dev/null | jq '{
             pvName: .metadata.name,
             pvSize: .spec.capacity.storage,
@@ -22,10 +22,11 @@ get_pv_details() {
     else
         echo "{}"
     fi
+    return 0
 }
 
 if ! DEPLOYMENT_INFO=$(kubectl get deployment -n "$NAMESPACE" "$DEPLOYMENT" -o json 2>&1); then
-    echo "Error: Failed to get deployment information"
+    echo "Failed to get deployment information"
     echo "$DEPLOYMENT_INFO"
     exit 1
 fi
@@ -57,13 +58,13 @@ echo "$DEPLOYMENT_INFO" | jq --arg namespace "$NAMESPACE" '
     )
   }' | jq -c '.' | while read -r volume_info; do
     claim_name=$(echo "$volume_info" | jq -r '.claimName // empty')
-    if [ -n "$claim_name" ]; then
+    if [[ -n "$claim_name" ]]; then
         pv_info=$(get_pv_details "$claim_name")
         echo "$volume_info" | jq --argjson pv_info "$pv_info" '. + $pv_info'
     else
         echo "$volume_info"
     fi
 done || {
-    echo "Error: Failed to process deployment information"
+    echo "Failed to process deployment information"
     exit 1
 }


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

While we decided to [remove](https://github.com/medic/cht-core/issues/10486) `cht-deploy` script, the now deleted get volume bindings is still needed when creating a clone of a Medic prod instance.  This PR restores the script to complete the [upstream docs issue](https://github.com/medic/cht-docs/issues/2107).



<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [x] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:docs-2110-restore-volume-binding-script/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:docs-2110-restore-volume-binding-script/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:docs-2110-restore-volume-binding-script/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

