### PR TITLE
fix(#10913): limit freetext generator results to skip+limit to preven…

### DIFF
--- a/shared-libs/search/src/freetext-query.js
+++ b/shared-libs/search/src/freetext-query.js
@@ -1,24 +1,27 @@
 const chtDatasource = require('@medic/cht-datasource');
 const logger = require('@medic/logger');
 
-const iterateGenerator = async (gen) => {
+const iterateGenerator = async (gen, limit) => {
   const rows = [];
 
   for await (const id of gen) {
     rows.push({
       id: id
     });
+    if (limit && rows.length >= limit) {
+      break;
+    }
   }
 
   return rows;
 };
 
-const queryFreetext = async (dataContext, request, type) => {
+const queryFreetext = async (dataContext, request, type, limit) => {
   try {
     const datasource = chtDatasource.getDatasource(dataContext);
     const generator = getGeneratorByType(datasource, request, type);
 
-    return await iterateGenerator(generator);
+    return await iterateGenerator(generator, limit);
   } catch (error) {
     logger.error('Error while querying freetext: ', error);
     // NOTE: added this exception clause to return an empty list

--- a/shared-libs/search/src/search.js
+++ b/shared-libs/search/src/search.js
@@ -8,7 +8,7 @@ const _ = require('lodash/core');
 _.flatten = require('lodash/flatten');
 _.intersection = require('lodash/intersection');
 const GenerateSearchRequests = require('./generate-search-requests');
-const { queryFreetext } = require('./freetext-query');
+const freetextQuery = require('./freetext-query');
 
 module.exports = function(DB, dataContext) {
   // Get the subset of rows, in appropriate order, according to options.
@@ -111,7 +111,7 @@ module.exports = function(DB, dataContext) {
       .map(denormalizeUnionRequest)
       .map(reqs => Promise.all(reqs.map(request => {
         if (request.freetext) {
-          return queryFreetext(dataContext, request, type);
+          return freetextQuery.queryFreetext(dataContext, request, type, options.skip + options.limit);
         }
         return queryView(request);
       })));

--- a/shared-libs/search/test/freetext-query.js
+++ b/shared-libs/search/test/freetext-query.js
@@ -95,4 +95,25 @@ describe('freetext-query', () => {
 
     chai.expect(result).to.deep.equal([]);
   });
+
+  it('should stop iterating once limit is reached', async () => {
+    const getUuidsByFreetext = sinon.stub().returns(createAsyncGenerator(['id1', 'id2', 'id3', 'id4', 'id5']));
+    sinon.stub(chtDatasource, 'getDatasource').returns({ v1: { report: { getUuidsByFreetext } } });
+
+    const request = { params: { key: 'term' } };
+    const result = await queryFreetext({}, request, 'reports', 3);
+
+    chai.expect(result).to.deep.equal([{ id: 'id1' }, { id: 'id2' }, { id: 'id3' }]);
+  });
+
+  it('should return all results when limit is not set', async () => {
+    const getUuidsByFreetext = sinon.stub().returns(createAsyncGenerator(['id1', 'id2', 'id3']));
+    sinon.stub(chtDatasource, 'getDatasource').returns({ v1: { report: { getUuidsByFreetext } } });
+
+    const request = { params: { key: 'term' } };
+    const result = await queryFreetext({}, request, 'reports');
+
+    chai.expect(result).to.deep.equal([{ id: 'id1' }, { id: 'id2' }, { id: 'id3' }]);
+  });
+
 });


### PR DESCRIPTION

Fixes #10913

When an online user searched contacts via select2, the freetext generator was calling `getUuidsByTypeFreetext` / `getUuidsByFreetext` which exhausted all matching results in 10,000-record batches before `getPageRows` sliced to the requested page size (e.g. 20). This caused repeated server requests and could crash the server with large datasets.

The fix makes `iterateGenerator` in `freetext-query.js` accept a `limit` parameter and break out of the generator loop early. `search.js` passes `options.skip + options.limit` as that limit, so only enough IDs to cover the current page are fetched.

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [x] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [ ] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

