### PR TITLE
fix(#10997): preserve query parameters in login redirect

### DIFF
--- a/api/src/controllers/login.js
+++ b/api/src/controllers/login.js
@@ -135,7 +135,7 @@ const sanitizeRequestedRedirect = (requested) => {
     return;
   }
   const parsed = new URL(resolved, 'resolve://');
-  const path = parsed.pathname + (parsed.hash || '');
+  const path = parsed.pathname + (parsed.search || '') + (parsed.hash || '');
   if (hasDoubleSlash(path)) {
     // double slash can be abused to redirect to another host
     // https://github.com/medic/cht-core/issues/9122

--- a/api/tests/mocha/controllers/login.spec.js
+++ b/api/tests/mocha/controllers/login.spec.js
@@ -132,6 +132,9 @@ describe('login controller', () => {
       '/lg/_design/medic/_rewrite#fragment',
       '/lg/_design/medic/_rewrite#path/fragment',
       '/lg/_design/medic/_rewrite/long/path',
+      '/reports?search=malaria&sort=date',
+      '/contacts?type=person&facility=abc123',
+      '/reports?search=malaria&sort=date#selected',
     ].forEach(requested => {
       it(`Good URL "${requested}" should redirect unchanged`, () => {
         chai.expect(controller.__get__('getRedirectUrl')({}, requested)).to.equal(requested);
@@ -154,6 +157,14 @@ describe('login controller', () => {
       {
         given: 'http://wrong.com:666/lg/_design/medic/_rewrite/long/path',
         expected: '/lg/_design/medic/_rewrite/long/path'
+      },
+      {
+        given: 'http://test.com:1234/reports?search=malaria&sort=date',
+        expected: '/reports?search=malaria&sort=date'
+      },
+      {
+        given: 'http://test.com:1234/reports?search=malaria#selected',
+        expected: '/reports?search=malaria#selected'
       },
     ].forEach(({ given, expected }) => {
       it(`Absolute URL "${given}" should redirect as a relative url`, () => {


### PR DESCRIPTION
## Description

Fixes #10997

`sanitizeRequestedRedirect()` in `api/src/controllers/login.js` drops `parsed.search` when constructing the redirect path after login. This means any URL with query parameters (e.g. filtered report views, deep links with state) loses its query string after authentication.

## Code Change

**Before:**
```js
const path = parsed.pathname + (parsed.hash || '');
```

**After:**
```js
const path = parsed.pathname + (parsed.search || '') + (parsed.hash || '');
```

Note that `resolveUrl()` already preserves query parameters correctly — only `sanitizeRequestedRedirect()` was stripping them.

## How to reproduce

1. Visit a URL with query params while logged out, e.g. `/reports?search=malaria&sort=date#selected`
2. Get redirected to login
3. Log in
4. Observe redirect goes to `/reports#selected` instead of `/reports?search=malaria&sort=date#selected`

## Test plan

- [x] Added test cases for relative URLs with query parameters
- [x] Added test cases for absolute URLs with query parameters
- [x] Added test cases for URLs with both query parameters and hash fragments
- [x] All 73 existing login controller tests continue to pass
- [x] ESLint passes