### PR TITLE
feat(#10674): add app_drawer_tab UI extensions support to sidebar menu

### DIFF
--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -1408,11 +1408,23 @@ mm-sidebar-menu .mat-sidenav-container {
       color: @text-secondary-color;
     }
 
-    mat-icon {
+    mat-icon,
+    .nav-icon {
       text-align: center;
       margin-right: 15px;
       margin-left: 10px;
       flex-shrink: 0;
+    }
+
+    .nav-icon {
+      width: @icon-extra-small;
+      height: @icon-extra-small;
+
+      img,
+      svg {
+        width: 100%;
+        height: 100%;
+      }
     }
 
     mat-icon.fa-graduation-cap:before {
@@ -1488,7 +1500,8 @@ mm-sidebar-menu .mat-sidenav-container {
       height: calc(@sidebar-menu-height - @sidebar-menu-header-mobile);
     }
 
-    .nav-item mat-icon {
+    .nav-item mat-icon,
+    .nav-item .nav-icon {
       margin-left: -6px;
     }
 

--- a/webapp/src/css/rtl.less
+++ b/webapp/src/css/rtl.less
@@ -182,7 +182,8 @@
   }
 
   @media (max-width: 767px) {
-    mm-sidebar-menu .mat-sidenav-container .nav-item mat-icon {
+    mm-sidebar-menu .mat-sidenav-container .nav-item mat-icon,
+    mm-sidebar-menu .mat-sidenav-container .nav-item .nav-icon {
       margin-right: -6px;
       margin-left: 15px;
     }

--- a/webapp/src/ts/components/sidebar-menu/sidebar-menu.component.html
+++ b/webapp/src/ts/components/sidebar-menu/sidebar-menu.component.html
@@ -5,15 +5,6 @@
     <mat-sidenav-content>
 
       <div class="nav-section">
-        <a *ngFor="let module of moduleOptions"
-          class="nav-item"
-          [routerLink]="module.routerLink"
-          (click)="close()"
-          [mmAuth]="module.hasPermissions">
-          <mat-icon [fontIcon]="module.icon"></mat-icon>
-          <span>{{ module.translationKey | translate }}</span>
-        </a>
-
         <a class="nav-item"
           [attr.href]="adminAppPath"
           mmAuth
@@ -71,13 +62,14 @@
       </div>
 
       <div class="nav-section">
-        <ng-container *ngFor="let option of secondaryOptions">
+        <ng-container *ngFor="let option of mergedOptions">
           <a class="nav-item"
             *ngIf="option.hasPermissions"
             [routerLink]="option.routerLink"
             [mmAuth]="option.hasPermissions"
             (click)="option.click && option.click(); close()">
-            <mat-icon [fontIcon]="option.icon"></mat-icon>
+            <span *ngIf="option.resourceIcon" [innerHTML]="option.resourceIcon | resourceIcon"></span>
+            <mat-icon *ngIf="!option.resourceIcon" [fontIcon]="option.icon"></mat-icon>
             <span>{{ option.translationKey | translate }}</span>
           </a>
 
@@ -85,7 +77,8 @@
             *ngIf="!option.hasPermissions && option.canDisplay"
             [routerLink]="option.routerLink"
             (click)="option.click && option.click(); close()">
-            <mat-icon [fontIcon]="option.icon"></mat-icon>
+            <span *ngIf="option.resourceIcon" [innerHTML]="option.resourceIcon | resourceIcon"></span>
+            <mat-icon *ngIf="!option.resourceIcon" [fontIcon]="option.icon"></mat-icon>
             <span>{{ option.translationKey | translate }}</span>
           </a>
         </ng-container>

--- a/webapp/src/ts/components/sidebar-menu/sidebar-menu.component.html
+++ b/webapp/src/ts/components/sidebar-menu/sidebar-menu.component.html
@@ -62,13 +62,13 @@
       </div>
 
       <div class="nav-section">
-        <ng-container *ngFor="let option of mergedOptions">
+        <ng-container *ngFor="let option of menuOptions">
           <a class="nav-item"
             *ngIf="option.hasPermissions"
             [routerLink]="option.routerLink"
             [mmAuth]="option.hasPermissions"
             (click)="option.click && option.click(); close()">
-            <span *ngIf="option.resourceIcon" [innerHTML]="option.resourceIcon | resourceIcon"></span>
+            <span class="nav-icon" *ngIf="option.resourceIcon" [innerHTML]="option.resourceIcon | resourceIcon"></span>
             <mat-icon *ngIf="!option.resourceIcon" [fontIcon]="option.icon"></mat-icon>
             <span>{{ option.translationKey | translate }}</span>
           </a>
@@ -77,7 +77,7 @@
             *ngIf="!option.hasPermissions && option.canDisplay"
             [routerLink]="option.routerLink"
             (click)="option.click && option.click(); close()">
-            <span *ngIf="option.resourceIcon" [innerHTML]="option.resourceIcon | resourceIcon"></span>
+            <span class="nav-icon" *ngIf="option.resourceIcon" [innerHTML]="option.resourceIcon | resourceIcon"></span>
             <mat-icon *ngIf="!option.resourceIcon" [fontIcon]="option.icon"></mat-icon>
             <span>{{ option.translationKey | translate }}</span>
           </a>

--- a/webapp/src/ts/components/sidebar-menu/sidebar-menu.component.ts
+++ b/webapp/src/ts/components/sidebar-menu/sidebar-menu.component.ts
@@ -8,6 +8,7 @@ import { AuthDirective } from '@mm-directives/auth.directive';
 import { MatIcon } from '@angular/material/icon';
 import { TranslatePipe } from '@ngx-translate/core';
 import { RelativeDatePipe } from '@mm-pipes/date.pipe';
+import { ResourceIconPipe } from '@mm-pipes/resource-icon.pipe';
 
 import { GlobalActions } from '@mm-actions/global';
 
@@ -16,6 +17,7 @@ import { LocationService } from '@mm-services/location.service';
 import { DBSyncService } from '@mm-services/db-sync.service';
 import { ModalService } from '@mm-services/modal.service';
 import { StorageInfoService } from '@mm-services/storage-info.service';
+import { UiExtensionsService } from '@mm-services/ui-extensions.service';
 
 import { filter } from 'rxjs/operators';
 import { Selectors } from '@mm-selectors/index';
@@ -36,6 +38,7 @@ import { Selectors } from '@mm-selectors/index';
     NgClass,
     TranslatePipe,
     RelativeDatePipe,
+    ResourceIconPipe,
   ],
 })
 export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, OnDestroy {
@@ -45,6 +48,8 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
   replicationStatus;
   moduleOptions: MenuOption[] = [];
   secondaryOptions: MenuOption[] = [];
+  uiExtensionOptions: MenuOption[] = [];
+  mergedOptions: MenuOption[] = [];
   adminAppPath: string = '';
 
   constructor(
@@ -54,6 +59,7 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
     protected modalService: ModalService,
     private router: Router,
     protected readonly storageInfoService: StorageInfoService,
+    private readonly uiExtensionsService: UiExtensionsService,
   ) {
     super(store, dbSyncService, modalService, storageInfoService);
     this.globalActions = new GlobalActions(store);
@@ -63,6 +69,7 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
     super.ngOnInit();
     this.adminAppPath = this.locationService.adminPath;
     this.setModuleOptions();
+    this.setUiExtensionOptions();
     this.setSecondaryOptions();
     this.additionalSubscriptions();
     this.subscribeToRouter();
@@ -137,6 +144,27 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
     ];
   }
 
+  private async setUiExtensionOptions() {
+    const extensions = await this.uiExtensionsService.getPropertiesByType('app_drawer_tab');
+    this.uiExtensionOptions = extensions
+      .filter(ext => ext.title)
+      .map(ext => ({
+        routerLink: `ui-extensions/${ext.id}`,
+        translationKey: ext.title!,
+        resourceIcon: ext.icon,
+        canDisplay: true,
+      }));
+    this.buildMergedOptions();
+  }
+
+  private buildMergedOptions() {
+    this.mergedOptions = [
+      ...this.moduleOptions,
+      ...this.uiExtensionOptions,
+      ...this.secondaryOptions,
+    ];
+  }
+
   private setSecondaryOptions(showPrivacyPolicy = false) {
     this.secondaryOptions = [
       {
@@ -170,11 +198,13 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
         click: () => this.openFeedback()
       },
     ];
+    this.buildMergedOptions();
   }
 }
 
 interface MenuOption {
-  icon: string;
+  icon?: string;
+  resourceIcon?: string;
   translationKey: string;
   routerLink?: string;
   hasPermissions?: string;

--- a/webapp/src/ts/components/sidebar-menu/sidebar-menu.component.ts
+++ b/webapp/src/ts/components/sidebar-menu/sidebar-menu.component.ts
@@ -22,6 +22,39 @@ import { UiExtensionsService } from '@mm-services/ui-extensions.service';
 import { filter } from 'rxjs/operators';
 import { Selectors } from '@mm-selectors/index';
 
+const TAB_MENU_OPTIONS = [
+  {
+    routerLink: 'messages',
+    icon: 'fa-envelope',
+    translationKey: 'Messages',
+    hasPermissions: 'can_view_messages,!can_view_messages_tab'
+  },
+  {
+    routerLink: 'tasks',
+    icon: 'fa-flag',
+    translationKey: 'Tasks',
+    hasPermissions: 'can_view_tasks,!can_view_tasks_tab'
+  },
+  {
+    routerLink: 'reports',
+    icon: 'fa-list-alt',
+    translationKey: 'Reports',
+    hasPermissions: 'can_view_reports,!can_view_reports_tab'
+  },
+  {
+    routerLink: 'contacts',
+    icon: 'fa-user',
+    translationKey: 'Contacts',
+    hasPermissions: 'can_view_contacts,!can_view_contacts_tab'
+  },
+  {
+    routerLink: 'analytics',
+    icon: 'fa-bar-chart-o',
+    translationKey: 'Analytics',
+    hasPermissions: 'can_view_analytics,!can_view_analytics_tab',
+  },
+];
+
 @Component({
   selector: 'mm-sidebar-menu',
   templateUrl: './sidebar-menu.component.html',
@@ -46,10 +79,7 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
   @ViewChild('sidebar') sidebar!: MatSidenav;
   private globalActions: GlobalActions;
   replicationStatus;
-  moduleOptions: MenuOption[] = [];
-  secondaryOptions: MenuOption[] = [];
-  uiExtensionOptions: MenuOption[] = [];
-  mergedOptions: MenuOption[] = [];
+  menuOptions: MenuOption[] = [];
   adminAppPath: string = '';
 
   constructor(
@@ -68,9 +98,6 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
   ngOnInit() {
     super.ngOnInit();
     this.adminAppPath = this.locationService.adminPath;
-    this.setModuleOptions();
-    this.setUiExtensionOptions();
-    this.setSecondaryOptions();
     this.additionalSubscriptions();
     this.subscribeToRouter();
   }
@@ -105,48 +132,13 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
 
     const subscribePrivacyPolicy = this.store
       .select(Selectors.getShowPrivacyPolicy)
-      .subscribe(showPrivacyPolicy => this.setSecondaryOptions(showPrivacyPolicy));
+      .subscribe(showPrivacyPolicy => this.setMenuOptions(showPrivacyPolicy));
     this.subscriptions.add(subscribePrivacyPolicy);
   }
 
-  private setModuleOptions() {
-    this.moduleOptions = [
-      {
-        routerLink: 'messages',
-        icon: 'fa-envelope',
-        translationKey: 'Messages',
-        hasPermissions: 'can_view_messages,!can_view_messages_tab'
-      },
-      {
-        routerLink: 'tasks',
-        icon: 'fa-flag',
-        translationKey: 'Tasks',
-        hasPermissions: 'can_view_tasks,!can_view_tasks_tab'
-      },
-      {
-        routerLink: 'reports',
-        icon: 'fa-list-alt',
-        translationKey: 'Reports',
-        hasPermissions: 'can_view_reports,!can_view_reports_tab'
-      },
-      {
-        routerLink: 'contacts',
-        icon: 'fa-user',
-        translationKey: 'Contacts',
-        hasPermissions: 'can_view_contacts,!can_view_contacts_tab'
-      },
-      {
-        routerLink: 'analytics',
-        icon: 'fa-bar-chart-o',
-        translationKey: 'Analytics',
-        hasPermissions: 'can_view_analytics,!can_view_analytics_tab',
-      },
-    ];
-  }
-
-  private async setUiExtensionOptions() {
+  private async getUiExtensionOptions() {
     const extensions = await this.uiExtensionsService.getPropertiesByType('app_drawer_tab');
-    this.uiExtensionOptions = extensions
+    return extensions
       .filter(ext => ext.title)
       .map(ext => ({
         routerLink: `ui-extensions/${ext.id}`,
@@ -154,19 +146,18 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
         resourceIcon: ext.icon,
         canDisplay: true,
       }));
-    this.buildMergedOptions();
   }
 
-  private buildMergedOptions() {
-    this.mergedOptions = [
-      ...this.moduleOptions,
-      ...this.uiExtensionOptions,
-      ...this.secondaryOptions,
+  private async setMenuOptions(showPrivacyPolicy: boolean) {
+    this.menuOptions = [
+      ...TAB_MENU_OPTIONS,
+      ...(await this.getUiExtensionOptions()),
+      ...this.getSecondaryOptions(showPrivacyPolicy),
     ];
   }
 
-  private setSecondaryOptions(showPrivacyPolicy = false) {
-    this.secondaryOptions = [
+  private getSecondaryOptions(showPrivacyPolicy: boolean) {
+    return [
       {
         routerLink: 'trainings',
         icon: 'fa-graduation-cap',
@@ -198,7 +189,6 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
         click: () => this.openFeedback()
       },
     ];
-    this.buildMergedOptions();
   }
 }
 

--- a/webapp/src/ts/providers/parse.provider.ts
+++ b/webapp/src/ts/providers/parse.provider.ts
@@ -1,9 +1,6 @@
 import {
   Lexer,
   Parser,
-  ParseSourceFile,
-  ParseLocation,
-  ParseSourceSpan,
   BindingPipe,
   PropertyRead,
   ImplicitReceiver,
@@ -16,6 +13,9 @@ import {
   KeyedRead,
   LiteralMap,
   LiteralArray,
+  ParseSourceSpan,
+  ParseSourceFile,
+  ParseLocation,
   ParenthesizedExpression,
 } from '@angular/compiler';
 import { Injectable } from '@angular/core';

--- a/webapp/src/ts/providers/parse.provider.ts
+++ b/webapp/src/ts/providers/parse.provider.ts
@@ -1,6 +1,9 @@
 import {
   Lexer,
   Parser,
+  ParseSourceFile,
+  ParseLocation,
+  ParseSourceSpan,
   BindingPipe,
   PropertyRead,
   ImplicitReceiver,
@@ -13,9 +16,6 @@ import {
   KeyedRead,
   LiteralMap,
   LiteralArray,
-  ParseSourceSpan,
-  ParseSourceFile,
-  ParseLocation,
   ParenthesizedExpression,
 } from '@angular/compiler';
 import { Injectable } from '@angular/core';

--- a/webapp/tests/karma/ts/app.component.spec.ts
+++ b/webapp/tests/karma/ts/app.component.spec.ts
@@ -52,6 +52,7 @@ import { SidebarMenuComponent } from '@mm-components/sidebar-menu/sidebar-menu.c
 import { ReloadingComponent } from '@mm-modals/reloading/reloading.component';
 import { StorageInfoService } from '@mm-services/storage-info.service';
 import { TasksNotificationService } from '@mm-services/task-notifications.service';
+import { UiExtensionsService } from '@mm-services/ui-extensions.service';
 
 describe('AppComponent', () => {
   let component: AppComponent;
@@ -95,6 +96,7 @@ describe('AppComponent', () => {
   let updateServiceWorkerService;
   let storageInfoService;
   let tasksNotificationService;
+  let uiExtensionsService;
   // End Services
 
   let globalActions;
@@ -196,6 +198,7 @@ describe('AppComponent', () => {
     };
     formService = { setUserContext: sinon.stub() };
     updateServiceWorkerService = { update: sinon.stub() };
+    uiExtensionsService = { getPropertiesByType: sinon.stub().resolves([]) };
     consoleErrorStub = sinon.stub(console, 'error');
 
     const mockedSelectors = [
@@ -251,6 +254,7 @@ describe('AppComponent', () => {
           { provide: StorageInfoService, useValue: storageInfoService },
           { provide: Router, useValue: router },
           { provide: TasksNotificationService, useValue: tasksNotificationService },
+          { provide: UiExtensionsService, useValue: uiExtensionsService },
         ]
       })
       .overrideComponent(SidebarMenuComponent, {

--- a/webapp/tests/karma/ts/components/sidebar-menu/sidebar-menu.component.spec.ts
+++ b/webapp/tests/karma/ts/components/sidebar-menu/sidebar-menu.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { MatSidenavModule } from '@angular/material/sidenav';
-import { MatIconModule } from '@angular/material/icon';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { provideMockStore } from '@ngrx/store/testing';
 import { TranslateFakeLoader, TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import sinon from 'sinon';
@@ -18,6 +18,9 @@ import { AuthService } from '@mm-services/auth.service';
 import { GlobalActions } from '@mm-actions/global';
 import { LogoutConfirmComponent } from '@mm-modals/logout/logout-confirm.component';
 import { FeedbackComponent } from '@mm-modals/feedback/feedback.component';
+import { UiExtensionsService } from '@mm-services/ui-extensions.service';
+import { CustomResourceService } from '@mm-services/custom-resource.service';
+import { ChangesService } from '@mm-services/changes.service';
 
 describe('SidebarMenuComponent', () => {
   let component: SidebarMenuComponent;
@@ -26,12 +29,20 @@ describe('SidebarMenuComponent', () => {
   let dbSyncService;
   let modalService;
   let authService;
+  let uiExtensionsService;
+  let customResourceService;
+  let changesService;
 
   beforeEach(async () => {
     locationService = { adminPath: '/admin/' };
     dbSyncService = { sync: sinon.stub() };
     modalService = { show: sinon.stub() };
     authService = { has: sinon.stub(), online: sinon.stub() };
+    uiExtensionsService = {
+      getPropertiesByType: sinon.stub().resolves([]),
+    };
+    customResourceService = { getImg: sinon.stub().returns('') };
+    changesService = { subscribe: sinon.stub().returns({ unsubscribe: sinon.stub() }) };
 
     await TestBed
       .configureTestingModule({
@@ -39,7 +50,7 @@ describe('SidebarMenuComponent', () => {
           RouterTestingModule,
           TranslateModule.forRoot({ loader: { provide: TranslateLoader, useClass: TranslateFakeLoader } }),
           MatSidenavModule,
-          MatIconModule,
+          MatIconTestingModule,
           SidebarMenuComponent,
           PanelHeaderComponent,
           AuthDirective,
@@ -51,10 +62,12 @@ describe('SidebarMenuComponent', () => {
           { provide: DBSyncService, useValue: dbSyncService },
           { provide: ModalService, useValue: modalService },
           { provide: AuthService, useValue: authService },
+          { provide: UiExtensionsService, useValue: uiExtensionsService },
+          { provide: CustomResourceService, useValue: customResourceService },
+          { provide: ChangesService, useValue: changesService },
         ],
       })
       .compileComponents();
-
     fixture = TestBed.createComponent(SidebarMenuComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -182,5 +195,123 @@ describe('SidebarMenuComponent', () => {
 
     expect(modalService.show.calledOnce).to.be.true;
     expect(modalService.show.args[0][0]).to.deep.equal(FeedbackComponent);
+  });
+
+  describe('UI Extension options (app_drawer_tab)', () => {
+
+    it('should call getPropertiesByType with app_drawer_tab on init', () => {
+      expect(uiExtensionsService.getPropertiesByType.calledWith('app_drawer_tab')).to.be.true;
+    });
+
+    it('should have empty uiExtensionOptions when no extensions are registered', () => {
+      expect(component.uiExtensionOptions).to.be.empty;
+    });
+
+    it('should have mergedOptions combining all three option arrays when no extensions', () => {
+      const expectedLength =
+        component.moduleOptions.length +
+        component.uiExtensionOptions.length +
+        component.secondaryOptions.length;
+      expect(component.mergedOptions).to.have.lengthOf(expectedLength);
+    });
+
+    describe('when app_drawer_tab extensions are registered', () => {
+      beforeEach(async () => {
+        uiExtensionsService.getPropertiesByType.resolves([
+          { id: 'ext-reports', type: 'app_drawer_tab', title: 'custom.reports', icon: 'reports-icon' },
+          { id: 'ext-map', type: 'app_drawer_tab', title: 'custom.map', icon: 'map-icon' },
+        ]);
+
+        await TestBed.resetTestingModule();
+        await TestBed
+          .configureTestingModule({
+            imports: [
+              RouterTestingModule,
+              TranslateModule.forRoot({ loader: { provide: TranslateLoader, useClass: TranslateFakeLoader } }),
+              MatSidenavModule,
+              MatIconTestingModule,
+              SidebarMenuComponent,
+              PanelHeaderComponent,
+              AuthDirective,
+            ],
+            providers: [
+              provideAnimations(),
+              provideMockStore(),
+              { provide: LocationService, useValue: locationService },
+              { provide: DBSyncService, useValue: dbSyncService },
+              { provide: ModalService, useValue: modalService },
+              { provide: AuthService, useValue: authService },
+              { provide: UiExtensionsService, useValue: uiExtensionsService },
+              { provide: CustomResourceService, useValue: customResourceService },
+              { provide: ChangesService, useValue: changesService },
+            ],
+          })
+          .compileComponents();
+
+        fixture = TestBed.createComponent(SidebarMenuComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+      });
+
+      it('should populate uiExtensionOptions from registered extensions', () => {
+        expect(component.uiExtensionOptions).to.have.lengthOf(2);
+      });
+
+      it('should map extension id to routerLink correctly', () => {
+        expect(component.uiExtensionOptions[0].routerLink).to.equal('ui-extensions/ext-reports');
+        expect(component.uiExtensionOptions[1].routerLink).to.equal('ui-extensions/ext-map');
+      });
+
+      it('should map extension properties.title to translationKey', () => {
+        expect(component.uiExtensionOptions[0].translationKey).to.equal('custom.reports');
+        expect(component.uiExtensionOptions[1].translationKey).to.equal('custom.map');
+      });
+
+      it('should map extension properties.icon to resourceIcon', () => {
+        expect(component.uiExtensionOptions[0].resourceIcon).to.equal('reports-icon');
+        expect(component.uiExtensionOptions[1].resourceIcon).to.equal('map-icon');
+      });
+
+      it('should set canDisplay true for all ui extension options', () => {
+        expect(component.uiExtensionOptions.every(opt => opt.canDisplay)).to.be.true;
+      });
+
+      it('should place ui extensions after moduleOptions in mergedOptions', () => {
+        const routes = component.mergedOptions.map(opt => opt.routerLink);
+        const lastModuleIdx = routes.lastIndexOf('analytics');
+        const firstExtIdx = routes.indexOf('ui-extensions/ext-reports');
+
+        expect(firstExtIdx).to.be.greaterThan(lastModuleIdx);
+      });
+
+      it('should place ui extensions before secondaryOptions in mergedOptions', () => {
+        const routes = component.mergedOptions.map(opt => opt.routerLink);
+        const lastExtIdx = routes.lastIndexOf('ui-extensions/ext-map');
+        const firstSecondaryIdx = routes.indexOf('trainings');
+
+        expect(firstSecondaryIdx).to.be.greaterThan(lastExtIdx);
+      });
+
+      it('should include all options in mergedOptions with correct total length', () => {
+        const expectedLength =
+          component.moduleOptions.length +
+          component.uiExtensionOptions.length +
+          component.secondaryOptions.length;
+
+        expect(component.mergedOptions).to.have.lengthOf(expectedLength);
+      });
+
+      it('should rebuild mergedOptions preserving extension positions when privacy policy changes', () => {
+        (component as any).setSecondaryOptions(true);
+
+        const routes = component.mergedOptions.map(opt => opt.routerLink);
+        const lastModuleIdx = routes.lastIndexOf('analytics');
+        const firstExtIdx = routes.indexOf('ui-extensions/ext-reports');
+        const firstSecondaryIdx = routes.indexOf('trainings');
+
+        expect(firstExtIdx).to.be.greaterThan(lastModuleIdx);
+        expect(firstSecondaryIdx).to.be.greaterThan(firstExtIdx);
+      });
+    });
   });
 });

--- a/webapp/tests/karma/ts/components/sidebar-menu/sidebar-menu.component.spec.ts
+++ b/webapp/tests/karma/ts/components/sidebar-menu/sidebar-menu.component.spec.ts
@@ -1,9 +1,9 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
-import { provideMockStore } from '@ngrx/store/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { TranslateFakeLoader, TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import sinon from 'sinon';
 import { assert, expect } from 'chai';
@@ -21,6 +21,7 @@ import { FeedbackComponent } from '@mm-modals/feedback/feedback.component';
 import { UiExtensionsService } from '@mm-services/ui-extensions.service';
 import { CustomResourceService } from '@mm-services/custom-resource.service';
 import { ChangesService } from '@mm-services/changes.service';
+import { Selectors } from '@mm-selectors/index';
 
 describe('SidebarMenuComponent', () => {
   let component: SidebarMenuComponent;
@@ -32,18 +33,9 @@ describe('SidebarMenuComponent', () => {
   let uiExtensionsService;
   let customResourceService;
   let changesService;
+  let store: MockStore;
 
-  beforeEach(async () => {
-    locationService = { adminPath: '/admin/' };
-    dbSyncService = { sync: sinon.stub() };
-    modalService = { show: sinon.stub() };
-    authService = { has: sinon.stub(), online: sinon.stub() };
-    uiExtensionsService = {
-      getPropertiesByType: sinon.stub().resolves([]),
-    };
-    customResourceService = { getImg: sinon.stub().returns('') };
-    changesService = { subscribe: sinon.stub().returns({ unsubscribe: sinon.stub() }) };
-
+  const createComponent = async () => {
     await TestBed
       .configureTestingModule({
         imports: [
@@ -68,9 +60,26 @@ describe('SidebarMenuComponent', () => {
         ],
       })
       .compileComponents();
+    store = TestBed.inject(MockStore);
+    store.overrideSelector(Selectors.getShowPrivacyPolicy, false);
     fixture = TestBed.createComponent(SidebarMenuComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    await fixture.whenStable();
+  };
+
+  beforeEach(async () => {
+    locationService = { adminPath: '/admin/' };
+    dbSyncService = { sync: sinon.stub() };
+    modalService = { show: sinon.stub() };
+    authService = { has: sinon.stub(), online: sinon.stub() };
+    uiExtensionsService = {
+      getPropertiesByType: sinon.stub().resolves([]),
+    };
+    customResourceService = { getImg: sinon.stub().returns('') };
+    changesService = { subscribe: sinon.stub().returns({ unsubscribe: sinon.stub() }) };
+
+    await createComponent();
   });
 
   afterEach(() => sinon.restore());
@@ -86,7 +95,7 @@ describe('SidebarMenuComponent', () => {
   it('should initialise component with menu options', () => {
     expect(component.adminAppPath).to.equal('/admin/');
 
-    expect(component.moduleOptions).have.deep.members([
+    expect(component.menuOptions).excluding('click').to.deep.equal([
       {
         routerLink: 'messages',
         icon: 'fa-envelope',
@@ -117,9 +126,6 @@ describe('SidebarMenuComponent', () => {
         translationKey: 'Analytics',
         hasPermissions: 'can_view_analytics,!can_view_analytics_tab',
       },
-    ]);
-
-    expect(component.secondaryOptions).excluding('click').have.deep.members([
       {
         routerLink: 'trainings',
         icon: 'fa-graduation-cap',
@@ -184,7 +190,7 @@ describe('SidebarMenuComponent', () => {
   });
 
   it('should show report bug modal', () => {
-    const reportBug = component.secondaryOptions.find(option => option.translationKey === 'Report Bug');
+    const reportBug = component.menuOptions.find(option => option.translationKey === 'Report Bug');
 
     if (!reportBug?.click) {
       assert.fail('should have report bug option');
@@ -198,120 +204,105 @@ describe('SidebarMenuComponent', () => {
   });
 
   describe('UI Extension options (app_drawer_tab)', () => {
+    beforeEach(async () => {
+      uiExtensionsService.getPropertiesByType.resolves([
+        { id: 'ext-reports', type: 'app_drawer_tab', title: 'custom.reports', icon: 'reports-icon' },
+        { id: 'ext-map', type: 'app_drawer_tab', title: 'custom.map', icon: 'map-icon' },
+      ]);
 
-    it('should call getPropertiesByType with app_drawer_tab on init', () => {
-      expect(uiExtensionsService.getPropertiesByType.calledWith('app_drawer_tab')).to.be.true;
+      await TestBed.resetTestingModule();
+      await createComponent();
     });
 
-    it('should have empty uiExtensionOptions when no extensions are registered', () => {
-      expect(component.uiExtensionOptions).to.be.empty;
+    it('should populate ui extension options from registered extensions', () => {
+      expect(uiExtensionsService.getPropertiesByType.args).to.deep.equal([['app_drawer_tab'], ['app_drawer_tab']]);
+
+      expect(component.menuOptions).excluding('click').to.deep.equal([
+        {
+          routerLink: 'messages',
+          icon: 'fa-envelope',
+          translationKey: 'Messages',
+          hasPermissions: 'can_view_messages,!can_view_messages_tab'
+        },
+        {
+          routerLink: 'tasks',
+          icon: 'fa-flag',
+          translationKey: 'Tasks',
+          hasPermissions: 'can_view_tasks,!can_view_tasks_tab'
+        },
+        {
+          routerLink: 'reports',
+          icon: 'fa-list-alt',
+          translationKey: 'Reports',
+          hasPermissions: 'can_view_reports,!can_view_reports_tab'
+        },
+        {
+          routerLink: 'contacts',
+          icon: 'fa-user',
+          translationKey: 'Contacts',
+          hasPermissions: 'can_view_contacts,!can_view_contacts_tab'
+        },
+        {
+          routerLink: 'analytics',
+          icon: 'fa-bar-chart-o',
+          translationKey: 'Analytics',
+          hasPermissions: 'can_view_analytics,!can_view_analytics_tab',
+        },
+        {
+          translationKey: 'custom.reports',
+          routerLink: 'ui-extensions/ext-reports',
+          resourceIcon: 'reports-icon',
+          canDisplay: true,
+        },
+        {
+          translationKey: 'custom.map',
+          routerLink: 'ui-extensions/ext-map',
+          resourceIcon: 'map-icon',
+          canDisplay: true,
+        },
+        {
+          routerLink: 'trainings',
+          icon: 'fa-graduation-cap',
+          translationKey: 'training_materials.page.title',
+          canDisplay: true,
+        },
+        {
+          routerLink: 'about',
+          icon: 'fa-question',
+          translationKey: 'about',
+          canDisplay: true,
+        },
+        {
+          routerLink: 'user',
+          icon: 'fa-user',
+          translationKey: 'edit.user.settings',
+          hasPermissions: 'can_edit_profile'
+        },
+        {
+          routerLink: 'privacy-policy',
+          icon: 'fa-lock',
+          translationKey: 'privacy.policy',
+          canDisplay: false,
+        },
+        {
+          icon: 'fa-bug',
+          translationKey: 'Report Bug',
+          canDisplay: true,
+        },
+      ]);
     });
 
-    it('should have mergedOptions combining all three option arrays when no extensions', () => {
-      const expectedLength =
-        component.moduleOptions.length +
-        component.uiExtensionOptions.length +
-        component.secondaryOptions.length;
-      expect(component.mergedOptions).to.have.lengthOf(expectedLength);
-    });
+    it('should rebuild menuOptions preserving extension positions when privacy policy changes', fakeAsync(() => {
+      expect(uiExtensionsService.getPropertiesByType.args).to.deep.equal([['app_drawer_tab'], ['app_drawer_tab']]);
+      store.overrideSelector(Selectors.getShowPrivacyPolicy, true);
+      store.refreshState();
+      flush();
 
-    describe('when app_drawer_tab extensions are registered', () => {
-      beforeEach(async () => {
-        uiExtensionsService.getPropertiesByType.resolves([
-          { id: 'ext-reports', type: 'app_drawer_tab', title: 'custom.reports', icon: 'reports-icon' },
-          { id: 'ext-map', type: 'app_drawer_tab', title: 'custom.map', icon: 'map-icon' },
-        ]);
-
-        await TestBed.resetTestingModule();
-        await TestBed
-          .configureTestingModule({
-            imports: [
-              RouterTestingModule,
-              TranslateModule.forRoot({ loader: { provide: TranslateLoader, useClass: TranslateFakeLoader } }),
-              MatSidenavModule,
-              MatIconTestingModule,
-              SidebarMenuComponent,
-              PanelHeaderComponent,
-              AuthDirective,
-            ],
-            providers: [
-              provideAnimations(),
-              provideMockStore(),
-              { provide: LocationService, useValue: locationService },
-              { provide: DBSyncService, useValue: dbSyncService },
-              { provide: ModalService, useValue: modalService },
-              { provide: AuthService, useValue: authService },
-              { provide: UiExtensionsService, useValue: uiExtensionsService },
-              { provide: CustomResourceService, useValue: customResourceService },
-              { provide: ChangesService, useValue: changesService },
-            ],
-          })
-          .compileComponents();
-
-        fixture = TestBed.createComponent(SidebarMenuComponent);
-        component = fixture.componentInstance;
-        fixture.detectChanges();
-      });
-
-      it('should populate uiExtensionOptions from registered extensions', () => {
-        expect(component.uiExtensionOptions).to.have.lengthOf(2);
-      });
-
-      it('should map extension id to routerLink correctly', () => {
-        expect(component.uiExtensionOptions[0].routerLink).to.equal('ui-extensions/ext-reports');
-        expect(component.uiExtensionOptions[1].routerLink).to.equal('ui-extensions/ext-map');
-      });
-
-      it('should map extension properties.title to translationKey', () => {
-        expect(component.uiExtensionOptions[0].translationKey).to.equal('custom.reports');
-        expect(component.uiExtensionOptions[1].translationKey).to.equal('custom.map');
-      });
-
-      it('should map extension properties.icon to resourceIcon', () => {
-        expect(component.uiExtensionOptions[0].resourceIcon).to.equal('reports-icon');
-        expect(component.uiExtensionOptions[1].resourceIcon).to.equal('map-icon');
-      });
-
-      it('should set canDisplay true for all ui extension options', () => {
-        expect(component.uiExtensionOptions.every(opt => opt.canDisplay)).to.be.true;
-      });
-
-      it('should place ui extensions after moduleOptions in mergedOptions', () => {
-        const routes = component.mergedOptions.map(opt => opt.routerLink);
-        const lastModuleIdx = routes.lastIndexOf('analytics');
-        const firstExtIdx = routes.indexOf('ui-extensions/ext-reports');
-
-        expect(firstExtIdx).to.be.greaterThan(lastModuleIdx);
-      });
-
-      it('should place ui extensions before secondaryOptions in mergedOptions', () => {
-        const routes = component.mergedOptions.map(opt => opt.routerLink);
-        const lastExtIdx = routes.lastIndexOf('ui-extensions/ext-map');
-        const firstSecondaryIdx = routes.indexOf('trainings');
-
-        expect(firstSecondaryIdx).to.be.greaterThan(lastExtIdx);
-      });
-
-      it('should include all options in mergedOptions with correct total length', () => {
-        const expectedLength =
-          component.moduleOptions.length +
-          component.uiExtensionOptions.length +
-          component.secondaryOptions.length;
-
-        expect(component.mergedOptions).to.have.lengthOf(expectedLength);
-      });
-
-      it('should rebuild mergedOptions preserving extension positions when privacy policy changes', () => {
-        (component as any).setSecondaryOptions(true);
-
-        const routes = component.mergedOptions.map(opt => opt.routerLink);
-        const lastModuleIdx = routes.lastIndexOf('analytics');
-        const firstExtIdx = routes.indexOf('ui-extensions/ext-reports');
-        const firstSecondaryIdx = routes.indexOf('trainings');
-
-        expect(firstExtIdx).to.be.greaterThan(lastModuleIdx);
-        expect(firstSecondaryIdx).to.be.greaterThan(firstExtIdx);
-      });
-    });
+      const privacyPolicy = component.menuOptions.find(opt => opt.routerLink === 'privacy-policy');
+      expect(privacyPolicy?.canDisplay).to.be.true;
+      expect(uiExtensionsService.getPropertiesByType.args).to.deep.equal([
+        ['app_drawer_tab'], ['app_drawer_tab'], ['app_drawer_tab']
+      ]);
+    }));
   });
 });


### PR DESCRIPTION
# Description

Adds support for displaying `app_drawer_tab` UI extensions in the sidebar menu ([#10674](https://github.com/medic/cht-core/issues/10674)).

- Loads `app_drawer_tab` extensions via `UiExtensionsService.getPropertiesByType('app_drawer_tab')` on component init
- Maps each extension to a sidebar option: `routerLink: ui-extensions/${id}`, `translationKey: title`, `resourceIcon: icon`
- Introduces a `mergedOptions` array (moduleOptions → UI extensions → secondaryOptions) so extensions appear between core module tabs and secondary options
- Extensions without a `title` are filtered out; role-based filtering is handled by `UiExtensionsService`
- Switches `sidebar-menu.component.spec.ts` to `MatIconTestingModule` so custom SVG icons in the template don't throw during tests

Fixes #10674

Depends on Issue #10670 (merged into `10224-ui-extensions`).

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [ ] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
