### PR TITLE
chore(#10644): add task filtering telemetry

### DIFF
--- a/webapp/src/ts/modules/tasks/tasks-sidebar-filter.component.ts
+++ b/webapp/src/ts/modules/tasks/tasks-sidebar-filter.component.ts
@@ -136,28 +136,28 @@ export class TasksSidebarFilterComponent implements OnInit, AfterViewInit, OnDes
 
   private recordToggleTelemetry() {
     if (this.isOpen) {
-      this.telemetryService.record('sidebar_filter:tasks:open');
+      this.telemetryService.record('tasks:filter:open');
     } else {
-      this.telemetryService.record('sidebar_filter:tasks:close');
+      this.telemetryService.record('tasks:filter:close');
     }
   }
 
   private recordApplyTelemetry() {
-    this.telemetryService.record('sidebar_filter:tasks:apply', this.filterCount.total);
+    this.telemetryService.record('tasks:filter:apply', this.filterCount.total);
     this.filters.forEach(filter => {
       const count = this.filterCount[filter.fieldId] || 0;
       if (count > 0) {
-        this.telemetryService.record(`sidebar_filter:tasks:apply:${filter.fieldId}`, count);
+        this.telemetryService.record(`tasks:filter:apply:${filter.fieldId}`, count);
       }
     });
   }
 
   private recordResetTelemetry() {
-    this.telemetryService.record('sidebar_filter:tasks:reset');
+    this.telemetryService.record('tasks:filter:reset');
   }
 
   private recordClearTelemetry(fieldIds: string[]) {
-    fieldIds.forEach(fieldId => this.telemetryService.record(`sidebar_filter:tasks:clear:${fieldId}`));
+    fieldIds.forEach(fieldId => this.telemetryService.record(`tasks:filter:clear:${fieldId}`));
   }
 
   ngOnDestroy() {

--- a/webapp/tests/karma/ts/modules/tasks/tasks-sidebar-filter.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/tasks/tasks-sidebar-filter.component.spec.ts
@@ -71,7 +71,7 @@ describe('TasksSidebarFilterComponent', () => {
     expect(setSidebarFilterStub.calledOnce).to.be.true;
     expect(setSidebarFilterStub.args[0][0]).to.deep.equal({ isOpen: true });
     expect(telemetryService.record.calledOnce).to.be.true;
-    expect(telemetryService.record.args[0][0]).to.equal('sidebar_filter:tasks:open');
+    expect(telemetryService.record.args[0][0]).to.equal('tasks:filter:open');
   });
 
   it('should toggle sidebar filter closed and record telemetry', () => {
@@ -84,7 +84,7 @@ describe('TasksSidebarFilterComponent', () => {
     expect(setSidebarFilterStub.calledOnce).to.be.true;
     expect(setSidebarFilterStub.args[0][0]).to.deep.equal({ isOpen: false });
     expect(telemetryService.record.calledOnce).to.be.true;
-    expect(telemetryService.record.args[0][0]).to.equal('sidebar_filter:tasks:close');
+    expect(telemetryService.record.args[0][0]).to.equal('tasks:filter:close');
   });
 
   it('should reset filters and record telemetry', () => {
@@ -96,9 +96,9 @@ describe('TasksSidebarFilterComponent', () => {
     expect(clearFiltersStub.calledOnce).to.be.true;
     expect(searchEmitSpy.calledOnce).to.be.true;
     expect(telemetryService.record.calledTwice).to.be.true;
-    expect(telemetryService.record.args[0][0]).to.equal('sidebar_filter:tasks:apply');
+    expect(telemetryService.record.args[0][0]).to.equal('tasks:filter:apply');
     expect(telemetryService.record.args[0][1]).to.equal(0);
-    expect(telemetryService.record.args[1][0]).to.equal('sidebar_filter:tasks:reset');
+    expect(telemetryService.record.args[1][0]).to.equal('tasks:filter:reset');
   });
 
   it('should not reset filters when disabled', () => {
@@ -119,7 +119,7 @@ describe('TasksSidebarFilterComponent', () => {
     expect(searchEmitSpy.calledOnce).to.be.true;
     expect(setSidebarFilterStub.calledOnce).to.be.true;
     expect(telemetryService.record.calledOnce).to.be.true;
-    expect(telemetryService.record.args[0][0]).to.equal('sidebar_filter:tasks:apply');
+    expect(telemetryService.record.args[0][0]).to.equal('tasks:filter:apply');
     expect(telemetryService.record.args[0][1]).to.equal(0);
   });
 
@@ -136,9 +136,9 @@ describe('TasksSidebarFilterComponent', () => {
     component.applyFilters();
 
     expect(telemetryService.record.calledThrice).to.be.true;
-    expect(telemetryService.record.args[0]).to.deep.equal(['sidebar_filter:tasks:apply', 3]);
-    expect(telemetryService.record.args[1]).to.deep.equal(['sidebar_filter:tasks:apply:overdueFilter', 1]);
-    expect(telemetryService.record.args[2]).to.deep.equal(['sidebar_filter:tasks:apply:taskTypeFilter', 2]);
+    expect(telemetryService.record.args[0]).to.deep.equal(['tasks:filter:apply', 3]);
+    expect(telemetryService.record.args[1]).to.deep.equal(['tasks:filter:apply:overdueFilter', 1]);
+    expect(telemetryService.record.args[2]).to.deep.equal(['tasks:filter:apply:taskTypeFilter', 2]);
   });
 
   it('should not apply filters when disabled', () => {
@@ -163,8 +163,8 @@ describe('TasksSidebarFilterComponent', () => {
     component.clearFilters(['overdue', 'taskType']);
 
     expect(telemetryService.record.calledTwice).to.be.true;
-    expect(telemetryService.record.args[0][0]).to.equal('sidebar_filter:tasks:clear:overdue');
-    expect(telemetryService.record.args[1][0]).to.equal('sidebar_filter:tasks:clear:taskType');
+    expect(telemetryService.record.args[0][0]).to.equal('tasks:filter:clear:overdue');
+    expect(telemetryService.record.args[1][0]).to.equal('tasks:filter:clear:taskType');
   });
 
   it('should not record clear telemetry when clearing all filters without fieldIds', () => {


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

#10644

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10644-add-task-filtering-telemetry/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10644-add-task-filtering-telemetry/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10644-add-task-filtering-telemetry/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

