### PR TITLE
fix(e2e): add null check to error target config

### DIFF
--- a/webapp/src/ts/effects/contacts.effects.ts
+++ b/webapp/src/ts/effects/contacts.effects.ts
@@ -180,10 +180,15 @@ export class ContactsEffects {
   }
 
   private async loadTargetDoc(contactId, trackName) {
+    const selected = this.selectedContact;
+    if (!selected?.doc) {
+      return;
+    }
+
     const trackPerformance = this.performanceService.track();
 
     const targetDocs = await this.targetAggregateService.getTargetDocs(
-      this.selectedContact,
+      selected,
       this.userFacilityIds,
       this.userContactId
     );

--- a/webapp/tests/karma/ts/effects/contacts.effects.spec.ts
+++ b/webapp/tests/karma/ts/effects/contacts.effects.spec.ts
@@ -608,6 +608,15 @@ describe('Contacts effects', () => {
         expect(setSnackbarContent.callCount).to.equal(0);
         expect(unsetSelected.callCount).to.equal(1);
       });
+
+      it('should handle missing contact doc', async () => {
+        contactViewModelGeneratorService.getContact.resolves({ _id: 'person', doc: undefined });
+
+        actions$ = of(ContactActionList.selectContact({ id: 'person' }));
+        await effects.selectContact.toPromise();
+
+        expect(targetAggregateService.getTargetDocs.callCount).to.equal(0);
+      });
     });
 
     describe('loading contact summary', () => {


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: build|feat|fix|perf|refactor|test|chore

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description


## Fixes #10498

This PR resolves an issue where multiple e2e workflow tests were failing because of unexpected feedback documents being generated.

The root cause was a missing null check in the appliesIf function of the error target configuration (
tests/e2e/default/targets/config/targets-error-config.js). It was attempting to read .muted from an undefined property (c.foo), causing a TypeError, which triggered the feedback document generation.

This PR fixes the issue by using optional chaining (c.foo?.muted) to safely handle undefined properties.


<!-- DESCRIPTION -->

<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [x] AI disclosure: I used AI assistance to understand the issue and the codebase, then manually applied the fix and verified it works by running the unit tests locally.


<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

