### PR TITLE
fix(#11003): include boundary values in age break comparison

### DIFF
--- a/webapp/src/ts/services/format-date.service.ts
+++ b/webapp/src/ts/services/format-date.service.ts
@@ -103,7 +103,7 @@ export class FormatDateService {
     for (let i = 0; i < this.config.ageBreaks.length; i++) {
       const ageBreak = this.config.ageBreaks[i];
       const diff = date.diff(end, ageBreak.unit);
-      if (Math.abs(diff) > ageBreak.min) {
+      if (Math.abs(diff) >= ageBreak.min) {
         return { quantity: diff, key: ageBreak.key };
       }
     }

--- a/webapp/tests/karma/ts/services/format-date.service.spec.ts
+++ b/webapp/tests/karma/ts/services/format-date.service.spec.ts
@@ -148,6 +148,22 @@ describe('FormatDate service', () => {
       expect(relativeTime.args[0]).to.deep.equal([0, true, 'dd', false]);
     });
 
+    it('shows singular year when exactly 1 year old', () => {
+      relativeTime.returns('1 year');
+      const dob = moment().subtract(1, 'years');
+      const actual = service.age(dob);
+      expect(actual).to.equal('1 year');
+      expect(relativeTime.args[0]).to.deep.equal([1, true, 'y', false]);
+    });
+
+    it('shows singular month when exactly 1 month old', () => {
+      relativeTime.returns('1 month');
+      const dob = moment().subtract(1, 'months');
+      const actual = service.age(dob);
+      expect(actual).to.equal('1 month');
+      expect(relativeTime.args[0]).to.deep.equal([1, true, 'M', false]);
+    });
+
     it('calculates age at death if known', () => {
       relativeTime.returns('100 years');
       const dob = moment().subtract(120, 'years');


### PR DESCRIPTION
## Description

Fixes #11003

`getDateDiff()` in `format-date.service.ts` uses strict greater-than (`>`) when comparing the date difference against `ageBreak.min`. Since both years and months age breaks have `min: 1`, exact boundary values (exactly 1 year, exactly 1 month) fail the check and fall through to the next smaller unit.

**Example:** A patient born exactly 1 year ago displays as "12 months" instead of "1 year".

## Code Change

```ts
// Before
if (Math.abs(diff) > ageBreak.min) {

// After
if (Math.abs(diff) >= ageBreak.min) {
```

The days break (`min: 0`) is unaffected since `>= 0` matches the same values as `> 0` for this context (the fallback at line 110 already handles the 0-day case).

## Test plan

- [x] Added test: exactly 1 year old displays with singular year key (`y`)
- [x] Added test: exactly 1 month old displays with singular month key (`M`)
- [x] Existing tests for 5 years, 16 months, 50 days, 1 day, 0 days, and age-at-death all continue to pass
- [x] ESLint passes