### PR TITLE
fix(#11005): guard null GitHub user in release notes script

### DIFF
--- a/scripts/release-notes/index.js
+++ b/scripts/release-notes/index.js
@@ -165,7 +165,7 @@ const getIssueNumbers = commitMessage => {
   const commitMadeByDependabot = commit => {
     let result = false;
     commit.authors.nodes.forEach((author) => {
-      if (BOTS.includes(author.user.login)) {
+      if (author.user && BOTS.includes(author.user.login)) {
         result = true;
       }
     });
@@ -176,7 +176,9 @@ const getIssueNumbers = commitMessage => {
     const authors = commit.authors.nodes;
     let authConcat = '';
     authors.forEach((author) => {
-      authConcat += ` (${author.user.login})`;
+      if (author.user) {
+        authConcat += ` (${author.user.login})`;
+      }
     });
     return authConcat.trim();
   };
@@ -321,6 +323,9 @@ Commits:
     const lines = [];
     const authors = commits.flatMap((commit) => commit.authors.nodes);
     authors.forEach((author) => {
+      if (!author.user) {
+        return;
+      }
       const { login, name, url } = author.user;
       if (login && !ignoreLogins.has(login)) {
         ignoreLogins.add(login);


### PR DESCRIPTION
## Description

Fixes #11005

The release notes generation script crashes with `TypeError: Cannot read properties of null (reading 'login')` when a commit in the release range was authored by someone whose email is not linked to a GitHub account or whose account has been deleted. The GitHub GraphQL API returns `user: null` in these cases.

## Code Changes

Added null guards in three locations in `scripts/release-notes/index.js`:

1. **`commitMadeByDependabot()`** (line 168) — check `author.user` before accessing `.login`
2. **`getCommitAuthorString()`** (line 179) — skip authors with no GitHub user
3. **`formatCommits()`** (line 324) — skip authors with no GitHub user

All three follow the same pattern: if `author.user` is null, skip that author instead of crashing.

## Test plan

- [x] Verified all three crash sites have null guards
- [x] Authors with valid GitHub users are unaffected
- [x] Authors with null users are silently skipped
- [x] ESLint passes