### PR TITLE
feat(7369): authentication

### DIFF
--- a/admin-tool/custom-webpack.config.js
+++ b/admin-tool/custom-webpack.config.js
@@ -7,6 +7,10 @@ module.exports = {
     fallback: {
       path: false,
       fs: false,
+      os: false,
+      zlib: false,
+      http: false,
+      https: false,
     }
   }
 };

--- a/admin-tool/package-lock.json
+++ b/admin-tool/package-lock.json
@@ -17,6 +17,8 @@
         "@angular/platform-browser": "19.1.7",
         "@angular/platform-browser-dynamic": "19.1.7",
         "@angular/router": "19.1.7",
+        "@medic/cht-datasource": "file:../shared-libs/cht-datasource",
+        "@medic/constants": "file:../shared-libs/constants",
         "@messageformat/core": "^3.4.0",
         "@ngx-translate/core": "^16.0.4",
         "bootstrap": "^3.4.1",
@@ -34,6 +36,21 @@
         "@angular/compiler-cli": "19.1.7",
         "@angular/localize": "19.1.7"
       }
+    },
+    "../shared-libs/cht-datasource": {
+      "name": "@medic/cht-datasource",
+      "version": "1.0.0",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@medic/contact-types-utils": "file:../contact-types-utils",
+        "@medic/logger": "file:../logger"
+      }
+    },
+    "../shared-libs/constants": {
+      "name": "@medic/constants",
+      "version": "1.0.0",
+      "license": "Apache-2.0"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -4040,6 +4057,14 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@medic/cht-datasource": {
+      "resolved": "../shared-libs/cht-datasource",
+      "link": true
+    },
+    "node_modules/@medic/constants": {
+      "resolved": "../shared-libs/constants",
+      "link": true
     },
     "node_modules/@messageformat/core": {
       "version": "3.4.0",
@@ -11323,6 +11348,16 @@
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/process-nextick-args": {

--- a/admin-tool/package.json
+++ b/admin-tool/package.json
@@ -29,6 +29,8 @@
     "@angular/platform-browser": "19.1.7",
     "@angular/platform-browser-dynamic": "19.1.7",
     "@angular/router": "19.1.7",
+    "@medic/cht-datasource": "file:../shared-libs/cht-datasource",
+    "@medic/constants": "file:../shared-libs/constants",
     "@messageformat/core": "^3.4.0",
 "@ngx-translate/core": "^16.0.4",
     "bootstrap": "^3.4.1",

--- a/admin-tool/src/ts/app-routing.module.ts
+++ b/admin-tool/src/ts/app-routing.module.ts
@@ -1,6 +1,8 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 
+import { AppRouteGuardProvider } from '@admin-tool-providers/app-route.guard.provider';
+
 import { routes as displayRoutes } from '@admin-tool-modules/display/display.routes';
 import { routes as usersRoutes } from '@admin-tool-modules/users/users.routes';
 import { routes as authorizationRoutes } from '@admin-tool-modules/authorization/authorization.routes';
@@ -13,18 +15,24 @@ import { routes as upgradeRoutes } from '@admin-tool-modules/upgrade/upgrade.rou
 import { routes as exportRoutes } from '@admin-tool-modules/export/export.routes';
 import { routes as backupRoutes } from '@admin-tool-modules/backup/backup.routes';
 
+const withGuard = (moduleRoutes: Routes, permissions: string[]): Routes => moduleRoutes.map(route => ({
+  ...route,
+  canActivate: [AppRouteGuardProvider],
+  data: { ...route.data, permissions },
+}));
+
 const routes: Routes = [
-  ...displayRoutes,
-  ...usersRoutes,
-  ...authorizationRoutes,
-  ...smsRoutes,
-  ...formsRoutes,
-  ...targetsRoutes,
-  ...imagesRoutes,
-  ...messageQueueRoutes,
-  ...upgradeRoutes,
-  ...exportRoutes,
-  ...backupRoutes,
+  ...withGuard(displayRoutes, ['can_configure']),
+  ...withGuard(usersRoutes, ['can_configure']),
+  ...withGuard(authorizationRoutes, ['can_configure']),
+  ...withGuard(smsRoutes, ['can_configure']),
+  ...withGuard(formsRoutes, ['can_configure']),
+  ...withGuard(targetsRoutes, ['can_configure']),
+  ...withGuard(imagesRoutes, ['can_configure']),
+  ...withGuard(messageQueueRoutes, ['can_view_outgoing_messages']),
+  ...withGuard(upgradeRoutes, ['can_upgrade']),
+  ...withGuard(exportRoutes, ['can_export_all']),
+  ...withGuard(backupRoutes, ['can_configure']),
   { path: '', redirectTo: 'display', pathMatch: 'full' },
   { path: '**', redirectTo: 'display' },
 ];

--- a/admin-tool/src/ts/app.config.ts
+++ b/admin-tool/src/ts/app.config.ts
@@ -1,11 +1,16 @@
-import { ApplicationConfig, importProvidersFrom } from '@angular/core';
+import { ApplicationConfig, importProvidersFrom, APP_INITIALIZER } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { withInterceptorsFromDi, provideHttpClient } from '@angular/common/http';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { BrowserModule } from '@angular/platform-browser';
 import { TranslateModule } from '@ngx-translate/core';
+import { CookieService } from 'ngx-cookie-service';
 
 import { AppRoutingModule } from './app-routing.module';
+import { SessionService } from '@admin-tool-services/session.service';
+import { AppRouteGuardProvider } from '@admin-tool-providers/app-route.guard.provider';
+
+const initSession = (session: SessionService) => () => session.init();
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -17,5 +22,13 @@ export const appConfig: ApplicationConfig = {
     ),
     provideHttpClient(withInterceptorsFromDi()),
     provideAnimations(),
+    CookieService,
+    AppRouteGuardProvider,
+    {
+      provide: APP_INITIALIZER,
+      useFactory: initSession,
+      deps: [SessionService],
+      multi: true,
+    },
   ]
 };

--- a/admin-tool/src/ts/components/sidebar/sidebar.component.html
+++ b/admin-tool/src/ts/components/sidebar/sidebar.component.html
@@ -1,36 +1,36 @@
 <div class="navigation">
   <ul>
-    <li routerLinkActive="active-nav">
+    <li routerLinkActive="active-nav" [mmAuth]="'can_configure'">
       <a routerLink="/display">Display</a>
     </li>
-    <li routerLinkActive="active-nav">
+    <li routerLinkActive="active-nav" [mmAuth]="'can_configure'">
       <a routerLink="/users">Users</a>
     </li>
-    <li routerLinkActive="active-nav">
+    <li routerLinkActive="active-nav" [mmAuth]="'can_configure'">
       <a routerLink="/authorization">Authorization</a>
     </li>
-    <li routerLinkActive="active-nav">
+    <li routerLinkActive="active-nav" [mmAuth]="'can_configure'">
       <a routerLink="/sms">SMS</a>
     </li>
-    <li routerLinkActive="active-nav">
+    <li routerLinkActive="active-nav" [mmAuth]="'can_configure'">
       <a routerLink="/forms">Forms</a>
     </li>
-    <li routerLinkActive="active-nav">
+    <li routerLinkActive="active-nav" [mmAuth]="'can_configure'">
       <a routerLink="/targets">Targets</a>
     </li>
-    <li routerLinkActive="active-nav">
+    <li routerLinkActive="active-nav" [mmAuth]="'can_configure'">
       <a routerLink="/images">Images</a>
     </li>
-    <li routerLinkActive="active-nav">
+    <li routerLinkActive="active-nav" [mmAuth]="'can_view_outgoing_messages'">
       <a routerLink="/message-queue">Message Queue</a>
     </li>
-    <li routerLinkActive="active-nav">
+    <li routerLinkActive="active-nav" [mmAuth]="'can_upgrade'">
       <a routerLink="/upgrade">Upgrade</a>
     </li>
-    <li routerLinkActive="active-nav">
+    <li routerLinkActive="active-nav" [mmAuth]="'can_export_all'">
       <a routerLink="/export">Export</a>
     </li>
-    <li routerLinkActive="active-nav">
+    <li routerLinkActive="active-nav" [mmAuth]="'can_configure'">
       <a routerLink="/backup">Backup</a>
     </li>
   </ul>

--- a/admin-tool/src/ts/components/sidebar/sidebar.component.ts
+++ b/admin-tool/src/ts/components/sidebar/sidebar.component.ts
@@ -1,9 +1,11 @@
 import { Component } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 
+import { AuthDirective } from '@admin-tool-directives/auth.directive';
+
 @Component({
   selector: 'app-sidebar',
-  imports: [RouterLink, RouterLinkActive],
+  imports: [RouterLink, RouterLinkActive, AuthDirective],
   templateUrl: './sidebar.component.html',
 })
 export class SidebarComponent { }

--- a/admin-tool/src/ts/directives/auth.directive.ts
+++ b/admin-tool/src/ts/directives/auth.directive.ts
@@ -1,0 +1,90 @@
+import { Directive, Input, HostBinding, OnChanges } from '@angular/core';
+import { AuthService } from '@admin-tool-services/auth.service';
+
+@Directive({
+  standalone: true,
+  selector: '[mmAuth]'
+})
+export class AuthDirective implements OnChanges {
+  @Input() mmAuth?: string;
+  @Input() mmAuthAny?: any;
+  @Input() mmAuthOnline?: boolean;
+
+  private hidden = true;
+
+  constructor(private authService: AuthService) { }
+
+  private compile() {
+    const dynamicChecks = allowed => {
+      if (allowed && this.mmAuthAny) {
+        const mmAuthAny = Array.isArray(this.mmAuthAny) ? this.mmAuthAny : [this.mmAuthAny];
+        if (mmAuthAny.some(property => property === true)) {
+          this.hidden = false;
+          return;
+        }
+
+        const permissionsGroups: string[][] = mmAuthAny
+          .filter(property => Array.isArray(property) || typeof property === 'string')
+          .map(property => Array.isArray(property)
+            ? (property as any[]).flat(Infinity) as string[]
+            : [ property as string ]);
+
+        if (!permissionsGroups.length) {
+          this.hidden = true;
+          return;
+        }
+
+        return updateVisibility([ this.authService.any(permissionsGroups) ]);
+      }
+    };
+
+    const updateVisibility = promises => {
+      return Promise
+        .all(promises)
+        .then(permissions => {
+          const allPermissions = permissions.every(permission => !!permission);
+          if (allPermissions) {
+            this.hidden = false;
+            return true;
+          }
+
+          this.hidden = true;
+          return false;
+        });
+    };
+
+    const staticChecks = () => {
+      const promises: Promise<boolean>[] = [];
+      if (this.mmAuth) {
+        promises.push(this.authService.has(this.mmAuth.split(',')));
+      }
+
+      if (this.mmAuthOnline !== undefined) {
+        const onlineResult = this.authService.online(this.mmAuthOnline);
+        promises.push(Promise.resolve(onlineResult));
+      }
+
+      if (!promises.length) {
+        return true;
+      }
+
+      return updateVisibility(promises);
+    };
+
+    const result = staticChecks();
+    if (result === true) {
+      dynamicChecks(true);
+    } else {
+      result.then(dynamicChecks);
+    }
+  }
+
+  ngOnChanges() {
+    this.compile();
+  }
+
+  @HostBinding('class.hidden')
+  public get isHidden(): boolean {
+    return this.hidden;
+  }
+}

--- a/admin-tool/src/ts/polyfills.ts
+++ b/admin-tool/src/ts/polyfills.ts
@@ -2,6 +2,8 @@ import '@angular/localize/init';
 import 'zone.js';
 
 (window as any).global = window;
+// process shim for Node.js libraries used in browser context
+(window as any).process = (window as any).process || { browser: true, env: {}, version: '', versions: {} };
 
 declare global {
   interface Window {

--- a/admin-tool/src/ts/providers/app-route.guard.provider.ts
+++ b/admin-tool/src/ts/providers/app-route.guard.provider.ts
@@ -1,0 +1,29 @@
+import { CanActivate, ActivatedRouteSnapshot, Router } from '@angular/router';
+import { Injectable } from '@angular/core';
+import { from, Observable, of } from 'rxjs';
+
+import { AuthService } from '@admin-tool-services/auth.service';
+
+@Injectable()
+export class AppRouteGuardProvider implements CanActivate {
+  constructor(
+    private authService: AuthService,
+    private router: Router,
+  ) {}
+
+  canActivate(route: ActivatedRouteSnapshot): Observable<boolean> {
+    if (!route.data || !route.data.permissions) {
+      return of(true);
+    }
+
+    return from(
+      this.authService.has(route.data.permissions).then((canActivate) => {
+        if (!canActivate) {
+          const redirectPath = route.data.redirect || ['error', '403'];
+          this.router.navigate(redirectPath);
+        }
+        return canActivate;
+      })
+    );
+  }
+}

--- a/admin-tool/src/ts/services/auth.service.ts
+++ b/admin-tool/src/ts/services/auth.service.ts
@@ -1,0 +1,86 @@
+import { Injectable } from '@angular/core';
+
+import { SessionService } from '@admin-tool-services/session.service';
+import { CHTDatasourceService } from '@admin-tool-services/cht-datasource.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AuthService {
+
+  constructor(
+    private session: SessionService,
+    private chtDatasourceService: CHTDatasourceService
+  ) { }
+
+  /**
+   * Returns true if the current user's role has all the permissions passed in as arguments.
+   * If a permission has a '!' prefix, resolves true only if the user doesn't have the permission.
+   * DB admins automatically have all permissions.
+   * Throws error when response has 503 status.
+   * @param permissions {string | string[]}
+   */
+  has(permissions?: string | string[]): Promise<boolean> {
+    return this.chtDatasourceService
+      .get()
+      .then(chtApi => {
+        const userCtx = this.session.userCtx();
+
+        if (!userCtx) {
+          console.debug('AuthService :: Not logged in.');
+          return false;
+        }
+
+        return chtApi.v1.hasPermissions(permissions, userCtx);
+      })
+      .catch((err) => {
+        if (err?.status === 503) {
+          throw err;
+        }
+        return false;
+      });
+  }
+
+  /**
+   * Receives a list of groups of permissions and returns a promise that will be resolved if the
+   * current user's role has all the permissions of any of the provided groups.
+   * @param permissionsGroupList {string | string[] | string[][]}
+   */
+  any(permissionsGroupList?: string | string[] | string[][]): Promise<boolean> {
+    // The `permissionsGroupList` is an array that contains groups of permissions,
+    // mainly attributed to the complexity of permission grouping
+    if (!Array.isArray(permissionsGroupList)) {
+      return this.has(permissionsGroupList);
+    }
+
+    return this.chtDatasourceService
+      .get()
+      .then(chtApi => {
+        const userCtx = this.session.userCtx();
+
+        if (!userCtx) {
+          console.debug('AuthService :: Not logged in');
+          return false;
+        }
+
+        return chtApi.v1.hasAnyPermission(permissionsGroupList, userCtx);
+      })
+      .catch(() => false);
+  }
+
+  online(online?): boolean {
+    const userCtx = this.session.userCtx();
+
+    if (!userCtx) {
+      return false;
+    }
+
+    if (this.session.isOnlineOnly(userCtx) !== Boolean(online)) {
+      const reason = online ? 'User missing online role' : 'User has online role';
+      console.debug(`AuthService :: ${reason}. User roles: ${userCtx.roles}`);
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/admin-tool/src/ts/services/cht-datasource.service.ts
+++ b/admin-tool/src/ts/services/cht-datasource.service.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { DataContext, getDatasource, getRemoteDataContext } from '@medic/cht-datasource';
+import { firstValueFrom } from 'rxjs';
+
+import { SessionService } from '@admin-tool-services/session.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CHTDatasourceService {
+  private initialized: Promise<void> | null = null;
+  private settings: any = null;
+  private userCtx: any = null;
+  private dataContext!: DataContext;
+
+  constructor(private http: HttpClient, private sessionService: SessionService) {}
+
+  private async init() {
+    this.userCtx = this.sessionService.userCtx();
+    const settings = await firstValueFrom(this.http.get('/api/v1/settings'));
+    this.settings = settings;
+    this.dataContext = getRemoteDataContext();
+  }
+
+  isInitialized() {
+    if (!this.initialized) {
+      this.initialized = this.init();
+    }
+    return this.initialized;
+  }
+
+  async get() {
+    await this.isInitialized();
+    const dataSource = getDatasource(this.dataContext);
+    return {
+      ...dataSource,
+      v1: {
+        ...dataSource.v1,
+        hasPermissions: (permissions, user?, chtSettings?) => {
+          const userRoles = user?.roles ?? this.userCtx?.roles;
+          const permsSettings = chtSettings?.permissions ?? this.settings?.permissions;
+          return dataSource.v1.hasPermissions(permissions, userRoles, permsSettings);
+        },
+        hasAnyPermission: (permissionsGroupList, user?, chtSettings?) => {
+          const userRoles = user?.roles ?? this.userCtx?.roles;
+          const permsSettings = chtSettings?.permissions ?? this.settings?.permissions;
+          return dataSource.v1.hasAnyPermission(permissionsGroupList, userRoles, permsSettings);
+        },
+      },
+    };
+  }
+}

--- a/admin-tool/src/ts/services/location.service.ts
+++ b/admin-tool/src/ts/services/location.service.ts
@@ -1,0 +1,19 @@
+import { Inject, Injectable } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LocationService {
+  dbName = 'medic';
+  path = '/';
+  adminPath = '/admin/';
+
+  url;
+
+  constructor(@Inject(DOCUMENT) private document: Document) {
+    const location = document.location;
+    const port = location.port ? ':' + location.port : '';
+    this.url = location.protocol + '//' + location.hostname + port + '/' + this.dbName;
+  }
+}

--- a/admin-tool/src/ts/services/session.service.ts
+++ b/admin-tool/src/ts/services/session.service.ts
@@ -1,0 +1,132 @@
+import { Injectable, Inject } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { CookieService } from 'ngx-cookie-service';
+import { DOCUMENT } from '@angular/common';
+
+import { LocationService } from '@admin-tool-services/location.service';
+import { USER_ROLES } from '@medic/constants';
+
+const COOKIE_NAME = 'userCtx';
+const ONLINE_ROLE = USER_ROLES.ONLINE;
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SessionService {
+  userCtxCookieValue: any = null;
+  httpOptions = { headers: new HttpHeaders({ Accept: 'application/json' }) };
+
+  constructor(
+    private cookieService: CookieService,
+    private http: HttpClient,
+    @Inject(DOCUMENT) private document: Document,
+    private location: LocationService
+  ) {}
+
+  navigateToLogin() {
+    console.warn('User must reauthenticate');
+    const params = new URLSearchParams();
+    params.append('redirect', this.document.location.href);
+    const userCtx = this.userCtx();
+    const username = userCtx && userCtx.name;
+    if (username) {
+      params.append('username', username);
+    }
+
+    this.cookieService.delete(COOKIE_NAME, '/');
+    this.userCtxCookieValue = undefined;
+    this.document.location.href = `/${this.location.dbName}/login?${params.toString()}`;
+  }
+
+  logout() {
+    return this.http
+      .delete('/_session', this.httpOptions)
+      .toPromise()
+      .catch(() => {
+        // Set cookie to force login before using app
+        this.cookieService.set('login', 'force', undefined, '/');
+      })
+      .then(() => {
+        this.navigateToLogin();
+      });
+  }
+
+  /**
+   * Get the user context of the logged in user. This will return
+   * null if the user is not logged in.
+   */
+  userCtx() {
+    if (!this.userCtxCookieValue) {
+      try {
+        this.userCtxCookieValue = JSON.parse(this.cookieService.get(COOKIE_NAME));
+      } catch (error) {
+        console.error('Cookie parsing error', error);
+        this.userCtxCookieValue = null;
+      }
+    }
+
+    return this.userCtxCookieValue;
+  }
+
+  private refreshUserCtx() {
+    return this.http
+      .get('/' + this.location.dbName + '/login/identity')
+      .toPromise()
+      .catch(this.logout);
+  }
+
+  public check() {
+    if (!this.cookieService.check(COOKIE_NAME)) {
+      this.navigateToLogin();
+    }
+  }
+
+  init() {
+    const userCtx = this.userCtx();
+    if (!userCtx || !userCtx.name) {
+      return this.logout();
+    }
+
+    return this.http
+      .get<{ userCtx: { name: string; roles: string[] } }>('/_session', { responseType: 'json', ...this.httpOptions })
+      .toPromise()
+      .then(value => {
+        const name = value && value.userCtx && value.userCtx.name;
+        if (name !== userCtx.name) {
+          // connected to the internet but server session is different
+          this.logout();
+          return;
+        }
+        const cookieRoles = userCtx.roles as string[];
+        const serverRoles = value!.userCtx.roles;
+        const rolesDiffer =
+          cookieRoles.some(r => !serverRoles.includes(r)) ||
+          serverRoles.some(r => !cookieRoles.includes(r));
+        if (rolesDiffer) {
+          return this.refreshUserCtx().then(() => true);
+        }
+      })
+      .catch(response => {
+        if (response.status === 401) {
+          // connected to the internet but no session on the server
+          this.navigateToLogin();
+        }
+      });
+  }
+
+  hasRole(role, userCtx?) {
+    userCtx = userCtx || this.userCtx();
+    return !!(userCtx && userCtx.roles?.includes(role));
+  }
+
+  isAdmin(userCtx?) {
+    return this.hasRole('_admin', userCtx);
+  }
+
+  /**
+   * Returns true if the logged in user is online only
+   */
+  isOnlineOnly(userCtx?) {
+    return this.isAdmin(userCtx) || this.hasRole(ONLINE_ROLE, userCtx);
+  }
+}

--- a/admin-tool/tests/karma/karma-unit.conf.js
+++ b/admin-tool/tests/karma/karma-unit.conf.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const webpack = require('webpack');
 const baseConfig = require('./karma-unit.base.conf');
 
 module.exports = function (config) {
@@ -15,5 +16,16 @@ module.exports = function (config) {
   config.buildWebpack.webpackConfig.resolve.fallback = {
     path: false,
     fs: false,
+    os: false,
+    zlib: false,
+    http: false,
+    https: false,
   };
+
+  const plugins = config.buildWebpack.webpackConfig.plugins;
+  plugins.push(
+    new webpack.ProvidePlugin({
+      process: 'process/browser',
+    })
+  );
 };

--- a/admin-tool/tests/karma/ts/app.config.spec.ts
+++ b/admin-tool/tests/karma/ts/app.config.spec.ts
@@ -1,3 +1,5 @@
+import { APP_INITIALIZER } from '@angular/core';
+import sinon from 'sinon';
 import { expect } from 'chai';
 import { appConfig } from '../../../src/ts/app.config';
 
@@ -12,5 +14,25 @@ describe('appConfig', () => {
 
   it('should have at least one provider configured', () => {
     expect(appConfig.providers.length).to.be.greaterThan(0);
+  });
+
+  it('should include APP_INITIALIZER for session', () => {
+    const initProvider = appConfig.providers.find(
+      (p: any) => p && p.provide === APP_INITIALIZER
+    );
+    expect(initProvider).to.exist;
+  });
+
+  it('initSession factory should return a function that calls session.init', () => {
+    const initProvider: any = appConfig.providers.find(
+      (p: any) => p && p.provide === APP_INITIALIZER
+    );
+    const sessionStub = { init: sinon.stub().resolves() };
+    const factory = initProvider.useFactory;
+    const initFn = factory(sessionStub);
+    expect(initFn).to.be.a('function');
+    initFn();
+    expect(sessionStub.init.callCount).to.equal(1);
+    sinon.restore();
   });
 });

--- a/admin-tool/tests/karma/ts/components/sidebar/sidebar.component.spec.ts
+++ b/admin-tool/tests/karma/ts/components/sidebar/sidebar.component.spec.ts
@@ -1,17 +1,28 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import sinon from 'sinon';
 import { expect } from 'chai';
 
 import { SidebarComponent } from '@admin-tool-components/sidebar/sidebar.component';
+import { AuthService } from '@admin-tool-services/auth.service';
 
 describe('SidebarComponent', () => {
   let component: SidebarComponent;
   let fixture: ComponentFixture<SidebarComponent>;
 
   beforeEach(waitForAsync(() => {
+    const authService = {
+      has: sinon.stub().resolves(true),
+      any: sinon.stub().resolves(true),
+      online: sinon.stub().returns(true),
+    };
+
     return TestBed
       .configureTestingModule({
         imports: [SidebarComponent, RouterTestingModule],
+        providers: [
+          { provide: AuthService, useValue: authService },
+        ],
       })
       .compileComponents()
       .then(() => {
@@ -20,6 +31,8 @@ describe('SidebarComponent', () => {
         fixture.detectChanges();
       });
   }));
+
+  afterEach(() => sinon.restore());
 
   it('should create the sidebar component', () => {
     expect(component).to.exist;

--- a/admin-tool/tests/karma/ts/directives/auth.directive.spec.ts
+++ b/admin-tool/tests/karma/ts/directives/auth.directive.spec.ts
@@ -1,0 +1,187 @@
+import { Component } from '@angular/core';
+import { TestBed, ComponentFixture, fakeAsync, tick } from '@angular/core/testing';
+import sinon from 'sinon';
+import { expect } from 'chai';
+
+import { AuthDirective } from '@admin-tool-directives/auth.directive';
+import { AuthService } from '@admin-tool-services/auth.service';
+
+@Component({
+  standalone: true,
+  imports: [AuthDirective],
+  template: `<div [mmAuth]="mmAuth" [mmAuthOnline]="mmAuthOnline" [mmAuthAny]="mmAuthAny"></div>`
+})
+class TestHostComponent {
+  mmAuth?: string;
+  mmAuthOnline?: boolean;
+  mmAuthAny?: any;
+}
+
+describe('AuthDirective', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let component: TestHostComponent;
+  let authService;
+
+  const getElement = () => fixture.nativeElement.querySelector('div');
+
+  beforeEach(() => {
+    authService = {
+      has: sinon.stub(),
+      any: sinon.stub(),
+      online: sinon.stub(),
+    };
+
+    TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [
+        { provide: AuthService, useValue: authService },
+      ]
+    });
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('mmAuth', () => {
+    it('should hide element when user lacks permission', fakeAsync(() => {
+      authService.has.resolves(false);
+      component.mmAuth = 'can_configure';
+
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(getElement().classList.contains('hidden')).to.be.true;
+    }));
+
+    it('should show element when user has permission', fakeAsync(() => {
+      authService.has.resolves(true);
+      component.mmAuth = 'can_configure';
+
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(getElement().classList.contains('hidden')).to.be.false;
+    }));
+
+    it('should pass comma-split permissions to has()', fakeAsync(() => {
+      authService.has.resolves(true);
+      component.mmAuth = 'can_configure,can_upgrade';
+
+      fixture.detectChanges();
+      tick();
+
+      expect(authService.has.calledWith(['can_configure', 'can_upgrade'])).to.be.true;
+    }));
+  });
+
+  describe('mmAuthOnline', () => {
+    it('should show element when online check passes', fakeAsync(() => {
+      authService.online.returns(true);
+      component.mmAuthOnline = true;
+
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(getElement().classList.contains('hidden')).to.be.false;
+    }));
+
+    it('should hide element when online check fails', fakeAsync(() => {
+      authService.online.returns(false);
+      component.mmAuthOnline = true;
+
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(getElement().classList.contains('hidden')).to.be.true;
+    }));
+  });
+
+  describe('mmAuthAny', () => {
+    it('should show element when mmAuthAny contains true', fakeAsync(() => {
+      authService.has.resolves(true);
+      component.mmAuth = 'can_configure';
+      component.mmAuthAny = [true];
+
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(getElement().classList.contains('hidden')).to.be.false;
+    }));
+
+    it('should call any() with permission groups', fakeAsync(() => {
+      authService.has.resolves(true);
+      authService.any.resolves(true);
+      component.mmAuth = 'can_configure';
+      component.mmAuthAny = [['can_upgrade'], ['can_export_all']];
+
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(authService.any.callCount).to.equal(1);
+      expect(getElement().classList.contains('hidden')).to.be.false;
+    }));
+
+    it('should hide element when any() returns false', fakeAsync(() => {
+      authService.has.resolves(true);
+      authService.any.resolves(false);
+      component.mmAuth = 'can_configure';
+      component.mmAuthAny = [['can_upgrade']];
+
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(getElement().classList.contains('hidden')).to.be.true;
+    }));
+
+    it('should hide element when mmAuthAny has no valid permission groups', fakeAsync(() => {
+      authService.has.resolves(true);
+      component.mmAuth = 'can_configure';
+      component.mmAuthAny = [123, null];
+
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(getElement().classList.contains('hidden')).to.be.true;
+    }));
+  });
+
+  describe('combined mmAuth + mmAuthOnline', () => {
+    it('should hide when mmAuth passes but mmAuthOnline fails', fakeAsync(() => {
+      authService.has.resolves(true);
+      authService.online.returns(false);
+      component.mmAuth = 'can_configure';
+      component.mmAuthOnline = true;
+
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(getElement().classList.contains('hidden')).to.be.true;
+    }));
+
+    it('should show when both mmAuth and mmAuthOnline pass', fakeAsync(() => {
+      authService.has.resolves(true);
+      authService.online.returns(true);
+      component.mmAuth = 'can_configure';
+      component.mmAuthOnline = true;
+
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(getElement().classList.contains('hidden')).to.be.false;
+    }));
+  });
+});

--- a/admin-tool/tests/karma/ts/modules/shell/main-layout.component.spec.ts
+++ b/admin-tool/tests/karma/ts/modules/shell/main-layout.component.spec.ts
@@ -1,16 +1,24 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import sinon from 'sinon';
 import { expect } from 'chai';
 
 import { MainLayoutComponent } from '@admin-tool-modules/shell/main-layout.component';
 import { HeaderComponent } from '@admin-tool-components/header/header.component';
 import { SidebarComponent } from '@admin-tool-components/sidebar/sidebar.component';
+import { AuthService } from '@admin-tool-services/auth.service';
 
 describe('MainLayoutComponent', () => {
   let component: MainLayoutComponent;
   let fixture: ComponentFixture<MainLayoutComponent>;
 
   beforeEach(waitForAsync(() => {
+    const authService = {
+      has: sinon.stub().resolves(true),
+      any: sinon.stub().resolves(true),
+      online: sinon.stub().returns(true),
+    };
+
     return TestBed
       .configureTestingModule({
         imports: [
@@ -18,6 +26,9 @@ describe('MainLayoutComponent', () => {
           MainLayoutComponent,
           HeaderComponent,
           SidebarComponent,
+        ],
+        providers: [
+          { provide: AuthService, useValue: authService },
         ],
       })
       .compileComponents()
@@ -27,6 +38,8 @@ describe('MainLayoutComponent', () => {
         fixture.detectChanges();
       });
   }));
+
+  afterEach(() => sinon.restore());
 
   it('should create the main layout component', () => {
     expect(component).to.exist;

--- a/admin-tool/tests/karma/ts/providers/app-route.guard.provider.spec.ts
+++ b/admin-tool/tests/karma/ts/providers/app-route.guard.provider.spec.ts
@@ -1,0 +1,87 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import sinon from 'sinon';
+import { expect } from 'chai';
+
+import { AppRouteGuardProvider } from '@admin-tool-providers/app-route.guard.provider';
+import { AuthService } from '@admin-tool-services/auth.service';
+
+describe('AppRouteGuardProvider', () => {
+  let guard: AppRouteGuardProvider;
+  let authService;
+  let router;
+
+  beforeEach(() => {
+    authService = { has: sinon.stub() };
+
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      providers: [
+        AppRouteGuardProvider,
+        { provide: AuthService, useValue: authService },
+      ]
+    });
+
+    guard = TestBed.inject(AppRouteGuardProvider);
+    router = TestBed.inject(Router);
+    sinon.stub(router, 'navigate');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should allow navigation when no permissions defined on route', (done) => {
+    const route: any = { data: {} };
+
+    guard.canActivate(route).subscribe(result => {
+      expect(result).to.be.true;
+      expect(authService.has.callCount).to.equal(0);
+      done();
+    });
+  });
+
+  it('should allow navigation when route has no data', (done) => {
+    const route: any = { data: null };
+
+    guard.canActivate(route).subscribe(result => {
+      expect(result).to.be.true;
+      done();
+    });
+  });
+
+  it('should allow navigation when user has required permissions', (done) => {
+    authService.has.resolves(true);
+    const route: any = { data: { permissions: ['can_configure'] } };
+
+    guard.canActivate(route).subscribe(result => {
+      expect(result).to.be.true;
+      expect(authService.has.calledWith(['can_configure'])).to.be.true;
+      expect((router.navigate as sinon.SinonStub).callCount).to.equal(0);
+      done();
+    });
+  });
+
+  it('should redirect to 403 when user lacks permissions', (done) => {
+    authService.has.resolves(false);
+    const route: any = { data: { permissions: ['can_configure'] } };
+
+    guard.canActivate(route).subscribe(result => {
+      expect(result).to.be.false;
+      expect((router.navigate as sinon.SinonStub).calledWith(['error', '403'])).to.be.true;
+      done();
+    });
+  });
+
+  it('should redirect to custom path when route specifies redirect', (done) => {
+    authService.has.resolves(false);
+    const route: any = { data: { permissions: ['can_upgrade'], redirect: ['upgrade', 'denied'] } };
+
+    guard.canActivate(route).subscribe(result => {
+      expect(result).to.be.false;
+      expect((router.navigate as sinon.SinonStub).calledWith(['upgrade', 'denied'])).to.be.true;
+      done();
+    });
+  });
+});

--- a/admin-tool/tests/karma/ts/services/auth.service.spec.ts
+++ b/admin-tool/tests/karma/ts/services/auth.service.spec.ts
@@ -1,0 +1,274 @@
+import { TestBed } from '@angular/core/testing';
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { of } from 'rxjs';
+
+import { HttpClient } from '@angular/common/http';
+import { SessionService } from '@admin-tool-services/session.service';
+import { AuthService } from '@admin-tool-services/auth.service';
+import { CHTDatasourceService } from '@admin-tool-services/cht-datasource.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let sessionService;
+  let chtDatasourceService: CHTDatasourceService;
+  let http;
+
+  beforeEach(() => {
+    sessionService = { userCtx: sinon.stub(), isOnlineOnly: sinon.stub() };
+    http = { get: sinon.stub().returns(of({})) };
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: SessionService, useValue: sessionService },
+        { provide: HttpClient, useValue: http },
+      ]
+    });
+
+    service = TestBed.inject(AuthService);
+    chtDatasourceService = TestBed.inject(CHTDatasourceService);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('has', () => {
+    it('should return false when no session', async () => {
+      sessionService.userCtx.returns(null);
+      http.get.returns(of({ permissions: {} }));
+      chtDatasourceService['initialized'] = null;
+
+      const result = await service.has('can_configure');
+
+      expect(result).to.be.false;
+    });
+
+    it('should return true when user is db admin', async () => {
+      sessionService.userCtx.returns({ roles: ['_admin'] });
+      http.get.returns(of({ permissions: { can_backup_facilities: ['national_admin'] } }));
+      chtDatasourceService['initialized'] = null;
+
+      const result = await service.has(['can_backup_facilities']);
+
+      expect(result).to.be.true;
+    });
+
+    it('should return false when user does not have permission', async () => {
+      sessionService.userCtx.returns({ roles: ['district_admin'] });
+      http.get.returns(of({ permissions: { can_backup_facilities: ['national_admin'] } }));
+      chtDatasourceService['initialized'] = null;
+
+      const result = await service.has('can_backup_facilities');
+
+      expect(result).to.be.false;
+    });
+
+    it('should return true when user has all permissions', async () => {
+      sessionService.userCtx.returns({ roles: ['national_admin'] });
+      http.get.returns(of({
+        permissions: {
+          can_backup_facilities: ['national_admin'],
+          can_export_messages: ['national_admin', 'district_admin'],
+        }
+      }));
+      chtDatasourceService['initialized'] = null;
+
+      const result = await service.has(['can_backup_facilities', 'can_export_messages']);
+
+      expect(result).to.be.true;
+    });
+
+    it('should return false when admin and !permission', async () => {
+      sessionService.userCtx.returns({ roles: ['_admin'] });
+      http.get.returns(of({ permissions: {} }));
+      chtDatasourceService['initialized'] = null;
+
+      const result = await service.has(['!can_backup_facilities']);
+
+      expect(result).to.be.false;
+    });
+
+    it('should return true when user has !permission they lack', async () => {
+      sessionService.userCtx.returns({ roles: ['analytics'] });
+      http.get.returns(of({
+        permissions: { can_backup_facilities: ['national_admin'] }
+      }));
+      chtDatasourceService['initialized'] = null;
+
+      const result = await service.has(['!can_backup_facilities']);
+
+      expect(result).to.be.true;
+    });
+
+    it('should throw error when server is offline (503)', async () => {
+      sessionService.userCtx.returns({ roles: ['district_admin'] });
+      http.get.returns(of({ permissions: {} }));
+      chtDatasourceService['initialized'] = null;
+      // Stub get() to reject with 503
+      sinon.stub(chtDatasourceService, 'get').rejects({ status: 503 });
+
+      try {
+        await service.has(['can_configure']);
+        expect.fail('should have thrown');
+      } catch (err: any) {
+        expect(err).to.deep.equal({ status: 503 });
+      }
+    });
+
+    it('should return false when settings fetch fails with non-503', async () => {
+      sessionService.userCtx.returns({ roles: ['district_admin'] });
+      chtDatasourceService['initialized'] = null;
+      sinon.stub(chtDatasourceService, 'get').rejects({ status: 500 });
+
+      const result = await service.has(['can_configure']);
+
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('any', () => {
+    it('should delegate to has() when not an array', async () => {
+      sessionService.userCtx.returns({ roles: ['national_admin'] });
+      http.get.returns(of({ permissions: { can_configure: ['national_admin'] } }));
+      chtDatasourceService['initialized'] = null;
+
+      const result = await service.any('can_configure');
+
+      expect(result).to.be.true;
+    });
+
+    it('should return false when no session', async () => {
+      sessionService.userCtx.returns(null);
+      http.get.returns(of({ permissions: {} }));
+      chtDatasourceService['initialized'] = null;
+
+      const result = await service.any([['can_edit'], ['can_configure']]);
+
+      expect(result).to.be.false;
+    });
+
+    it('should return true when admin and no disallowed permissions', async () => {
+      sessionService.userCtx.returns({ roles: ['_admin'] });
+      http.get.returns(of({ permissions: { can_edit: ['chw'] } }));
+      chtDatasourceService['initialized'] = null;
+
+      const result = await service.any([['can_backup_facilities'], ['can_export_messages']]);
+
+      expect(result).to.be.true;
+    });
+
+    it('should return true when user has all permissions in one group', async () => {
+      sessionService.userCtx.returns({ roles: ['district_admin'] });
+      http.get.returns(of({
+        permissions: {
+          can_backup_facilities: ['national_admin', 'district_admin'],
+          can_export_messages: ['national_admin', 'district_admin'],
+        }
+      }));
+      chtDatasourceService['initialized'] = null;
+
+      const result = await service.any([
+        ['can_backup_facilities', 'can_export_messages'],
+        ['can_add_people'],
+      ]);
+
+      expect(result).to.be.true;
+    });
+
+    it('should return false when get() throws in any() path', async () => {
+      sessionService.userCtx.returns({ roles: ['district_admin'] });
+      chtDatasourceService['initialized'] = null;
+      sinon.stub(chtDatasourceService, 'get').rejects(new Error('network error'));
+
+      const result = await service.any([['can_configure'], ['can_upgrade']]);
+
+      expect(result).to.be.false;
+    });
+
+    it('should return false when user has none of the permissions in any group', async () => {
+      sessionService.userCtx.returns({ roles: ['district_admin'] });
+      http.get.returns(of({
+        permissions: {
+          can_backup_facilities: ['national_admin'],
+          can_backup_people: ['national_admin'],
+        }
+      }));
+      chtDatasourceService['initialized'] = null;
+
+      const result = await service.any([
+        ['can_backup_facilities', 'can_backup_people'],
+        ['can_export_messages'],
+      ]);
+
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('online', () => {
+    it('should return false when no session', () => {
+      sessionService.userCtx.returns(null);
+
+      const result = service.online(true);
+
+      expect(result).to.be.false;
+      expect(sessionService.isOnlineOnly.callCount).to.equal(0);
+    });
+
+    it('should return true when requesting online and user is online', () => {
+      sessionService.userCtx.returns({ roles: ['mm-online'] });
+      sessionService.isOnlineOnly.returns(true);
+
+      const result = service.online(true);
+
+      expect(result).to.be.true;
+      expect(sessionService.isOnlineOnly.callCount).to.equal(1);
+    });
+
+    it('should return true when requesting offline and user is offline', () => {
+      sessionService.userCtx.returns({ roles: ['chw'] });
+      sessionService.isOnlineOnly.returns(false);
+
+      const result = service.online(false);
+
+      expect(result).to.be.true;
+    });
+
+    it('should return false when requesting online and user is offline', () => {
+      sessionService.userCtx.returns({ roles: ['chw'] });
+      sessionService.isOnlineOnly.returns(false);
+
+      const result = service.online(true);
+
+      expect(result).to.be.false;
+    });
+
+    it('should return false when requesting offline and user is online', () => {
+      sessionService.userCtx.returns({ roles: ['mm-online'] });
+      sessionService.isOnlineOnly.returns(true);
+
+      const result = service.online(false);
+
+      expect(result).to.be.false;
+    });
+
+    it('should accept truthy input', () => {
+      sessionService.userCtx.returns({ roles: ['mm-online'] });
+      sessionService.isOnlineOnly.returns(true);
+
+      expect(service.online('yes')).to.be.true;
+      expect(service.online(['something'])).to.be.true;
+      expect(sessionService.isOnlineOnly.callCount).to.equal(2);
+    });
+
+    it('should accept falsy input', () => {
+      sessionService.userCtx.returns({ roles: ['chw'] });
+      sessionService.isOnlineOnly.returns(false);
+
+      expect(service.online()).to.be.true;
+      expect(service.online(undefined)).to.be.true;
+      expect(service.online(null)).to.be.true;
+      expect(sessionService.isOnlineOnly.callCount).to.equal(3);
+    });
+  });
+});

--- a/admin-tool/tests/karma/ts/services/cht-datasource.service.spec.ts
+++ b/admin-tool/tests/karma/ts/services/cht-datasource.service.spec.ts
@@ -1,0 +1,128 @@
+import { TestBed } from '@angular/core/testing';
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { of } from 'rxjs';
+
+import { HttpClient } from '@angular/common/http';
+import { CHTDatasourceService } from '@admin-tool-services/cht-datasource.service';
+import { SessionService } from '@admin-tool-services/session.service';
+
+describe('CHTDatasourceService', () => {
+  let service: CHTDatasourceService;
+  let sessionService;
+  let http;
+
+  beforeEach(() => {
+    sessionService = { userCtx: sinon.stub() };
+    http = { get: sinon.stub() };
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: SessionService, useValue: sessionService },
+        { provide: HttpClient, useValue: http },
+      ]
+    });
+
+    service = TestBed.inject(CHTDatasourceService);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('isInitialized', () => {
+    it('should initialize and fetch settings', async () => {
+      const settings = { permissions: { can_configure: ['admin'] } };
+      sessionService.userCtx.returns({ name: 'admin', roles: ['_admin'] });
+      http.get.withArgs('/api/v1/settings').returns(of(settings));
+
+      await service.isInitialized();
+
+      expect(http.get.calledWith('/api/v1/settings')).to.be.true;
+      expect(sessionService.userCtx.callCount).to.equal(1);
+    });
+
+    it('should only initialize once', async () => {
+      sessionService.userCtx.returns({ name: 'admin', roles: ['_admin'] });
+      http.get.returns(of({}));
+
+      await service.isInitialized();
+      await service.isInitialized();
+
+      expect(http.get.callCount).to.equal(1);
+    });
+  });
+
+  describe('get', () => {
+    it('should return datasource with wrapped permission methods', async () => {
+      const settings = { permissions: { can_configure: ['national_admin'] } };
+      const userCtx = { name: 'admin', roles: ['national_admin'] };
+      sessionService.userCtx.returns(userCtx);
+      http.get.withArgs('/api/v1/settings').returns(of(settings));
+
+      const datasource = await service.get();
+
+      expect(datasource).to.have.property('v1');
+      expect(datasource.v1).to.have.property('hasPermissions');
+      expect(datasource.v1).to.have.property('hasAnyPermission');
+    });
+
+    it('hasPermissions should delegate to datasource with service userCtx roles', async () => {
+      const settings = { permissions: { can_configure: ['national_admin'] } };
+      const userCtx = { name: 'admin', roles: ['national_admin'] };
+      sessionService.userCtx.returns(userCtx);
+      http.get.withArgs('/api/v1/settings').returns(of(settings));
+
+      const datasource = await service.get();
+      const result = datasource.v1.hasPermissions('can_configure');
+
+      expect(result).to.be.true;
+    });
+
+    it('hasPermissions should use provided user roles over service userCtx', async () => {
+      const settings = { permissions: { can_configure: ['national_admin'] } };
+      sessionService.userCtx.returns({ roles: ['chw'] });
+      http.get.withArgs('/api/v1/settings').returns(of(settings));
+
+      const datasource = await service.get();
+      const result = datasource.v1.hasPermissions('can_configure', { roles: ['national_admin'] });
+
+      expect(result).to.be.true;
+    });
+
+    it('hasPermissions should return false when user lacks permission', async () => {
+      const settings = { permissions: { can_configure: ['national_admin'] } };
+      const userCtx = { name: 'chw', roles: ['chw'] };
+      sessionService.userCtx.returns(userCtx);
+      http.get.withArgs('/api/v1/settings').returns(of(settings));
+
+      const datasource = await service.get();
+      const result = datasource.v1.hasPermissions('can_configure');
+
+      expect(result).to.be.false;
+    });
+
+    it('hasAnyPermission should return true when user has at least one group of permissions', async () => {
+      const settings = { permissions: { can_configure: ['national_admin'], can_view: ['chw'] } };
+      sessionService.userCtx.returns({ roles: ['chw'] });
+      http.get.withArgs('/api/v1/settings').returns(of(settings));
+
+      const datasource = await service.get();
+      const result = datasource.v1.hasAnyPermission([['can_configure'], ['can_view']]);
+
+      expect(result).to.be.true;
+    });
+
+    it('hasAnyPermission should use provided settings over service settings', async () => {
+      const serviceSettings = { permissions: { can_configure: ['national_admin'] } };
+      const customSettings = { permissions: { can_configure: ['chw'] } };
+      sessionService.userCtx.returns({ roles: ['chw'] });
+      http.get.withArgs('/api/v1/settings').returns(of(serviceSettings));
+
+      const datasource = await service.get();
+      const result = datasource.v1.hasAnyPermission([['can_configure']], undefined, customSettings);
+
+      expect(result).to.be.true;
+    });
+  });
+});

--- a/admin-tool/tests/karma/ts/services/location.service.spec.ts
+++ b/admin-tool/tests/karma/ts/services/location.service.spec.ts
@@ -1,0 +1,67 @@
+import { TestBed } from '@angular/core/testing';
+import { expect } from 'chai';
+import { DOCUMENT } from '@angular/common';
+
+import { LocationService } from '@admin-tool-services/location.service';
+
+describe('LocationService', () => {
+  let service: LocationService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: DOCUMENT,
+          useValue: {
+            location: {
+              protocol: 'https:',
+              hostname: 'localhost',
+              port: '5988',
+              href: 'https://localhost:5988/medic/admin/',
+            }
+          }
+        }
+      ]
+    });
+    service = TestBed.inject(LocationService);
+  });
+
+  it('should have dbName set to medic', () => {
+    expect(service.dbName).to.equal('medic');
+  });
+
+  it('should build url from document.location', () => {
+    expect(service.url).to.equal('https://localhost:5988/medic');
+  });
+
+  it('should have default paths', () => {
+    expect(service.path).to.equal('/');
+    expect(service.adminPath).to.equal('/admin/');
+  });
+
+  describe('when port is empty', () => {
+    beforeEach(() => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          {
+            provide: DOCUMENT,
+            useValue: {
+              location: {
+                protocol: 'https:',
+                hostname: 'example.com',
+                port: '',
+                href: 'https://example.com/medic/',
+              }
+            }
+          }
+        ]
+      });
+      service = TestBed.inject(LocationService);
+    });
+
+    it('should build url without port', () => {
+      expect(service.url).to.equal('https://example.com/medic');
+    });
+  });
+});

--- a/admin-tool/tests/karma/ts/services/session.service.spec.ts
+++ b/admin-tool/tests/karma/ts/services/session.service.spec.ts
@@ -1,0 +1,278 @@
+import { TestBed } from '@angular/core/testing';
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { HttpClient } from '@angular/common/http';
+import { of, throwError } from 'rxjs';
+import { DOCUMENT } from '@angular/common';
+
+import { SessionService } from '@admin-tool-services/session.service';
+import { LocationService } from '@admin-tool-services/location.service';
+import { CookieService } from 'ngx-cookie-service';
+
+describe('SessionService', () => {
+  let service: SessionService;
+  let cookieSet;
+  let cookieGet;
+  let cookieCheck;
+  let cookieDelete;
+  let location;
+  let http;
+  let Location;
+
+  beforeEach(() => {
+    cookieSet = sinon.stub();
+    cookieDelete = sinon.stub();
+    cookieGet = sinon.stub();
+    cookieCheck = sinon.stub();
+    Location = { dbName: 'medic' };
+    location = { href: '' };
+    http = {
+      get: sinon.stub(),
+      delete: sinon.stub(),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: CookieService,
+          useValue: { get: cookieGet, set: cookieSet, delete: cookieDelete, check: cookieCheck },
+        },
+        { provide: LocationService, useValue: Location },
+        { provide: DOCUMENT, useValue: { location } },
+        { provide: HttpClient, useValue: http },
+      ],
+    });
+    service = TestBed.inject(SessionService);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('userCtx', () => {
+    it('should parse user context from cookie', () => {
+      const expected = { name: 'admin', roles: ['_admin'] };
+      cookieGet.returns(JSON.stringify(expected));
+      const actual = service.userCtx();
+      expect(actual).to.deep.equal(expected);
+      expect(cookieGet.args[0][0]).to.equal('userCtx');
+    });
+
+    it('should return null when cookie is invalid JSON', () => {
+      cookieGet.returns('not-json');
+      const actual = service.userCtx();
+      expect(actual).to.be.null;
+    });
+
+    it('should cache the parsed cookie value', () => {
+      const expected = { name: 'admin' };
+      cookieGet.returns(JSON.stringify(expected));
+      service.userCtx();
+      service.userCtx();
+      expect(cookieGet.callCount).to.equal(1);
+    });
+  });
+
+  describe('navigateToLogin', () => {
+    it('should redirect to login with redirect and username params', () => {
+      const consoleWarnMock = sinon.stub(console, 'warn');
+      cookieGet.returns(JSON.stringify({ name: 'admin' }));
+      location.href = 'https://localhost/medic/admin/';
+      Location.dbName = 'medic';
+
+      service.navigateToLogin();
+
+      expect(location.href).to.contain('/medic/login?');
+      expect(location.href).to.contain('username=admin');
+      expect(cookieDelete.calledWith('userCtx', '/')).to.be.true;
+      expect(consoleWarnMock.callCount).to.equal(1);
+    });
+
+    it('should redirect without username when not logged in', () => {
+      sinon.stub(console, 'warn');
+      cookieGet.returns(JSON.stringify({}));
+      location.href = 'https://localhost/medic/';
+      Location.dbName = 'medic';
+
+      service.navigateToLogin();
+
+      expect(location.href).to.contain('/medic/login?');
+      expect(location.href).not.to.contain('username');
+    });
+  });
+
+  describe('logout', () => {
+    it('should delete session and navigate to login', async () => {
+      sinon.stub(console, 'warn');
+      const userCtx = { name: 'admin' };
+      cookieGet.returns(JSON.stringify(userCtx));
+      location.href = 'CURRENT_URL';
+      Location.dbName = 'DB_NAME';
+      http.delete.withArgs('/_session').returns(of(null));
+
+      await service.logout();
+
+      expect(location.href).to.contain('/DB_NAME/login');
+      expect(cookieDelete.args[0][0]).to.equal('userCtx');
+    });
+
+    it('should set force login cookie if delete fails', async () => {
+      sinon.stub(console, 'warn');
+      cookieGet.returns(JSON.stringify({ name: 'admin' }));
+      location.href = 'URL';
+      Location.dbName = 'medic';
+      http.delete.returns(throwError(new Error('network error')));
+
+      await service.logout();
+
+      expect(cookieSet.calledWith('login', 'force', undefined, '/')).to.be.true;
+    });
+  });
+
+  describe('init', () => {
+    it('should logout when no userCtx', async () => {
+      sinon.stub(console, 'warn');
+      cookieGet.returns(JSON.stringify({}));
+      location.href = 'URL';
+      Location.dbName = 'medic';
+      http.delete.returns(of(null));
+
+      await service.init();
+
+      expect(cookieDelete.args[0][0]).to.equal('userCtx');
+    });
+
+    it('should navigate to login on 401 response', async () => {
+      sinon.stub(console, 'warn');
+      cookieGet.returns(JSON.stringify({ name: 'admin' }));
+      Location.dbName = 'medic';
+      http.get.withArgs('/_session').returns(throwError({ status: 401 }));
+
+      await service.init();
+
+      expect(cookieDelete.args[0][0]).to.equal('userCtx');
+    });
+
+    it('should not logout when server not found (status 0)', async () => {
+      cookieGet.returns(JSON.stringify({ name: 'admin' }));
+      http.get.withArgs('/_session').returns(throwError({ status: 0 }));
+
+      await service.init();
+
+      expect(cookieDelete.callCount).to.equal(0);
+    });
+
+    it('should logout when remote name does not match cookie', async () => {
+      sinon.stub(console, 'warn');
+      cookieGet.returns(JSON.stringify({ name: 'admin' }));
+      location.href = 'URL';
+      Location.dbName = 'medic';
+      http.get.withArgs('/_session').returns(of({ userCtx: { name: 'other', roles: [] } }));
+      http.delete.returns(of(null));
+
+      await service.init();
+
+      expect(location.href).to.contain('/medic/login');
+    });
+
+    it('should not logout when remote session is consistent', async () => {
+      cookieGet.returns(JSON.stringify({ name: 'admin', roles: ['_admin'] }));
+      http.get.withArgs('/_session').returns(of({ userCtx: { name: 'admin', roles: ['_admin'] } }));
+
+      await service.init();
+
+      expect(cookieDelete.callCount).to.equal(0);
+    });
+
+    it('should refresh userCtx when server has extra roles compared to cookie', async () => {
+      cookieGet.returns(JSON.stringify({ name: 'admin', roles: ['_admin'] }));
+      Location.dbName = 'medic';
+      // Server has extra role
+      http.get.withArgs('/_session').returns(of({ userCtx: { name: 'admin', roles: ['_admin', 'new_role'] } }));
+      http.get.withArgs('/medic/login/identity').returns(of({}));
+
+      await service.init();
+
+      expect(http.get.calledWith('/medic/login/identity')).to.be.true;
+    });
+  });
+
+  describe('check', () => {
+    it('should navigate to login when cookie is missing', () => {
+      sinon.stub(console, 'warn');
+      cookieCheck.returns(false);
+      cookieGet.returns('{}');
+      location.href = 'URL';
+      Location.dbName = 'medic';
+
+      service.check();
+
+      expect(location.href).to.contain('/medic/login');
+    });
+
+    it('should not navigate when cookie is present', () => {
+      cookieCheck.returns(true);
+      location.href = 'URL';
+
+      service.check();
+
+      expect(location.href).to.equal('URL');
+    });
+  });
+
+  describe('hasRole', () => {
+    it('should return false if user has no roles', () => {
+      cookieGet.returns(JSON.stringify({}));
+      expect(service.hasRole('chw')).to.be.false;
+    });
+
+    it('should return false if user does not have the role', () => {
+      cookieGet.returns(JSON.stringify({ roles: ['nurse'] }));
+      expect(service.hasRole('chw')).to.be.false;
+    });
+
+    it('should return true if user has the role', () => {
+      cookieGet.returns(JSON.stringify({ roles: ['nurse', 'chw'] }));
+      expect(service.hasRole('chw')).to.be.true;
+    });
+
+    it('should use provided userCtx instead of cookie', () => {
+      expect(service.hasRole('_admin', { roles: ['_admin'] })).to.be.true;
+      expect(cookieGet.callCount).to.equal(0);
+    });
+  });
+
+  describe('isAdmin', () => {
+    it('should return false when not logged in', () => {
+      cookieGet.returns(JSON.stringify({}));
+      expect(service.isAdmin()).to.equal(false);
+    });
+
+    it('should return true for _admin role', () => {
+      cookieGet.returns(JSON.stringify({ roles: ['_admin'] }));
+      expect(service.isAdmin()).to.equal(true);
+    });
+
+    it('should return false for national_admin', () => {
+      cookieGet.returns(JSON.stringify({ roles: ['national_admin'] }));
+      expect(service.isAdmin()).to.equal(false);
+    });
+  });
+
+  describe('isOnlineOnly', () => {
+    it('should return true for _admin', () => {
+      cookieGet.returns(JSON.stringify({ roles: ['_admin'] }));
+      expect(service.isOnlineOnly()).to.be.true;
+    });
+
+    it('should return true for mm-online role', () => {
+      cookieGet.returns(JSON.stringify({ roles: ['mm-online'] }));
+      expect(service.isOnlineOnly()).to.be.true;
+    });
+
+    it('should return false for regular user', () => {
+      cookieGet.returns(JSON.stringify({ roles: ['chw'] }));
+      expect(service.isOnlineOnly()).to.be.false;
+    });
+  });
+});

--- a/admin-tool/tsconfig.json
+++ b/admin-tool/tsconfig.json
@@ -20,7 +20,9 @@
       "@admin-tool-components/*": ["src/ts/components/*"],
       "@admin-tool-environments/*": ["src/ts/environments/*"],
       "@admin-tool-modules/*": ["src/ts/modules/*"],
-      "@admin-tool-services/*": ["src/ts/services/*"]
+      "@admin-tool-services/*": ["src/ts/services/*"],
+      "@admin-tool-directives/*": ["src/ts/directives/*"],
+      "@admin-tool-providers/*": ["src/ts/providers/*"]
     },
     "strictNullChecks": true,
     "alwaysStrict": true,


### PR DESCRIPTION
# feat(7369): Authentication

# Description
Full authentication stack to the admin-tool. This included four new services (LocationService, SessionService, ChtDatasourceService, AuthService),  an AppRouteGuardProvider for route-level permission checks, and an [mmAuth]  directive for template-based conditional rendering. The app config was updated with an APP_INITIALIZER to run session.init() on startup, and routes now declare required permissions via a withGuard() helper. Browser compatibility for @medic/cht-datasource required adding a process shim in polyfills.ts and webpack/karma fallbacks for Node built-ins (os, zlib, http, https). The sidebar was updated to use the auth directive to conditionally show nav links based on user permissions. M2 shipped with 150 tests and 100% function coverage.

<img width="591" height="506" alt="image" src="https://github.com/user-attachments/assets/a5267616-2eb6-47e5-9031-5b58c43afe6e" />


# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [x] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [x] AI disclosure: Design by humans, written by Claude based on the webapp application

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

