### PR TITLE
fix(na): fix docker helper grep error

### DIFF
--- a/scripts/docker-helper/cht-docker-compose.sh
+++ b/scripts/docker-helper/cht-docker-compose.sh
@@ -56,11 +56,11 @@ get_compose_download_url() {
 }
 
 get_all_known_versions() {
-  curl -s "${stagingUrl}"/_design/builds/_view/releases\?descending=true |  tr -d \\n | grep -o "medic\:medic\:[A-Za-z0-9\.\_\/\-]*" | cut -f3 -d: | sort
+  curl -s "${stagingUrl}"/_design/builds/_view/releases\?descending=true |  tr -d \\n | grep -o "medic:medic:[A-Za-z0-9\.\_\/\-]*" | cut -f3 -d: | sort
 }
 
 get_latest_version_string() {
-  curl -s "${stagingUrl}"/_design/builds/_view/releases\?limit=1\&descending=true |  tr -d \\n | grep -o 'medic\:medic\:[0-9\.]*' | cut -f3 -d:
+  curl -s "${stagingUrl}"/_design/builds/_view/releases\?limit=1\&descending=true |  tr -d \\n | grep -o 'medic:medic:[0-9\.]*' | cut -f3 -d:
 }
 
 create_compose_files() {


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->

In the docker helper shell script there was the `stray \ before` error:

```
 ./cht-docker-compose.sh    
           
Would you like to initialize a new project [y/N]? y        
           
Do you want to run the latest CHT Core version (5.0.1) [Y/n]? n        
grep: warning: stray \ before :    
grep: warning: stray \ before :    
           
Select a version by entering 1 through 106 or 'ctrl + c' to quit:      
```

This PR removes the 4 `\` which caused the error

<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [x] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

closes https://github.com/medic/cht-core/issues/9310

# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:fix-docker-helper-grep-error/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:fix-docker-helper-grep-error/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:fix-docker-helper-grep-error/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

