### PR TITLE
feat(10908): add weight-based sorting for header tabs

### DIFF
--- a/webapp/src/ts/components/header/header.component.html
+++ b/webapp/src/ts/components/header/header.component.html
@@ -15,35 +15,10 @@
           </div>
         </a>
         <ul id="header-dropdown" *dropdownMenu class="dropdown-menu mm-dropdown-menu" role="menu" aria-labelledby="header-dropdown-link">
-          <li role="presentation" mmAuth="can_view_messages,!can_view_messages_tab">
-            <a role="menuitem" tabindex="-1" routerLink="messages">
-              <i class="fa fa-fw fa-envelope"></i>
-              <span>{{'Messages' | translate}}</span>
-            </a>
-          </li>
-          <li role="presentation" mmAuth="can_view_tasks,!can_view_tasks_tab">
-            <a role="menuitem" tabindex="-1" routerLink="tasks">
-              <i class="fa fa-fw fa-flag"></i>
-              <span>{{'Tasks' | translate}}</span>
-            </a>
-          </li>
-          <li role="presentation" mmAuth="can_view_reports,!can_view_reports_tab">
-            <a role="menuitem" tabindex="-1" routerLink="reports">
-              <i class="fa fa-fw fa-list-alt"></i>
-              <span>{{'Reports' | translate}}</span>
-            </a>
-          </li>
-          <li role="presentation" mmAuth="can_view_contacts,!can_view_contacts_tab">
-            <a role="menuitem" tabindex="-1" routerLink="contacts">
-              <i class="fa fa-fw fa-user"></i>
-              <span>{{'Contacts' | translate}}</span>
-            </a>
-          </li>
-
-          <li role="presentation" mmAuth="can_view_analytics,!can_view_analytics_tab">
-            <a role="menuitem" tabindex="-1" routerLink="analytics" routerLink-opts="{reload: true}">
-              <i class="fa fa-bar-chart-o"></i>
-              <span>{{'Analytics' | translate}}</span>
+          <li role="presentation" *ngFor="let tab of allTabs" [mmAuth]="getLegacyMenuPermissions(tab)">
+            <a role="menuitem" tabindex="-1" [routerLink]="tab.route" [routerLink-opts]="tab.name === 'analytics' ? { reload: true } : {}">
+              <i class="fa fa-fw" [ngClass]="tab.icon || tab.defaultIcon"></i>
+              <span>{{tab.translation | translate}}</span>
             </a>
           </li>
           <li role="presentation" class="desktop-only" mmAuth [mmAuthAny]="[ 'can_configure', 'can_view_outgoing_messages', 'can_export_all' ]" [mmAuthOnline]="true">

--- a/webapp/src/ts/components/header/header.component.ts
+++ b/webapp/src/ts/components/header/header.component.ts
@@ -51,6 +51,7 @@ export class HeaderComponent extends BaseMenuComponent implements OnInit, OnDest
   // replicationStatus;
   currentTab;
   bubbleCount = {};
+  allTabs: HeaderTab[] = [];
   permittedTabs: HeaderTab[] = [];
 
   constructor(
@@ -74,6 +75,16 @@ export class HeaderComponent extends BaseMenuComponent implements OnInit, OnDest
     super.ngOnDestroy();
   }
 
+  getLegacyMenuPermissions(tab: HeaderTab) {
+    if (Array.isArray(tab.permissions)) {
+      if (tab.permissions.length === 2) {
+        return `${tab.permissions[0]},!${tab.permissions[1]}`;
+      }
+      return tab.permissions.join(',');
+    }
+    return tab.permissions;
+  }
+
   private additionalSubscriptions(){
     const currentTab = this.store
       .select(Selectors.getCurrentTab)
@@ -95,7 +106,10 @@ export class HeaderComponent extends BaseMenuComponent implements OnInit, OnDest
   private getHeaderTabs() {
     this.settingsService
       .get()
-      .then(settings => this.headerTabsService.getAuthorizedTabs(settings))
+      .then(settings => {
+        this.allTabs = this.headerTabsService.get(settings);
+        return this.headerTabsService.getAuthorizedTabs(settings);
+      })
       .then(permittedTabs => {
         this.permittedTabs = permittedTabs;
       });

--- a/webapp/src/ts/components/sidebar-menu/sidebar-menu.component.ts
+++ b/webapp/src/ts/components/sidebar-menu/sidebar-menu.component.ts
@@ -19,6 +19,8 @@ import { StorageInfoService } from '@mm-services/storage-info.service';
 
 import { filter } from 'rxjs/operators';
 import { Selectors } from '@mm-selectors/index';
+import { SettingsService } from '@mm-services/settings.service';
+import { HeaderTab, HeaderTabsService } from '@mm-services/header-tabs.service';
 
 @Component({
   selector: 'mm-sidebar-menu',
@@ -54,6 +56,8 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
     protected modalService: ModalService,
     private router: Router,
     protected readonly storageInfoService: StorageInfoService,
+    private settingsService: SettingsService,
+    private headerTabsService: HeaderTabsService,
   ) {
     super(store, dbSyncService, modalService, storageInfoService);
     this.globalActions = new GlobalActions(store);
@@ -103,38 +107,25 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
   }
 
   private setModuleOptions() {
-    this.moduleOptions = [
-      {
-        routerLink: 'messages',
-        icon: 'fa-envelope',
-        translationKey: 'Messages',
-        hasPermissions: 'can_view_messages,!can_view_messages_tab'
-      },
-      {
-        routerLink: 'tasks',
-        icon: 'fa-flag',
-        translationKey: 'Tasks',
-        hasPermissions: 'can_view_tasks,!can_view_tasks_tab'
-      },
-      {
-        routerLink: 'reports',
-        icon: 'fa-list-alt',
-        translationKey: 'Reports',
-        hasPermissions: 'can_view_reports,!can_view_reports_tab'
-      },
-      {
-        routerLink: 'contacts',
-        icon: 'fa-user',
-        translationKey: 'Contacts',
-        hasPermissions: 'can_view_contacts,!can_view_contacts_tab'
-      },
-      {
-        routerLink: 'analytics',
-        icon: 'fa-bar-chart-o',
-        translationKey: 'Analytics',
-        hasPermissions: 'can_view_analytics,!can_view_analytics_tab',
-      },
-    ];
+    this.settingsService.get().then(settings => {
+      const tabs = this.headerTabsService.get(settings);
+      this.moduleOptions = tabs.map(tab => ({
+        routerLink: tab.route,
+        icon: tab.icon || tab.defaultIcon,
+        translationKey: tab.translation,
+        hasPermissions: this.getSidebarPermissions(tab),
+      }));
+    });
+  }
+
+  private getSidebarPermissions(tab: HeaderTab) {
+    if (Array.isArray(tab.permissions)) {
+      if (tab.permissions.length === 2) {
+        return `${tab.permissions[0]},!${tab.permissions[1]}`;
+      }
+      return tab.permissions.join(',');
+    }
+    return tab.permissions;
   }
 
   private setSecondaryOptions(showPrivacyPolicy = false) {

--- a/webapp/src/ts/services/header-tabs.service.ts
+++ b/webapp/src/ts/services/header-tabs.service.ts
@@ -1,6 +1,14 @@
 import { Injectable } from '@angular/core';
-
 import { AuthService } from '@mm-services/auth.service';
+
+const DEFAULT_WEIGHTS: {[key: string]: number} = {
+  messages: 1,
+  tasks: 2,
+  reports: 3,
+  contacts: 4,
+  analytics: 5,
+};
+const CUSTOM_WEIGHT = 6;
 
 @Injectable({
   providedIn: 'root'
@@ -20,6 +28,7 @@ export class HeaderTabsService {
       typeName: 'message',
       icon: undefined,
       resourceIcon: undefined,
+      weight: DEFAULT_WEIGHTS.messages,
     },
     {
       name: 'tasks',
@@ -30,6 +39,7 @@ export class HeaderTabsService {
       typeName: 'task',
       icon: undefined,
       resourceIcon: undefined,
+      weight: DEFAULT_WEIGHTS.tasks,
     },
     {
       name: 'reports',
@@ -40,6 +50,7 @@ export class HeaderTabsService {
       typeName: 'report',
       icon: undefined,
       resourceIcon: undefined,
+      weight: DEFAULT_WEIGHTS.reports,
     },
     {
       name: 'contacts',
@@ -49,6 +60,7 @@ export class HeaderTabsService {
       permissions: ['can_view_contacts', 'can_view_contacts_tab'],
       icon: undefined,
       resourceIcon: undefined,
+      weight: DEFAULT_WEIGHTS.contacts,
     },
     {
       name: 'analytics',
@@ -58,6 +70,7 @@ export class HeaderTabsService {
       permissions: ['can_view_analytics', 'can_view_analytics_tab'],
       icon: undefined,
       resourceIcon: undefined,
+      weight: DEFAULT_WEIGHTS.analytics,
     }
   ];
 
@@ -70,25 +83,50 @@ export class HeaderTabsService {
    * @returns HeaderTab[]
    */
   get(settings?): HeaderTab[] {
-    if (!settings?.header_tabs) {
-      return this.tabs;
+    const tabs = this.tabs.map(tab => ({ ...tab }));
+
+    if (settings?.header_tabs) {
+      Object.keys(settings.header_tabs).forEach(tabName => {
+        let tab = tabs.find(t => t.name === tabName);
+        const settingsTab = settings.header_tabs[tabName];
+
+        if (!tab) {
+          const name = tabName || settingsTab.id;
+          tab = {
+            name,
+            route: settingsTab.route || name,
+            defaultIcon: settingsTab.default_icon || settingsTab.defaultIcon || 'fa-external-link',
+            translation: settingsTab.translation || settingsTab.label || name,
+            permissions: settingsTab.permissions || [],
+            weight: settingsTab.weight || CUSTOM_WEIGHT,
+          };
+          tabs.push(tab);
+        }
+
+        if (settingsTab.icon && settingsTab.icon.startsWith('fa-')) {
+          tab.icon = settingsTab.icon;
+        }
+
+        if (settingsTab.resource_icon) {
+          tab.resourceIcon = settingsTab.resource_icon;
+        }
+
+        if (settingsTab.weight !== undefined) {
+          tab.weight = settingsTab.weight;
+        }
+      });
     }
 
-    this.tabs.forEach(tab => {
-      if (!settings.header_tabs[tab.name]) {
-        return;
+    return tabs.sort((a, b) => {
+      const weightA = a.weight ?? CUSTOM_WEIGHT;
+      const weightB = b.weight ?? CUSTOM_WEIGHT;
+
+      if (weightA !== weightB) {
+        return weightA - weightB;
       }
 
-      if (settings.header_tabs[tab.name].icon && settings.header_tabs[tab.name].icon.startsWith('fa-')) {
-        tab.icon = settings.header_tabs[tab.name].icon;
-      }
-
-      if (settings.header_tabs[tab.name].resource_icon) {
-        tab.resourceIcon = settings.header_tabs[tab.name].resource_icon;
-      }
+      return a.translation.localeCompare(b.translation);
     });
-
-    return this.tabs;
   }
 
   /**
@@ -126,8 +164,9 @@ export interface HeaderTab {
   route: string;
   defaultIcon: string;
   translation: string;
-  permissions: string[];
+  permissions: string | string[];
   typeName?: string;
   icon?: string;
   resourceIcon?: string;
+  weight?: number;
 }


### PR DESCRIPTION
# Description

This PR implements a **configurable, weight-based ordering system** for header tabs, replacing the existing fixed ordering.

It allows deployments to control the order of tabs (and therefore the default landing tab) while ensuring consistent ordering across the **header**, **sidebar**, and **legacy navigation menu**.

---

### Key Changes
- Added support for an optional `weight` property in:
  - `header_tabs` configuration
  - UI Extension tab definitions
- Implemented centralized sorting logic in `HeaderTabsService`
- Updated components to consume the same sorted tab list:
  - Header (`header.component.ts/html`)
  - Sidebar (`sidebar-menu.component.ts`)
  - Legacy header dropdown menu
- Ensured backward compatibility when `weight` is not defined

---

### Sorting Logic

**Default weights:**
- messages → 1  
- tasks → 2  
- reports → 3  
- contacts → 4  
- analytics → 5  
- custom tabs → 6 (default)

**Ordering rules:**
1. Sort by `weight` (ascending)  
2. For equal weights, sort alphabetically by label  

---

### Result
- Enables flexible tab ordering for deployments  
- Provides consistent navigation across all UI areas  
- Supports extensibility for UI Extensions  

---

Closes #10908 

# Code review checklist
- [x] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [ ] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

