### PR TITLE
feat(#10670): add ui-extensions service to webapp

### DIFF
--- a/webapp/src/ts/services/ui-extensions.service.ts
+++ b/webapp/src/ts/services/ui-extensions.service.ts
@@ -23,7 +23,7 @@ interface UiExtension {
 })
 export class UiExtensionsService {
   private extensionProperties: UiExtensionProperties[] = [];
-  private extensionScripts: Record<string, any> = {};
+  private extensionScripts: Record<string, new () => HTMLElement> = {};
   private initialized = false;
 
   constructor(
@@ -63,7 +63,6 @@ export class UiExtensionsService {
     if (!Element || !(Element.prototype instanceof HTMLElement)) {
       throw new Error(`Could not load UI Extension element with id [${id}].`);
     }
-    this.extensionScripts[id] = Element;
     return Element as new () => HTMLElement;
   }
 
@@ -85,7 +84,7 @@ export class UiExtensionsService {
     const properties = await this.getProperties(id);
 
     if (!this.extensionScripts[id]) {
-      await this.loadExtensionScript(id);
+      this.extensionScripts[id] = await this.loadExtensionScript(id);
     }
 
     return {

--- a/webapp/tests/karma/ts/services/ui-extensions.service.spec.ts
+++ b/webapp/tests/karma/ts/services/ui-extensions.service.spec.ts
@@ -31,7 +31,7 @@ describe('UiExtensionsService', () => {
   });
 
   describe('init()', () => {
-    it('should load extension properties on first call', async () => {
+    it('should load extension properties only on first call', async () => {
       const extensions = [
         { id: 'ext-1', type: 'tab' },
         { id: 'ext-2', type: 'tab' },
@@ -41,15 +41,11 @@ describe('UiExtensionsService', () => {
       await service.getPropertiesByType('tab');
 
       expect(http.get.calledOnceWithExactly('/ui-extension', { responseType: 'json' })).to.be.true;
-    });
-
-    it('should only initialize once when called multiple times', async () => {
-      http.get.returns(of([]));
 
       await service.getPropertiesByType('tab');
-      await service.getPropertiesByType('tab');
-      await service.getPropertiesByType('tab');
+      await service.getProperties('ext-1');
 
+      // Not fetched again on later requests
       expect(http.get.callCount).to.equal(1);
     });
 
@@ -174,7 +170,7 @@ describe('UiExtensionsService', () => {
   });
 
   describe('getExtension()', () => {
-    it('should load and return extension with Element', async () => {
+    it('should load and return extension with Element and cache it', async () => {
       const extensions = [{ id: 'ext-1', type: 'tab' }];
       http.get.onCall(0).returns(of(extensions));
       http.get.onCall(1).returns(of(
@@ -186,20 +182,13 @@ describe('UiExtensionsService', () => {
       expect(result).to.not.be.undefined;
       expect(result.properties).to.deep.equal({ id: 'ext-1', type: 'tab' });
       expect(result.Element.prototype).to.be.an.instanceof(HTMLElement);
+      expect(http.get.callCount).to.equal(2);
       expect(http.get.args[1][0]).to.equal('/ui-extension/ext-1');
       expect(http.get.args[1][1]).to.deep.equal({ responseType: 'text' });
-    });
-
-    it('should cache extension script and not reload on second call', async () => {
-      const extensions = [{ id: 'ext-1', type: 'tab' }];
-      http.get.onCall(0).returns(of(extensions));
-      http.get.onCall(1).returns(of(
-        'module.exports = class HelloWorldComponent extends HTMLElement {}'
-      ));
 
       await service.getExtension('ext-1');
-      await service.getExtension('ext-1');
 
+      // cached extensions are not re-fetched.
       expect(http.get.callCount).to.equal(2);
     });
 


### PR DESCRIPTION
This PR introduces the `UiExtensionsService` to the webapp as part of the UI extensions feature.

The service is responsible for:
- Fetching UI extension properties from `/api/v1/ui-extension`
- Filtering extensions based on the current user's roles
- Lazy loading extension scripts from `/ui-extension/:id`
- Caching loaded extension scripts to avoid redundant network requests
- Exposing methods to retrieve extensions by type or ID

Unit tests are included covering:
- Initialization and single-load behaviour
- Role-based filtering logic
- Property lookup by type and ID
- Extension script loading, caching, and error handling

Closes #10670