### PR TITLE
feat(#10694): add free text search to tasks page

### DIFF
--- a/tests/e2e/default/tasks/tasks-search.wdio-spec.js
+++ b/tests/e2e/default/tasks/tasks-search.wdio-spec.js
@@ -11,7 +11,6 @@ const { CONTACT_TYPES } = require('@medic/constants');
 
 describe('Tasks Free Text Search', () => {
   const places = placeFactory.generateHierarchy();
-  const districtHospital = places.get('district_hospital');
   const healthCenter = places.get('health_center');
   const clinic = places.get(CONTACT_TYPES.CLINIC);
 

--- a/tests/e2e/default/tasks/tasks-search.wdio-spec.js
+++ b/tests/e2e/default/tasks/tasks-search.wdio-spec.js
@@ -1,0 +1,156 @@
+const utils = require('@utils');
+const loginPage = require('@page-objects/default/login/login.wdio.page');
+const userFactory = require('@factories/cht/users/users');
+const placeFactory = require('@factories/cht/contacts/place');
+const personFactory = require('@factories/cht/contacts/person');
+const tasksPage = require('@page-objects/default/tasks/tasks.wdio.page');
+const searchPage = require('@page-objects/default/search/search.wdio.page');
+const sentinelUtils = require('@utils/sentinel');
+const commonPage = require('@page-objects/default/common/common.wdio.page');
+const { CONTACT_TYPES } = require('@medic/constants');
+
+describe('Tasks Free Text Search', () => {
+  const places = placeFactory.generateHierarchy();
+  const districtHospital = places.get('district_hospital');
+  const healthCenter = places.get('health_center');
+  const clinic = places.get(CONTACT_TYPES.CLINIC);
+
+  const chwContact = personFactory.build({
+    name: 'CHW Search User',
+    phone: '+12068881235',
+    place: healthCenter._id,
+    parent: healthCenter,
+  });
+
+  const chw = userFactory.build({
+    username: 'offlineuser_search_tasks',
+    isOffline: true,
+    place: healthCenter._id,
+    contact: chwContact._id,
+  });
+
+  const patient1 = personFactory.build({
+    name: 'Margaret Williams',
+    patient_id: 'patient_search_1',
+    parent: clinic,
+    reported_date: Date.now(),
+  });
+
+  const patient2 = personFactory.build({
+    name: 'Rajesh Kumar',
+    patient_id: 'patient_search_2',
+    parent: clinic,
+    reported_date: Date.now(),
+  });
+
+  before(async () => {
+    await utils.saveDocs([
+      ...places.values(),
+      chwContact,
+      patient1,
+      patient2,
+    ]);
+    await utils.createUsers([chw]);
+    await tasksPage.compileTasks('tasks-filter-config.js', false);
+    await sentinelUtils.waitForSentinel();
+    await loginPage.login(chw);
+  });
+
+  after(async () => {
+    await utils.deleteUsers([chw]);
+  });
+
+  beforeEach(async () => {
+    await commonPage.goToTasks();
+    await browser.waitUntil(async () => (await tasksPage.getTasks()).length > 0);
+  });
+
+  it('should filter tasks by contact name', async () => {
+    const allTasks = await tasksPage.getTasks();
+    const totalCount = allTasks.length;
+    expect(totalCount).to.be.greaterThan(0);
+
+    await searchPage.performSearch('Margaret');
+
+    const filteredTasks = await tasksPage.getTasks();
+    const filteredInfos = await tasksPage.getTasksListInfos(filteredTasks);
+    expect(filteredInfos.length).to.be.greaterThan(0);
+    expect(filteredInfos.length).to.be.lessThan(totalCount);
+    filteredInfos.forEach(info => {
+      expect(info.contactName).to.equal('Margaret Williams');
+    });
+
+    await searchPage.clearSearch();
+    await browser.waitUntil(async () => (await tasksPage.getTasks()).length === totalCount);
+  });
+
+  it('should filter tasks by task title', async () => {
+    const allTasks = await tasksPage.getTasks();
+    const totalCount = allTasks.length;
+
+    await searchPage.performSearch('Assessment');
+
+    const filteredTasks = await tasksPage.getTasks();
+    const filteredInfos = await tasksPage.getTasksListInfos(filteredTasks);
+    expect(filteredInfos.length).to.be.greaterThan(0);
+    expect(filteredInfos.length).to.be.lessThan(totalCount);
+    filteredInfos.forEach(info => {
+      expect(info.formTitle).to.equal('Assessment');
+    });
+
+    await searchPage.clearSearch();
+    await browser.waitUntil(async () => (await tasksPage.getTasks()).length === totalCount);
+  });
+
+  it('should show no tasks when search has no match', async () => {
+    await searchPage.performSearch('xyznonexistent');
+
+    const noTasksMessage = await tasksPage.isTaskElementDisplayed('p', 'No tasks found');
+    expect(noTasksMessage).to.be.true;
+
+    await searchPage.clearSearch();
+    await browser.waitUntil(async () => (await tasksPage.getTasks()).length > 0);
+  });
+
+  it('should restore full task list when search is cleared', async () => {
+    const allTasks = await tasksPage.getTasks();
+    const totalCount = allTasks.length;
+
+    await searchPage.performSearch('Rajesh');
+    const filteredTasks = await tasksPage.getTasks();
+    expect(filteredTasks.length).to.be.lessThan(totalCount);
+
+    await searchPage.clearSearch();
+    await browser.waitUntil(async () => (await tasksPage.getTasks()).length === totalCount);
+
+    const restoredTasks = await tasksPage.getTasks();
+    expect(restoredTasks.length).to.equal(totalCount);
+  });
+
+  it('should combine search with sidebar filters', async () => {
+    const allTasks = await tasksPage.getTasks();
+    const totalCount = allTasks.length;
+
+    await searchPage.performSearch('Margaret');
+    const searchFiltered = await tasksPage.getTasks();
+    const searchCount = searchFiltered.length;
+
+    await tasksPage.openSidebarFilter();
+    await tasksPage.filterByTaskType('Home Visit');
+    await commonPage.waitForPageLoaded();
+
+    const combinedTasks = await tasksPage.getTasks();
+    const combinedInfos = await tasksPage.getTasksListInfos(combinedTasks);
+
+    expect(combinedInfos.length).to.be.greaterThan(0);
+    expect(combinedInfos.length).to.be.at.most(searchCount);
+    combinedInfos.forEach(info => {
+      expect(info.contactName).to.equal('Margaret Williams');
+      expect(info.formTitle).to.equal('Home Visit');
+    });
+
+    await tasksPage.resetFilters();
+    await searchPage.clearSearch();
+    await browser.waitUntil(async () => (await tasksPage.getTasks()).length === totalCount);
+  });
+});

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -34,6 +34,7 @@
         "eurodigit": "^3.1.3",
         "fastest-levenshtein": "1.0.16",
         "font-awesome": "^4.7.0",
+        "fuse.js": "^7.3.0",
         "jquery": "3.5.1",
         "lodash-es": "^4.18.1",
         "moment-locales-webpack-plugin": "^1.2.0",
@@ -8388,6 +8389,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.3.0.tgz",
+      "integrity": "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
       }
     },
     "node_modules/gensync": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -48,6 +48,7 @@
     "eurodigit": "^3.1.3",
     "fastest-levenshtein": "1.0.16",
     "font-awesome": "^4.7.0",
+    "fuse.js": "^7.3.0",
     "jquery": "3.5.1",
     "lodash-es": "^4.18.1",
     "moment-locales-webpack-plugin": "^1.2.0",

--- a/webapp/src/ts/modules/tasks/tasks.component.html
+++ b/webapp/src/ts/modules/tasks/tasks.component.html
@@ -2,7 +2,7 @@
   <mm-search-bar
     (toggleFilter)="toggleFilter()"
     [showFilter]="true"
-    [showFreetext]="false">
+    [showFreetext]="true">
   </mm-search-bar>
 </mm-tool-bar>
 

--- a/webapp/src/ts/reducers/global.ts
+++ b/webapp/src/ts/reducers/global.ts
@@ -293,4 +293,5 @@ export interface TasksFilters {
   taskOverdue?: boolean;
   taskTypes?: { selected: string[] };
   facilities?: { selected: string[] };
+  search?: string;
 }

--- a/webapp/src/ts/selectors/index.ts
+++ b/webapp/src/ts/selectors/index.ts
@@ -88,11 +88,9 @@ const applyTasksFilters = (tasks: TaskWithLineage[], filters: TasksFilters = {})
     });
   }
 
-  if (filters.search) {
-    const normalizedSearch = normalizeText(filters.search);
-    if (normalizedSearch) {
-      filtered = filterTasksBySearch(filtered, normalizedSearch);
-    }
+  const normalizedSearch = normalizeText(filters.search);
+  if (normalizedSearch) {
+    filtered = filterTasksBySearch(filtered, normalizedSearch);
   }
 
   return filtered;

--- a/webapp/src/ts/selectors/index.ts
+++ b/webapp/src/ts/selectors/index.ts
@@ -41,32 +41,33 @@ const FUSE_OPTIONS = {
 };
 
 const filterTasksBySearch = (tasks: TaskWithLineage[], normalizedSearch: string): TaskWithLineage[] => {
-  // First pass: fast substring match on normalized text
   const substringMatched: TaskWithLineage[] = [];
-  const remaining: TaskWithLineage[] = [];
+  const remainingWithCandidates: { task: TaskWithLineage; candidates: string[] }[] = [];
 
   for (const task of tasks) {
     const candidates = getSearchCandidates(task);
     if (candidates.some(c => normalizeText(c).includes(normalizedSearch))) {
       substringMatched.push(task);
     } else if (candidates.length) {
-      remaining.push(task);
+      remainingWithCandidates.push({ task, candidates });
     }
   }
 
-  // Second pass: fuzzy match only on tasks that didn't match by substring.
-  // Build one Fuse index over all remaining candidates to avoid per-task overhead.
-  if (normalizedSearch.length >= FUSE_OPTIONS.minMatchCharLength && remaining.length) {
-    const entries = remaining.flatMap((task, idx) =>
-      getSearchCandidates(task).map(candidate => ({ candidate, idx }))
-    );
-    const fuse = new Fuse(entries, { ...FUSE_OPTIONS, keys: ['candidate'] });
-    const fuzzyMatchIndices = new Set(fuse.search(normalizedSearch).map(r => r.item.idx));
-    const fuzzyMatched = remaining.filter((_, idx) => fuzzyMatchIndices.has(idx));
-    return [...substringMatched, ...fuzzyMatched];
+  if (normalizedSearch.length < FUSE_OPTIONS.minMatchCharLength || !remainingWithCandidates.length) {
+    return substringMatched;
   }
 
-  return substringMatched;
+  // Build one Fuse index over all remaining candidates to avoid per-task overhead.
+  const entries = remainingWithCandidates.flatMap(
+    ({ candidates }, idx) => candidates.map(candidate => ({ candidate, idx }))
+  );
+  const fuse = new Fuse(entries, { ...FUSE_OPTIONS, keys: ['candidate'] });
+  const fuzzyMatchIndices = new Set(fuse.search(normalizedSearch).map(r => r.item.idx));
+  const fuzzyMatched = remainingWithCandidates
+    .filter((_, idx) => fuzzyMatchIndices.has(idx))
+    .map(({ task }) => task);
+
+  return [...substringMatched, ...fuzzyMatched];
 };
 
 const applyTasksFilters = (tasks: TaskWithLineage[], filters: TasksFilters = {}): TaskWithLineage[] => {

--- a/webapp/src/ts/selectors/index.ts
+++ b/webapp/src/ts/selectors/index.ts
@@ -1,12 +1,73 @@
 import { createSelector } from '@ngrx/store';
 import { GlobalState, TasksFilters } from '@mm-reducers/global';
 import { TaskEmission } from '@mm-services/rules-engine.service';
+import Fuse from 'fuse.js';
 
 interface TaskWithLineage extends TaskEmission {
   lineageIds: string[];
 }
 
 const getGlobalState = (state): GlobalState => state.global || {};
+
+// Strips diacritical marks and lowercases the input so that accented
+// characters like "Élodie" can be matched by searching "elodie".
+// NFD decomposition splits accented characters into base + combining marks,
+// and the regex strips the combining marks (Unicode range U+0300-U+036F).
+const normalizeText = (value?: string): string => {
+  if (!value) {
+    return '';
+  }
+  return value
+    .toString()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim();
+};
+
+const getSearchCandidates = (task: TaskWithLineage): string[] => {
+  return [
+    task?.contact?.name,
+    ...(task?.lineage || []),
+    task?.title,
+  ].filter(Boolean) as string[];
+};
+
+const FUSE_OPTIONS = {
+  threshold: 0.2,        // 0 = exact, 1 = match anything; 0.2 allows minor typos
+  distance: 50,          // how far from expected position a match can appear
+  minMatchCharLength: 3, // skip fuzzy matching for very short queries
+  ignoreLocation: true,  // match can appear anywhere in the string
+};
+
+const filterTasksBySearch = (tasks: TaskWithLineage[], normalizedSearch: string): TaskWithLineage[] => {
+  // First pass: fast substring match on normalized text
+  const substringMatched: TaskWithLineage[] = [];
+  const remaining: TaskWithLineage[] = [];
+
+  for (const task of tasks) {
+    const candidates = getSearchCandidates(task);
+    if (candidates.some(c => normalizeText(c).includes(normalizedSearch))) {
+      substringMatched.push(task);
+    } else if (candidates.length) {
+      remaining.push(task);
+    }
+  }
+
+  // Second pass: fuzzy match only on tasks that didn't match by substring.
+  // Build one Fuse index over all remaining candidates to avoid per-task overhead.
+  if (normalizedSearch.length >= FUSE_OPTIONS.minMatchCharLength && remaining.length) {
+    const entries = remaining.flatMap((task, idx) =>
+      getSearchCandidates(task).map(candidate => ({ candidate, idx }))
+    );
+    const fuse = new Fuse(entries, { ...FUSE_OPTIONS, keys: ['candidate'] });
+    const fuzzyMatchIndices = new Set(fuse.search(normalizedSearch).map(r => r.item.idx));
+    const fuzzyMatched = remaining.filter((_, idx) => fuzzyMatchIndices.has(idx));
+    return [...substringMatched, ...fuzzyMatched];
+  }
+
+  return substringMatched;
+};
 
 const applyTasksFilters = (tasks: TaskWithLineage[], filters: TasksFilters = {}): TaskWithLineage[] => {
   let filtered = tasks;
@@ -24,6 +85,13 @@ const applyTasksFilters = (tasks: TaskWithLineage[], filters: TasksFilters = {})
     filtered = filtered.filter(task => {
       return task.lineageIds.some(id => filters.facilities?.selected.includes(id));
     });
+  }
+
+  if (filters.search) {
+    const normalizedSearch = normalizeText(filters.search);
+    if (normalizedSearch) {
+      filtered = filterTasksBySearch(filtered, normalizedSearch);
+    }
   }
 
   return filtered;

--- a/webapp/tests/karma/ts/selectors/index.spec.ts
+++ b/webapp/tests/karma/ts/selectors/index.spec.ts
@@ -609,6 +609,136 @@ describe('Selectors', () => {
         const result = Selectors.getFilteredTasksList.projector(tasksState, globalState);
         expect(result).to.deep.equal([]);
       });
+
+      it('should filter by freetext matching contact name, lineage, or title', () => {
+        const tasksState = {
+          tasksList: [
+            {
+              _id: 'task1',
+              title: 'Follow up',
+              contact: { name: 'Alice Johnson' },
+              lineage: ['Village Alpha'],
+              lineageIds: ['contact1']
+            },
+            {
+              _id: 'task2',
+              title: 'Vaccination',
+              contact: { name: 'Bob Smith' },
+              lineage: ['Village Beta'],
+              lineageIds: ['contact2']
+            },
+            {
+              _id: 'task3',
+              title: 'ANC Visit',
+              contact: { name: 'Carol' },
+              lineage: ['Village Gamma'],
+              lineageIds: ['contact3']
+            },
+          ],
+        };
+
+        const globalStateByName = { filters: { search: 'alice' } } as any;
+        const resultByName = Selectors.getFilteredTasksList.projector(tasksState, globalStateByName);
+        expect(resultByName).to.deep.equal([tasksState.tasksList[0]]);
+
+        const globalStateByLineage = { filters: { search: 'beta' } } as any;
+        const resultByLineage = Selectors.getFilteredTasksList.projector(tasksState, globalStateByLineage);
+        expect(resultByLineage).to.deep.equal([tasksState.tasksList[1]]);
+
+        const globalStateByTitle = { filters: { search: 'anc' } } as any;
+        const resultByTitle = Selectors.getFilteredTasksList.projector(tasksState, globalStateByTitle);
+        expect(resultByTitle).to.deep.equal([tasksState.tasksList[2]]);
+      });
+
+      it('should support search with Nepali and Arabic characters', () => {
+        const tasksState = {
+          tasksList: [
+            {
+              _id: 'task1',
+              title: 'Follow up',
+              contact: { name: 'रामकुमारी' },   
+              lineage: ['गाउँपालिका'],           
+              lineageIds: ['contact1']
+            },
+            {
+              _id: 'task2',
+              title: 'ANC Visit',
+              contact: { name: 'فاطمة' },        
+              lineage: ['مستشفى المدينة'],       
+              lineageIds: ['contact2']
+            },
+          ],
+        };
+
+        const nepaliState = { filters: { search: 'रामकुमारी' } } as any;
+        const nepaliResult = Selectors.getFilteredTasksList.projector(tasksState, nepaliState);
+        expect(nepaliResult).to.deep.equal([tasksState.tasksList[0]]);
+
+        const arabicState = { filters: { search: 'فاطمة' } } as any;
+        const arabicResult = Selectors.getFilteredTasksList.projector(tasksState, arabicState);
+        expect(arabicResult).to.deep.equal([tasksState.tasksList[1]]);
+
+        const crossScriptState = { filters: { search: 'فاطمة' } } as any;
+        const crossScriptResult = Selectors.getFilteredTasksList.projector(tasksState, crossScriptState);
+        expect(crossScriptResult).to.deep.equal([tasksState.tasksList[1]]);
+      });
+
+      it('should normalize diacritics in search', () => {
+        const tasksState = {
+          tasksList: [
+            {
+              _id: 'task1',
+              title: 'Follow up',
+              contact: { name: 'Élodie' },
+              lineage: ['Village Alpha'],
+              lineageIds: ['contact1']
+            },
+          ],
+        };
+
+        const globalState = { filters: { search: 'elodie' } } as any;
+        const result = Selectors.getFilteredTasksList.projector(tasksState, globalState);
+        expect(result).to.deep.equal([tasksState.tasksList[0]]);
+      });
+
+      it('should return all tasks when search is empty', () => {
+        const tasksState = {
+          tasksList: [
+            { _id: 'task1', title: 'Follow up', contact: { name: 'Alice' }, lineage: [], lineageIds: ['c1'] },
+            { _id: 'task2', title: 'ANC Visit', contact: { name: 'Bob' }, lineage: [], lineageIds: ['c2'] },
+          ],
+        };
+
+        const globalState = { filters: { search: '' } } as any;
+        const result = Selectors.getFilteredTasksList.projector(tasksState, globalState);
+        expect(result).to.deep.equal(tasksState.tasksList);
+      });
+
+      it('should return empty array when no tasks match the search', () => {
+        const tasksState = {
+          tasksList: [
+            { _id: 'task1', title: 'Follow up', contact: { name: 'Alice' }, lineage: ['Village'], lineageIds: ['c1'] },
+          ],
+        };
+
+        const globalState = { filters: { search: 'zzzznotfound' } } as any;
+        const result = Selectors.getFilteredTasksList.projector(tasksState, globalState);
+        expect(result).to.deep.equal([]);
+      });
+
+      it('should combine search with other filters', () => {
+        const tasksState = {
+          tasksList: [
+            { _id: 'task1', title: 'Home Visit', overdue: true, contact: { name: 'Alice' }, lineage: [], lineageIds: ['c1'] },
+            { _id: 'task2', title: 'Home Visit', overdue: false, contact: { name: 'Alice' }, lineage: [], lineageIds: ['c2'] },
+            { _id: 'task3', title: 'Assessment', overdue: true, contact: { name: 'Bob' }, lineage: [], lineageIds: ['c3'] },
+          ],
+        };
+
+        const globalState = { filters: { search: 'alice', taskOverdue: true } } as any;
+        const result = Selectors.getFilteredTasksList.projector(tasksState, globalState);
+        expect(result).to.deep.equal([tasksState.tasksList[0]]);
+      });
     });
   });
 });

--- a/webapp/tests/karma/ts/selectors/index.spec.ts
+++ b/webapp/tests/karma/ts/selectors/index.spec.ts
@@ -729,9 +729,18 @@ describe('Selectors', () => {
       it('should combine search with other filters', () => {
         const tasksState = {
           tasksList: [
-            { _id: 'task1', title: 'Home Visit', overdue: true, contact: { name: 'Alice' }, lineage: [], lineageIds: ['c1'] },
-            { _id: 'task2', title: 'Home Visit', overdue: false, contact: { name: 'Alice' }, lineage: [], lineageIds: ['c2'] },
-            { _id: 'task3', title: 'Assessment', overdue: true, contact: { name: 'Bob' }, lineage: [], lineageIds: ['c3'] },
+            {
+              _id: 'task1', title: 'Home Visit', overdue: true,
+              contact: { name: 'Alice' }, lineage: [], lineageIds: ['c1'],
+            },
+            {
+              _id: 'task2', title: 'Home Visit', overdue: false,
+              contact: { name: 'Alice' }, lineage: [], lineageIds: ['c2'],
+            },
+            {
+              _id: 'task3', title: 'Assessment', overdue: true,
+              contact: { name: 'Bob' }, lineage: [], lineageIds: ['c3'],
+            },
           ],
         };
 


### PR DESCRIPTION
# Description

Implements free text search on the tasks page, allowing users to filter the task list by typing in the search bar. The search matches against contact name, lineage (place hierarchy) and task title.

This picks up from #10727 and addresses all outstanding review feedback:
- **Performance**: replaced per-task Fuse.js instantiation with a single shared index built over unmatched candidates, avoiding redundant overhead on large task lists.
- **Two-pass strategy**: substring matching runs first for speed; fuzzy matching via Fuse.js only runs on the remaining tasks when the query is ≥ 3 characters.
- **Text normalisation**: input is lowercased and diacritics are stripped (NFD decomposition), so accented characters (e.g. `Élodie` → `elodie`) and non-Latin scripts (Nepali, Arabic) match as expected.
- **e2e tests**: added a new spec (`tasks-search.wdio-spec.js`) covering search by contact name, by task title, no-match state, clearing search, and combining search with sidebar filters.

Closes #10694

## Changes

| File | What |
|---|---|
| `webapp/src/ts/modules/tasks/tasks.component.html` | Enable `showFreetext` on the search bar |
| `webapp/src/ts/reducers/global.ts` | Add `search` field to `TasksFilters` interface |
| `webapp/src/ts/selectors/index.ts` | Search filtering logic with normalisation + Fuse.js |
| `webapp/package.json` | Add `fuse.js` dependency |
| `webapp/tests/karma/ts/selectors/index.spec.ts` | Unit tests for search, diacritics, Nepali/Arabic, edge cases |
| `tests/e2e/default/tasks/tasks-search.wdio-spec.js` | e2e tests for free text search |

# Code review checklist

- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [x] Tested: Unit and e2e tests included
- [x] Internationalised: Search supports accented, Nepali and Arabic characters
- [x] Backwards compatible: Search is additive; existing task filtering is unchanged

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.