### PR TITLE
feat: add server-check to verify CHT CouchDB version (#9860)

### DIFF
--- a/couchdb/10-docker-default.ini
+++ b/couchdb/10-docker-default.ini
@@ -46,3 +46,6 @@ compression_level = 8
 [nouveau]
 enable = true
 url = http://nouveau:5987
+
+[cht]
+version = 5.1.0

--- a/shared-libs/server-checks/src/checks.js
+++ b/shared-libs/server-checks/src/checks.js
@@ -107,6 +107,19 @@ const checkCouchDbVersion = async (couchUrl) => {
   console.log(`CouchDB Version: ${version}`);
 };
 
+const checkCouchDbFlavor = async (couchUrl) => {
+  try {
+    const response = await request.get({ url: `${couchUrl}_node/_local/_config/cht/version`, json: true });
+    if (!response) {
+      throw new Error('Empty response');
+    }
+  } catch {
+    throw new Error('This version of the CHT API is incompatible with the version of CouchDB you are using. ' +
+                    'Please make sure you are using the official CHT CouchDB image. ' +
+                    'See: https://docs.communityhealthtoolkit.org/core/install/hosting/docker/#couchdb');
+  }
+};
+
 module.exports = {
   checkNodeVersion,
   checkServerUrl,
@@ -114,4 +127,5 @@ module.exports = {
   checkCouchDbNoAdminPartyMode,
   checkCouchDbCluster,
   checkCouchDbSystemDbs,
+  checkCouchDbFlavor,
 };

--- a/shared-libs/server-checks/src/index.js
+++ b/shared-libs/server-checks/src/index.js
@@ -25,6 +25,7 @@ const checkCouchDb = async (serverUrl) => {
   do {
     try {
       await checks.checkCouchDbVersion(serverUrl);
+      await checks.checkCouchDbFlavor(serverUrl);
       await checks.checkCouchDbNoAdminPartyMode(serverUrl);
       await checks.checkCouchDbCluster(serverUrl);
       await checks.checkCouchDbSystemDbs(serverUrl);

--- a/shared-libs/server-checks/test/checks.js
+++ b/shared-libs/server-checks/test/checks.js
@@ -163,4 +163,25 @@ describe('checks', () => {
 
   });
 
+  describe('checkCouchDbFlavor', () => {
+
+    it('CHT CouchDB', async () => {
+      sinon.stub(request, 'get').resolves({ version: '5.1.0' });
+      await service.checkCouchDbFlavor('http://admin:pass@localhost:5984/');
+      chai.expect(request.get.callCount).to.equal(1);
+      chai.expect(request.get.args[0][0].url).to.equal('http://admin:pass@localhost:5984/_node/_local/_config/cht/version');
+    });
+
+    it('non-CHT CouchDB', () => {
+      sinon.stub(request, 'get').rejects({ status: 404 });
+      return service.checkCouchDbFlavor('http://admin:pass@localhost:5984/')
+        .then(() => chai.assert.fail('should have thrown'))
+        .catch(err => {
+          chai.expect(err.toString()).to.include('incompatible with the version of CouchDB you are using');
+          chai.expect(request.get.callCount).to.equal(1);
+        });
+    });
+
+  });
+
 });

--- a/shared-libs/server-checks/test/index.js
+++ b/shared-libs/server-checks/test/index.js
@@ -30,6 +30,7 @@ describe('entry point', () => {
     sinon.stub(checks, 'checkNodeVersion').resolves();
     sinon.stub(checks, 'checkServerUrl').resolves();
     sinon.stub(checks, 'checkCouchDbVersion').resolves();
+    sinon.stub(checks, 'checkCouchDbFlavor').resolves();
     sinon.stub(checks, 'checkCouchDbNoAdminPartyMode').resolves();
     sinon.stub(checks, 'checkCouchDbCluster').resolves();
     sinon.stub(checks, 'checkCouchDbSystemDbs').resolves();
@@ -37,11 +38,13 @@ describe('entry point', () => {
     chai.expect(checks.checkNodeVersion.callCount).to.equal(1);
     chai.expect(checks.checkServerUrl.callCount).to.equal(1);
     chai.expect(checks.checkCouchDbVersion.callCount).to.equal(1);
+    chai.expect(checks.checkCouchDbFlavor.callCount).to.equal(1);
     chai.expect(checks.checkCouchDbNoAdminPartyMode.callCount).to.equal(1);
     chai.expect(checks.checkCouchDbCluster.callCount).to.equal(1);
     chai.expect(checks.checkCouchDbSystemDbs.callCount).to.equal(1);
     chai.expect(checks.checkServerUrl.args[0][0]).to.equal('http://admin:pass@localhost/medic');
     chai.expect(checks.checkCouchDbVersion.args[0][0]).to.equal('http://admin:pass@localhost/');
+    chai.expect(checks.checkCouchDbFlavor.args[0][0]).to.equal('http://admin:pass@localhost/');
     chai.expect(checks.checkCouchDbNoAdminPartyMode.args[0][0]).to.equal('http://admin:pass@localhost/');
     chai.expect(checks.checkCouchDbCluster.args[0][0]).to.equal('http://admin:pass@localhost/');
     chai.expect(checks.checkCouchDbSystemDbs.args[0][0]).to.equal('http://admin:pass@localhost/');
@@ -65,6 +68,7 @@ describe('entry point', () => {
     checkCouchDbVersion.throws(new Error('db not found'));
     checkCouchDbVersion.onCall(100).resolves();
     sinon.stub(checks, 'checkCouchDbNoAdminPartyMode').resolves();
+    sinon.stub(checks, 'checkCouchDbFlavor').resolves();
     sinon.stub(checks, 'checkCouchDbCluster').resolves();
     sinon.stub(checks, 'checkCouchDbSystemDbs').resolves();
 
@@ -75,6 +79,7 @@ describe('entry point', () => {
     chai.expect(checks.checkNodeVersion.callCount).to.equal(1);
     chai.expect(checks.checkServerUrl.callCount).to.equal(1);
     chai.expect(checks.checkCouchDbVersion.callCount).to.equal(101);
+    chai.expect(checks.checkCouchDbFlavor.callCount).to.equal(1);
     chai.expect(checks.checkCouchDbNoAdminPartyMode.callCount).to.equal(1);
     chai.expect(checks.checkCouchDbCluster.callCount).to.equal(1);
     chai.expect(checks.checkCouchDbSystemDbs.callCount).to.equal(1);


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: build|feat|fix|perf|refactor|test|chore

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

### Fixes: #9860

This PR implements a server-check during the CHT API startup sequence to verify that the system is running against a compatible CHT-customized version of CouchDB.

## Problem:
Currently, the CHT API starts silently even when connected to a standard "vanilla" CouchDB image. Standard images lack specific CHT optimisations and configurations (such as session handling and cluster settings), which leads to:
- Users being randomly logged out due to incorrect session timeouts.
- Potential data corruption or loss in multi-node clusters.


## Changes:

**CouchDB Fingerprinting:** Added a custom [cht] configuration section to the official CHT CouchDB image (10-docker-default.ini).

**API Verification:** Added a new check (checkCouchDbFlavor) in the server-checks library. This check attempts to read the CHT fingerprint from CouchDB at startup.

**Fail-fast:** If the fingerprint is missing, the API will fail to start and provide a clear error message directing the user to the official hosting documentation.


 ## Testing:

Added unit tests in shared-libs/server-checks/test/checks.js to verify:
- Success: API starts correctly when fingerprint is present.
- Failure: API refuses to start when fingerprint is missing (e.g., standard CouchDB).























<!-- DESCRIPTION -->

<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [ ] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

