### PR TITLE
feat(#9339): update phone widget to display formatted number in proxy input

### DIFF
--- a/webapp/src/js/enketo/widgets/phone-widget.js
+++ b/webapp/src/js/enketo/widgets/phone-widget.js
@@ -88,8 +88,11 @@ class PhoneWidget extends Widget {
 
 const formatAndCopy = ( $from, $to, settings ) => {
   $from.change( function() {
+    const formattedValue = getFormattedValue( settings, $from.val() );
     // Also trigger the change() event, since input was not by user.
-    $to.val( getFormattedValue( settings, $from.val() ) ).change();
+    $to.val( formattedValue ).change();
+    // Update the proxy input to display the formatted value to the user.
+    $from.val( formattedValue );
   } );
 };
 

--- a/webapp/tests/karma/js/enketo/widgets/phone-widget.spec.ts
+++ b/webapp/tests/karma/js/enketo/widgets/phone-widget.spec.ts
@@ -149,6 +149,7 @@ describe('Enketo: Phone Widget', () => {
     expect(proxyInput.length).to.equal(1);
     expect(input.length).to.equal(1);
     expect(input.val()).to.equal(NORMALIZED_NUMBER);
+    expect(proxyInput.val()).to.equal(NORMALIZED_NUMBER);
     expect(settingsService.get.calledOnceWithExactly()).to.be.true;
     expect(phoneNumberNormalize.args).to.deep.equal([
       // [{ }, DENORMALIZED_NUMBER],
@@ -170,6 +171,7 @@ describe('Enketo: Phone Widget', () => {
       .change();
 
     expect(input.val()).to.equal(NORMALIZED_NUMBER);
+    expect(proxyInput.val()).to.equal(NORMALIZED_NUMBER);
     expect(settingsService.get.calledOnceWithExactly()).to.be.true;
     expect(phoneNumberNormalize.calledOnceWithExactly({ }, DENORMALIZED_NUMBER)).to.be.true;
     expect(consoleError.calledOnceWithExactly('Error getting settings:', expectedError)).to.be.true;
@@ -187,6 +189,7 @@ describe('Enketo: Phone Widget', () => {
       .change();
 
     expect(input.val()).to.equal(DENORMALIZED_NUMBER);
+    expect(proxyInput.val()).to.equal(DENORMALIZED_NUMBER);
     expect(settingsService.get.calledOnceWithExactly()).to.be.true;
     expect(phoneNumberNormalize.calledOnceWithExactly(SETTINGS, DENORMALIZED_NUMBER)).to.be.true;
   });
@@ -202,6 +205,7 @@ describe('Enketo: Phone Widget', () => {
       .change();
 
     expect(input.val()).to.equal(NORMALIZED_NUMBER);
+    expect(proxyInput.val()).to.equal(NORMALIZED_NUMBER);
     expect(settingsService.get.calledOnceWithExactly()).to.be.true;
     expect(phoneNumberNormalize.calledOnceWithExactly(SETTINGS, NORMALIZED_NUMBER)).to.be.true;
   });


### PR DESCRIPTION
# Description

Closes #9339

Currently, when a user enters a phone number in the phone widget, the number gets normalized/formatted before being saved to the form's model (hidden input). However, the visible input field (proxy input) still shows the raw value the user originally typed. This can be confusing because what the user sees doesn't match what actually gets saved.

This change updates the `formatAndCopy` function to also set the proxy input's value to the formatted number after the change event fires. Now the user sees exactly what gets stored in the model.

**What changed:**
- In `formatAndCopy()`, after copying the formatted value to the hidden real input, we now also update the visible proxy input to display the same formatted value
- If the phone number is invalid (normalization returns `false`), the proxy input keeps the original value so the validation error still makes sense

**Example:**
- User types: `+1 (650) 222-3333`
- Before this change: proxy still shows `+1 (650) 222-3333`, model stores `+16502223333`
- After this change: proxy updates to `+16502223333`, model stores `+16502223333`

# Code review checklist

- [x] UI/UX backwards compatible: The proxy input now updates to show the formatted value after entry. The actual number itself does not change, only the formatting.
- [x] Readable: Concise, well named, follows the style guide
- [x] Tested: Unit tests updated to verify the proxy input displays the formatted value
- [ ] Documentation: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs)
- [x] Internationalized: All user facing text
- [x] Backwards compatible: Works with existing data and configuration. No breaking changes.
- [x] A disclosure: I used AI tools to assist with this implementation.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
