### PR TITLE
chore(#10633): fix api error logging misses

### DIFF
--- a/api/src/services/config-watcher.js
+++ b/api/src/services/config-watcher.js
@@ -50,7 +50,7 @@ const initTransitionLib = () => {
   try {
     transitionsLib.loadTransitions(true);
   } catch (err) {
-    logger.error(err);
+    logger.error('Error loading transitions - starting up anyway: %o', err);
   }
   config.setTransitionsLib(transitionsLib);
 };

--- a/api/src/services/forms.js
+++ b/api/src/services/forms.js
@@ -32,11 +32,10 @@ module.exports = {
     try {
       return await db.medic.getAttachment(docId, name);
     } catch (error) {
-      if (error.status === 404) {
-        logger.error(error);
-        return null;
+      if (error.status !== 404) {
+        throw error;
       }
-      throw error;
+      logger.warn(`Form attachment ${name} not found for doc ${docId}`);
     }
   },
   /**

--- a/api/src/services/generate-xform.js
+++ b/api/src/services/generate-xform.js
@@ -28,7 +28,7 @@ const processErrorHandler = (xsltproc, err, reject) => {
     logger.error(errMsg);
     return reject(new Error(errMsg));
   }
-  logger.error(err);
+  logger.error('%o', err);
   return reject(new Error(`Unknown Error: An error occurred when executing '${XSLTPROC_CMD}' command`));
 };
 

--- a/api/tests/mocha/services/forms.spec.js
+++ b/api/tests/mocha/services/forms.spec.js
@@ -42,8 +42,6 @@ describe('forms service', () => {
 
       sinon.stub(db.medic, 'getAttachment').resolves(fakeAttachment);
       sinon.stub(logger, 'error');
-
-
       const result = await service.getAttachment(fakeDoc._id, fakeName);
 
       expect(result).to.equal(fakeAttachment);
@@ -51,7 +49,7 @@ describe('forms service', () => {
       expect(logger.error.called).to.be.false;
     });
 
-    it('should return null and log error when error status is 404', async () => {
+    it('should return undefined and log warning when error status is 404', async () => {
       const fakeDoc = { _id: 'doc1', _rev: '1-abc' };
       const fakeName = 'missing.txt';
       const notFoundError = new Error('Not found');
@@ -59,10 +57,12 @@ describe('forms service', () => {
 
       sinon.stub(db.medic, 'getAttachment').rejects(notFoundError);
       sinon.stub(logger, 'error');
+      sinon.stub(logger, 'warn');
       const result = await service.getAttachment(fakeDoc._id, fakeName);
 
-      expect(result).to.be.null;
-      expect(logger.error.calledOnceWith(notFoundError)).to.be.true;
+      expect(result).to.be.undefined;
+      expect(logger.error.called).to.be.false;
+      expect(logger.warn.called).to.be.true;
     });
 
     it('should throw error for non-404 errors', async () => {


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

closes #10633

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10633-fix-api-logging/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10633-fix-api-logging/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10633-fix-api-logging/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

