### PR TITLE
fix(#10929): translate hardcoded aria-label text in menu buttons

### DIFF
--- a/api/resources/translations/messages-en.properties
+++ b/api/resources/translations/messages-en.properties
@@ -1,6 +1,7 @@
 Accept\ plain-text\ messages = Accept plain-text messages
 Accept\ plain-text\ messages\ help = Check this box if you want to accept regular SMS messages in addition to reports. If unchecked, an error message will be sent to anyone who submits anything other than a report.
 Activity = Activity
+actions.menu = Actions menu
 Add\ Message = Add message
 Add\ User = Add user
 Add\ Validation = Add validation
@@ -25,6 +26,7 @@ api.startup.install = Installing
 api.startup.index = Indexing data
 api.startup.migrate = Migrating data
 api.startup.title = {{ branding.name }} is starting
+application.menu = Application menu
 Application\ Text = Application text
 Apply = Apply
 Appointment\ Date = Appointment date

--- a/api/resources/translations/messages-es.properties
+++ b/api/resources/translations/messages-es.properties
@@ -1,6 +1,7 @@
 Accept\ plain-text\ messages = Aceptar mensajes de texto sin formato
 Accept\ plain-text\ messages\ help = Marque esta casilla si desea aceptar mensajes SMS normales además de informes. Si no está marcada, se enviará un mensaje de error a cualquiera que envíe algo que no sea un informe.
 Activity = Actividad
+actions.menu = Menú de acciones
 Add\ Message = Agregar mensaje
 Add\ User = Agregar usuario
 Add\ Validation = Agregar validación
@@ -25,6 +26,7 @@ api.startup.install = Instalando
 api.startup.index = Indexación de datos
 api.startup.migrate = Migrando datos
 api.startup.title = {{ branding.name }} está iniciando
+application.menu = Menú de la aplicación
 Application\ Text = Texto de la aplicación
 Apply = Aplicar
 Appointment\ Date = Fecha de la cita

--- a/api/resources/translations/messages-fr.properties
+++ b/api/resources/translations/messages-fr.properties
@@ -1,6 +1,7 @@
 Accept\ plain-text\ messages = Accepter les messages
 Accept\ plain-text\ messages\ help = Cochez cette case si vous souhaitez accepter les messages SMS ainsi que les rapports. Si décoché, un message d'erreur sera envoyé à toute personne qui soumet un message qui n'est pas reconnu comme un rapport.
 Activity = Activité
+actions.menu = Menu des actions
 Add\ Message = Ajouter un message
 Add\ User = Ajouter utilisateur
 Add\ Validation = Ajouter validation
@@ -25,6 +26,7 @@ api.startup.install = Installation en cours
 api.startup.index = Indexation des données en cours
 api.startup.migrate = Migration des données en cours
 api.startup.title = Démarrage de {{ branding.name }} en cours
+application.menu = Menu de l'application
 Application\ Text = Texte de l'application
 Apply = Appliquer
 Appointment\ Date = Date du rendez-vous

--- a/api/resources/translations/messages-ne.properties
+++ b/api/resources/translations/messages-ne.properties
@@ -1,6 +1,7 @@
 Accept\ plain-text\ messages = सादा सन्देश स्वीकार गर्ने
 Accept\ plain-text\ messages\ help = तपाईं रिपोर्ट वाहेक नियमित एसएमएस सन्देशहरू स्वीकार गर्न चाहनुहुन्छ भने यहाँ टिक लगाउनु होस्। अन्यथा रिपोर्ट बाहेक अरु केहि आएको खण्डमा त्रुटि भयो भनेर सन्देश पठाइने छ।
 Activity = कृयाकलाप
+actions.menu = कार्य मेनु
 Add\ Message = सन्देश थप्नुहोस
 Add\ User = प्रयोगकर्ता थप्नुहोस्
 Add\ Validation = मान्यता थप्नुहोस्
@@ -25,6 +26,7 @@ api.startup.install = इन्स्टल गर्दै
 api.startup.index = डाटा इन्डेक्स गर्दै
 api.startup.migrate = डाटा माइग्रेट गर्दै
 api.startup.title = {{ branding.name }} सुरु हुँदै छ
+application.menu = एप्लिकेसन मेनु
 Application\ Text = एप्लिकेसन टेक्स्ट
 Apply = लागु गर्नुहोस
 Appointment\ Date = जाँच गराउने मिति

--- a/api/resources/translations/messages-sw.properties
+++ b/api/resources/translations/messages-sw.properties
@@ -1,6 +1,7 @@
 Accept\ plain-text\ messages = Itikia ujumbe wa kawaida
 Accept\ plain-text\ messages\ help = Angalia hapa kama unataka kuitikia ujumbe wa kawaida  ili kuongezea ripoti.Ikikosa kuangaliwa ujumbe wa kosa utatumwa kwa mtu yeyote ambaye atatuma kitu hapa ambacho si ripoti
 Activity = Shughuli
+actions.menu = Menyu ya vitendo
 Add\ Message = Ongeza ujumbe
 Add\ User = Ongeza mtumizi
 Add\ Validation = Ongezea thibitisho
@@ -25,6 +26,7 @@ api.startup.install = Kusakinisha
 api.startup.index = Kuweka data faharasa
 api.startup.migrate = Kuhamisha data
 api.startup.title = {{ branding.name }} inaanza
+application.menu = Menyu ya programu
 Application\ Text = Lugha ya nakala
 Apply = Tumia
 Appointment\ Date = Tarehe ya kutembele kliniki

--- a/webapp/src/ts/components/tool-bar/tool-bar.component.html
+++ b/webapp/src/ts/components/tool-bar/tool-bar.component.html
@@ -2,7 +2,7 @@
   <div class="inner">
     <ng-content/>
     <h2 class="ellipsis-title"> {{ title | translate }}</h2>
-    <button class="app-menu-button" mat-icon-button (click)="openMenu()" aria-label="Application menu">
+    <button class="app-menu-button" mat-icon-button (click)="openMenu()" [attr.aria-label]="'application.menu' | translate">
       <mat-icon fontIcon="fa-bars"></mat-icon>
     </button>
     <mm-navigation></mm-navigation>

--- a/webapp/src/ts/modules/contacts/contacts-more-menu.component.html
+++ b/webapp/src/ts/modules/contacts/contacts-more-menu.component.html
@@ -2,7 +2,7 @@
   class="more-options-menu-container"
   *ngIf="(displayExportOption() || displayDeleteOption() || displayEditOption())">
 
-  <button mat-icon-button [matMenuTriggerFor]="moreOptionsMenu" aria-label="Actions menu">
+  <button mat-icon-button [matMenuTriggerFor]="moreOptionsMenu" [attr.aria-label]="'actions.menu' | translate">
     <mat-icon fontIcon="fa-ellipsis-v"></mat-icon>
   </button>
 

--- a/webapp/src/ts/modules/messages/messages-more-menu.component.html
+++ b/webapp/src/ts/modules/messages/messages-more-menu.component.html
@@ -1,6 +1,6 @@
 @if (displayExportOption()) {
   <section class="more-options-menu-container">
-    <button mat-icon-button [matMenuTriggerFor]="moreOptionsMenu" aria-label="Actions menu">
+    <button mat-icon-button [matMenuTriggerFor]="moreOptionsMenu" [attr.aria-label]="'actions.menu' | translate">
       <mat-icon fontIcon="fa-ellipsis-v"></mat-icon>
     </button>
 

--- a/webapp/src/ts/modules/reports/reports-more-menu.component.html
+++ b/webapp/src/ts/modules/reports/reports-more-menu.component.html
@@ -2,7 +2,7 @@
   class="more-options-menu-container"
   *ngIf="(displayExportOption() || displayDeleteOption() || displayEditOption())">
 
-  <button mat-icon-button [matMenuTriggerFor]="moreOptionsMenu" aria-label="Actions menu" [dir]="direction">
+  <button mat-icon-button [matMenuTriggerFor]="moreOptionsMenu" [attr.aria-label]="'actions.menu' | translate" [dir]="direction">
     <mat-icon fontIcon="fa-ellipsis-v"></mat-icon>
   </button>
 


### PR DESCRIPTION
## Summary
- Replaces hardcoded English `aria-label` values with translatable keys (`actions.menu`, `application.menu`) using `[attr.aria-label]` bindings in 4 template files.
- Adds corresponding translation keys to `messages-en.properties`.

## Related Issue
Closes #10929

## Test plan
- [ ] Run webapp unit tests
- [ ] Verify the More Options buttons (reports, messages, contacts) and the application menu button still have accessible names
- [ ] Switch to a non-English language and confirm the accessible labels are translated