### PR TITLE
test(#10112): stabilize flaky upgrade e2e test

### DIFF
--- a/tests/page-objects/default/common/common.wdio.page.js
+++ b/tests/page-objects/default/common/common.wdio.page.js
@@ -177,9 +177,16 @@ const waitForLoaders = async (timeout = 5000) => {
   });
 };
 
-const waitForAngularLoaded = async (timeout = 40000) => {
-  await hamburgerMenuSelectors.hamburgerMenu().waitForDisplayed({ timeout });
-};
+ const waitForAngularLoaded = async (timeout = 40000) => {
+  await browser.waitUntil(async () => {
+    const menu = await hamburgerMenuSelectors.hamburgerMenu();
+    return await menu.isDisplayed();
+  }, {
+    timeout,
+    interval: 500,
+    timeoutMsg: 'Application menu did not appear in time'
+  });
+ };
 
 const waitForPageLoaded = async (timeout) => {
   // if we immediately check for app loaders, we might bypass the initial page load (the bootstrap loader)


### PR DESCRIPTION
# Description
This PR stabilizes the flaky upgrade e2e test by replacing the use of `waitForDisplayed` with a more reliable `waitUntil` check in `waitForAngularLoaded`.

Previously, the test relied on a single visibility check which could fail due to timing issues during page load. This caused intermittent failures where the application menu was not yet rendered.

The updated implementation retries until the menu is actually visible, making the test more robust and consistent.

Closes #10112

# Code review checklist
- [x] Readable: Concise, well named, follows the style guide
- [x] Tested: e2e test behavior improved and validated via CI
- [x] Backwards compatible: No functional changes to application behavior

# License
The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.