### PR TITLE
fix(#9997): add delay after couchdb restart in integration test

### DIFF
--- a/tests/integration/api/server.spec.js
+++ b/tests/integration/api/server.spec.js
@@ -183,6 +183,8 @@ describe('server', () => {
     it('should respond to changes even after services are restarted', async () => {
       await utils.stopHaproxy(); // this will also crash API
       await utils.startHaproxy();
+
+      await utils.delayPromise(1000);
       await utils.listenForApi();
 
       const forms = await utils.db.allDocs({
@@ -213,16 +215,16 @@ describe('server', () => {
       await utils.stopApi();
       await utils.startApi(false);
       await utils.startHaproxy();
-      await utils.delayPromise(1000);
 
+      await utils.delayPromise(1000);
       await utils.listenForApi();
     });
 
     it('should work after restarting CouchDb @docker', async () => {
       await utils.stopCouchDb();
       await utils.startCouchDb();
-      await utils.delayPromise(1000);
 
+      await utils.delayPromise(1000);
       await utils.listenForApi();
     });
   });


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Adds small delay before starting checking API. Apparently that container comes up and down depending on other services availability and it takes more than 1s to become stable again. 

closes #9997

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9997-fix-docker-restart-test/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9997-fix-docker-restart-test/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9997-fix-docker-restart-test/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

