### PR TITLE
chore(#10639): fix k3d tests

### DIFF
--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -1258,14 +1258,15 @@ const createCluster = async (dataDir) => {
     endpoint:
       - http://${K3D_REPO()}
 `;
+  console.log('Registry URL:', K3D_REPO());
+  console.log('Config content:', configContent);
   await fs.writeFile(registriesConfig, configContent);
 
   await runCommand(
     `k3d cluster create ${PROJECT_NAME} ` +
     `--port ${hostPort}:443@loadbalancer ` +
     `--volume ${dataDir}:${K3D_DATA_PATH} --kubeconfig-switch-context=false ` +
-    `--registry-use ${K3D_REPO()} ` +
-    `--registry-config ${registriesConfig}`
+    `--registry-use ${K3D_REPO()} `
   );
 };
 


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Tests started failing due to local docker registry only responding to http. 
Adds docker registry config for http.

closes #10639

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10639-fix-k3d-tests/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10639-fix-k3d-tests/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10639-fix-k3d-tests/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

