### PR TITLE
fix(#10712): replace nullish coalescing with logical OR in isRelevantChange

### DIFF
--- a/webapp/src/ts/services/contact-change-filter.service.ts
+++ b/webapp/src/ts/services/contact-change-filter.service.ts
@@ -80,8 +80,8 @@ export class ContactChangeFilterService {
   }
 
   isRelevantChange(change, contact) {
-    return this.matchContact(change, contact) ??
-      this.isRelevantContact(change, contact) ??
+    return this.matchContact(change, contact) ||
+      this.isRelevantContact(change, contact) ||
       this.isRelevantReport(change, contact);
   }
 }

--- a/webapp/tests/karma/ts/services/contact-change-filter.service.spec.ts
+++ b/webapp/tests/karma/ts/services/contact-change-filter.service.spec.ts
@@ -362,6 +362,85 @@ describe('ContactChangeFilter service', () => {
     });
   });
 
+  describe('isRelevantChange', () => {
+    it('returns true when change matches contact directly', () => {
+      const change = { id: 'contact1', doc: { _id: 'contact1' } };
+      const contact = { doc: { _id: 'contact1' } };
+      expect(service.isRelevantChange(change, contact)).to.equal(true);
+    });
+
+    it('returns true when change is a relevant child contact', () => {
+      const change = { id: 'child1', doc: { _id: 'child1', type: 'person', parent: { _id: 'contact1' } } };
+      const contact = { doc: { _id: 'contact1' } };
+      expect(service.isRelevantChange(change, contact)).to.equal(true);
+    });
+
+    it('returns true when change is a relevant report for the contact', () => {
+      const change = {
+        id: 'report1',
+        doc: {
+          _id: 'report1',
+          form: 'stock_report',
+          type: 'data_record',
+          fields: { patient_id: 'contact1' }
+        }
+      };
+      const contact = { doc: { _id: 'contact1', patient_id: 'patient1' } };
+      contactTypesIncludes.returns(false);
+      expect(service.isRelevantChange(change, contact)).to.equal(true);
+    });
+
+    it('returns true when change is a relevant report for a child contact', () => {
+      const change = {
+        id: 'report1',
+        doc: {
+          _id: 'report1',
+          form: 'assessment',
+          type: 'data_record',
+          fields: { patient_id: 'child_patient1' }
+        }
+      };
+      const contact = {
+        doc: { _id: 'contact1' },
+        children: [
+          {
+            type: { id: 'person' },
+            contacts: [
+              { doc: { _id: 'child1', patient_id: 'child_patient1' } }
+            ]
+          }
+        ]
+      };
+      contactTypesIncludes.returns(false);
+      expect(service.isRelevantChange(change, contact)).to.equal(true);
+    });
+
+    it('returns false when change is unrelated', () => {
+      const change = {
+        id: 'other1',
+        doc: {
+          _id: 'other1',
+          form: 'some_form',
+          type: 'data_record',
+          fields: { patient_id: 'someone_else' }
+        }
+      };
+      const contact = {
+        doc: { _id: 'contact1', patient_id: 'patient1' },
+        children: [],
+        lineage: []
+      };
+      contactTypesIncludes.returns(false);
+      expect(service.isRelevantChange(change, contact)).to.equal(false);
+    });
+
+    it('returns false for invalid inputs', () => {
+      expect(service.isRelevantChange({}, {})).to.equal(false);
+      expect(service.isRelevantChange(undefined, undefined)).to.equal(false);
+      expect(service.isRelevantChange({ id: '1' }, { doc: { _id: '2' } })).to.equal(false);
+    });
+  });
+
   describe('isDeleted', () => {
     it('returns true when deleted', () => {
       const change = { doc: { _id: '123' }, deleted: true };


### PR DESCRIPTION
# Description

`isRelevantChange` used nullish coalescing (`??`) instead of logical OR (`||`). Since `matchContact` returns a boolean, `false ?? expr` short-circuits to `false`, making `isRelevantContact` and `isRelevantReport` dead code.

Fixes #10712

# Code review checklist
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [x] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.