### PR TITLE
fix(#10999): only normalize slashes in URL pathname, not query params

### DIFF
--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -208,7 +208,8 @@ app.use(
 app.use(rateLimiterMiddleware);
 app.use(jsonQueryParser);
 app.use((req, res, next) => {
-  req.url = req.url.replace(/\/+/g, '/');
+  const [pathname, ...rest] = req.url.split('?');
+  req.url = pathname.replace(/\/+/g, '/') + (rest.length ? '?' + rest.join('?') : '');
   next();
 });
 

--- a/api/tests/mocha/routing.spec.js
+++ b/api/tests/mocha/routing.spec.js
@@ -1,6 +1,11 @@
 const rewire = require('rewire');
 const chai = require('chai');
 
+const normalizeUrl = (url) => {
+  const [pathname, ...rest] = url.split('?');
+  return pathname.replace(/\/+/g, '/') + (rest.length ? '?' + rest.join('?') : '');
+};
+
 describe('Routing', () => {
   before(() => global.angular = {
     module: () => ({
@@ -17,5 +22,33 @@ describe('Routing', () => {
     const actualBuildDb = adminUpgrade.__get__('DEFAULT_BUILDS_URL');
     chai.expect(cspBuildDb).to.not.eq(undefined);
     chai.expect(cspBuildDb).to.include(actualBuildDb);
+  });
+
+  describe('URL slash normalization', () => {
+    it('should collapse double slashes in pathname', () => {
+      chai.expect(normalizeUrl('//some//path')).to.equal('/some/path');
+    });
+
+    it('should not modify query parameter values', () => {
+      chai.expect(normalizeUrl('/path?redirect=https://example.com/a//b'))
+        .to.equal('/path?redirect=https://example.com/a//b');
+    });
+
+    it('should handle URLs without query strings', () => {
+      chai.expect(normalizeUrl('/some//path')).to.equal('/some/path');
+    });
+
+    it('should preserve query params with multiple ? characters', () => {
+      chai.expect(normalizeUrl('/path?a=1?2&b=3')).to.equal('/path?a=1?2&b=3');
+    });
+
+    it('should handle URL with only pathname', () => {
+      chai.expect(normalizeUrl('/clean/path')).to.equal('/clean/path');
+    });
+
+    it('should normalize pathname but preserve query with slashes', () => {
+      chai.expect(normalizeUrl('//api//v1?url=http://test.com'))
+        .to.equal('/api/v1?url=http://test.com');
+    });
   });
 });


### PR DESCRIPTION
## Description

Fixes #10999

The global middleware in `api/src/routing.js` normalizes double slashes by replacing all consecutive slashes in `req.url`:

```js
req.url = req.url.replace(/\/+/g, '/');
```

Since `req.url` includes the query string, this corrupts any query parameter containing URL-like values or double slashes.

**Example:**
- Input: `/some/path?redirect=https://example.com/a//b`
- Before fix: `/some/path?redirect=https:/example.com/a/b`
- After fix: `/some/path?redirect=https://example.com/a//b`

## Code Change

```js
// Before
req.url = req.url.replace(/\/+/g, '/');

// After
const [pathname, ...rest] = req.url.split('?');
req.url = pathname.replace(/\/+/g, '/') + (rest.length ? '?' + rest.join('?') : '');
```

The fix splits the URL at the query boundary, normalizes only the pathname, and preserves the query string as-is. It also handles edge cases like multiple `?` characters in the URL.

## Test plan

- [x] Added 6 test cases covering pathname normalization, query preservation, and edge cases
- [x] All existing routing tests continue to pass
- [x] ESLint passes