### PR TITLE
fix(#10941): correct ng-show boolean evaluation for missing translations banner

### DIFF
--- a/admin/src/templates/display_languages.html
+++ b/admin/src/templates/display_languages.html
@@ -57,7 +57,7 @@
     </div>
     <div id="locale-{{localeModel.doc.code}}-body" class="panel-collapse collapse" role="tabpanel">
       <div class="panel-body action-list">
-        <div class="alert alert-warning" role="alert" ng-show="{{localeModel.missing > 0}}" translate translate-values="localeModel">Missing translations</div>
+        <div class="alert alert-warning" role="alert" ng-show="localeModel.missing > 0" translate translate-values="localeModel">Missing translations</div>
         <div>
           <button type="button" class="btn btn-link" ng-click="editLanguage(localeModel.doc)">
             <i class="fa fa-pencil"></i><span translate>edit</span>


### PR DESCRIPTION
# Description

Fixes #10941 in the Admin Languages screen where the "Missing translations" warning was always visible due to incorrect use of AngularJS interpolation in ng-show. The expression was evaluated as a string instead of a boolean, making it always truthy.

# Changes 
 
Replaced interpolated ng-show with a direct boolean expression
File: admin/src/templates/display_languages.html:60

Previously, ng-show="{{localeModel.missing > 0}}"
Now, ng-show="localeModel.missing > 0"

# Code review checklist

- [x] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [ ] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

