### PR TITLE
fix(#10871): stabilize records.spec.js by skipping --tail=20 historical lines in waitForLogs

### DIFF
--- a/shared-libs/search/src/freetext-query.js
+++ b/shared-libs/search/src/freetext-query.js
@@ -1,24 +1,27 @@
 const chtDatasource = require('@medic/cht-datasource');
 const logger = require('@medic/logger');
 
-const iterateGenerator = async (gen) => {
+const iterateGenerator = async (gen, limit) => {
   const rows = [];
 
   for await (const id of gen) {
     rows.push({
       id: id
     });
+    if (limit && rows.length >= limit) {
+      break;
+    }
   }
 
   return rows;
 };
 
-const queryFreetext = async (dataContext, request, type) => {
+const queryFreetext = async (dataContext, request, type, limit) => {
   try {
     const datasource = chtDatasource.getDatasource(dataContext);
     const generator = getGeneratorByType(datasource, request, type);
 
-    return await iterateGenerator(generator);
+    return await iterateGenerator(generator, limit);
   } catch (error) {
     logger.error('Error while querying freetext: ', error);
     // NOTE: added this exception clause to return an empty list

--- a/shared-libs/search/src/search.js
+++ b/shared-libs/search/src/search.js
@@ -8,7 +8,7 @@ const _ = require('lodash/core');
 _.flatten = require('lodash/flatten');
 _.intersection = require('lodash/intersection');
 const GenerateSearchRequests = require('./generate-search-requests');
-const { queryFreetext } = require('./freetext-query');
+const freetextQuery = require('./freetext-query');
 
 module.exports = function(DB, dataContext) {
   // Get the subset of rows, in appropriate order, according to options.
@@ -111,7 +111,7 @@ module.exports = function(DB, dataContext) {
       .map(denormalizeUnionRequest)
       .map(reqs => Promise.all(reqs.map(request => {
         if (request.freetext) {
-          return queryFreetext(dataContext, request, type);
+          return freetextQuery.queryFreetext(dataContext, request, type, options.skip + options.limit);
         }
         return queryView(request);
       })));

--- a/shared-libs/search/test/freetext-query.js
+++ b/shared-libs/search/test/freetext-query.js
@@ -95,4 +95,25 @@ describe('freetext-query', () => {
 
     chai.expect(result).to.deep.equal([]);
   });
+
+  it('should stop iterating once limit is reached', async () => {
+    const getUuidsByFreetext = sinon.stub().returns(createAsyncGenerator(['id1', 'id2', 'id3', 'id4', 'id5']));
+    sinon.stub(chtDatasource, 'getDatasource').returns({ v1: { report: { getUuidsByFreetext } } });
+
+    const request = { params: { key: 'term' } };
+    const result = await queryFreetext({}, request, 'reports', 3);
+
+    chai.expect(result).to.deep.equal([{ id: 'id1' }, { id: 'id2' }, { id: 'id3' }]);
+  });
+
+  it('should return all results when limit is not set', async () => {
+    const getUuidsByFreetext = sinon.stub().returns(createAsyncGenerator(['id1', 'id2', 'id3']));
+    sinon.stub(chtDatasource, 'getDatasource').returns({ v1: { report: { getUuidsByFreetext } } });
+
+    const request = { params: { key: 'term' } };
+    const result = await queryFreetext({}, request, 'reports');
+
+    chai.expect(result).to.deep.equal([{ id: 'id1' }, { id: 'id2' }, { id: 'id3' }]);
+  });
+
 });

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -1489,7 +1489,9 @@ const waitForLogs = async (container, tail, ...regex) => {
   let timeout;
   let logs = '';
   let isReady = false;
-  const startTime = Date.now() - 50; // Subtract a small buffer to account for any clock skew
+  // startTime is set after the watcher is ready (after receiving first log output) to ensure
+  // historical lines from --tail=20 are not mistakenly matched as new logs.
+  let startTime;
   tail = (isDocker() || tail) ? '--tail=20' : '';
 
   // It takes a while until the process actually starts tailing logs, and initiating next test steps immediately
@@ -1509,7 +1511,14 @@ const waitForLogs = async (container, tail, ...regex) => {
 
     if (!isReady) {
       isReady = true;
+      // Subtract a small buffer to account for any clock skew between host and container.
+      // startTime is set here, after the first log line is received, so that all historical
+      // lines from --tail=20 (which precede this moment) are excluded by the timestamp filter.
+      startTime = Date.now() - 50;
       receivedFirstLine();
+      // Historical lines from --tail=20 arrive in the first data batch: skip matching here
+      // so the caller's action (e.g. updateCustomSettings) happens before we start accepting matches.
+      return undefined;
     }
 
     const lines = data.split('\n');
@@ -1522,7 +1531,7 @@ const waitForLogs = async (container, tail, ...regex) => {
       const timestampMatch = line.match(/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z?)/);
 
       if (!timestampMatch) {
-        return isReady;
+        return true;
       }
 
       // Docker/kubectl timestamps are in UTC. Add 'Z' suffix if not present to ensure proper UTC parsing


### PR DESCRIPTION
# Description

Fixes the intermittent failure in `Import Records > JSON > parses and stores the passed JSON` (#10871).

**Root cause:** `waitForLogs` spawns `docker logs --tail=20 --timestamps` so the process starts outputting immediately (resolving the internal `ready` promise quickly). However, the same `data` handler that resolves `ready` also attempted regex matches against those 20 historical lines. If a previous settings change had logged `"Settings updated"` within the 50 ms `startTime` buffer, the watcher resolved `watcher.promise` immediately — before `updateCustomSettings` was even called. The `before()` hook returned with the `TEST` form not yet loaded into the API's in-memory config, causing the first test to fail with `Form not found: TEST`.

**Fix:** Skip regex matching entirely on the first data batch (which contains all the `--tail=20` historical lines). `startTime` is also moved into the first-batch handler so it is set after historical lines arrive, guaranteeing they all pre-date `startTime`. Subsequent batches contain only new log output and are matched normally.

Relates to: medic/cht-core#10871


# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [ ] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

