### PR TITLE
feat(#9207): add API endpoint for getting generic entity data

### DIFF
--- a/api/src/controllers/entity.js
+++ b/api/src/controllers/entity.js
@@ -1,0 +1,62 @@
+const { Entity, Qualifier } = require('@medic/cht-datasource');
+const ctx = require('../services/data-context');
+const serverUtils = require('../server-utils');
+const auth = require('../auth');
+
+const getEntity = ctx.bind(Entity.v1.get);
+
+/**
+ * @openapi
+ * tags:
+ *   - name: Entity
+ *     description: Operations for generic database documents
+ */
+module.exports = {
+  /**
+   * @openapi
+   * /api/v1/entity/{id}:
+   *   get:
+   *     summary: Get a document by id
+   *     operationId: v1EntityIdGet
+   *     description: Returns a generic database document from the medic database.
+   *     tags: [Entity]
+   *     x-since: 5.2.0
+   *     x-permissions:
+   *       isOnline: true
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: The id of the document to retrieve
+   *     responses:
+   *       '200':
+   *         description: The document
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *       '401':
+   *         $ref: '#/components/responses/Unauthorized'
+   *       '403':
+   *         $ref: '#/components/responses/Forbidden'
+   *       '404':
+   *         $ref: '#/components/responses/NotFound'
+   */
+  get: serverUtils.doOrError(async (req, res) => {
+    await auth.assertPermissions(req, { isOnline: true });
+    const docId = req.params.id;
+    if (!docId) {
+      return serverUtils.error({ status: 400, message: 'Missing id' }, req, res);
+    }
+
+    const doc = await getEntity(Qualifier.byUuid(docId));
+
+    if (!doc) {
+      return serverUtils.error({ status: 404, message: 'Document not found' }, req, res);
+    }
+
+    return res.json(doc);
+  }),
+};

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -41,6 +41,7 @@ const users = require('./controllers/users');
 const contact = require('./controllers/contact');
 const person = require('./controllers/person');
 const place = require('./controllers/place');
+const entity = require('./controllers/entity');
 const report = require('./controllers/report');
 const { people, places } = require('@medic/contacts')(config, db, dataContext);
 const upgrade = require('./controllers/upgrade');
@@ -738,6 +739,8 @@ app.get('/api/v1/person', person.v1.getAll);
 app.get('/api/v1/person/:uuid', person.v1.get);
 app.postJson('/api/v1/person', person.v1.create);
 app.putJson('/api/v1/person/:uuid', person.v1.update);
+
+app.get('/api/v1/entity/:id', entity.get);
 
 app.get('/api/v1/contact/uuid', contact.v1.getUuids);
 app.get('/api/v1/contact/:uuid', contact.v1.get);

--- a/shared-libs/cht-datasource/src/entity.ts
+++ b/shared-libs/cht-datasource/src/entity.ts
@@ -4,9 +4,7 @@ import * as Remote from './remote';
 import * as Local from './local';
 import { LocalDataContext } from './local/libs/data-context';
 import { RemoteDataContext } from './remote/libs/data-context';
-import { Nullable } from './libs/core';
 import { assertUuidQualifier } from './libs/parameter-validators';
-import { Doc } from './libs/doc';
 
 /** */
 export namespace v1 {

--- a/shared-libs/cht-datasource/src/entity.ts
+++ b/shared-libs/cht-datasource/src/entity.ts
@@ -1,0 +1,33 @@
+import { UuidQualifier } from './qualifier';
+import { adapt, assertDataContext, DataContext } from './libs/data-context';
+import * as Remote from './remote';
+import * as Local from './local';
+import { LocalDataContext } from './local/libs/data-context';
+import { RemoteDataContext } from './remote/libs/data-context';
+import { Nullable } from './libs/core';
+import { assertUuidQualifier } from './libs/parameter-validators';
+import { Doc } from './libs/doc';
+
+/** */
+export namespace v1 {
+  const getEntity =
+    <T>(
+      localFn: (c: LocalDataContext) => (qualifier: UuidQualifier) => Promise<T>,
+      remoteFn: (c: RemoteDataContext) => (qualifier: UuidQualifier) => Promise<T>
+    ) => (context: DataContext) => {
+      assertDataContext(context);
+      const fn = adapt(context, localFn, remoteFn);
+      return async (qualifier: UuidQualifier): Promise<T> => {
+        assertUuidQualifier(qualifier);
+        return fn(qualifier);
+      };
+    };
+
+  /**
+   * Returns a generic database document for the given qualifier.
+   * @param context the current data context
+   * @returns the document or `null` if no document is found for the qualifier
+   * @throws Error if the provided context or qualifier is invalid
+   */
+  export const get = getEntity(Local.Entity.v1.get, Remote.Entity.v1.get);
+}

--- a/shared-libs/cht-datasource/src/index.ts
+++ b/shared-libs/cht-datasource/src/index.ts
@@ -32,6 +32,7 @@ import { assertDataContext, DataContext } from './libs/data-context';
 import * as Contact from './contact';
 import * as Person from './person';
 import * as Place from './place';
+import * as Entity from './entity';
 import * as Qualifier from './qualifier';
 import { and, byContactId, byContactIds, byReportingPeriod } from './qualifier';
 import * as Report from './report';
@@ -47,6 +48,7 @@ export { InvalidArgumentError, ResourceNotFoundError } from './libs/error';
 export * as Contact from './contact';
 export * as Person from './person';
 export * as Place from './place';
+export * as Entity from './entity';
 export * as Qualifier from './qualifier';
 export * as Input from './input';
 export * as Report from './report';
@@ -87,6 +89,15 @@ export const getDatasource = (ctx: DataContext) => {
         userRoles: string[],
         chtPermissionsSettings?: Record<string, string[]>
       ) => ctx.bind(hasAnyPermission)(permissionsGroupList, userRoles, chtPermissionsSettings),
+      entity: {
+        /**
+         * Returns a generic database document by its UUID.
+         * @param uuid the UUID of the document to retrieve
+         * @returns the document or `null` if no document is found for the UUID
+         * @throws InvalidArgumentError if no UUID is provided
+         */
+        getByUuid: (uuid: string) => ctx.bind(Entity.v1.get)(Qualifier.byUuid(uuid)),
+      },
       contact: {
         /**
          * Returns a contact by their UUID.

--- a/shared-libs/cht-datasource/src/local/entity.ts
+++ b/shared-libs/cht-datasource/src/local/entity.ts
@@ -1,0 +1,16 @@
+import { Doc } from '../libs/doc';
+import { Nullable } from '../libs/core';
+import { UuidQualifier } from '../qualifier';
+import { getDocById } from './libs/doc';
+import { LocalDataContext } from './libs/data-context';
+
+/** @internal */
+export namespace v1 {
+  /** @internal */
+  export const get = ({ medicDb }: LocalDataContext) => {
+    const getMedicDocById = getDocById(medicDb);
+    return async (identifier: UuidQualifier): Promise<Nullable<Doc>> => {
+      return getMedicDocById(identifier.uuid);
+    };
+  };
+}

--- a/shared-libs/cht-datasource/src/local/index.ts
+++ b/shared-libs/cht-datasource/src/local/index.ts
@@ -1,6 +1,7 @@
 export * as Contact from './contact';
 export * as Person from './person';
 export * as Place from './place';
+export * as Entity from './entity';
 export * as Report from './report';
 export * as Target from './target';
 export { getLocalDataContext } from './libs/data-context';

--- a/shared-libs/cht-datasource/src/remote/entity.ts
+++ b/shared-libs/cht-datasource/src/remote/entity.ts
@@ -1,0 +1,14 @@
+import { Nullable } from '../libs/core';
+import { UuidQualifier } from '../qualifier';
+import { getResource, RemoteDataContext } from './libs/data-context';
+import { Doc } from '../libs/doc';
+
+/** @internal */
+export namespace v1 {
+  const getEntity = (remoteContext: RemoteDataContext) => getResource(remoteContext, 'api/v1/entity');
+
+  /** @internal */
+  export const get = (remoteContext: RemoteDataContext) => (
+    identifier: UuidQualifier
+  ): Promise<Nullable<Doc>> => getEntity(remoteContext)(identifier.uuid);
+}

--- a/shared-libs/cht-datasource/src/remote/index.ts
+++ b/shared-libs/cht-datasource/src/remote/index.ts
@@ -1,6 +1,7 @@
 export * as Contact from './contact';
 export * as Person from './person';
 export * as Place from './place';
+export * as Entity from './entity';
 export * as Report from './report';
 export * as Target from './target';
 export { getRemoteDataContext } from './libs/data-context';

--- a/shared-libs/cht-datasource/test/entity.spec.ts
+++ b/shared-libs/cht-datasource/test/entity.spec.ts
@@ -1,0 +1,72 @@
+import * as Entity from '../src/entity';
+import * as Local from '../src/local';
+import * as Remote from '../src/remote';
+import * as Qualifier from '../src/qualifier';
+import * as Context from '../src/libs/data-context';
+import sinon, { SinonStub } from 'sinon';
+import { expect } from 'chai';
+import { DataContext } from '../src';
+
+describe('entity', () => {
+  const dataContext = {} as DataContext;
+  let assertDataContext: SinonStub;
+  let adapt: SinonStub;
+  let isUuidQualifier: SinonStub;
+
+  beforeEach(() => {
+    assertDataContext = sinon.stub(Context, 'assertDataContext');
+    adapt = sinon.stub(Context, 'adapt');
+    isUuidQualifier = sinon.stub(Qualifier, 'isUuidQualifier');
+  });
+
+  afterEach(() => sinon.restore());
+
+  describe('v1', () => {
+    describe('get', () => {
+      const entity = { _id: 'my-entity' };
+      const qualifier = { uuid: entity._id } as const;
+      let getEntity: SinonStub;
+
+      beforeEach(() => {
+        getEntity = sinon.stub();
+        adapt.returns(getEntity);
+      });
+
+      it('retrieves the entity for the given qualifier from the data context', async () => {
+        isUuidQualifier.returns(true);
+        getEntity.resolves(entity);
+
+        const result = await Entity.v1.get(dataContext)(qualifier);
+
+        expect(result).to.equal(entity);
+        expect(assertDataContext.calledOnceWithExactly(dataContext)).to.be.true;
+        expect(adapt.calledOnceWithExactly(dataContext, Local.Entity.v1.get, Remote.Entity.v1.get)).to.be.true;
+        expect(isUuidQualifier.calledOnceWithExactly(qualifier)).to.be.true;
+        expect(getEntity.calledOnceWithExactly(qualifier)).to.be.true;
+      });
+
+      it('throws an error if the qualifier is invalid', async () => {
+        isUuidQualifier.returns(false);
+
+        await expect(Entity.v1.get(dataContext)(qualifier))
+          .to.be.rejectedWith(`Invalid identifier [${JSON.stringify(qualifier)}].`);
+
+        expect(assertDataContext.calledOnceWithExactly(dataContext)).to.be.true;
+        expect(adapt.calledOnceWithExactly(dataContext, Local.Entity.v1.get, Remote.Entity.v1.get)).to.be.true;
+        expect(isUuidQualifier.calledOnceWithExactly(qualifier)).to.be.true;
+        expect(getEntity.notCalled).to.be.true;
+      });
+
+      it('throws an error if the data context is invalid', () => {
+        assertDataContext.throws(new Error(`Invalid data context [null].`));
+
+        expect(() => Entity.v1.get(dataContext)).to.throw(`Invalid data context [null].`);
+
+        expect(assertDataContext.calledOnceWithExactly(dataContext)).to.be.true;
+        expect(adapt.notCalled).to.be.true;
+        expect(isUuidQualifier.notCalled).to.be.true;
+        expect(getEntity.notCalled).to.be.true;
+      });
+    });
+  });
+});

--- a/shared-libs/cht-datasource/test/local/entity.spec.ts
+++ b/shared-libs/cht-datasource/test/local/entity.spec.ts
@@ -1,0 +1,52 @@
+import sinon, { SinonStub } from 'sinon';
+import { Doc } from '../../src/libs/doc';
+import * as Entity from '../../src/local/entity';
+import * as LocalDoc from '../../src/local/libs/doc';
+import { expect } from 'chai';
+import { LocalDataContext } from '../../src/local/libs/data-context';
+
+describe('local entity', () => {
+  let localContext: LocalDataContext;
+
+  beforeEach(() => {
+    localContext = {
+      medicDb: {} as PouchDB.Database<Doc>,
+    } as unknown as LocalDataContext;
+  });
+
+  afterEach(() => sinon.restore());
+
+  describe('v1', () => {
+    describe('get', () => {
+      const identifier = { uuid: 'uuid' } as const;
+      let getDocByIdOuter: SinonStub;
+      let getDocByIdInner: SinonStub;
+
+      beforeEach(() => {
+        getDocByIdInner = sinon.stub();
+        getDocByIdOuter = sinon.stub(LocalDoc, 'getDocById').returns(getDocByIdInner);
+      });
+
+      it('returns an entity by UUID', async () => {
+        const doc = { type: 'some_type', _id: 'uuid', _rev: '1' };
+        getDocByIdInner.resolves(doc);
+
+        const result = await Entity.v1.get(localContext)(identifier);
+
+        expect(result).to.equal(doc);
+        expect(getDocByIdOuter.calledOnceWithExactly(localContext.medicDb)).to.be.true;
+        expect(getDocByIdInner.calledOnceWithExactly(identifier.uuid)).to.be.true;
+      });
+
+      it('returns null if doc is not found', async () => {
+        getDocByIdInner.resolves(null);
+
+        const result = await Entity.v1.get(localContext)(identifier);
+
+        expect(result).to.be.null;
+        expect(getDocByIdOuter.calledOnceWithExactly(localContext.medicDb)).to.be.true;
+        expect(getDocByIdInner.calledOnceWithExactly(identifier.uuid)).to.be.true;
+      });
+    });
+  });
+});

--- a/shared-libs/cht-datasource/test/remote/entity.spec.ts
+++ b/shared-libs/cht-datasource/test/remote/entity.spec.ts
@@ -1,0 +1,53 @@
+import sinon, { SinonStub } from 'sinon';
+import { expect } from 'chai';
+import * as RemoteEnv from '../../src/remote/libs/data-context';
+import { RemoteDataContext } from '../../src/remote/libs/data-context';
+
+describe('remote entity', () => {
+  const remoteContext = {} as RemoteDataContext;
+
+  let Entity: typeof import('../../src/remote/entity');
+  let getResourceInner: SinonStub;
+  let getResourceOuter: SinonStub;
+
+  before(() => {
+    Reflect.deleteProperty(require.cache, require.resolve('../../src/remote/entity'));
+    Entity = require('../../src/remote/entity');
+  });
+
+  beforeEach(() => {
+    getResourceInner = sinon.stub();
+    getResourceOuter = sinon.stub(RemoteEnv, 'getResource').returns(getResourceInner);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('v1', () => {
+    const identifier = { uuid: 'uuid' } as const;
+
+    describe('get', () => {
+      it('returns an entity by UUID', async () => {
+        const doc = { _id: 'uuid', type: 'some_type' };
+        getResourceInner.resolves(doc);
+
+        const result = await Entity.v1.get(remoteContext)(identifier);
+
+        expect(result).to.equal(doc);
+        expect(getResourceOuter.calledOnceWithExactly(remoteContext, 'api/v1/entity')).to.be.true;
+        expect(getResourceInner.calledOnceWithExactly(identifier.uuid)).to.be.true;
+      });
+
+      it('returns null if the identified doc is not found', async () => {
+        getResourceInner.resolves(null);
+
+        const result = await Entity.v1.get(remoteContext)(identifier);
+
+        expect(result).to.be.null;
+        expect(getResourceOuter.calledOnceWithExactly(remoteContext, 'api/v1/entity')).to.be.true;
+        expect(getResourceInner.calledOnceWithExactly(identifier.uuid)).to.be.true;
+      });
+    });
+  });
+});

--- a/tests/integration/api/controllers/entity.spec.js
+++ b/tests/integration/api/controllers/entity.spec.js
@@ -1,0 +1,61 @@
+const utils = require('@utils');
+const { USER_ROLES } = require('@medic/constants');
+const { expect } = require('chai');
+
+describe('Entity API', () => {
+  const doc1 = { _id: 'doc1', type: 'some_type', name: 'Document 1' };
+  const onlineUser = {
+    username: 'online-user',
+    password: 'password',
+    roles: [USER_ROLES.ONLINE],
+  };
+  const offlineUser = {
+    username: 'offline-user',
+    password: 'password',
+    roles: ['chw'],
+    place: 'some_place'
+  };
+
+  before(async () => {
+    await utils.saveDocs([doc1]);
+    await utils.createUsers([onlineUser, offlineUser]);
+  });
+
+  after(async () => {
+    await utils.revertDb([]);
+    await utils.deleteUsers([onlineUser, offlineUser]);
+  });
+
+  describe('GET /api/v1/entity/:id', () => {
+    it('returns the document for an online user', async () => {
+      const response = await utils.request({
+        method: 'GET',
+        path: `/api/v1/entity/${doc1._id}`,
+        auth: { username: onlineUser.username, password: onlineUser.password }
+      });
+      expect(response.status).to.equal(200);
+      expect(response.body._id).to.equal(doc1._id);
+      expect(response.body.name).to.equal(doc1.name);
+    });
+
+    it('returns 403 for an offline user', async () => {
+      const response = await utils.request({
+        method: 'GET',
+        path: `/api/v1/entity/${doc1._id}`,
+        auth: { username: offlineUser.username, password: offlineUser.password }
+      });
+      expect(response.status).to.equal(403);
+      expect(response.body.message).to.equal('Insufficient privileges');
+    });
+
+    it('returns 404 for a non-existent document', async () => {
+      const response = await utils.request({
+        method: 'GET',
+        path: '/api/v1/entity/non-existent-id',
+        auth: { username: onlineUser.username, password: onlineUser.password }
+      });
+      expect(response.status).to.equal(404);
+      expect(response.body.message).to.equal('Document not found');
+    });
+  });
+});


### PR DESCRIPTION

# Description

A generic entity retrieval system that allows fetching any document from the medic database via a REST API

I followed the project's architectural pattern by adding a new Entity module to the shared library. This allows the same logic to be used by the API (direct DB access) and potentially the Webapp in the future.

   * Endpoint: Created api/src/controllers/entity.js which implements GET /api/v1/entity/:id.
   * Routing: Registered the new controller in api/src/routing.js so the server recognizes the /api/v1/entity/ path.
   * Unit Tests: Added tests for the new Entity module in cht-datasource to verify that the local and remote logic correctly handles document retrieval and missing IDs.
   
Addresses #9207 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [X] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [X] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [X] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

