### PR TITLE
chore(#10546): add constant for contact document type

### DIFF
--- a/shared-libs/constants/src/index.js
+++ b/shared-libs/constants/src/index.js
@@ -17,6 +17,7 @@ const CONTACT_TYPES = {
 const DOC_TYPES = {
   TOKEN_LOGIN: 'token_login',
   TRANSLATIONS: 'translations',
+  CONTACT: 'contact',
 };
 
 // HTTP Headers

--- a/shared-libs/contact-types-utils/src/index.js
+++ b/shared-libs/contact-types-utils/src/index.js
@@ -1,4 +1,4 @@
-const { CONTACT_TYPES } = require('@medic/constants');
+const { CONTACT_TYPES, DOC_TYPES } = require('@medic/constants');
 
 const HARDCODED_PERSON_TYPE = 'person';
 const HARDCODED_TYPES = [
@@ -21,7 +21,7 @@ const getTypeId = (doc) => {
   if (!doc) {
     return;
   }
-  return doc.type === 'contact' ? doc.contact_type : doc.type;
+  return doc.type === DOC_TYPES.CONTACT ? doc.contact_type : doc.type;
 };
 
 const getTypeById = (config, typeId) => {

--- a/webapp/src/js/bootstrapper/offline-ddocs/medic-offline-freetext/contacts_by_type_freetext.js
+++ b/webapp/src/js/bootstrapper/offline-ddocs/medic-offline-freetext/contacts_by_type_freetext.js
@@ -1,14 +1,15 @@
 module.exports.map = (doc) => {
-  const skip = [ '_id', '_rev', 'type', 'refid', 'geolocation' ];
+  const { DOC_TYPES } = require('@medic/constants');
+  const skip = ['_id', '_rev', 'type', 'refid', 'geolocation'];
   const keyShouldBeSkipped = key => skip.indexOf(key) !== -1 || /_date$/.test(key);
 
   const usedKeys = [];
-  const emitMaybe = function(type, key, value) {
+  const emitMaybe = function (type, key, value) {
     if (usedKeys.indexOf(key) === -1 && // Not already used
       key.length > 2 // Not too short
     ) {
       usedKeys.push(key);
-      emit([ type, key ], value);
+      emit([type, key], value);
     }
   };
 
@@ -32,7 +33,7 @@ module.exports.map = (doc) => {
   };
 
   const getType = () => {
-    if (doc.type !== 'contact') {
+    if (doc.type !== DOC_TYPES.CONTACT) {
       return doc.type;
     }
 
@@ -40,9 +41,9 @@ module.exports.map = (doc) => {
   };
 
   const getTypeIndex = type => {
-    const types = [ 'district_hospital', 'health_center', 'clinic', 'person' ];
+    const types = ['district_hospital', 'health_center', 'clinic', 'person'];
     const typeIndex = types.indexOf(type);
-    if (typeIndex === -1 && doc.type === 'contact') {
+    if (typeIndex === -1 && doc.type === DOC_TYPES.CONTACT) {
       return type;
     }
 
@@ -60,5 +61,5 @@ module.exports.map = (doc) => {
   const order = `${dead} ${muted} ${idx} ${doc.name && doc.name.toLowerCase()}`;
   Object
     .keys(doc)
-    .forEach(key  => emitField(type, key, doc[key], order));
+    .forEach(key => emitField(type, key, doc[key], order));
 };

--- a/webapp/src/ts/reducers/contacts.ts
+++ b/webapp/src/ts/reducers/contacts.ts
@@ -1,5 +1,6 @@
 import { createReducer, on } from '@ngrx/store';
 
+import { DOC_TYPES } from '@medic/constants';
 import { UniqueSortedList } from '@mm-reducers/utils';
 import { ContactTypesService } from '@mm-services/contact-types.service';
 import { Actions } from '@mm-actions/contacts';
@@ -16,7 +17,7 @@ const initialState = {
 };
 
 const getContactTypeOrder = (contact) => {
-  if (contact.type === 'contact') {
+  if (contact.type === DOC_TYPES.CONTACT) {
     const idx = ContactTypesService.HARDCODED_TYPES().indexOf(contact.contact_type);
     if (idx !== -1) {
       // matches a hardcoded type - order by the index
@@ -72,7 +73,7 @@ const updateContacts = (state, newContacts) => {
 };
 
 const removeContact = (state, contact) => {
-  const contacts = [ ...state.contacts];
+  const contacts = [...state.contacts];
   const contactsById = new Map(state.contactsById);
 
   const list = new UniqueSortedList(contacts, contactsById, orderBy);
@@ -130,7 +131,7 @@ const updateSelectedContactsTasks = (state, tasks) => {
     });
     return { ...group, contacts };
   });
-  return { ...state, selected: { ...state.selected, tasks: mappedTasks, children }};
+  return { ...state, selected: { ...state.selected, tasks: mappedTasks, children } };
 };
 
 const receiveSelectedContactTargetDoc = (state, targetDoc) => {
@@ -148,18 +149,18 @@ const _contactsReducer = createReducer(
   on(Actions.removeContactFromList, (state, { payload: { contact } }) => removeContact(state, contact)),
   on(Actions.setSelectedContact, (state, { payload: { selected } }) => setSelectedContact(state, selected)),
   on(Actions.setLoadingSelectedContact, (state) => setLoadingSelectedContact(state)),
-  on(Actions.setContactsLoadingSummary, (state, { payload: { value }}) => setContactsLoadingSummary(state, value)),
-  on(Actions.receiveSelectedContactChildren, (state, { payload: { children }}) => {
+  on(Actions.setContactsLoadingSummary, (state, { payload: { value } }) => setContactsLoadingSummary(state, value)),
+  on(Actions.receiveSelectedContactChildren, (state, { payload: { children } }) => {
     return receiveSelectedContactChildren(state, children);
   }),
-  on(Actions.receiveSelectedContactReports, (state, { payload: { reports }}) => {
+  on(Actions.receiveSelectedContactReports, (state, { payload: { reports } }) => {
     return receiveSelectedContactReports(state, reports);
   }),
-  on(Actions.updateSelectedContactSummary, (state, { payload: { summary }}) => {
+  on(Actions.updateSelectedContactSummary, (state, { payload: { summary } }) => {
     return updateSelectedContactSummary(state, summary);
   }),
-  on(Actions.updateSelectedContactsTasks, (state, { payload: { tasks }}) => updateSelectedContactsTasks(state, tasks)),
-  on(Actions.receiveSelectedContactTargetDoc, (state, { payload: { targetDoc }}) => {
+  on(Actions.updateSelectedContactsTasks, (state, { payload: { tasks } }) => updateSelectedContactsTasks(state, tasks)),
+  on(Actions.receiveSelectedContactTargetDoc, (state, { payload: { targetDoc } }) => {
     return receiveSelectedContactTargetDoc(state, targetDoc);
   }),
 );

--- a/webapp/src/ts/services/contact-types.service.ts
+++ b/webapp/src/ts/services/contact-types.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { DOC_TYPES } from '@medic/constants';
 import * as contactTypesUtils from '@medic/contact-types-utils';
 
 import { SettingsService } from '@mm-services/settings.service';
@@ -7,7 +8,7 @@ import { SettingsService } from '@mm-services/settings.service';
   providedIn: 'root'
 })
 export class ContactTypesService {
-  constructor(private settingsService:SettingsService) {
+  constructor(private settingsService: SettingsService) {
   }
 
   static HARDCODED_TYPES() {
@@ -26,7 +27,7 @@ export class ContactTypesService {
   /**
    * Returns a Promise to resolve an array of configured contact types.
    */
-  getAll () {
+  getAll() {
     return this.settingsService
       .get()
       .then(config => contactTypesUtils.getContactTypes(config));
@@ -48,7 +49,7 @@ export class ContactTypesService {
     if (!type) {
       return false;
     }
-    return type === 'contact' ||   // configurable hierarchy
+    return type === DOC_TYPES.CONTACT ||   // configurable hierarchy
       contactTypesUtils.isHardcodedType(type);  // hardcoded
   }
 
@@ -119,7 +120,7 @@ export class ContactTypesService {
     if (!typeId || !types?.length) {
       return false;
     }
-    return !!types.find((type:ContactType) => type?.id === typeId);
+    return !!types.find((type: ContactType) => type?.id === typeId);
   }
 }
 


### PR DESCRIPTION
# Description

Adds a shared constant for the `contact` document type and replaces
hard-coded usages with the new constant. This improves consistency and
maintainability by avoiding repeated string literals across the codebase.

Fixes #10546

# Code review checklist
- [x] Readable: Concise, well named, follows the style guide.
- [x] Backwards compatible: Works with existing data and configuration.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
