### PR TITLE
ci: disable cleanup workflow on forks

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -10,6 +10,7 @@ env:
 jobs:
   cleanup:
     name: Deleting old published artefacts
+    if: github.repository == 'medic/cht-core'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: build|feat|fix|perf|refactor|test|chore

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description


## Fixes #10174

This PR resolves an issue where the scheduled cleanup.yml workflow was continuously failing for contributors who forked the repository.

Because the AUTH_MARKET_URL secret is unavailable on contributor forks, the script would fail daily and send unnecessary error notification emails. I've resolved this by adding an if: github.repository == 'medic/cht-core' condition to the job, which guarantees the workflow only runs on the upstream repository and never on user forks.



<!-- DESCRIPTION -->

<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [x] AI disclosure: No AI was used in this contribution

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

