### PR TITLE
fix(#10955): replace eval() with strict comparison for boolean CSV parsing

### DIFF
--- a/shared-libs/user-management/src/users.js
+++ b/shared-libs/user-management/src/users.js
@@ -744,8 +744,7 @@ const assignCsvCellValue = (data, attribute, value) => {
   data[attribute] = value.replace(/^"|"$/g, '').trim();
 
   if (['TRUE', 'FALSE'].includes(data[attribute])) {
-    // converts the "TRUE" or "FALSE" string to boolean
-    data[attribute] = eval(data[attribute].toLowerCase());
+    data[attribute] = data[attribute] === 'TRUE';
   }
 };
 


### PR DESCRIPTION
## Description

Fixes #10955

Replaces the use of `eval()` in `assignCsvCellValue` with a direct strict comparison for converting `"TRUE"`/`"FALSE"` CSV strings to boolean values.

## Changes

**Before:**
```javascript
if (['TRUE', 'FALSE'].includes(data[attribute])) {
  // converts the "TRUE" or "FALSE" string to boolean
  data[attribute] = eval(data[attribute].toLowerCase());
}
```

**After:**
```javascript
if (['TRUE', 'FALSE'].includes(data[attribute])) {
  data[attribute] = data[attribute] === 'TRUE';
}
```

## Why

- `eval()` is flagged by ESLint's `no-eval` rule and security audit tools
- Using `eval()` for string-to-boolean conversion is unnecessary when a strict comparison works
- Reduces risk surface — even though the current guard limits input to "TRUE"/"FALSE", future code changes could weaken that guard
- No behavioral change — existing unit tests confirm `TRUE` → `true` and `FALSE` → `false`

## Test plan

- [x] Existing unit tests in `users.spec.js` cover this exact behavior (parseCsv tests verify TRUE→true, FALSE→false)
- [ ] Verify CSV bulk user upload still works correctly with boolean fields like `token_login`