### PR TITLE
fix(#10705): stop consuming rate limit on 429 responses

### DIFF
--- a/api/src/middleware/rate-limiter.js
+++ b/api/src/middleware/rate-limiter.js
@@ -4,8 +4,12 @@ const serverUtils = require('../server-utils');
 
 const registerReqFinishHandler = (req, res) => {
   res.on('finish', () => {
-    if (res.statusCode === 401 || res.statusCode === 429) {
-      // log in failed - punish user
+    // Only authentication failures (401) increment the failed-login counter.
+    // 429 is the rate-limiter's own response, so consuming on it would
+    // re-punish callers who happen to share a key (e.g. a proxy IP) with a
+    // genuinely failing client and lock out their otherwise-valid
+    // credentials. See #10705.
+    if (res.statusCode === 401) {
       rateLimitService.consume(req);
     }
   });

--- a/api/tests/mocha/middleware/rate-limiter.spec.js
+++ b/api/tests/mocha/middleware/rate-limiter.spec.js
@@ -80,15 +80,29 @@ describe('Rate limiter middleware', () => {
     expect(rateLimitService.consume.args[0][0]).to.equal(req);
   });
 
-  it('consumes on 429', async () => {
+  it('does not consume on 429 (#10705)', async () => {
+    // 429 is the rate limiter's own response. Consuming on it would
+    // double-punish callers that happen to share a key (e.g. a proxy IP)
+    // with a genuinely-failing client and would lock out their valid
+    // credentials, so the finish handler must ignore it.
     rateLimitService.isLimited.resolves(false);
     res.statusCode = 429;
     await middleware(req, res, next);
     expect(next.callCount).to.equal(1);
     expect(rateLimitService.consume.callCount).to.equal(0);
     finish();
-    expect(rateLimitService.consume.callCount).to.equal(1);
-    expect(rateLimitService.consume.args[0][0]).to.equal(req);
+    expect(rateLimitService.consume.callCount).to.equal(0);
+  });
+
+  it('does not consume on non-401 status codes', async () => {
+    rateLimitService.isLimited.resolves(false);
+    for (const statusCode of [200, 400, 403, 404, 500]) {
+      res = { on: sinon.stub(), statusCode };
+      await middleware(req, res, next);
+      const listener = res.on.args[0][1];
+      listener();
+    }
+    expect(rateLimitService.consume.callCount).to.equal(0);
   });
 
 });


### PR DESCRIPTION
# Description

The api rate-limit middleware tracks failed login attempts by client IP, basic-auth username, basic-auth password, and the body `user`/`password` fields, allowing 10 failures per key per 10 second window. Until now the finish handler also called `rateLimitService.consume` whenever a response went out with status code 429.

That double-counted the rate limiter's own response. When several clients share a single key (most importantly a single `req.ip`, because a reverse proxy is not forwarding the real client address), one badly behaved client can exhaust that shared key, after which every other caller gets 429 from the controller. Each of those 429 responses then re-consumed the victim's other keys (their valid username, their valid password), which could lock those credentials out instance-wide even though they had never sent a failing request. The reporter observed exactly this affecting `couch2pg` and other basic-auth integrations on production.

Limiting the finish handler to only authentication failures (401) keeps the protective behaviour against real brute-force attempts while letting unrelated callers recover as soon as the existing 10 second window elapses. The middleware still rejects requests upfront with 429 when the caller's keys are already over the limit; this PR only changes whether *that* rejection should re-punish the caller.

## Verification

`npm run unit-api` for the affected suite (`api/tests/mocha/middleware/rate-limiter.spec.js`):

- The pre-existing `consumes on 401` and `does nothing if not limited` cases still pass.
- The previous `consumes on 429` test, which asserted the buggy behaviour, has been replaced with `does not consume on 429 (#10705)` that asserts no consume call happens.
- New `does not consume on non-401 status codes` test guards the implicit contract that 200/4xx-other-than-401/5xx responses also do not trigger consumption.

`npm run lint` is clean for both modified files.

Fixes #10705

# Code review checklist
<!-- UI/UX, internationalisation, and documentation are not affected. -->
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [x] Tested: Unit tests cover the previous and new behaviour
- [x] Backwards compatible: The middleware still issues 429 for callers already over the limit and still consumes on real 401s; only the redundant double-consume on the rate limiter's own 429 has been removed.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.