### PR TITLE
feat(webapp): support capping target counts past goal

### DIFF
--- a/webapp/src/ts/modules/analytics/analytics-targets.component.html
+++ b/webapp/src/ts/modules/analytics/analytics-targets.component.html
@@ -4,30 +4,32 @@
   </div>
 
   <div class="item-content empty-selection" *ngIf="!targetsDisabled && loading">
-    <div><div class="loader"></div></div>
+    <div>
+      <div class="loader"></div>
+    </div>
   </div>
 
   <div class="item-content empty-selection" *ngIf="!targetsDisabled && !loading && !targets?.length && !errorStack">
     <div>{{ 'targets.no_targets' | translate }}</div>
   </div>
 
-  <error-log class="targets" *ngIf="!targetsDisabled && !loading && !!errorStack" [errorStack]="errorStack" [errorFor]="'targets'"></error-log>
+  <error-log class="targets" *ngIf="!targetsDisabled && !loading && !!errorStack" [errorStack]="errorStack"
+    [errorFor]="'targets'"></error-log>
 
   <div class="targets" *ngIf="!targetsDisabled && !loading && targets?.length && !errorStack">
     <div class="target" *ngFor="let target of targets"
       [ngClass]="{ 'has-goal': target.goal >= 0, 'goal-met': (target.value?.pass >= target.goal) || (target.value?.percent >= target.goal) }"
       attr.test-target-id="{{ target.id }}">
       <div class="body">
-        <mm-analytics-targets-progress
-          *ngIf="target.type === 'percent'"
-          [target]="target" [value]="target.value" [direction]="direction"
-          [aggregate]="false">
+        <mm-analytics-targets-progress *ngIf="target.type === 'percent'" [target]="target" [value]="target.value"
+          [direction]="direction" [aggregate]="false">
         </mm-analytics-targets-progress>
         <div class="count" *ngIf="target.type !== 'percent'">
           <div class="goal" *ngIf="target.goal >= 0">
             <p>{{ 'analytics.target.monthly_goal' | translate }} {{ target.goal | localizeNumber }}</p>
           </div>
-          <div class="number">{{ target.value?.pass | localizeNumber }}</div>
+          <div class="number">{{ (hideCountsPastGoal && target.goal >= 0 && target.value?.pass > target.goal ?
+            target.goal : target.value?.pass) | localizeNumber }}</div>
         </div>
       </div>
       <div class="heading">

--- a/webapp/src/ts/modules/analytics/analytics-targets.component.ts
+++ b/webapp/src/ts/modules/analytics/analytics-targets.component.ts
@@ -3,6 +3,7 @@ import { Store } from '@ngrx/store';
 
 import { RulesEngineService } from '@mm-services/rules-engine.service';
 import { PerformanceService } from '@mm-services/performance.service';
+import { SettingsService } from '@mm-services/settings.service';
 import { NgIf, NgFor, NgClass } from '@angular/common';
 import { ErrorLogComponent } from '@mm-components/error-log/error-log.component';
 import {
@@ -35,10 +36,12 @@ export class AnalyticsTargetsComponent implements OnInit {
   errorStack;
   trackPerformance;
   direction;
+  hideCountsPastGoal = false;
 
   constructor(
     private rulesEngineService: RulesEngineService,
     private performanceService: PerformanceService,
+    private settingsService: SettingsService,
     private store: Store,
   ) {
     this.trackPerformance = this.performanceService.track();
@@ -48,6 +51,9 @@ export class AnalyticsTargetsComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    this.settingsService.get().then(settings => {
+      this.hideCountsPastGoal = settings.targets_hide_counts_past_goal;
+    });
     this.getTargets();
   }
 
@@ -67,7 +73,7 @@ export class AnalyticsTargetsComponent implements OnInit {
         this.loading = false;
         this.targets = targets.filter(target => target.visible !== false);
         this.trackPerformance?.stop({
-          name: [ 'analytics', 'targets', 'load' ].join(':'),
+          name: ['analytics', 'targets', 'load'].join(':'),
           recordApdex: true,
         });
       });


### PR DESCRIPTION
This PR implements a feature to cap the displayed count of targets at the goal value if configured.
- Read `targets_hide_counts_past_goal` from settings
- Update template to show goal value instead of actual value when goal is exceeded and setting is enabled