### PR TITLE
fix(#10802): check status before a scheduled_task is updated

### DIFF
--- a/shared-libs/transitions/src/schedule/due_tasks.js
+++ b/shared-libs/transitions/src/schedule/due_tasks.js
@@ -11,6 +11,7 @@ const lineage = require('@medic/lineage')(Promise, db.medic);
 const messageUtils = require('@medic/message-utils');
 
 const BATCH_SIZE = 1000;
+const SCHEDULED_STATE = 'scheduled';
 
 const getTemplateContext = async (doc) => {
   const context = {
@@ -44,6 +45,12 @@ const updateScheduledTasks = (doc, context, dueDates, clearFailing=false) => {
   let updatedTasks = false;
   // set task to pending for gateway to pick up
   doc.scheduled_tasks.forEach(task => {
+    // only process tasks that are still in 'scheduled' state - skip tasks that have already
+    // progressed to other states (e.g. pending, sent, delivered) to prevent re-sending
+    if (task.state !== SCHEDULED_STATE) {
+      return;
+    }
+
     // use the same due calculation as the `messages_by_state` view
     let due = task.due || task.timestamp || doc.reported_date;
     if (typeof due !== 'string') {
@@ -160,8 +167,8 @@ module.exports = {
     const overdue = now.clone().subtract(7, 'days');
     const opts = {
       include_docs: true,
-      endkey: JSON.stringify([ 'scheduled', now.valueOf() ]),
-      startkey: JSON.stringify([ 'scheduled', overdue.valueOf() ]),
+      endkey: JSON.stringify([ SCHEDULED_STATE, now.valueOf() ]),
+      startkey: JSON.stringify([ SCHEDULED_STATE, overdue.valueOf() ]),
       limit: BATCH_SIZE,
     };
 

--- a/shared-libs/transitions/test/unit/due_tasks.js
+++ b/shared-libs/transitions/test/unit/due_tasks.js
@@ -1971,4 +1971,83 @@ describe('due tasks', () => {
     });
   });
 
+  it('should not set already-sent tasks to pending when another task with the same due date is scheduled', () => {
+    // Reproduction of https://github.com/medic/cht-core/issues/10802
+    //
+    // Scenario: A document has two scheduled_tasks with the same due date.
+    // Task A (e.g. "Vaccination Day") has been sent successfully.
+    // Task B (e.g. "Age Based") is stuck in scheduled state because it cannot generate messages.
+    // The view returns the doc because of Task B. dueTasks collects the due date,
+    // then iterates ALL scheduled_tasks matching that due date — including Task A.
+    // Bug: Task A gets reset from sent back to pending.
+    const due = moment();
+    const id = 'report-with-duplicate-due';
+
+    const doc = {
+      scheduled_tasks: [
+        {
+          // Task A: already sent successfully
+          due: due.toISOString(),
+          state: 'sent',
+          state_history: [
+            { state: 'scheduled', timestamp: moment().subtract(10, 'days').toISOString() },
+            { state: 'pending', timestamp: moment().subtract(1, 'day').toISOString() },
+            { state: 'sent', timestamp: moment().subtract(1, 'day').toISOString() },
+          ],
+          type: 'Immunization Reminders Vaccination Day',
+          messages: [
+            {
+              to: '+1234567890',
+              uuid: 'msg-uuid-1',
+              message: 'Please visit the health facility',
+            },
+          ],
+        },
+        {
+          // Task B: stuck in scheduled, same due date, no messages (generation fails)
+          due: due.toISOString(),
+          state: 'scheduled',
+          state_history: [
+            { state: 'scheduled', timestamp: moment().subtract(10, 'days').toISOString() },
+          ],
+          type: 'Immunization Reminders Age Based',
+          message_key: 'some.translation.key',
+          recipient: 'clinic',
+          // no messages — generation will fail
+        },
+      ],
+    };
+
+    // The view returns this doc because Task B is in 'scheduled' state
+    const view = sinon.stub(request, 'get').resolves({
+      rows: [
+        {
+          id: id,
+          key: ['scheduled', due.valueOf()],
+          doc: doc,
+        },
+      ],
+    });
+
+    sinon.stub(schedule._lineage, 'hydrateDocs').resolves([doc]);
+    sinon.stub(utils, 'getRegistrations').resolves([]);
+    // translate returns empty to simulate failed message generation for Task B
+    sinon.stub(utils, 'translate').returns('');
+
+    const saveDoc = sinon.stub(db.medic, 'put').resolves({});
+
+    return schedule.execute().then(() => {
+      assert.equal(view.callCount, 1);
+
+      // Task A should NOT have been touched — it's already sent
+      assert.equal(doc.scheduled_tasks[0].state, 'sent', 'Task A (already sent) should not have its state changed');
+
+      // Task B should still be scheduled (message generation failed)
+      assert.equal(doc.scheduled_tasks[1].state, 'scheduled', 'Task B should remain scheduled');
+
+      // The document should NOT be saved since no valid state changes occurred
+      assert.equal(saveDoc.callCount, 0, 'Document should not be saved when no tasks were validly updated');
+    });
+  });
+
 });

--- a/tests/integration/sentinel/schedules/due-tasks.spec.js
+++ b/tests/integration/sentinel/schedules/due-tasks.spec.js
@@ -100,6 +100,48 @@ const contacts = [
   },
 ];
 
+const reportWithDuplicateDueDate = {
+  _id: 'report_duplicate_due',
+  type: 'data_record',
+  contact: {
+    _id: 'chw1',
+    parent: { _id: 'clinic1', parent: { _id: CONTACT_TYPES.HEALTH_CENTER, parent: { _id: 'district_hospital' } } }
+  },
+  fields: { patient_id: 'patient1', value: 5 },
+  reported_date: oneMonthAgo,
+  scheduled_tasks: [
+    {
+      // Task A: already sent, same due date as Task B
+      due: twoDaysAgo,
+      message_key: 'messages.one',
+      recipient: 'clinic',
+      state_history: [
+        { state: 'scheduled', timestamp: oneMonthAgo },
+        { state: 'pending', timestamp: threeDaysAgo },
+        { state: 'sent', timestamp: threeDaysAgo },
+      ],
+      state: 'sent',
+      messages: [
+        {
+          to: '111222',
+          uuid: 'uuid-already-sent',
+          message: 'ONE. Reported by Chw1. Patient Patient1 (patient1). Value 5',
+        },
+      ],
+    },
+    {
+      // Task B: stuck in scheduled, same due date as Task A, missing translation
+      due: twoDaysAgo,
+      message_key: 'non.exisiting.key',
+      recipient: 'clinic',
+      state_history: [
+        { state: 'scheduled', timestamp: oneMonthAgo },
+      ],
+      state: 'scheduled',
+    },
+  ],
+};
+
 const reports = [
   {
     _id: 'report1', // no tasks
@@ -498,5 +540,32 @@ describe('Due Tasks', () => {
       to: '555666' // health_center
     });
     chai.expect(report7.scheduled_tasks[3].messages).to.equal(undefined);
+  });
+
+  it('should not reset already-sent tasks when another task with the same due date is stuck in scheduled', async () => {
+    // Reproduction of https://github.com/medic/cht-core/issues/10802
+    // When a document has two scheduled_tasks with the same due date and one is stuck in
+    // 'scheduled' state (e.g. missing translation), dueTasks should NOT reset the other
+    // task that has already been sent back to 'pending'.
+    await sentinelUtils.waitForSentinel();
+    await utils.toggleSentinelTransitions();
+    await utils.saveDoc(reportWithDuplicateDueDate);
+    await utils.toggleSentinelTransitions();
+    await utils.runSentinelTasks();
+    await sentinelUtils.waitForSentinel([reportWithDuplicateDueDate._id]);
+
+    // Wait briefly for dueTasks scheduler to process
+    await new Promise(resolve => setTimeout(resolve, 5000));
+
+    const report = await utils.getDoc(reportWithDuplicateDueDate._id);
+
+    // Task A (already sent) should NOT have been changed to pending
+    chai.expect(report.scheduled_tasks[0].state).to.equal('sent',
+      'Already-sent task should not be reset to pending when another task with the same due date is scheduled');
+
+    // Task B (stuck with missing translation) should remain scheduled
+    chai.expect(report.scheduled_tasks[1].state).to.equal('scheduled',
+      'Task with missing translation should remain in scheduled state');
+    chai.expect(report.scheduled_tasks[1].messages).to.equal(undefined);
   });
 });


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: build|feat|fix|perf|refactor|test|chore

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

(cherry picked from commit https://github.com/medic/cht-core/commit/6a5867bb8b30d7e8bfb25187aabe44f6ac11a4c0)

#10802

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [ ] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10802-5.1.x/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10802-5.1.x/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10802-5.1.x/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

