### PR TITLE
fix(#10988): use JSON.stringify for manifest generation instead of lodash template

### DIFF
--- a/api/src/services/manifest.js
+++ b/api/src/services/manifest.js
@@ -2,19 +2,33 @@ const { promisify } = require('util');
 const fs = require('fs');
 const path = require('path');
 
-const _ = require('lodash');
-
 const resources = require('../resources');
 const brandingService = require('./branding');
 
 const webappPath = resources.webappPath;
 const MANIFEST_OUTPUT_PATH = path.join(webappPath, 'manifest.json');
-const TEMPLATE_PATH = path.join(__dirname, '..', 'templates', 'manifest.json');
 
 const writeJson = async (branding) => {
-  const file = await promisify(fs.readFile)(TEMPLATE_PATH, { encoding: 'utf-8' });
-  const template = _.template(file);
-  const json = template({ branding });
+  const manifest = {
+    start_url: './',
+    name: branding.name,
+    display: 'standalone',
+    background_color: '#323232',
+    theme_color: '#323232',
+    icons: [
+      {
+        src: `/img/${branding.icon}`,
+        sizes: 'any',
+        purpose: 'any',
+      },
+      {
+        src: '/favicon.ico',
+        sizes: '32x32',
+        type: 'image',
+      },
+    ],
+  };
+  const json = JSON.stringify(manifest, null, 2);
   return await promisify(fs.writeFile)(MANIFEST_OUTPUT_PATH, json);
 };
 

--- a/api/tests/mocha/services/manifest.spec.js
+++ b/api/tests/mocha/services/manifest.spec.js
@@ -9,11 +9,6 @@ const brandingService = require('../../../src/services/branding');
 const service = require('../../../src/services/manifest');
 const baseDir = path.join(__dirname, '..', '..', '..');
 
-const JSON_TEMPLATE = JSON.stringify({
-  name: '{{ branding.name }}',
-  icon: '{{ branding.icon }}'
-});
-
 describe('manifest service', () => {
 
   afterEach(() => {
@@ -29,16 +24,15 @@ describe('manifest service', () => {
     };
 
     const get = sinon.stub(brandingService, 'get').resolves(branding);
-    const readFile = sinon.stub(fs, 'readFile').callsArgWith(2, null, JSON_TEMPLATE);
     const writeFile = sinon.stub(fs, 'writeFile').callsArgWith(2, null, null);
 
     await service.generate();
     chai.expect(get.callCount).to.equal(1);
-    chai.expect(readFile.callCount).to.equal(1);
-    chai.expect(readFile.args[0][0]).to.equal(baseDir + '/src/templates/manifest.json');
     chai.expect(writeFile.callCount).to.equal(1);
     chai.expect(writeFile.args[0][0]).to.equal(baseDir + '/build/static/webapp/manifest.json');
-    chai.expect(writeFile.args[0][1]).to.equal('{"name":"CHT","icon":"logo.png"}');
+    const manifest = JSON.parse(writeFile.args[0][1]);
+    chai.expect(manifest.name).to.equal('CHT');
+    chai.expect(manifest.icons[0].src).to.equal('/img/logo.png');
   });
 
   it('uses configured branding doc and extracts logo', async () => {
@@ -59,20 +53,35 @@ describe('manifest service', () => {
     };
 
     const get = sinon.stub(brandingService, 'get').resolves(branding);
-    const readFile = sinon.stub(fs, 'readFile').callsArgWith(2, null, JSON_TEMPLATE);
     const writeFile = sinon.stub(fs, 'writeFile').callsArgWith(2, null, null);
 
     sinon.stub(Buffer, 'from').returns('base64xyz');
 
     await service.generate();
     chai.expect(get.callCount).to.equal(1);
-    chai.expect(readFile.callCount).to.equal(1);
-    chai.expect(readFile.args[0][0]).to.equal(baseDir + '/src/templates/manifest.json');
     chai.expect(writeFile.callCount).to.equal(2);
     chai.expect(writeFile.args[0][0]).to.equal(baseDir + '/build/static/webapp/manifest.json');
-    chai.expect(writeFile.args[0][1]).to.equal('{"name":"CHT","icon":"logo.png"}');
+    const manifest = JSON.parse(writeFile.args[0][1]);
+    chai.expect(manifest.name).to.equal('CHT');
+    chai.expect(manifest.icons[0].src).to.equal('/img/logo.png');
     chai.expect(writeFile.args[1][0]).to.equal(baseDir + '/build/static/webapp/img/logo.png');
     chai.expect(writeFile.args[1][1]).to.equal('base64xyz');
+  });
+
+  it('generates valid JSON when branding name contains special characters', async () => {
+
+    const branding = {
+      name: 'CHT "Community" Health\\Tool',
+      icon: 'icon.png',
+      doc: {}
+    };
+
+    sinon.stub(brandingService, 'get').resolves(branding);
+    const writeFile = sinon.stub(fs, 'writeFile').callsArgWith(2, null, null);
+
+    await service.generate();
+    const manifest = JSON.parse(writeFile.args[0][1]);
+    chai.expect(manifest.name).to.equal('CHT "Community" Health\\Tool');
   });
 
 });


### PR DESCRIPTION
Fixes #10988

## Summary

- The `manifest.json` was generated using a lodash `_.template` with raw `{{ }}` interpolation. Branding names containing `"`, `\`, or other JSON-special characters produced invalid JSON, breaking PWA installability.
- Replaced the template approach with `JSON.stringify`, which handles all escaping correctly. This also removes the dependency on `lodash` and the `manifest.json` template file from the service.
- Added a test case that verifies a branding name with quotes and backslashes produces valid, parseable JSON.

## Test plan

- [x] All 3 manifest unit tests pass
- [ ] Set a branding name containing quotes (e.g. `CHT "Community"`) and verify `/manifest.json` returns valid JSON
- [ ] Verify PWA install prompt still works with a normal branding name