### PR TITLE
fix(#11001): use route params instead of matrix params for deceased contact navigation

### DIFF
--- a/webapp/src/ts/modules/contacts/contacts-deceased.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-deceased.component.ts
@@ -69,7 +69,7 @@ export class ContactsDeceasedComponent implements OnInit, OnDestroy {
       callback: (change) => {
         if (change.deleted) {
           const parentId = this.selectedContact?.doc?.parent?._id;
-          return this.router.navigate(['/contacts', { id: parentId || null }]);
+          return this.router.navigate(parentId ? ['/contacts', parentId] : ['/contacts']);
         }
         // refresh the updated contact
         this.selectContact(change.id, true);


### PR DESCRIPTION
## Description

Fixes #11001

After a deceased contact is deleted, `contacts-deceased.component.ts` navigates using Angular matrix parameters instead of route parameters:

```ts
// Before — creates /contacts;id=parent-id (matrix params)
this.router.navigate(['/contacts', { id: parentId || null }]);

// After — creates /contacts/parent-id (route params)
this.router.navigate(parentId ? ['/contacts', parentId] : ['/contacts']);
```

The contacts route expects a path parameter (`:id`), not matrix params. This mismatch causes the user to land on the wrong view after deletion instead of seeing the parent contact.

## How to reproduce

1. Navigate to a contact that has a deceased child contact
2. Open the deceased child contact
3. Delete the contact
4. Observe the URL — it shows `/contacts;id=<parent-id>` instead of `/contacts/<parent-id>`

## Test plan

- [x] Verified the contacts route definition expects `:id` as a path segment
- [x] Confirmed other components in the same module use `['/contacts', id]` for navigation (e.g. `contacts-content.component.ts`, `contacts-report.component.ts`)
- [x] When `parentId` exists, navigates to `/contacts/<parentId>`
- [x] When no parent, navigates to `/contacts`
- [x] ESLint passes