### PR TITLE
chore(na): update PR template to include AI disclosure check

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,11 +26,12 @@ https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message
 # Code review checklist
 <!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
 - [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
-- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
+- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
 - [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
 - [ ] Tested: Unit and/or e2e where appropriate
 - [ ] Internationalised: All user facing text
 - [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
+- [ ] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).
 
 <!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->
 


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Per an [internal discussion on Slack](https://medic.slack.com/archives/C024KS283/p1772168630899759?thread_ts=1772154073.327829&cid=C024KS283):

> Just curious.. How do you quantify AIs contribution? Assuming I use Claude for a PR without stating that I did.

Even though we published a [forum post](https://forum.communityhealthtoolkit.org/t/ai-assistance-guidelines-for-cht-contributors/5443) about it, not everyone is aware of the new [AI Guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/) on PRs. Adding a check item on the PR to help nudge folks in the right direction.

<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:mrjones-plip-patch-2/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:mrjones-plip-patch-2/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:mrjones-plip-patch-2/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

