### PR TITLE
fix: correct monitoring query bounds to use startkey/endkey

### DIFF
--- a/api/src/services/monitoring.js
+++ b/api/src/services/monitoring.js
@@ -270,15 +270,15 @@ const getWeeklyOutgoingMessageStatusCounts = () => {
   const endDate = moment().valueOf();
 
   const optionsList = MESSAGE_QUEUE_STATUS_KEYS.map(key => ({
-    start_key: [key, startDate],
-    end_key: [key, endDate],
+    startkey: [key, startDate],
+    endkey: [key, endDate],
     reduce: true,
   }));
 
   const query = (options) => db.medic
     .query('medic-admin/message_queue', options)
     .catch(err => {
-      logger.error(`Error fetching weekly outgoing message status counts ${options.start_key}: %o`, err);
+      logger.error(`Error fetching weekly outgoing message status counts ${options.startkey}: %o`, err);
       return { rows: [{ value: -1 }] };
     });
 
@@ -300,7 +300,7 @@ const getWeeklyOutgoingMessageStatusCounts = () => {
 const getLastHundredStatusCountsPerGroup = ({group, statuses}) => {
   const options = {
     descending: true,
-    start_key: [group, moment().valueOf()],
+    startkey: [group, moment().valueOf()],
     endkey: [group, 0],
     limit: 100,
   };

--- a/api/tests/mocha/services/monitoring.spec.js
+++ b/api/tests/mocha/services/monitoring.spec.js
@@ -227,11 +227,11 @@ const setUpMocks = () => {
       { key: [ 'delivered' ], value: 10 },
     ] });
   medicQuery
-    .withArgs('medic-admin/message_queue', sinon.match({ start_key: sinon.match.array.startsWith(['due'])}))
+    .withArgs('medic-admin/message_queue', sinon.match({ startkey: sinon.match.array.startsWith(['due'])}))
     .resolves({ rows: [{ key: undefined, value: 20 }] })
-    .withArgs('medic-admin/message_queue', sinon.match({ start_key: sinon.match.array.startsWith(['delivered'])}))
+    .withArgs('medic-admin/message_queue', sinon.match({ startkey: sinon.match.array.startsWith(['delivered'])}))
     .resolves({ rows: [{ key: undefined, value: 15 }] })
-    .withArgs('medic-admin/message_queue', sinon.match({ start_key: sinon.match.array.startsWith(['failed'])}))
+    .withArgs('medic-admin/message_queue', sinon.match({ startkey: sinon.match.array.startsWith(['failed'])}))
     .resolves({ rows: [{ key: undefined, value: 5 }] });
 
   medicQuery.withArgs('medic-conflicts/conflicts')
@@ -273,11 +273,11 @@ const setupV2Mocks = (statusCounters) => {
     cleared: statusCounters.cleared,
   });
   db.medic.query
-    .withArgs(view, sinon.match({ start_key: sinon.match.array.startsWith(['final']) }))
+    .withArgs(view, sinon.match({ startkey: sinon.match.array.startsWith(['final']) }))
     .resolves({ rows: finalRows })
-    .withArgs(view, sinon.match({ start_key: sinon.match.array.startsWith(['pending']) }))
+    .withArgs(view, sinon.match({ startkey: sinon.match.array.startsWith(['pending']) }))
     .resolves({ rows: pendingRows })
-    .withArgs(view, sinon.match({ start_key: sinon.match.array.startsWith(['muted']) }))
+    .withArgs(view, sinon.match({ startkey: sinon.match.array.startsWith(['muted']) }))
     .resolves({ rows: mutedRows });
 };
 
@@ -569,6 +569,26 @@ describe('Monitoring service', () => {
       chai.expect(actual.date.current).to.equal(0);
       chai.expect(actual.replication_limit.count).to.equal(1);
       chai.expect(actual.connected_users.count).to.equal(2);
+      const weeklyOptions = db.medic.query.args
+        .filter(([viewName, options]) => viewName === 'medic-admin/message_queue' && options && options.startkey)
+        .map(([, options]) => options);
+      chai.expect(weeklyOptions.length).to.equal(5);
+      weeklyOptions.forEach(options => {
+        chai.expect(options).to.have.property('startkey');
+        chai.expect(options).to.have.property('endkey');
+        chai.expect(options).to.not.have.property('start_key');
+        chai.expect(options).to.not.have.property('end_key');
+      });
+
+      const lastHundredOptions = db.medic.query.args
+        .filter(([viewName]) => viewName === 'medic-sms/messages_by_last_updated_state')
+        .map(([, options]) => options);
+      chai.expect(lastHundredOptions.length).to.equal(3);
+      lastHundredOptions.forEach(options => {
+        chai.expect(options).to.have.property('startkey');
+        chai.expect(options).to.have.property('endkey');
+        chai.expect(options).to.not.have.property('start_key');
+      });
       chai.expect(request.get.args).to.deep.equalInAnyOrder([
         [{ json: true, url: environment.serverUrl }],
         [{ json: true, url: `${environment.serverUrl}/${environment.db}/_design/medic/_info` }],


### PR DESCRIPTION

<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: build|feat|fix|perf|refactor|test|chore

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Fixes #10946.

`api/src/services/monitoring.js` used `start_key`/`end_key` for map/reduce view bounds in weekly and last-hundred message metrics. CouchDB/PouchDB expects `startkey`/`endkey`, so the previous options could produce inaccurate monitoring windows.

This PR:
- Replaces `start_key` → `startkey` and `end_key` → `endkey` in monitoring service queries.
- Updates related tests in `api/tests/mocha/services/monitoring.spec.js`.
- Adds regression assertions to verify bounded queries use `startkey/endkey` and no legacy underscore keys.

Validation:
- Static file checks pass for changed files.
- Attempted local run: `UNIT_TEST_ENV=1 npx mocha api/tests/mocha/services/monitoring.spec.js`.
- In this environment the run is blocked by missing local test dependency/config state (`chai-exclude` not resolved from `.mocharc.js`).

<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [x] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
