### PR TITLE
fix(#10852): nullcheck accept_patient_reports transition messages

### DIFF
--- a/shared-libs/transitions/src/transitions/accept_patient_reports.js
+++ b/shared-libs/transitions/src/transitions/accept_patient_reports.js
@@ -201,6 +201,10 @@ const messageRelevant = (msg, doc) => {
 };
 
 const addMessagesToDoc = (doc, config, registrations, placeRegistrations) => {
+  if (!Array.isArray(config.messages)) {
+    return;
+  }
+
   config.messages.forEach(msg => {
     if (messageRelevant(msg, doc)) {
       messages.addMessage(doc, msg, msg.recipient, {

--- a/shared-libs/transitions/test/unit/transitions/accept_patient_reports.js
+++ b/shared-libs/transitions/test/unit/transitions/accept_patient_reports.js
@@ -174,6 +174,34 @@ describe('accept_patient_reports', () => {
         validation.validate.args[0].slice(0, 2).should.deep.equal([doc, undefined]); // 3rd arg is a function
       });
     });
+
+    it('should not throw error on bad config', () => {
+      const doc = {
+        fields: { patient_id: 'x' },
+        from: '+123',
+        form: 'aaa',
+        patient: { patient_id: 'x' }
+      };
+      sinon.stub(utils, 'getSubjectIds').returns(['x', 'y']);
+      sinon.stub(utils, 'getReportsBySubject').resolves([]);
+      sinon.stub(validation, 'validate').resolves([]);
+
+      config.get.returns([{
+        form: 'aaa',
+      }]);
+
+      return transition.onMatch({ doc }).then((changed) => {
+        changed.should.equal(true);
+        (typeof doc.errors).should.equal('undefined');
+        (typeof doc.tasks).should.equal('undefined');
+        utils.getReportsBySubject.callCount.should.equal(1);
+        utils.getReportsBySubject.args[0].should.deep.equal([{ ids: ['x', 'y'], registrations: true }]);
+        utils.getSubjectIds.callCount.should.equal(1);
+        utils.getSubjectIds.args[0].should.deep.equal([doc.patient]);
+        validation.validate.callCount.should.equal(1);
+        validation.validate.args[0].slice(0, 2).should.deep.equal([doc, undefined]); // 3rd arg is a function
+      });
+    });
   });
 
   describe('handleReport', () => {


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: build|feat|fix|perf|refactor|test|chore

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

`messages` property is documented as optional: https://docs.communityhealthtoolkit.org/building/reference/app-settings/patient_reports/#app_settingsjson-patient_reports. this PR makes it so. 

closes #10852

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [ ] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10852-fix-error/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10852-fix-error/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10852-fix-error/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

