### PR TITLE
fix(#10974): handle Android back button for dropdowns via Angular state

### DIFF
--- a/webapp/src/ts/components/filters/analytics-filter/analytics-filter.component.html
+++ b/webapp/src/ts/components/filters/analytics-filter/analytics-filter.component.html
@@ -1,6 +1,6 @@
 <div class="analytics-sidebar-filter">
-  <span *ngIf="analyticsModules?.length > 1" class="dropdown mm-dropdown analytics-module">
-    <span id="module" class="mm-button" data-toggle="dropdown">
+  <span *ngIf="analyticsModules?.length > 1" class="dropdown mm-dropdown analytics-module" dropdown mmDropdownTracking>
+    <span id="module" class="mm-button" dropdownToggle>
       <span class="mm-button-icon">
         <span class="fa fa-bar-chart-o"></span>
       </span>
@@ -12,7 +12,7 @@
       </ng-container>
     </span>
 
-    <ul role="menu" aria-labelledby="module" class="dropdown-menu mm-dropdown-menu">
+    <ul role="menu" aria-labelledby="module" *dropdownMenu class="dropdown-menu mm-dropdown-menu">
       <li role="presentation" *ngFor="let module of analyticsModules" [attr.data-id]="module.id">
         <a [routerLink]="module.route" role="menuitem" tabindex="-1">{{ module.label | translate }}</a>
       </li>

--- a/webapp/src/ts/components/filters/analytics-filter/analytics-filter.component.ts
+++ b/webapp/src/ts/components/filters/analytics-filter/analytics-filter.component.ts
@@ -20,11 +20,13 @@ import { AGGREGATE_TARGETS_ID, TARGETS_ID } from '@mm-services/analytics-modules
 import { NgIf, NgFor } from '@angular/common';
 import { MatIcon } from '@angular/material/icon';
 import { TranslatePipe } from '@ngx-translate/core';
+import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
+import { DropdownTrackingDirective } from '@mm-directives/dropdown-tracking.directive';
 
 @Component({
   selector: 'mm-analytics-filters',
   templateUrl: './analytics-filter.component.html',
-  imports: [NgIf, NgFor, RouterLink, MatIcon, TranslatePipe]
+  imports: [NgIf, NgFor, RouterLink, MatIcon, TranslatePipe, BsDropdownModule, DropdownTrackingDirective]
 })
 export class AnalyticsFilterComponent implements AfterContentInit, AfterContentChecked, OnInit, OnDestroy {
   @Input() analyticsModules: any[] = [];

--- a/webapp/src/ts/components/filters/date-filter/date-filter.component.html
+++ b/webapp/src/ts/components/filters/date-filter/date-filter.component.html
@@ -1,4 +1,4 @@
-<div class="dropdown mm-dropdown" [class.disabled]="disabled" dropdown [insideClick]="true">
+<div class="dropdown mm-dropdown" [class.disabled]="disabled" dropdown [insideClick]="true" mmDropdownTracking>
   <a [id]="fieldId" class="mm-button" href dropdownToggle (click)="false">
     <span class="mm-button-icon">
        <span class="fa fa-calendar"></span>

--- a/webapp/src/ts/components/filters/date-filter/date-filter.component.ts
+++ b/webapp/src/ts/components/filters/date-filter/date-filter.component.ts
@@ -13,11 +13,12 @@ import { GlobalActions } from '@mm-actions/global';
 import { Selectors } from '@mm-selectors/index';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TranslatePipe } from '@ngx-translate/core';
+import { DropdownTrackingDirective } from '@mm-directives/dropdown-tracking.directive';
 
 @Component({
   selector: 'mm-date-filter',
   templateUrl: './date-filter.component.html',
-  imports: [BsDropdownModule, NgIf, TranslatePipe]
+  imports: [BsDropdownModule, NgIf, TranslatePipe, DropdownTrackingDirective]
 })
 export class DateFilterComponent implements OnInit, OnDestroy, AfterViewInit {
   private globalActions: GlobalActions;

--- a/webapp/src/ts/components/filters/sort-filter/sort-filter.component.html
+++ b/webapp/src/ts/components/filters/sort-filter/sort-filter.component.html
@@ -1,4 +1,4 @@
-<span *ngIf="lastVisitedDateExtras" class="dropdown mm-dropdown sort-dropdown no-reset" dropdown>
+<span *ngIf="lastVisitedDateExtras" class="dropdown mm-dropdown sort-dropdown no-reset" dropdown mmDropdownTracking>
   <span class="sort-results">
     <a
       id="sort-results"

--- a/webapp/src/ts/components/filters/sort-filter/sort-filter.component.ts
+++ b/webapp/src/ts/components/filters/sort-filter/sort-filter.component.ts
@@ -2,11 +2,12 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { NgIf } from '@angular/common';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TranslatePipe } from '@ngx-translate/core';
+import { DropdownTrackingDirective } from '@mm-directives/dropdown-tracking.directive';
 
 @Component({
   selector: 'mm-sort-filter',
   templateUrl: './sort-filter.component.html',
-  imports: [NgIf, BsDropdownModule, TranslatePipe]
+  imports: [NgIf, BsDropdownModule, TranslatePipe, DropdownTrackingDirective]
 })
 export class SortFilterComponent {
   @Input() lastVisitedDateExtras;

--- a/webapp/src/ts/components/header/header.component.html
+++ b/webapp/src/ts/components/header/header.component.html
@@ -8,7 +8,7 @@
 
     <div class="extras">
 
-      <span class="dropdown options" dropdown>
+      <span class="dropdown options" dropdown mmDropdownTracking>
         <a href dropdownToggle (click)="false" id="header-dropdown-link" aria-controls="header-dropdown">
           <div class="mm-icon mm-icon-inverse">
             <span class="fa fa-fw fa-bars"></span>

--- a/webapp/src/ts/components/header/header.component.ts
+++ b/webapp/src/ts/components/header/header.component.ts
@@ -14,6 +14,7 @@ import { AuthDirective } from '@mm-directives/auth.directive';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { NgClass, NgFor, NgIf } from '@angular/common';
 import { MobileDetectionComponent } from '@mm-components/mobile-detection/mobile-detection.component';
+import { DropdownTrackingDirective } from '@mm-directives/dropdown-tracking.directive';
 
 import { TranslatePipe } from '@ngx-translate/core';
 import { RelativeDatePipe } from '@mm-pipes/date.pipe';
@@ -35,6 +36,7 @@ export const OLD_NAV_PERMISSION = 'can_view_old_navigation';
     NgClass,
     NgFor,
     MobileDetectionComponent,
+    DropdownTrackingDirective,
     TranslatePipe,
     HeaderLogoPipe,
     ResourceIconPipe,

--- a/webapp/src/ts/directives/dropdown-tracking.directive.ts
+++ b/webapp/src/ts/directives/dropdown-tracking.directive.ts
@@ -1,0 +1,28 @@
+import { Directive, HostListener, OnDestroy, Self } from '@angular/core';
+import { BsDropdownDirective } from 'ngx-bootstrap/dropdown';
+import { DropdownService } from '@mm-services/dropdown.service';
+
+@Directive({
+  selector: '[dropdown][mmDropdownTracking]',
+  standalone: true,
+})
+export class DropdownTrackingDirective implements OnDestroy {
+  constructor(
+    @Self() private dropdown: BsDropdownDirective,
+    private dropdownService: DropdownService
+  ) {}
+
+  @HostListener('onShown')
+  onShown() {
+    this.dropdownService.register(this.dropdown);
+  }
+
+  @HostListener('onHidden')
+  onHidden() {
+    this.dropdownService.unregister(this.dropdown);
+  }
+
+  ngOnDestroy() {
+    this.dropdownService.unregister(this.dropdown);
+  }
+}

--- a/webapp/src/ts/services/android-api.service.ts
+++ b/webapp/src/ts/services/android-api.service.ts
@@ -5,6 +5,7 @@ import { GeolocationService } from '@mm-services/geolocation.service';
 import { MRDTService } from '@mm-services/mrdt.service';
 import { SessionService } from '@mm-services/session.service';
 import { NavigationService } from '@mm-services/navigation.service';
+import { DropdownService } from '@mm-services/dropdown.service';
 
 /**
  * An API to provide integration with the medic-android app.
@@ -24,6 +25,7 @@ export class AndroidApiService {
     private sessionService:SessionService,
     private zone:NgZone,
     private navigationService:NavigationService,
+    private dropdownService:DropdownService,
   ) { }
 
   private runInZone(property:string, args:any[]=[]) {
@@ -72,9 +74,7 @@ export class AndroidApiService {
     // todo: this probably won't work because dropdowns are now angular directives!
 
     // If there is a dropdown menu open, close it
-    const $dropdown = $container.find('.filter.dropdown.open:visible');
-    if ($dropdown.length) {
-      $dropdown.removeClass('open');
+    if (this.dropdownService.closeAll()) {
       return true;
     }
 
@@ -121,10 +121,8 @@ export class AndroidApiService {
       return true;
     }
 
-    // If the hotdog hamburger options menu is open, close it
-    const $optionsMenu = $('.dropdown.options.open');
-    if ($optionsMenu.length) {
-      $optionsMenu.removeClass('open');
+    // If any angular dropdown menu is open, close it
+    if (this.dropdownService.closeAll()) {
       return true;
     }
 

--- a/webapp/src/ts/services/dropdown.service.ts
+++ b/webapp/src/ts/services/dropdown.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { BsDropdownDirective } from 'ngx-bootstrap/dropdown';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DropdownService {
+  private openDropdowns: BsDropdownDirective[] = [];
+
+  register(dropdown: BsDropdownDirective) {
+    if (!this.openDropdowns.includes(dropdown)) {
+      this.openDropdowns.push(dropdown);
+    }
+  }
+
+  unregister(dropdown: BsDropdownDirective) {
+    this.openDropdowns = this.openDropdowns.filter(d => d !== dropdown);
+  }
+
+  closeAll(): boolean {
+    if (this.openDropdowns.length === 0) {
+      return false;
+    }
+
+    this.openDropdowns.forEach(dropdown => dropdown.hide());
+    this.openDropdowns = [];
+    return true;
+  }
+}

--- a/webapp/tests/karma/ts/services/android-api.service.spec.ts
+++ b/webapp/tests/karma/ts/services/android-api.service.spec.ts
@@ -9,6 +9,7 @@ import { GeolocationService } from '@mm-services/geolocation.service';
 import { MRDTService } from '@mm-services/mrdt.service';
 import { NavigationService } from '@mm-services/navigation.service';
 import { AndroidAppLauncherService } from '@mm-services/android-app-launcher.service';
+import { DropdownService } from '@mm-services/dropdown.service';
 
 describe('AndroidApi service', () => {
 
@@ -19,6 +20,7 @@ describe('AndroidApi service', () => {
   let consoleErrorMock;
   let navigationService;
   let androidAppLauncherService;
+  let dropdownService;
 
   beforeEach(() => {
     sessionService = {
@@ -44,6 +46,9 @@ describe('AndroidApi service', () => {
     androidAppLauncherService = {
       resolveAndroidAppResponse: sinon.stub()
     };
+    dropdownService = {
+      closeAll: sinon.stub()
+    };
 
     consoleErrorMock = sinon.stub(console, 'error');
 
@@ -54,6 +59,7 @@ describe('AndroidApi service', () => {
         { provide: MRDTService, useValue: mrdtService },
         { provide: NavigationService, useValue: navigationService },
         { provide: AndroidAppLauncherService, useValue: androidAppLauncherService },
+        { provide: DropdownService, useValue: dropdownService },
       ],
     });
 
@@ -72,6 +78,16 @@ describe('AndroidApi service', () => {
   });
 
   describe('back', () => {
+    it('should call dropdownService.closeAll()', () => {
+      dropdownService.closeAll.returns(true);
+
+      const result = service.back();
+
+      expect(result).to.be.true;
+      expect(dropdownService.closeAll.callCount).to.be.at.least(1);
+      expect(navigationService.goBack.callCount).to.equal(0);
+    });
+
     it('should return true and not navigate to primary tab when navigationService.goBack() is true', () => {
       navigationService.goBack.returns(true);
 


### PR DESCRIPTION
This PR replaces the legacy jQuery-based dropdown closing logic in AndroidApiService with a modern Angular-native approach.

### Changes:
- Created `DropdownService` to track open `ngx-bootstrap` dropdowns.
- Created `DropdownTrackingDirective` (`mmDropdownTracking`) to automatically register/unregister dropdowns with the service.
- Refactored `AndroidApiService` to use `DropdownService.closeAll()` instead of jQuery DOM manipulation.
- Migrated `AnalyticsFilterComponent` to use `ngx-bootstrap` dropdowns.
- Applied the tracking directive to dropdowns in Header, Analytics, Date, and Sort filters.
- Updated `AndroidApiService` unit tests.

This ensures that dropdown state remains synchronized with Angular when closed via the hardware back button, resolving inconsistencies and potential UI breakage.