### PR TITLE
chore: fix #10639 k3d integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,7 +211,7 @@ jobs:
             allure-report
             tests/logs
             tests/results/
-        if: ${{ failure() }} 
+        if: ${{ failure() }}
 
   translations:
     needs: build


### PR DESCRIPTION
Resolves https://github.com/medic/cht-core/issues/10639

**Cause**
https://github.com/actions/runner-images/issues/13474

>Target date
Image deployment will start on Monday February 9th, 2026 and will take about 3 days.

From Slack:
>Docker updated on the GH runner. Rolled out across last few days. 
Updated docker moved to containerd image store, which doesn't respect http registry.