### PR TITLE
chore(#10883): replace 'any' with HttpHeaders in webapp services

### DIFF
--- a/webapp/src/ts/services/update-password.service.ts
+++ b/webapp/src/ts/services/update-password.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 
 @Injectable({
   providedIn: 'root'
@@ -20,11 +20,11 @@ export class UpdatePasswordService {
    */
   update(username, currentPassword, newPassword): Promise<Object> {
     const url = '/api/v1/users/' + username;
-    const headers: any = {
+    const headers = new HttpHeaders({
       'Content-Type': 'application/json',
       Accept: 'application/json',
       Authorization: 'Basic ' + window.btoa(username + ':' + currentPassword)
-    };
+    });
     const updates = { password: newPassword };
     return this.http.post(url, updates, { headers }).toPromise() as Promise<Object>;
   }

--- a/webapp/src/ts/services/user-login.service.ts
+++ b/webapp/src/ts/services/user-login.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { LocationService } from '@mm-services/location.service';
 
 @Injectable({
@@ -22,10 +22,10 @@ export class UserLoginService {
 
     const url = '/' + this.location.dbName + '/login';
 
-    const headers: any = {
+    const headers = new HttpHeaders({
       'Content-Type': 'application/json',
       Accept: 'application/json',
-    };
+    });
 
     const data = JSON.stringify({
       user: username,


### PR DESCRIPTION
## Summary
Partial fix for #10883. Replaces `headers: any` with `new HttpHeaders({...})` in two service files, following the pattern established in `session.service.ts`.

Files updated:
- `webapp/src/ts/services/update-password.service.ts`
- `webapp/src/ts/services/user-login.service.ts`

The remaining files (`cache.service.ts` and `extract-lineage.service.ts`) are not in this PR. Happy to follow up in a separate PR — let me know if you'd prefer them bundled instead.

## Test plan
- [x] `npm run compile` (webapp) passes
- [x] `npm run lint` passes
- [x] `npm run unit` (webapp Karma) — 2664 tests passing
- [x] Existing specs for both services still pass without changes (the `headers.get('...')` API works identically for `HttpHeaders` and object literals)