### PR TITLE
fix(#8816): support Couch admins pre-definied in `.ini` file

### DIFF
--- a/tests/integration/transitions/utils.js
+++ b/tests/integration/transitions/utils.js
@@ -1,6 +1,4 @@
 const utils = require('@utils');
-const sentinelUtils = require('@utils/sentinel');
-
 
 const getApiSmsChanges = (messages) => {
   const expectedMessages = messages.map(message => message.content);
@@ -31,12 +29,8 @@ const getApiSmsChanges = (messages) => {
         if (!expectedMessages.length) {
           listener.cancel();
           clearTimeout(timeout);
-          sentinelUtils
-            .waitForSentinel(ids)
-            .then(() => resolve(changes))
-            .catch(reject);
+          resolve(changes);
         }
-
       }
     });
   });


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: build|feat|fix|perf|refactor|test|chore

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

## Fixes: #8816 

## Root Cause: 
The CouchDB docker-entrypoint.sh script previously used a hardcoded grep search sequence (grep -Pzq "\[admins\]\n$COUCHDB_USER =") to verify if the server admin was already populated in cluster-credentials.ini. This approach is extremely fragile because it strictly requires the target user to appear on the exact line immediately following the [admins] header. If multiple admins exist, the check silently fails, causing the script to inadvertently append a duplicate [admins] block and corrupt the server configuration across container restarts.

## Solution: 
I replaced the fragile regex with a robust, POSIX-compliant awk INI parser exactly where the admin checks occur. This guarantees that the script targets exclusively within the active [admins] block and correctly parses the username key regardless of its position in the list or surrounding spaces. When the user is successfully identified, it cleanly skips the duplicate insertion and preserves the config integrity.







<!-- DESCRIPTION -->

<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [x] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [ ] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

