### PR TITLE
ci(#10891): adds gha concurrency and splits ci-webdriver-default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -289,7 +289,9 @@ jobs:
           - cmd: ci-webdriver-default
             suite: lowLevel
           - cmd: ci-webdriver-default
-            suite: workflows
+            suite: workflows_1
+          - cmd: ci-webdriver-default
+            suite: workflows_2
         exclude: # temporary until all suites run on Chrome 107
           - cmd: ci-integration-all
             chrome-version: 107

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,10 @@ name: Build and test
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   COUCH_URL: http://admin:pass@localhost:5984/medic-test
   BUILDS_SERVER: ${{ secrets.AUTH_MARKET_URL && '_couch/builds_testing' || '_couch/builds_external' }}

--- a/tests/e2e/default/suites.js
+++ b/tests/e2e/default/suites.js
@@ -11,12 +11,14 @@ const SUITES = {
     './old-navigation/**/*.wdio-spec.js',
     './privacy-policy/**/*.wdio-spec.js',
   ],
-  workflows: [
+  workflows_1: [
     './contacts/**/*.wdio-spec.js',
+    './sms/**/*.wdio-spec.js',
+  ],
+  workflows_2: [
     './reports/**/*.wdio-spec.js',
     './targets/**/*.wdio-spec.js',
     './tasks/**/*.wdio-spec.js',
-    './sms/**/*.wdio-spec.js',
   ],
   data: [
     './db/**/*.wdio-spec.js',

--- a/webapp/src/ts/modules/about/about.component.html
+++ b/webapp/src/ts/modules/about/about.component.html
@@ -12,7 +12,6 @@
         </mat-card-content>
       </mat-card>
 
-
       <mat-card>
         <mat-card-header>
           <mat-card-title (click)="secretDoor()" translate>about</mat-card-title>

--- a/webapp/src/ts/modules/about/about.component.html
+++ b/webapp/src/ts/modules/about/about.component.html
@@ -12,6 +12,7 @@
         </mat-card-content>
       </mat-card>
 
+
       <mat-card>
         <mat-card-header>
           <mat-card-title (click)="secretDoor()" translate>about</mat-card-title>


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: build|feat|fix|perf|refactor|test|chore

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->

closes #10891
closes #10892 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [ ] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10891-gha-concurrency/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10891-gha-concurrency/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10891-gha-concurrency/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

