### PR TITLE
fix(#10598): fix admin languages service db request

### DIFF
--- a/admin/src/js/services/languages.js
+++ b/admin/src/js/services/languages.js
@@ -1,5 +1,3 @@
-const _ = require('lodash/core');
-
 /*
  * Get all enabled languages
  */
@@ -11,9 +9,9 @@ angular.module('inboxServices').factory('Languages',
     'ngInject';
     return function() {
       return DB()
-        .query('medic-client/doc_by_type', { key: [ 'translations', true ] })
+        .allDocs({ start_key: 'messages-', end_key: 'messages-\ufff0', include_docs: true })
         .then(function(result) {
-          return _.map(result.rows, 'value');
+          return result.rows.map(row => ({ code: row.doc.code, name: row.doc.name }));
         });
     };
   });

--- a/admin/tests/unit/services/languages.spec.js
+++ b/admin/tests/unit/services/languages.spec.js
@@ -1,0 +1,70 @@
+describe('Languages service', function() {
+
+  'use strict';
+
+  let service;
+  let allDocs;
+
+  beforeEach(function() {
+    allDocs = sinon.stub();
+    module('adminApp');
+    module(function($provide) {
+      $provide.factory('DB', KarmaUtils.mockDB({ allDocs }));
+    });
+    inject(function(_Languages_) {
+      service = _Languages_;
+    });
+  });
+
+  afterEach(function() {
+    KarmaUtils.restore(allDocs);
+  });
+
+  it('returns all enabled languages', function(done) {
+    allDocs.resolves({
+      rows: [
+        { doc: { code: 'en', name: 'English', generic: {} } },
+        { doc: { code: 'es', name: 'Spanish', generic: {} } },
+        { doc: { code: 'fr', name: 'French', generic: {} } }
+      ]
+    });
+
+    service().then(function(result) {
+      chai.expect(allDocs.callCount).to.equal(1);
+      chai.expect(allDocs.args[0][0]).to.deep.equal({
+        start_key: 'messages-',
+        end_key: 'messages-\ufff0',
+        include_docs: true
+      });
+      chai.expect(result).to.deep.equal([
+        { code: 'en', name: 'English' },
+        { code: 'es', name: 'Spanish' },
+        { code: 'fr', name: 'French' }
+      ]);
+      done();
+    }).catch(done);
+  });
+
+  it('returns empty array when no languages exist', function(done) {
+    allDocs.resolves({ rows: [] });
+
+    service().then(function(result) {
+      chai.expect(allDocs.callCount).to.equal(1);
+      chai.expect(result).to.deep.equal([]);
+      done();
+    }).catch(done);
+  });
+
+  it('rejects when DB query fails', function(done) {
+    const error = new Error('DB connection failed');
+    allDocs.rejects(error);
+
+    service().then(function() {
+      done(new Error('Expected promise to be rejected'));
+    }).catch(function(err) {
+      chai.expect(err).to.equal(error);
+      done();
+    });
+  });
+
+});


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Update missed db query that accessed old docs_by_type path

closes #10598 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10598-fix-privacy-policies/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10598-fix-privacy-policies/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10598-fix-privacy-policies/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

