### PR TITLE
feat(#10217): add telemetry for android app launches

### DIFF
--- a/webapp/src/ts/services/android-app-launcher.service.ts
+++ b/webapp/src/ts/services/android-app-launcher.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { TelemetryService } from './telemetry.service';
 
 @Injectable({
   providedIn: 'root'
@@ -6,7 +7,7 @@ import { Injectable } from '@angular/core';
 export class AndroidAppLauncherService {
   private resolve?: Function | null;
 
-  constructor() { }
+  constructor(private telemetryService: TelemetryService) { }
 
   isEnabled() {
     return !!(
@@ -25,6 +26,7 @@ export class AndroidAppLauncherService {
   }
 
   launchAndroidApp(chtAndroidApp: ChtAndroidApp): Promise<any> {
+    this.telemetryService.record('android_app_launcher:launch');
     return new Promise((resolve, reject) => {
       this.resolve = resolve;
       try {


### PR DESCRIPTION
Closes #10217 

This PR adds telemetry recording to key WebApp areas for better visibility into user activity.
- Injected TelemetryService into AndroidAppLauncherService to record app launches
~~- - Injected TelemetryService into TasksComponent to record task counts~~
~~- - Included TypeScript and lint fixes for TasksComponent~~