### PR TITLE
chore(na): dependabot cooldown for main and adming apps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,12 @@ updates:
       angular:
         patterns:
         - "angular*"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
+
   - package-ecosystem: "npm"
     directory: "/webapp"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,11 @@ updates:
       - dependency-name: "node-fetch" # ESM Modules https://github.com/medic/cht-core/issues/9770
       - dependency-name: "url-join" # ESM Modules https://github.com/medic/cht-core/issues/9770
       - dependency-name: "uuid" # ES2022 issue https://github.com/medic/cht-core/issues/10114
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
 
   - package-ecosystem: "npm"
     directory: "/admin"
@@ -69,3 +74,8 @@ updates:
       - dependency-name: "@angular*" #https://github.com/medic/cht-core/issues/10029
       - dependency-name: "@ngrx*" #https://github.com/medic/cht-core/issues/10029
       - dependency-name: "ngx*" #https://github.com/medic/cht-core/issues/10029
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: build|feat|fix|perf|refactor|test|chore

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

With recent supply chain attacks, [specifically on npm](https://socket.dev/blog/axios-npm-package-compromised),  we're trying to do a security in depth approach (see [pinning effort](https://github.com/medic/cht-core/pull/10837#issue-4241479122)).  Based off [my research](https://daniakash.com/posts/simplest-supply-chain-defense/), I think one defense is to add a [cooldown](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-) to dependabot so that it doesn't suggest a PR to bump something released hours or even days ago that may have a vulnerability that hasn't been discovered yet.

This is obviously a balance as one of the other good defenses in depth is to always be up to date.  I think a 7 day cooldown period is a good trade off here.

Noteworthy is that this [doesn't prevent us](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-) from getting security/CVE patches right away:

> The `cooldown` option is only available for version updates, not security updates.

# Code review checklist
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)




# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:dependabot-cooldown/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:dependabot-cooldown/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:dependabot-cooldown/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

