### PR TITLE
fix(#10851): normalize Latin and Devanagari digits in Nouveau freetext queries

### DIFF
--- a/shared-libs/cht-datasource/src/local/libs/nouveau.ts
+++ b/shared-libs/cht-datasource/src/local/libs/nouveau.ts
@@ -11,6 +11,30 @@ import { getDocById } from './doc';
 
 const MEDIC_NOUVEAU_PATH = '_design/medic/_nouveau';
 const jsonContentTypeHeaders = new Headers({ 'Content-Type': 'application/json' });
+const DEVANAGARI_TO_LATIN_DIGITS: Record<string, string> = {
+  '०': '0',
+  '१': '1',
+  '२': '2',
+  '३': '3',
+  '४': '4',
+  '५': '5',
+  '६': '6',
+  '७': '7',
+  '८': '8',
+  '९': '9',
+};
+const LATIN_TO_DEVANAGARI_DIGITS: Record<string, string> = {
+  '0': '०',
+  '1': '१',
+  '2': '२',
+  '3': '३',
+  '4': '४',
+  '5': '५',
+  '6': '६',
+  '7': '७',
+  '8': '८',
+  '9': '९',
+};
 const SORT_BY_VIEW: Record<string, string> = {
   'contacts_by_freetext': 'sort_order',
   'reports_by_freetext': 'reported_date',
@@ -31,12 +55,28 @@ const fetchWithDb = (
   // @ts-expect-error
 ) => db.fetch(url, opts);
 
+const normalizeDigitsToLatin = (value: string): string => value
+  .replace(/[०-९]/g, digit => DEVANAGARI_TO_LATIN_DIGITS[digit] ?? digit);
+
+const normalizeDigitsToDevanagari = (value: string): string => value
+  .replace(/[0-9]/g, digit => LATIN_TO_DEVANAGARI_DIGITS[digit] ?? digit);
+
+const getFreetextVariants = (value: string): string[] => (
+  [...new Set([ value, normalizeDigitsToLatin(value), normalizeDigitsToDevanagari(value) ])]
+);
+
 const getQueryByFreetext = (qualifier: FreetextQualifier) => {
-  if (isKeyedFreetextQualifier(qualifier)) {
-    return `exact_match:"${qualifier.freetext}"`;
+  const variants = getFreetextVariants(qualifier.freetext);
+  const getQueryForVariant = isKeyedFreetextQualifier(qualifier)
+    ? (variant: string) => `exact_match:"${variant}"`
+    : (variant: string) => `${escapeKeys(variant)}*`;
+  const queries = variants.map(getQueryForVariant);
+
+  if (queries.length === 1) {
+    return queries[0];
   }
-  // Fuzzy match
-  return `${escapeKeys(qualifier.freetext)}*`;
+  // return a single query with OR between the variants
+  return `(${queries.join(' OR ')})`;
 };
 
 const getQueryByTypeFreetext = (qualifier: FreetextQualifier & Partial<ContactTypeQualifier>) => {

--- a/shared-libs/cht-datasource/test/local/libs/nouveau.spec.ts
+++ b/shared-libs/cht-datasource/test/local/libs/nouveau.spec.ts
@@ -31,7 +31,14 @@ describe('nouveau', () => {
 
     ([
       ['key:value', 'exact_match:"key:value"'],
-      ['searchterm', 'searchterm*']
+      ['searchterm', 'searchterm*'],
+      ['12346', '(12346* OR १२३४६*)'],
+      ['१२३४६', '(१२३४६* OR 12346*)'],
+      ['0123', '(0123* OR ०१२३*)'],
+      ['०१२३', '(०१२३* OR 0123*)'],
+      ['9999999999', '(9999999999* OR ९९९९९९९९९९*)'],
+      ['1२3४', '(1२3४* OR 1234* OR १२३४*)'],
+      ['१2३4', '(१2३4* OR 1234* OR १२३४*)'],
     ] as [string, string][]).forEach(([freetext, q]) => {
       it('should query for freetext qualifier', async () => {
         const qualifier = Qualifier.byFreetext(freetext);
@@ -54,8 +61,38 @@ describe('nouveau', () => {
     });
 
     ([
+      ['(123)', ['123', '१२३']],
+      ['123-456', ['123-456', '१२३-४५६']],
+      ['123.456', ['123.456', '१२३.४५६']],
+      ['+9779800', ['+9779800', '+९७७९८००']],
+    ] as [string, string[]][]).forEach(([freetext, expectedTokens]) => {
+      it(`should normalize numerals with special characters [${freetext}]`, async () => {
+        const qualifier = Qualifier.byFreetext(freetext);
+        dbFetch.resolves(mockResponse);
+
+        await queryByFreetext(db, 'reports_by_freetext')(qualifier, null, 10);
+
+        const callArgs = dbFetch.getCall(0).args[1];
+        const body = JSON.parse(callArgs.body);
+        const escapeForNouveau = (token: string) => token.replace(/([+!(){}[\]^"~*?:\\/|-]|&&|\|\|)/g, '\\$1');
+        expectedTokens.forEach((token) => {
+          const escapedToken = escapeForNouveau(token);
+          const includesRawOrEscaped = [token, escapedToken].some((value) => body.q.includes(value));
+          expect(includesRawOrEscaped).to.equal(true);
+        });
+      });
+    });
+
+    ([
       ['key:value', 'contact_type:"person" AND exact_match:"key:value"'],
-      ['searchterm', 'contact_type:"person" AND searchterm*']
+      ['searchterm', 'contact_type:"person" AND searchterm*'],
+      ['12346', 'contact_type:"person" AND (12346* OR १२३४६*)'],
+      ['१२३४६', 'contact_type:"person" AND (१२३४६* OR 12346*)'],
+      ['0123', 'contact_type:"person" AND (0123* OR ०१२३*)'],
+      ['०१२३', 'contact_type:"person" AND (०१२३* OR 0123*)'],
+      ['9999999999', 'contact_type:"person" AND (9999999999* OR ९९९९९९९९९९*)'],
+      ['1२3४', 'contact_type:"person" AND (1२3४* OR 1234* OR १२३४*)'],
+      ['१2३4', 'contact_type:"person" AND (१2३4* OR 1234* OR १२३४*)'],
     ] as [string, string][]).forEach(([freetext, q]) => {
       it('should query with contact type and freetext qualifier', async () => {
         const qualifier = Qualifier.and(
@@ -79,7 +116,6 @@ describe('nouveau', () => {
         )).to.be.true;
       });
     });
-
 
     it('should return next cursor when data fills limit and bookmark changes', async () => {
       const qualifier = Qualifier.byFreetext('searchterm');


### PR DESCRIPTION

# Description
This PR fixes a regression in online contact freetext search where equivalent Latin and Devanagari numerals no longer cross-matched.

In CHT 5.1.1, the Nouveau freetext query path searches only the exact numeral script entered by the user (for example, 12346 only matched Latin digits, and १२३४६ only matched Devanagari digits). This change restores cross-script matching by expanding freetext terms to both numeral systems at query generation time.

**Technical Implementation**
- Numeral Variant Expansion:  Updated Nouveau freetext query generation in `shared-libs/cht-datasource/src/local/libs/nouveau.ts` to generate Latin and Devanagari numeral variants for each freetext input and combine them with OR.
- Keyed + Fuzzy Coverage:  Applied the same variant expansion for both keyed freetext queries (exact_match:"key:value") and fuzzy freetext queries (term*), preserving existing non-numeric behavior.
- Mixed Numeral Handling:  Variant generation supports mixed-script inputs (for example 1२3४) and deduplicates equivalent query variants before building the final query.

**Regression Testing**

Added unit test coverage in `shared-libs/cht-datasource/test/local/libs/nouveau.spec.ts` for:
- Cross-script matching:
  - Latin input (eg 12346) includes Devanagari variant
  - Devanagari input (eg १२३४६) includes Latin variant
- Edge numeric forms:
  - leading zeros (0123, ०१२३)
  - long numeric strings (9999999999)
  - mixed-script numerals (1२3४, १2३4, 12३४)
- Special characters with numerals
  - (123), 123-456, 123.456, +9876348

Fixes #10851

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [x] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [ ] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

