### PR TITLE
feat(#10224): implement dynamic header navigation tabs from UI extensions

### DIFF
--- a/webapp/src/ts/components/header/header.component.ts
+++ b/webapp/src/ts/components/header/header.component.ts
@@ -6,8 +6,6 @@ import { Selectors } from '@mm-selectors/index';
 import { DBSyncService } from '@mm-services/db-sync.service';
 import { ModalService } from '@mm-services/modal.service';
 import { StorageInfoService } from '@mm-services/storage-info.service';
-import { SettingsService } from '@mm-services/settings.service';
-
 
 import { RouterLink } from '@angular/router';
 import { AuthDirective } from '@mm-directives/auth.directive';
@@ -58,7 +56,6 @@ export class HeaderComponent extends BaseMenuComponent implements OnInit, OnDest
     protected readonly dbSyncService: DBSyncService,
     protected readonly modalService: ModalService,
     protected readonly storageInfoService: StorageInfoService,
-    private settingsService: SettingsService,
     private headerTabsService: HeaderTabsService,
   ) {
     super(store, dbSyncService, modalService, storageInfoService);
@@ -93,9 +90,8 @@ export class HeaderComponent extends BaseMenuComponent implements OnInit, OnDest
   }
 
   private getHeaderTabs() {
-    this.settingsService
-      .get()
-      .then(settings => this.headerTabsService.getAuthorizedTabs(settings))
+    this.headerTabsService
+      .getAuthorizedTabs()
       .then(permittedTabs => {
         this.permittedTabs = permittedTabs;
       });

--- a/webapp/src/ts/services/header-tabs.service.ts
+++ b/webapp/src/ts/services/header-tabs.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 
 import { AuthService } from '@mm-services/auth.service';
 import { UiExtensionsService } from '@mm-services/ui-extensions.service';
+import { SettingsService } from '@mm-services/settings.service';
 
 @Injectable({
   providedIn: 'root'
@@ -9,10 +10,11 @@ import { UiExtensionsService } from '@mm-services/ui-extensions.service';
 export class HeaderTabsService {
   constructor(
     private readonly authService: AuthService,
+    private readonly settingsService: SettingsService,
     private readonly uiExtensionsService: UiExtensionsService
   ) { }
 
-  private readonly tabs: HeaderTab[] = [
+  private readonly DEFAULT_TABS: HeaderTab[] = [
     {
       name: 'messages',
       route: 'messages',
@@ -22,7 +24,6 @@ export class HeaderTabsService {
       typeName: 'message',
       icon: undefined,
       resourceIcon: undefined,
-      weight: 0,
     },
     {
       name: 'tasks',
@@ -33,7 +34,6 @@ export class HeaderTabsService {
       typeName: 'task',
       icon: undefined,
       resourceIcon: undefined,
-      weight: 10,
     },
     {
       name: 'reports',
@@ -44,7 +44,6 @@ export class HeaderTabsService {
       typeName: 'report',
       icon: undefined,
       resourceIcon: undefined,
-      weight: 20,
     },
     {
       name: 'contacts',
@@ -54,7 +53,6 @@ export class HeaderTabsService {
       permissions: ['can_view_contacts', 'can_view_contacts_tab'],
       icon: undefined,
       resourceIcon: undefined,
-      weight: 30,
     },
     {
       name: 'analytics',
@@ -64,84 +62,63 @@ export class HeaderTabsService {
       permissions: ['can_view_analytics', 'can_view_analytics_tab'],
       icon: undefined,
       resourceIcon: undefined,
-      weight: 40,
     }
   ];
 
-  /**
-   * Returns the list of header tabs.
-   * If settings are passed as parameter, then it will add the tab.icon and tab.resourceIcon when available.
-   *
-   * @param settings {Object} Settings of CHT-Core instance.
-   *
-   * @returns HeaderTab[]
-   */
-  get(settings?): HeaderTab[] {
-    const tabs = this.tabs.map(tab => ({ ...tab }));
-    if (!settings?.header_tabs) {
-      return tabs;
-    }
+  private tabs?: HeaderTab[];
 
-    tabs.forEach(tab => {
-      if (!settings.header_tabs[tab.name]) {
-        return;
-      }
-
-      if (settings.header_tabs[tab.name].icon && settings.header_tabs[tab.name].icon.startsWith('fa-')) {
-        tab.icon = settings.header_tabs[tab.name].icon;
-      }
-
-      if (settings.header_tabs[tab.name].resource_icon) {
-        tab.resourceIcon = settings.header_tabs[tab.name].resource_icon;
-      }
+  private async getHeaderTabs() {
+    const { header_tabs } = await this.settingsService.get();
+    const headerTabs = this.DEFAULT_TABS.map(tab => {
+      const tabSettings = header_tabs?.[tab.name];
+      return {
+        ...tab,
+        icon: tabSettings?.icon?.startsWith('fa-') ? tabSettings.icon : tab.icon,
+        resourceIcon: tabSettings?.resource_icon ? tabSettings.resource_icon : tab.resourceIcon
+      };
     });
 
-    return tabs;
+    const tabAuthorization = await Promise.all(headerTabs.map(tab => this.authService.has(tab.permissions)));
+    return headerTabs.filter((tab, index) => tabAuthorization[index]);
+  }
+
+  private async getUiExtensionTabs() {
+    const extensions = await this.uiExtensionsService.getPropertiesByType('app_main_tab');
+    return extensions.map(ext => ({
+      name: `ui-extension-${ext.id}`,
+      route: `ui-extensions/${ext.id}`,
+      defaultIcon: 'fa-question-circle',
+      translation: ext.title!,
+      permissions: [], // Extensions are already filtered by role in getPropertiesByType
+      resourceIcon: ext.resource_icon,
+      icon: ext.icon
+    }));
   }
 
   /**
    * Returns the list of authorized header tabs according to the current user's permissions.
-   * If settings are passed as parameter, then it will add the tab.icon and tab.resourceIcon when available.
-   *
-   * @param settings {Object} Settings of CHT-Core instance.
    *
    * @returns Promise<HeaderTab[]>
    */
-  async getAuthorizedTabs(settings?): Promise<HeaderTab[]> {
-    const extensions = await this.uiExtensionsService.getPropertiesByType('app_main_tab');
-    const extensionTabs: HeaderTab[] = extensions.map(ext => ({
-      name: `ui-extension-${ext.id}`,
-      route: `ui-extensions/${ext.id}`,
-      defaultIcon: 'fa-question-circle',
-      translation: ext.title || '',
-      permissions: [], // Extensions are already filtered by role in getPropertiesByType
-      resourceIcon: ext.icon,
-      weight: ext.weight,
-    }));
+  async getAuthorizedTabs(): Promise<HeaderTab[]> {
+    if (!this.tabs) {
+      const [headerTabs, uiExtensionTabs] = await Promise.all([
+        this.getHeaderTabs(),
+        this.getUiExtensionTabs()
+      ]);
+      this.tabs = [...headerTabs, ...uiExtensionTabs];
+    }
 
-    const tabs = [...this.get(settings), ...extensionTabs];
-    const tabAuthorization = await Promise.all(tabs.map(tab => {
-      if (!tab.permissions?.length) {
-        return true;
-      }
-      return this.authService.has(tab.permissions);
-    }));
-
-    return tabs
-      .filter((tab, index) => tabAuthorization[index])
-      .sort((a, b) => (a.weight || 0) - (b.weight || 0));
+    return this.tabs;
   }
 
   /**
    * Returns the primary tab according to the current user's permissions.
-   * If settings are passed as parameter, then it will add the tab.icon and tab.resourceIcon when available.
-   *
-   * @param settings {Object} Settings of CHT-Core instance.
    *
    * @returns Promise<HeaderTab>
    */
-  async getPrimaryTab(settings?): Promise<HeaderTab> {
-    const tabs = await this.getAuthorizedTabs(settings);
+  async getPrimaryTab(): Promise<HeaderTab> {
+    const tabs = await this.getAuthorizedTabs();
 
     return tabs?.[0];
   }
@@ -156,5 +133,4 @@ export interface HeaderTab {
   typeName?: string;
   icon?: string;
   resourceIcon?: string;
-  weight?: number;
 }

--- a/webapp/src/ts/services/header-tabs.service.ts
+++ b/webapp/src/ts/services/header-tabs.service.ts
@@ -8,8 +8,8 @@ import { UiExtensionsService } from '@mm-services/ui-extensions.service';
 })
 export class HeaderTabsService {
   constructor(
-    private authService: AuthService,
-    private uiExtensionsService: UiExtensionsService
+    private readonly authService: AuthService,
+    private readonly uiExtensionsService: UiExtensionsService
   ) { }
 
   private readonly tabs: HeaderTab[] = [

--- a/webapp/src/ts/services/header-tabs.service.ts
+++ b/webapp/src/ts/services/header-tabs.service.ts
@@ -1,13 +1,15 @@
 import { Injectable } from '@angular/core';
 
 import { AuthService } from '@mm-services/auth.service';
+import { UiExtensionsService } from '@mm-services/ui-extensions.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class HeaderTabsService {
   constructor(
-    private authService: AuthService
+    private authService: AuthService,
+    private uiExtensionsService: UiExtensionsService
   ) { }
 
   private readonly tabs: HeaderTab[] = [
@@ -20,6 +22,7 @@ export class HeaderTabsService {
       typeName: 'message',
       icon: undefined,
       resourceIcon: undefined,
+      weight: 0,
     },
     {
       name: 'tasks',
@@ -30,6 +33,7 @@ export class HeaderTabsService {
       typeName: 'task',
       icon: undefined,
       resourceIcon: undefined,
+      weight: 10,
     },
     {
       name: 'reports',
@@ -40,6 +44,7 @@ export class HeaderTabsService {
       typeName: 'report',
       icon: undefined,
       resourceIcon: undefined,
+      weight: 20,
     },
     {
       name: 'contacts',
@@ -49,6 +54,7 @@ export class HeaderTabsService {
       permissions: ['can_view_contacts', 'can_view_contacts_tab'],
       icon: undefined,
       resourceIcon: undefined,
+      weight: 30,
     },
     {
       name: 'analytics',
@@ -58,6 +64,7 @@ export class HeaderTabsService {
       permissions: ['can_view_analytics', 'can_view_analytics_tab'],
       icon: undefined,
       resourceIcon: undefined,
+      weight: 40,
     }
   ];
 
@@ -70,11 +77,12 @@ export class HeaderTabsService {
    * @returns HeaderTab[]
    */
   get(settings?): HeaderTab[] {
+    const tabs = this.tabs.map(tab => ({ ...tab }));
     if (!settings?.header_tabs) {
-      return this.tabs;
+      return tabs;
     }
 
-    this.tabs.forEach(tab => {
+    tabs.forEach(tab => {
       if (!settings.header_tabs[tab.name]) {
         return;
       }
@@ -88,7 +96,7 @@ export class HeaderTabsService {
       }
     });
 
-    return this.tabs;
+    return tabs;
   }
 
   /**
@@ -100,10 +108,28 @@ export class HeaderTabsService {
    * @returns Promise<HeaderTab[]>
    */
   async getAuthorizedTabs(settings?): Promise<HeaderTab[]> {
-    const tabs = this.get(settings);
-    const tabAuthorization = await Promise.all(tabs.map(tab => this.authService.has(tab.permissions)));
+    const extensions = await this.uiExtensionsService.getPropertiesByType('app_main_tab');
+    const extensionTabs: HeaderTab[] = extensions.map(ext => ({
+      name: `ui-extension-${ext.id}`,
+      route: `ui-extensions/${ext.id}`,
+      defaultIcon: 'fa-question-circle',
+      translation: ext.title || '',
+      permissions: [], // Extensions are already filtered by role in getPropertiesByType
+      resourceIcon: ext.icon,
+      weight: ext.weight,
+    }));
 
-    return tabs.filter((tab, index) => tabAuthorization[index]);
+    const tabs = [...this.get(settings), ...extensionTabs];
+    const tabAuthorization = await Promise.all(tabs.map(tab => {
+      if (!tab.permissions?.length) {
+        return true;
+      }
+      return this.authService.has(tab.permissions);
+    }));
+
+    return tabs
+      .filter((tab, index) => tabAuthorization[index])
+      .sort((a, b) => (a.weight || 0) - (b.weight || 0));
   }
 
   /**
@@ -130,4 +156,5 @@ export interface HeaderTab {
   typeName?: string;
   icon?: string;
   resourceIcon?: string;
+  weight?: number;
 }

--- a/webapp/src/ts/services/ui-extensions.service.ts
+++ b/webapp/src/ts/services/ui-extensions.service.ts
@@ -9,8 +9,8 @@ interface UiExtensionProperties {
   readonly type: string;
   readonly roles?: string[];
   readonly icon?: string;
+  readonly resource_icon?: string;
   readonly title?: string;
-  readonly weight?: number;
   readonly config?: Record<string, unknown>;
 }
 
@@ -43,7 +43,7 @@ export class UiExtensionsService {
   private async loadExtensionProperties() {
     try {
       const request = this.http.get<UiExtensionProperties[]>('/ui-extension', { responseType: 'json' });
-      const extensions = (await lastValueFrom(request)) as UiExtensionProperties[];
+      const extensions = await lastValueFrom(request);
       this.extensionProperties = extensions.filter(extension => {
         if (!extension.roles?.length) {
           return true;

--- a/webapp/src/ts/services/ui-extensions.service.ts
+++ b/webapp/src/ts/services/ui-extensions.service.ts
@@ -10,6 +10,7 @@ interface UiExtensionProperties {
   readonly roles?: string[];
   readonly icon?: string;
   readonly title?: string;
+  readonly weight?: number;
   readonly config?: Record<string, unknown>;
 }
 
@@ -42,7 +43,7 @@ export class UiExtensionsService {
   private async loadExtensionProperties() {
     try {
       const request = this.http.get<UiExtensionProperties[]>('/ui-extension', { responseType: 'json' });
-      const extensions = await lastValueFrom(request);
+      const extensions = (await lastValueFrom(request)) as UiExtensionProperties[];
       this.extensionProperties = extensions.filter(extension => {
         if (!extension.roles?.length) {
           return true;

--- a/webapp/tests/karma/ts/components/header/header.component.spec.ts
+++ b/webapp/tests/karma/ts/components/header/header.component.spec.ts
@@ -155,12 +155,12 @@ describe('Header Component', () => {
     expect(component.showPrivacyPolicy).to.be.true;
   });
 
-  it('should load header tabs from settings service', async () => {
+  it('should load header tabs from header tabs service', async () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    expect(settingsService.get.callCount).to.equal(1);
     expect(headerTabsService.getAuthorizedTabs.callCount).to.equal(1);
+    expect(headerTabsService.getAuthorizedTabs.args[0]).to.deep.equal([]);
   });
 
   it('should set permitted tabs after loading', async () => {

--- a/webapp/tests/karma/ts/components/header/header.component.spec.ts
+++ b/webapp/tests/karma/ts/components/header/header.component.spec.ts
@@ -10,7 +10,6 @@ import { HeaderComponent } from '@mm-components/header/header.component';
 import { DBSyncService } from '@mm-services/db-sync.service';
 import { ModalService } from '@mm-services/modal.service';
 import { StorageInfoService } from '@mm-services/storage-info.service';
-import { SettingsService } from '@mm-services/settings.service';
 import { HeaderTabsService } from '@mm-services/header-tabs.service';
 import { CustomResourceService } from '@mm-services/custom-resource.service';
 import { ChangesService } from '@mm-services/changes.service';
@@ -23,7 +22,6 @@ describe('Header Component', () => {
   let dbSyncService;
   let modalService;
   let storageInfoService;
-  let settingsService;
   let headerTabsService;
   let customResourceService;
   let changesService;
@@ -35,7 +33,6 @@ describe('Header Component', () => {
       init: sinon.stub(),
       stop: sinon.stub()
     };
-    settingsService = { get: sinon.stub().resolves({ header_tabs: {} }) };
     headerTabsService = {
       get: sinon.stub().returns([]),
       getAuthorizedTabs: sinon.stub().resolves([
@@ -72,7 +69,6 @@ describe('Header Component', () => {
           { provide: DBSyncService, useValue: dbSyncService },
           { provide: ModalService, useValue: modalService },
           { provide: StorageInfoService, useValue: storageInfoService },
-          { provide: SettingsService, useValue: settingsService },
           { provide: HeaderTabsService, useValue: headerTabsService },
           { provide: CustomResourceService, useValue: customResourceService },
           { provide: ChangesService, useValue: changesService },

--- a/webapp/tests/karma/ts/modules/home/home.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/home/home.component.spec.ts
@@ -7,19 +7,19 @@ import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 
 import { HomeComponent } from '@mm-modules/home/home.component';
-import { AuthService } from '@mm-services/auth.service';
+import { HeaderTabsService } from '@mm-services/header-tabs.service';
 
 describe('HomeComponent', () => {
 
   let component: HomeComponent;
   let fixture: ComponentFixture<HomeComponent>;
-  let authServiceMock;
+  let headerTabsServiceMock;
   let routerMock;
 
   beforeEach(waitForAsync(() => {
 
-    authServiceMock = {
-      has: sinon.stub(),
+    headerTabsServiceMock = {
+      getPrimaryTab: sinon.stub().resolves({ route: 'messages' }),
     };
     routerMock = {
       navigate: sinon.stub(),
@@ -34,7 +34,7 @@ describe('HomeComponent', () => {
           HomeComponent,
         ],
         providers: [
-          { provide: AuthService, useValue: authServiceMock },
+          { provide: HeaderTabsService, useValue: headerTabsServiceMock },
           { provide: Router, useValue: routerMock },
         ]
       })
@@ -50,7 +50,7 @@ describe('HomeComponent', () => {
   });
 
   it('handles no permissions', async () => {
-    authServiceMock.has.resolves(false);
+    headerTabsServiceMock.getPrimaryTab.resolves(undefined);
 
     await component.ngOnInit();
     expect(routerMock.navigate.callCount).to.equal(1);
@@ -58,12 +58,7 @@ describe('HomeComponent', () => {
   });
 
   it('handles some permissions', async () => {
-    authServiceMock.has
-      .withArgs(['can_view_messages', 'can_view_messages_tab']).resolves(false)
-      .withArgs(['can_view_tasks', 'can_view_tasks_tab']).resolves(false)
-      .withArgs(['can_view_reports', 'can_view_reports_tab']).resolves(true)
-      .withArgs(['can_view_analytics', 'can_view_analytics_tab']).resolves(false)
-      .withArgs(['can_view_contacts', 'can_view_contacts_tab']).resolves(true);
+    headerTabsServiceMock.getPrimaryTab.resolves({ route: 'reports' });
 
     await component.ngOnInit();
     expect(routerMock.navigate.callCount).to.equal(1);

--- a/webapp/tests/karma/ts/services/header-tabs.service.spec.ts
+++ b/webapp/tests/karma/ts/services/header-tabs.service.spec.ts
@@ -1,26 +1,28 @@
 import { TestBed } from '@angular/core/testing';
-import * as chai from 'chai';
 import { expect } from 'chai';
 import sinon from 'sinon';
-chai.use(require('chai-shallow-deep-equal'));
 
 import { HeaderTabsService } from '@mm-services/header-tabs.service';
 import { AuthService } from '@mm-services/auth.service';
+import { SettingsService } from '@mm-services/settings.service';
 import { UiExtensionsService } from '@mm-services/ui-extensions.service';
 
 describe('HeaderTabs service', () => {
-  let service:HeaderTabsService;
+  let service: HeaderTabsService;
   let authService;
+  let settingsService;
   let uiExtensionsService;
 
   beforeEach(() => {
-    authService = { has: sinon.stub() };
+    authService = { has: sinon.stub().returns(true) };
+    settingsService = { get: sinon.stub().resolves({}) };
     uiExtensionsService = { getPropertiesByType: sinon.stub().resolves([]) };
 
     TestBed.configureTestingModule({
       providers: [
         { provide: AuthService, useValue: authService },
-        { provide: UiExtensionsService, useValue: uiExtensionsService }
+        { provide: SettingsService, useValue: settingsService },
+        { provide: UiExtensionsService, useValue: uiExtensionsService },
       ]
     });
 
@@ -28,67 +30,6 @@ describe('HeaderTabs service', () => {
   });
 
   afterEach(() => sinon.restore());
-
-  describe('get()', () => {
-    it('should return default tabs when settings not provided', () => {
-      const tabs = service.get();
-      // @ts-ignore
-      expect(tabs).to.shallowDeepEqual([
-        { name: 'messages', defaultIcon: 'fa-envelope', icon: undefined, weight: 0 },
-        { name: 'tasks', defaultIcon: 'fa-flag', icon: undefined, weight: 10 },
-        { name: 'reports', defaultIcon: 'fa-list-alt', icon: undefined, weight: 20 },
-        { name: 'contacts', defaultIcon: 'fa-user', icon: undefined, weight: 30 },
-        { name: 'analytics', defaultIcon: 'fa-bar-chart-o', icon: undefined, weight: 40 },
-      ]);
-
-      expect(service.get({})).to.deep.equal(tabs);
-      expect(service.get({ key: 'value' })).to.deep.equal(tabs);
-      expect(service.get({ header_tabs: {} })).to.deep.equal(tabs);
-    });
-
-    it('should replace icons when provided', () => {
-      const headerTabsSettings = {
-        tasks: { icon: 'fa-whatever' },
-        reports: { resource_icon: 'some-icon' },
-        analytics: { resource_icon: 'other-icon', icon: 'fa-icon' },
-        contacts: { resource_icon: 'one-icon', icon: 'not-fa-icon' },
-      };
-
-      const tabs = service.get({ header_tabs: headerTabsSettings });
-      // @ts-ignore
-      expect(tabs).to.shallowDeepEqual([
-        { name: 'messages', icon: undefined, resourceIcon: undefined, defaultIcon: 'fa-envelope', weight: 0 },
-        { name: 'tasks', icon: 'fa-whatever', resourceIcon: undefined, defaultIcon: 'fa-flag', weight: 10 },
-        { name: 'reports', icon: undefined, resourceIcon: 'some-icon', defaultIcon: 'fa-list-alt', weight: 20 },
-        { name: 'contacts', icon: undefined, resourceIcon: 'one-icon', defaultIcon: 'fa-user', weight: 30 },
-        { name: 'analytics', icon: 'fa-icon', resourceIcon: 'other-icon', defaultIcon: 'fa-bar-chart-o', weight: 40 },
-      ]);
-    });
-
-    it('should include typeName property for tabs that need bubble counters', () => {
-      const tabs = service.get();
-
-      const messagesTab = tabs.find(tab => tab.name === 'messages');
-      expect(messagesTab).to.exist;
-      expect(messagesTab!.typeName).to.equal('message');
-
-      const tasksTab = tabs.find(tab => tab.name === 'tasks');
-      expect(tasksTab).to.exist;
-      expect(tasksTab!.typeName).to.equal('task');
-
-      const reportsTab = tabs.find(tab => tab.name === 'reports');
-      expect(reportsTab).to.exist;
-      expect(reportsTab!.typeName).to.equal('report');
-
-      const contactsTab = tabs.find(tab => tab.name === 'contacts');
-      expect(contactsTab).to.exist;
-      expect(contactsTab!.typeName).to.be.undefined;
-
-      const analyticsTab = tabs.find(tab => tab.name === 'analytics');
-      expect(analyticsTab).to.exist;
-      expect(analyticsTab!.typeName).to.be.undefined;
-    });
-  });
 
   describe('getAuthorizedTabs()', () => {
     it('should return authorized tabs', async () => {
@@ -110,7 +51,6 @@ describe('HeaderTabs service', () => {
           typeName: 'message',
           icon: undefined,
           resourceIcon: undefined,
-          weight: 0,
         },
         {
           name: 'reports',
@@ -121,7 +61,6 @@ describe('HeaderTabs service', () => {
           typeName: 'report',
           icon: undefined,
           resourceIcon: undefined,
-          weight: 20,
         },
         {
           name: 'analytics',
@@ -131,7 +70,6 @@ describe('HeaderTabs service', () => {
           permissions: ['can_view_analytics', 'can_view_analytics_tab'],
           icon: undefined,
           resourceIcon: undefined,
-          weight: 40,
         }
       ]);
     });
@@ -144,7 +82,8 @@ describe('HeaderTabs service', () => {
       expect(tabs).to.deep.equal([]);
     });
 
-    it('should return default tabs when settings not provided', async () => {
+    it('should return default tabs when settings have no header_tabs config', async () => {
+      settingsService.get.resolves({ key: 'value' });
       authService.has.withArgs(['can_view_messages', 'can_view_messages_tab']).returns(false);
       authService.has.withArgs(['can_view_tasks', 'can_view_tasks_tab']).returns(true);
       authService.has.withArgs(['can_view_reports', 'can_view_reports_tab']).returns(false);
@@ -163,7 +102,6 @@ describe('HeaderTabs service', () => {
           typeName: 'task',
           icon: undefined,
           resourceIcon: undefined,
-          weight: 10,
         },
         {
           name: 'contacts',
@@ -173,7 +111,6 @@ describe('HeaderTabs service', () => {
           permissions: ['can_view_contacts', 'can_view_contacts_tab'],
           icon: undefined,
           resourceIcon: undefined,
-          weight: 30,
         },
         {
           name: 'analytics',
@@ -183,26 +120,51 @@ describe('HeaderTabs service', () => {
           permissions: ['can_view_analytics', 'can_view_analytics_tab'],
           icon: undefined,
           resourceIcon: undefined,
-          weight: 40,
         }
       ]);
     });
 
-    it('should replace icons when provided', async () => {
-      const headerTabsSettings = {
-        messages: { resource_icon: 'pomegranate-icon' },
-        tasks: { icon: 'fa-apple' },
-        contacts: { resource_icon: 'pear-icon', icon: 'not-fa-pear-icon' },
-        reports: { resource_icon: 'pineapple-icon', icon: 'not-fa-pineapple-icon' },
-        analytics: { resource_icon: 'mango-icon', icon: 'fa-mango-icon' },
-      };
+    it('should include typeName property for tabs that need bubble counters', async () => {
+      const tabs = await service.getAuthorizedTabs();
+
+      const messagesTab = tabs.find(tab => tab.name === 'messages');
+      expect(messagesTab).to.exist;
+      expect(messagesTab!.typeName).to.equal('message');
+
+      const tasksTab = tabs.find(tab => tab.name === 'tasks');
+      expect(tasksTab).to.exist;
+      expect(tasksTab!.typeName).to.equal('task');
+
+      const reportsTab = tabs.find(tab => tab.name === 'reports');
+      expect(reportsTab).to.exist;
+      expect(reportsTab!.typeName).to.equal('report');
+
+      const contactsTab = tabs.find(tab => tab.name === 'contacts');
+      expect(contactsTab).to.exist;
+      expect(contactsTab!.typeName).to.be.undefined;
+
+      const analyticsTab = tabs.find(tab => tab.name === 'analytics');
+      expect(analyticsTab).to.exist;
+      expect(analyticsTab!.typeName).to.be.undefined;
+    });
+
+    it('should replace icons from settings when provided', async () => {
+      settingsService.get.resolves({
+        header_tabs: {
+          messages: { resource_icon: 'pomegranate-icon' },
+          tasks: { icon: 'fa-apple' },
+          contacts: { resource_icon: 'pear-icon', icon: 'not-fa-pear-icon' },
+          reports: { resource_icon: 'pineapple-icon', icon: 'not-fa-pineapple-icon' },
+          analytics: { resource_icon: 'mango-icon', icon: 'fa-mango-icon' },
+        }
+      });
       authService.has.withArgs(['can_view_messages', 'can_view_messages_tab']).returns(true);
       authService.has.withArgs(['can_view_tasks', 'can_view_tasks_tab']).returns(true);
       authService.has.withArgs(['can_view_reports', 'can_view_reports_tab']).returns(false);
       authService.has.withArgs(['can_view_contacts', 'can_view_contacts_tab']).returns(true);
       authService.has.withArgs(['can_view_analytics', 'can_view_analytics_tab']).returns(true);
 
-      const tabs = await service.getAuthorizedTabs({ header_tabs: headerTabsSettings });
+      const tabs = await service.getAuthorizedTabs();
 
       expect(tabs).to.deep.equal([
         {
@@ -214,7 +176,6 @@ describe('HeaderTabs service', () => {
           typeName: 'message',
           icon: undefined,
           resourceIcon: 'pomegranate-icon',
-          weight: 0,
         },
         {
           name: 'tasks',
@@ -225,7 +186,6 @@ describe('HeaderTabs service', () => {
           typeName: 'task',
           icon: 'fa-apple',
           resourceIcon: undefined,
-          weight: 10,
         },
         {
           name: 'contacts',
@@ -235,7 +195,6 @@ describe('HeaderTabs service', () => {
           permissions: ['can_view_contacts', 'can_view_contacts_tab'],
           icon: undefined,
           resourceIcon: 'pear-icon',
-          weight: 30,
         },
         {
           name: 'analytics',
@@ -245,9 +204,18 @@ describe('HeaderTabs service', () => {
           permissions: ['can_view_analytics', 'can_view_analytics_tab'],
           icon: 'fa-mango-icon',
           resourceIcon: 'mango-icon',
-          weight: 40,
         }
       ]);
+    });
+
+    it('should cache tabs after first call', async () => {
+      await service.getAuthorizedTabs();
+      const tabs = await service.getAuthorizedTabs();
+      await service.getAuthorizedTabs();
+
+      expect(settingsService.get.callCount).to.equal(1);
+      expect(uiExtensionsService.getPropertiesByType.callCount).to.equal(1);
+      expect(tabs).to.have.length(5);
     });
   });
 
@@ -270,11 +238,10 @@ describe('HeaderTabs service', () => {
         typeName: 'message',
         icon: undefined,
         resourceIcon: undefined,
-        weight: 0,
       });
     });
 
-    it('should return the primary tab and it is not the first tab from the original list', async () => {
+    it('should return the primary tab when it is not the first tab from the original list', async () => {
       authService.has.withArgs(['can_view_messages', 'can_view_messages_tab']).returns(false);
       authService.has.withArgs(['can_view_tasks', 'can_view_tasks_tab']).returns(false);
       authService.has.withArgs(['can_view_reports', 'can_view_reports_tab']).returns(true);
@@ -292,7 +259,6 @@ describe('HeaderTabs service', () => {
         typeName: 'report',
         icon: undefined,
         resourceIcon: undefined,
-        weight: 20,
       });
     });
 
@@ -304,7 +270,7 @@ describe('HeaderTabs service', () => {
       expect(tab).to.be.undefined;
     });
 
-    it('should return default tab when settings not provided', async () => {
+    it('should return default tab when settings have no header_tabs config', async () => {
       authService.has.withArgs(['can_view_messages', 'can_view_messages_tab']).returns(false);
       authService.has.withArgs(['can_view_tasks', 'can_view_tasks_tab']).returns(false);
       authService.has.withArgs(['can_view_reports', 'can_view_reports_tab']).returns(false);
@@ -321,25 +287,26 @@ describe('HeaderTabs service', () => {
         permissions: ['can_view_contacts', 'can_view_contacts_tab'],
         icon: undefined,
         resourceIcon: undefined,
-        weight: 30,
       });
     });
 
-    it('should replace icons when provided', async () => {
-      const headerTabsSettings = {
-        messages: { resource_icon: 'pomegranate-icon' },
-        tasks: { icon: 'fa-apple' },
-        contacts: { resource_icon: 'pear-icon', icon: 'not-fa-pear-icon' },
-        reports: { resource_icon: 'pineapple-icon', icon: 'not-fa-pineapple-icon' },
-        analytics: { resource_icon: 'mango-icon', icon: 'fa-mango-icon' },
-      };
+    it('should replace icons from settings when provided', async () => {
+      settingsService.get.resolves({
+        header_tabs: {
+          messages: { resource_icon: 'pomegranate-icon' },
+          tasks: { icon: 'fa-apple' },
+          contacts: { resource_icon: 'pear-icon', icon: 'not-fa-pear-icon' },
+          reports: { resource_icon: 'pineapple-icon', icon: 'not-fa-pineapple-icon' },
+          analytics: { resource_icon: 'mango-icon', icon: 'fa-mango-icon' },
+        }
+      });
       authService.has.withArgs(['can_view_messages', 'can_view_messages_tab']).returns(false);
       authService.has.withArgs(['can_view_tasks', 'can_view_tasks_tab']).returns(false);
       authService.has.withArgs(['can_view_reports', 'can_view_reports_tab']).returns(false);
       authService.has.withArgs(['can_view_contacts', 'can_view_contacts_tab']).returns(false);
       authService.has.withArgs(['can_view_analytics', 'can_view_analytics_tab']).returns(true);
 
-      const tab = await service.getPrimaryTab({ header_tabs: headerTabsSettings });
+      const tab = await service.getPrimaryTab();
 
       expect(tab).to.deep.equal({
         name: 'analytics',
@@ -349,54 +316,103 @@ describe('HeaderTabs service', () => {
         permissions: ['can_view_analytics', 'can_view_analytics_tab'],
         icon: 'fa-mango-icon',
         resourceIcon: 'mango-icon',
-        weight: 40,
       });
     });
   });
- 
+
   describe('Custom UI Extensions', () => {
-    it('should include UI extension tabs sorted by weight', async () => {
+    it('should append UI extension tabs after the default tabs', async () => {
       authService.has.returns(true);
-      uiExtensionsService.getPropertiesByType.withArgs('app_main_tab').resolves([
-        { id: 'first', title: 'First Extension', weight: 5, icon: 'icon-1' },
-        { id: 'last', title: 'Last Extension', weight: 100, icon: 'icon-2' },
-        { id: 'middle', title: 'Middle Extension', weight: 25, icon: 'icon-3' },
-      ]);
- 
+      uiExtensionsService.getPropertiesByType
+        .withArgs('app_main_tab')
+        .resolves([
+          { id: 'first', title: 'First Extension', icon: 'fa-icon-1', resource_icon: 'res-1' },
+          { id: 'middle', title: 'Middle Extension', icon: 'fa-icon-3' },
+          { id: 'last', title: 'Last Extension', resource_icon: 'res-2' },
+        ]);
+
       const tabs = await service.getAuthorizedTabs();
- 
+
       expect(tabs.map(t => t.name)).to.deep.equal([
-        'messages',        // weight 0
-        'ui-extension-first', // weight 5
-        'tasks',           // weight 10
-        'reports',         // weight 20
-        'ui-extension-middle', // weight 25
-        'contacts',        // weight 30
-        'analytics',       // weight 40
-        'ui-extension-last'   // weight 100
+        'messages',
+        'tasks',
+        'reports',
+        'contacts',
+        'analytics',
+        'ui-extension-first',
+        'ui-extension-middle',
+        'ui-extension-last',
       ]);
- 
-      const firstExt = tabs.find(t => t.name === 'ui-extension-first');
-      expect(firstExt).to.deep.include({
+
+      const [,,,,,firstExt, middleExt, lastExt] = tabs;
+      expect(firstExt).to.deep.equal({
+        name: 'ui-extension-first',
         route: 'ui-extensions/first',
         defaultIcon: 'fa-question-circle',
         translation: 'First Extension',
-        resourceIcon: 'icon-1',
-        weight: 5
+        permissions: [],
+        icon: 'fa-icon-1',
+        resourceIcon: 'res-1',
+      });
+      expect(middleExt).to.deep.equal({
+        name: 'ui-extension-middle',
+        route: 'ui-extensions/middle',
+        defaultIcon: 'fa-question-circle',
+        translation: 'Middle Extension',
+        permissions: [],
+        icon: 'fa-icon-3',
+        resourceIcon: undefined,
+      });
+      expect(lastExt).to.deep.equal({
+        name: 'ui-extension-last',
+        route: 'ui-extensions/last',
+        defaultIcon: 'fa-question-circle',
+        translation: 'Last Extension',
+        permissions: [],
+        icon: undefined,
+        resourceIcon: 'res-2',
       });
     });
- 
-    it('should default missing weights to 0', async () => {
-      authService.has.returns(true);
+
+    it('should include UI extensions even when no default tabs are authorized', async () => {
+      authService.has.returns(false);
       uiExtensionsService.getPropertiesByType.withArgs('app_main_tab').resolves([
-        { id: 'no-weight', title: 'No Weight', icon: 'icon' },
+        { id: 'ext', title: 'Extension', icon: 'fa-icon' },
       ]);
- 
+
       const tabs = await service.getAuthorizedTabs();
- 
-      // Both messages and no-weight have weight 0, so order depends on original array concat order
-      expect(tabs[0].name).to.equal('messages');
-      expect(tabs[1].name).to.equal('ui-extension-no-weight');
+
+      expect(tabs).to.deep.equal([
+        {
+          name: 'ui-extension-ext',
+          route: 'ui-extensions/ext',
+          defaultIcon: 'fa-question-circle',
+          translation: 'Extension',
+          permissions: [],
+          icon: 'fa-icon',
+          resourceIcon: undefined,
+        }
+      ]);
+      expect(authService.has.callCount).to.equal(5);
+    });
+
+    it('should return UI extension tab as primary when no default tabs are authorized', async () => {
+      authService.has.returns(false);
+      uiExtensionsService.getPropertiesByType.withArgs('app_main_tab').resolves([
+        { id: 'ext', title: 'Extension', icon: 'fa-icon' },
+      ]);
+
+      const tab = await service.getPrimaryTab();
+
+      expect(tab).to.deep.equal({
+        name: 'ui-extension-ext',
+        route: 'ui-extensions/ext',
+        defaultIcon: 'fa-question-circle',
+        translation: 'Extension',
+        permissions: [],
+        icon: 'fa-icon',
+        resourceIcon: undefined,
+      });
     });
   });
 });

--- a/webapp/tests/karma/ts/services/header-tabs.service.spec.ts
+++ b/webapp/tests/karma/ts/services/header-tabs.service.spec.ts
@@ -6,17 +6,21 @@ chai.use(require('chai-shallow-deep-equal'));
 
 import { HeaderTabsService } from '@mm-services/header-tabs.service';
 import { AuthService } from '@mm-services/auth.service';
+import { UiExtensionsService } from '@mm-services/ui-extensions.service';
 
 describe('HeaderTabs service', () => {
   let service:HeaderTabsService;
   let authService;
+  let uiExtensionsService;
 
   beforeEach(() => {
     authService = { has: sinon.stub() };
+    uiExtensionsService = { getPropertiesByType: sinon.stub().resolves([]) };
 
     TestBed.configureTestingModule({
       providers: [
-        { provide: AuthService, useValue: authService }
+        { provide: AuthService, useValue: authService },
+        { provide: UiExtensionsService, useValue: uiExtensionsService }
       ]
     });
 
@@ -30,11 +34,11 @@ describe('HeaderTabs service', () => {
       const tabs = service.get();
       // @ts-ignore
       expect(tabs).to.shallowDeepEqual([
-        { name: 'messages', defaultIcon: 'fa-envelope', icon: undefined },
-        { name: 'tasks', defaultIcon: 'fa-flag', icon: undefined },
-        { name: 'reports', defaultIcon: 'fa-list-alt', icon: undefined },
-        { name: 'contacts', defaultIcon: 'fa-user', icon: undefined },
-        { name: 'analytics', defaultIcon: 'fa-bar-chart-o', icon: undefined },
+        { name: 'messages', defaultIcon: 'fa-envelope', icon: undefined, weight: 0 },
+        { name: 'tasks', defaultIcon: 'fa-flag', icon: undefined, weight: 10 },
+        { name: 'reports', defaultIcon: 'fa-list-alt', icon: undefined, weight: 20 },
+        { name: 'contacts', defaultIcon: 'fa-user', icon: undefined, weight: 30 },
+        { name: 'analytics', defaultIcon: 'fa-bar-chart-o', icon: undefined, weight: 40 },
       ]);
 
       expect(service.get({})).to.deep.equal(tabs);
@@ -53,11 +57,11 @@ describe('HeaderTabs service', () => {
       const tabs = service.get({ header_tabs: headerTabsSettings });
       // @ts-ignore
       expect(tabs).to.shallowDeepEqual([
-        { name: 'messages', icon: undefined, resourceIcon: undefined, defaultIcon: 'fa-envelope' },
-        { name: 'tasks', icon: 'fa-whatever', resourceIcon: undefined, defaultIcon: 'fa-flag' },
-        { name: 'reports', icon: undefined, resourceIcon: 'some-icon', defaultIcon: 'fa-list-alt' },
-        { name: 'contacts', icon: undefined, resourceIcon: 'one-icon', defaultIcon: 'fa-user' },
-        { name: 'analytics', icon: 'fa-icon', resourceIcon: 'other-icon', defaultIcon: 'fa-bar-chart-o' },
+        { name: 'messages', icon: undefined, resourceIcon: undefined, defaultIcon: 'fa-envelope', weight: 0 },
+        { name: 'tasks', icon: 'fa-whatever', resourceIcon: undefined, defaultIcon: 'fa-flag', weight: 10 },
+        { name: 'reports', icon: undefined, resourceIcon: 'some-icon', defaultIcon: 'fa-list-alt', weight: 20 },
+        { name: 'contacts', icon: undefined, resourceIcon: 'one-icon', defaultIcon: 'fa-user', weight: 30 },
+        { name: 'analytics', icon: 'fa-icon', resourceIcon: 'other-icon', defaultIcon: 'fa-bar-chart-o', weight: 40 },
       ]);
     });
 
@@ -106,6 +110,7 @@ describe('HeaderTabs service', () => {
           typeName: 'message',
           icon: undefined,
           resourceIcon: undefined,
+          weight: 0,
         },
         {
           name: 'reports',
@@ -116,6 +121,7 @@ describe('HeaderTabs service', () => {
           typeName: 'report',
           icon: undefined,
           resourceIcon: undefined,
+          weight: 20,
         },
         {
           name: 'analytics',
@@ -125,6 +131,7 @@ describe('HeaderTabs service', () => {
           permissions: ['can_view_analytics', 'can_view_analytics_tab'],
           icon: undefined,
           resourceIcon: undefined,
+          weight: 40,
         }
       ]);
     });
@@ -156,6 +163,7 @@ describe('HeaderTabs service', () => {
           typeName: 'task',
           icon: undefined,
           resourceIcon: undefined,
+          weight: 10,
         },
         {
           name: 'contacts',
@@ -165,6 +173,7 @@ describe('HeaderTabs service', () => {
           permissions: ['can_view_contacts', 'can_view_contacts_tab'],
           icon: undefined,
           resourceIcon: undefined,
+          weight: 30,
         },
         {
           name: 'analytics',
@@ -174,6 +183,7 @@ describe('HeaderTabs service', () => {
           permissions: ['can_view_analytics', 'can_view_analytics_tab'],
           icon: undefined,
           resourceIcon: undefined,
+          weight: 40,
         }
       ]);
     });
@@ -204,6 +214,7 @@ describe('HeaderTabs service', () => {
           typeName: 'message',
           icon: undefined,
           resourceIcon: 'pomegranate-icon',
+          weight: 0,
         },
         {
           name: 'tasks',
@@ -214,6 +225,7 @@ describe('HeaderTabs service', () => {
           typeName: 'task',
           icon: 'fa-apple',
           resourceIcon: undefined,
+          weight: 10,
         },
         {
           name: 'contacts',
@@ -223,6 +235,7 @@ describe('HeaderTabs service', () => {
           permissions: ['can_view_contacts', 'can_view_contacts_tab'],
           icon: undefined,
           resourceIcon: 'pear-icon',
+          weight: 30,
         },
         {
           name: 'analytics',
@@ -232,6 +245,7 @@ describe('HeaderTabs service', () => {
           permissions: ['can_view_analytics', 'can_view_analytics_tab'],
           icon: 'fa-mango-icon',
           resourceIcon: 'mango-icon',
+          weight: 40,
         }
       ]);
     });
@@ -256,6 +270,7 @@ describe('HeaderTabs service', () => {
         typeName: 'message',
         icon: undefined,
         resourceIcon: undefined,
+        weight: 0,
       });
     });
 
@@ -277,6 +292,7 @@ describe('HeaderTabs service', () => {
         typeName: 'report',
         icon: undefined,
         resourceIcon: undefined,
+        weight: 20,
       });
     });
 
@@ -305,6 +321,7 @@ describe('HeaderTabs service', () => {
         permissions: ['can_view_contacts', 'can_view_contacts_tab'],
         icon: undefined,
         resourceIcon: undefined,
+        weight: 30,
       });
     });
 
@@ -332,7 +349,54 @@ describe('HeaderTabs service', () => {
         permissions: ['can_view_analytics', 'can_view_analytics_tab'],
         icon: 'fa-mango-icon',
         resourceIcon: 'mango-icon',
+        weight: 40,
       });
+    });
+  });
+ 
+  describe('Custom UI Extensions', () => {
+    it('should include UI extension tabs sorted by weight', async () => {
+      authService.has.returns(true);
+      uiExtensionsService.getPropertiesByType.withArgs('app_main_tab').resolves([
+        { id: 'first', title: 'First Extension', weight: 5, icon: 'icon-1' },
+        { id: 'last', title: 'Last Extension', weight: 100, icon: 'icon-2' },
+        { id: 'middle', title: 'Middle Extension', weight: 25, icon: 'icon-3' },
+      ]);
+ 
+      const tabs = await service.getAuthorizedTabs();
+ 
+      expect(tabs.map(t => t.name)).to.deep.equal([
+        'messages',        // weight 0
+        'ui-extension-first', // weight 5
+        'tasks',           // weight 10
+        'reports',         // weight 20
+        'ui-extension-middle', // weight 25
+        'contacts',        // weight 30
+        'analytics',       // weight 40
+        'ui-extension-last'   // weight 100
+      ]);
+ 
+      const firstExt = tabs.find(t => t.name === 'ui-extension-first');
+      expect(firstExt).to.deep.include({
+        route: 'ui-extensions/first',
+        defaultIcon: 'fa-question-circle',
+        translation: 'First Extension',
+        resourceIcon: 'icon-1',
+        weight: 5
+      });
+    });
+ 
+    it('should default missing weights to 0', async () => {
+      authService.has.returns(true);
+      uiExtensionsService.getPropertiesByType.withArgs('app_main_tab').resolves([
+        { id: 'no-weight', title: 'No Weight', icon: 'icon' },
+      ]);
+ 
+      const tabs = await service.getAuthorizedTabs();
+ 
+      // Both messages and no-weight have weight 0, so order depends on original array concat order
+      expect(tabs[0].name).to.equal('messages');
+      expect(tabs[1].name).to.equal('ui-extension-no-weight');
     });
   });
 });


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: build|feat|fix|perf|refactor|test|chore

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

## Fixes: #10672 
This PR adds support for dynamic navigation tabs in the CHT header using UI extensions of type app_main_tab. It also introduces a weight-based sorting system to allow developers to control the order of both system and custom tabs.

### Changes
1. Dynamic Tab Integration
**HeaderTabsService:** Injected UiExtensionsService to fetch extensions of type app_main_tab. These are now merged with the standard system tabs (Messages, Tasks, Reports, etc.) in getAuthorizedTabs().

**Weight-based Sorting:** Added a weight property to the HeaderTab interface.
System tabs are assigned default weights (0, 10, 20, 30, 40).
UI extensions default to a weight of 0 but can be customised in the extension configuration.
The header now sorts all authorised tabs numerically by weight.

2. Bug Fixes & Refactoring
**State Mutation Fix:** Resolved a pre-existing bug in HeaderTabsService.get() where calling the method with settings would permanently modify the internal tabs array.
**Type Safety:** Updated UiExtensionProperties in UiExtensionsService to include the weight property and implemented explicit type casting for better TypeScript support.

3. Test Improvements
**HeaderTabsService Spec:** Added comprehensive test cases for dynamic merging and weight-based sorting.
**HomeComponent Spec:** Updated tests to mock HeaderTabsService correctly, fixing a dependency regression.






















<!-- DESCRIPTION -->

<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [ ] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

