### PR TITLE
feat(#10139): add ability to hide contact forms for muted places

### DIFF
--- a/api/resources/translations/messages-ar.properties
+++ b/api/resources/translations/messages-ar.properties
@@ -1011,6 +1011,7 @@ permission.description.can_bulk_delete_reports = السماح باستخدام �
 permission.description.can_configure = يسمح بتهيئة جميع تكوينات التطبيق.
 permission.description.can_create_people = السماح بإنشاء أشخاص جدد.
 permission.description.can_create_places = السماح بإنشاء أماكن جديدة.
+permission.description.can_create_contacts_under_muted_places = السماح بإنشاء أشخاص أو أماكن جديدة في الأماكن المكتومة.
 permission.description.can_create_records = السماح بالوصول إلى واجهات برمجة التطبيقات لإنشاء التقارير.
 permission.description.can_create_users = السماح بإنشاء مستخدمين.
 permission.description.can_delete_contacts = السماح بحذف الأشخاص والأماكن.

--- a/api/resources/translations/messages-en.properties
+++ b/api/resources/translations/messages-en.properties
@@ -1011,6 +1011,7 @@ permission.description.can_bulk_delete_reports = Allowed to use bulk delete func
 permission.description.can_configure = Allowed to configure all the application configurations.
 permission.description.can_create_people = Allowed to create new people.
 permission.description.can_create_places = Allowed to create new places.
+permission.description.can_create_contacts_under_muted_places = Allowed to create new people or places under muted places.
 permission.description.can_create_records = Allowed to access the APIs to create reports.
 permission.description.can_create_users = Allowed to create users.
 permission.description.can_delete_contacts = Allowed to delete people and places.

--- a/api/resources/translations/messages-es.properties
+++ b/api/resources/translations/messages-es.properties
@@ -1011,6 +1011,7 @@ permission.description.can_bulk_delete_reports = Usar las funciones de eliminaci
 permission.description.can_configure = Administrar todas las configuraciones de la aplicación.
 permission.description.can_create_people = Crear nuevas personas.
 permission.description.can_create_places = Crear nuevos centros medicos.
+permission.description.can_create_contacts_under_muted_places = Crear nuevas personas o centros medicos en lugares silenciados.
 permission.description.can_create_records = Acceder a las APIs para crear informes.
 permission.description.can_create_users = Crear usuarios.
 permission.description.can_delete_contacts = Eliminar personas y centros medicos.

--- a/api/resources/translations/messages-fr.properties
+++ b/api/resources/translations/messages-fr.properties
@@ -1011,6 +1011,7 @@ permission.description.can_bulk_delete_reports = Autorisé à utiliser les fonct
 permission.description.can_configure = Autorisé à configurer toutes les configurations de l'application.
 permission.description.can_create_people = Autorisé à créer de nouvelles personnes.
 permission.description.can_create_places = Autorisé à créer des nouvelles places.
+permission.description.can_create_contacts_under_muted_places = Autorisé à créer de nouvelles personnes ou places dans les places désactivées.
 permission.description.can_create_records = Autorisé à accéder aux API pour créer des rapports.
 permission.description.can_create_users = Autorisé à créer des utilisateurs.
 permission.description.can_delete_contacts = Autorisé à supprimer des personnes et des places.

--- a/api/resources/translations/messages-ne.properties
+++ b/api/resources/translations/messages-ne.properties
@@ -1011,6 +1011,7 @@ permission.description.can_bulk_delete_reports = एकैपटक धेरै
 permission.description.can_configure = सबै एप्लिकेशन कन्फिगरेसनहरू कन्फिगर गर्न अनुमति दिइएको।
 permission.description.can_create_people = नयाँ व्यक्तिहरू सिर्जना गर्न अनुमति दिइएको।
 permission.description.can_create_places = नयाँ स्थानहरू सिर्जना गर्न अनुमति दिइएको।
+permission.description.can_create_contacts_under_muted_places = मौन स्थानहरूमा नयाँ व्यक्ति वा स्थान सिर्जना गर्न अनुमति दिइएको।
 permission.description.can_create_records = रिपोर्टहरू सिर्जना गर्न एपीआई पहुँच गर्न अनुमति दिइएको।
 permission.description.can_create_users = प्रयोगकर्ताहरू सिर्जना गर्न अनुमति दिइएको।
 permission.description.can_delete_contacts = व्यक्तिहरू र स्थानहरू मेटाउन अनुमति दिइएको।

--- a/api/resources/translations/messages-pt.properties
+++ b/api/resources/translations/messages-pt.properties
@@ -1011,6 +1011,7 @@ permission.description.can_bulk_delete_reports = Permitido usar funções de exc
 permission.description.can_configure = Permitido configurar todas as configurações da aplicação.
 permission.description.can_create_people = Permitido criar novas pessoas.
 permission.description.can_create_places = Permitido criar novos locais.
+permission.description.can_create_contacts_under_muted_places = Permitido criar novas pessoas ou locais sob locais silenciados.
 permission.description.can_create_records = Permitido acessar as APIs para criar relatórios.
 permission.description.can_create_users = Permitido criar usuários.
 permission.description.can_delete_contacts = Permitido excluir pessoas e locais.

--- a/api/resources/translations/messages-sw.properties
+++ b/api/resources/translations/messages-sw.properties
@@ -1011,6 +1011,7 @@ permission.description.can_bulk_delete_reports = Inaruhusiwa kutumia vipengele v
 permission.description.can_configure = Inaruhusiwa kusanidi usanidi wote wa programu
 permission.description.can_create_people = Inaruhusiwa kuongeza watu wapya.
 permission.description.can_create_places = Inaruhusiwa kuongeza maeneo mapya.
+permission.description.can_create_contacts_under_muted_places = Inaruhusiwa kuongeza watu au maeneo mapya katika maeneo yaliyokomewa.
 permission.description.can_create_records = Inaruhusiwa kufikia API ili kuunda ripoti.
 permission.description.can_create_users = Inaruhusiwa kuongeza watumiaji wapya.
 permission.description.can_delete_contacts = Inaruhusiwa kufuta watu na maeneo.

--- a/config/covid-19/app_settings.json
+++ b/config/covid-19/app_settings.json
@@ -46,6 +46,7 @@
       "chw_supervisor",
       "chw"
     ],
+    "can_create_contacts_under_muted_places": [],
     "can_create_records": [
       "chw_supervisor",
       "chw"

--- a/config/covid-19/app_settings/base_settings.json
+++ b/config/covid-19/app_settings/base_settings.json
@@ -46,6 +46,7 @@
       "chw_supervisor",
       "chw"
     ],
+    "can_create_contacts_under_muted_places": [],
     "can_create_records": [
       "chw_supervisor",
       "chw"

--- a/tests/config.default.json
+++ b/tests/config.default.json
@@ -94,6 +94,7 @@
     "can_create_users": ["national_admin"],
     "can_create_people": [],
     "can_create_places": [],
+    "can_create_contacts_under_muted_places": [],
     "can_view_tasks": [],
     "can_view_tasks_tab": [],
     "can_view_tasks_group": [],

--- a/webapp/src/ts/modules/contacts/contacts-content.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-content.component.ts
@@ -291,6 +291,7 @@ export class ContactsContentComponent implements OnInit, OnDestroy {
       xmlReportForms: this.relevantReportForms,
       childContactTypes: this.childContactTypes,
       parentFacilityId: this.selectedContact.doc?._id,
+      parentContact: this.selectedContact.doc,
       communicationContext: {
         sendTo: this.selectedContact?.type?.person && this.selectedContact?.doc,
         callbackOpenSendMessage: (sendTo) => this.openSendMessageModal(sendTo),


### PR DESCRIPTION
# Description
This PR introduces a permission-based control to hide the “Add Person” and “Add Place” contact form options for muted places.

Resolves #10139

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [x] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Tested: Unit and/or e2e where appropriate

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

