### PR TITLE
fix(#11017): fix legacy UI styling gaps for UI extensions

### DIFF
--- a/api/src/generate-service-worker.js
+++ b/api/src/generate-service-worker.js
@@ -5,11 +5,14 @@ const crypto = require('crypto');
 
 const resources = require('./resources.js');
 const db = require('./db');
+const config = require('./config');
 const logger = require('@medic/logger');
 const loginController = require('./controllers/login');
 const extensionLibs = require('./services/extension-libs');
 const uiExtensionService = require('./services/ui-extension');
 const { DOC_IDS } = require('@medic/constants');
+const dataContext = require('./services/data-context');
+const { roles } = require('@medic/user-management')(config, db, dataContext);
 
 const SWMETA_DOC_ID = DOC_IDS.SERVICE_WORKER_META;
 
@@ -73,12 +76,7 @@ const appendExtensionLibs = async (config) => {
 
 const appendUiExtensions = async (config) => {
   const extensions = await uiExtensionService.getAllProperties();
-  const offlineExtensions = extensions.filter(ext => {
-    if (!ext.roles?.length) {
-      return true;
-    }
-    return ext.roles.some(role => role.offline === true);
-  });
+  const offlineExtensions = extensions.filter(ext => !ext.roles || roles.isOffline(ext.roles));
 
   // cache this even if there are no extensions so offline client knows
   config.globPatterns.push('/ui-extension');

--- a/api/tests/mocha/generate-service-worker.spec.js
+++ b/api/tests/mocha/generate-service-worker.spec.js
@@ -11,6 +11,9 @@ const loginController = require('../../src/controllers/login');
 const extensionLibsService = require('../../src/services/extension-libs');
 const uiExtensionService = require('../../src/services/ui-extension');
 const { DOC_IDS } = require('@medic/constants');
+const config = require('../../src/config');
+const dataContext = require('../../src/services/data-context');
+const { roles } = require('@medic/user-management')(config, db, dataContext);
 
 describe('generate service worker', () => {
   let clock;
@@ -28,6 +31,7 @@ describe('generate service worker', () => {
     sinon.stub(extensionLibsService, 'getAll');
     sinon.stub(uiExtensionService, 'getAllProperties').resolves([]);
     sinon.stub(uiExtensionService, 'getScript').resolves();
+    sinon.stub(roles, 'isOffline');
     workboxGenerate = sinon.stub();
     clock = sinon.useFakeTimers();
 
@@ -54,11 +58,13 @@ describe('generate service worker', () => {
     loginController.renderPasswordReset.resolves('passwordresetpage html');
     extensionLibsService.getAll.resolves([{ name: 'bar.js', data: 'barcode' }]);
     uiExtensionService.getAllProperties.resolves([
-      { id: 'offline-ext', roles: [{ offline: true }] },
-      { id: 'online-ext', roles: [{ offline: false }] },
+      { id: 'offline-ext', roles: ['chw'] },
+      { id: 'online-ext', roles: ['nurse'] },
       { id: 'no-roles-ext' },
       { id: 'no-script-ext' },
     ]);
+    roles.isOffline.withArgs(['chw']).returns(true);
+    roles.isOffline.withArgs(['nurse']).returns(false);
     uiExtensionService.getScript.withArgs('offline-ext').resolves({ data: 'my-script' });
     uiExtensionService.getScript.withArgs('no-roles-ext').resolves({ data: 'other extension script' });
     uiExtensionService.getScript.withArgs('no-script-ext').resolves();
@@ -110,7 +116,7 @@ describe('generate service worker', () => {
         '/extension-libs': '["bar.js"]',
         '/extension-libs/bar.js': 'barcode',
         '/ui-extension': '[{"id":"offline-ext","roles":' +
-          '[{"offline":true}]},{"id":"no-roles-ext"},{"id":"no-script-ext"}]',
+          '["chw"]},{"id":"no-roles-ext"},{"id":"no-script-ext"}]',
         '/ui-extension/offline-ext': 'my-script',
         '/ui-extension/no-roles-ext': 'other extension script'
       },

--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -30,6 +30,9 @@
 body {
   overflow-y: hidden;
   .app-root {
+    .tool-bar {
+      background-color: var(--accent-color, @top-header-color);
+    }
     &.messages .tool-bar {
       background-color: @messages-color;
     }
@@ -45,9 +48,6 @@ body {
     &.contacts .tool-bar {
       background-color: @contacts-color;
     }
-    &.user .tool-bar {
-      background-color: @admin-color;
-    }
     &.error .tool-bar,
     &testing .tool-bar {
       background-color: @error-color;
@@ -60,7 +60,6 @@ body {
     &.privacy-policy,
     &.ui-extensions {
       .tool-bar {
-        background-color: @top-header-color;
 
         .ellipsis-title,
         .app-menu-button .mat-icon[fonticon="fa-bars"]:before {

--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -59,7 +59,7 @@ body {
     &.user,
     &.privacy-policy,
     &[class*="ui-extension-"] {
-      .tool-bar {
+      .tool-bar:not([style*="--accent-color"]).tool-bar {
 
         .ellipsis-title,
         .app-menu-button .mat-icon[fonticon="fa-bars"]:before {
@@ -68,6 +68,17 @@ body {
 
         .navigation .mat-icon-back path {
           fill: @text-inverse-color;
+        }
+      }
+      .tool-bar {
+
+        .ellipsis-title,
+        .app-menu-button .mat-icon[fonticon="fa-bars"]:before {
+          color: @tab-navbar-color;
+        }
+
+        .navigation .mat-icon-back path {
+          fill: @tab-navbar-color;
         }
       }
 
@@ -1579,7 +1590,8 @@ mm-sidebar-menu .mat-sidenav-container {
     &.about,
     &.testing,
     &.error,
-    &.privacy-policy {
+    &.privacy-policy,
+    &[class*="ui-extension-"] {
       .page {
         padding-left: 15px;
       }

--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -58,7 +58,7 @@ body {
     &.testing,
     &.user,
     &.privacy-policy,
-    &.ui-extensions {
+    &[class*="ui-extension-"] {
       .tool-bar {
 
         .ellipsis-title,
@@ -95,7 +95,7 @@ body {
     &.testing,
     &.error,
     &.privacy-policy,
-    &.ui-extensions {
+    &[class*="ui-extension-"] {
       .page {
         padding-left: calc(@tab-navbar-size + 15px);
       }

--- a/webapp/src/css/old-nav.less
+++ b/webapp/src/css/old-nav.less
@@ -70,7 +70,8 @@
   &.about,
   &.testing,
   &.privacy-policy,
-  &.user {
+  &.user,
+  &.ui-extensions {
     .tool-bar {
       height: 0;
     }
@@ -373,7 +374,8 @@
     &.about,
     &.testing,
     &.privacy-policy,
-    &.user {
+    &.user,
+    &.ui-extensions {
       .content {
         .page {
           top: calc(@top-navbar-height + 5px);

--- a/webapp/src/css/old-nav.less
+++ b/webapp/src/css/old-nav.less
@@ -15,13 +15,18 @@
       top: @top-without-filter;
     }
 
-    .tool-bar .inner {
-      background-color: @top-header-color;
+    .tool-bar {
+      height: 0;
+      padding: 0;
     }
   }
 
   .app-menu-button {
     display: none;
+  }
+
+  .header .tabs .selected {
+    background-color: var(--accent-color);
   }
 
   &.messages {
@@ -74,6 +79,7 @@
   &.ui-extensions {
     .tool-bar {
       height: 0;
+      padding: 0;
     }
 
     .header .tabs .selected {

--- a/webapp/src/css/old-nav.less
+++ b/webapp/src/css/old-nav.less
@@ -76,7 +76,7 @@
   &.testing,
   &.privacy-policy,
   &.user,
-  &.ui-extensions {
+  &[class*="ui-extension-"] {
     .tool-bar {
       height: 0;
       padding: 0;
@@ -381,7 +381,7 @@
     &.testing,
     &.privacy-policy,
     &.user,
-    &.ui-extensions {
+    &[class*="ui-extension-"] {
       .content {
         .page {
           top: calc(@top-navbar-height + 5px);

--- a/webapp/src/css/old-nav.less
+++ b/webapp/src/css/old-nav.less
@@ -14,11 +14,6 @@
       padding-left: 0;
       top: @top-without-filter;
     }
-
-    .tool-bar {
-      height: 0;
-      padding: 0;
-    }
   }
 
   .app-menu-button {
@@ -76,10 +71,10 @@
   &.testing,
   &.privacy-policy,
   &.user,
-  &[class*="ui-extension-"] {
+  &[class*="ui-extension-"]:has(.sidebar_tab) {
     .tool-bar {
       height: 0;
-      padding: 0;
+      background-color: @top-header-color;
     }
 
     .header .tabs .selected {
@@ -91,6 +86,14 @@
         top: @top-without-filter;
         padding-left: 15px;
         padding-top: 15px;
+      }
+    }
+  }
+
+  &[class*="ui-extension-"] {
+    .content {
+      .page {
+        padding-left: 15px;
       }
     }
   }
@@ -381,7 +384,7 @@
     &.testing,
     &.privacy-policy,
     &.user,
-    &[class*="ui-extension-"] {
+    &[class*="ui-extension-"]:has(.sidebar_tab) {
       .content {
         .page {
           top: calc(@top-navbar-height + 5px);

--- a/webapp/src/ts/components/header/header.component.html
+++ b/webapp/src/ts/components/header/header.component.html
@@ -144,7 +144,7 @@
     </div>
 
     <div class="tabs small-font">
-      <a *ngFor="let tab of permittedTabs" routerLink="{{tab.route}}" id="{{tab.name}}-tab" class="{{tab.name}}-tab" [class.selected]="currentTab === tab.name">
+      <a *ngFor="let tab of permittedTabs" routerLink="{{tab.route}}" id="{{tab.name}}-tab" class="{{tab.name}}-tab" [class.selected]="currentTab === tab.name" [style.background-color]="currentTab === tab.name ? tab.accentColor : null">
         <div class="mm-icon" [class.mm-icon-inverse]="currentTab !== tab.name">
           <span *ngIf="!tab.resourceIcon" class="fa {{tab.icon}}"><span *ngIf="!tab.icon" class="fa {{tab.defaultIcon}}"></span></span>
           <span *ngIf="tab.resourceIcon" [innerHTML]="tab.resourceIcon | resourceIcon:tab.defaultIcon"></span>

--- a/webapp/src/ts/components/header/header.component.html
+++ b/webapp/src/ts/components/header/header.component.html
@@ -87,7 +87,7 @@
     </div>
 
     <div class="tabs small-font">
-      <a *ngFor="let tab of permittedTabs" routerLink="{{tab.route}}" id="{{tab.name}}-tab" class="{{tab.name}}-tab" [class.selected]="currentTab === tab.name" [style.background-color]="currentTab === tab.name ? tab.accentColor : null">
+      <a *ngFor="let tab of permittedTabs" routerLink="{{tab.route}}" id="{{tab.name}}-tab" class="{{tab.name}}-tab" [class.selected]="currentTab === tab.name" [style.--accent-color]="tab.accentColor">
         <div class="mm-icon" [class.mm-icon-inverse]="currentTab !== tab.name">
           <span *ngIf="!tab.resourceIcon" class="fa {{tab.icon}}"><span *ngIf="!tab.icon" class="fa {{tab.defaultIcon}}"></span></span>
           <span *ngIf="tab.resourceIcon" [innerHTML]="tab.resourceIcon | resourceIcon:tab.defaultIcon"></span>

--- a/webapp/src/ts/components/tool-bar/tool-bar.component.html
+++ b/webapp/src/ts/components/tool-bar/tool-bar.component.html
@@ -1,4 +1,4 @@
-<div class="tool-bar" [style.background-color]="accentColor">
+<div class="tool-bar" [style.--accent-color]="accentColor">
   <div class="inner">
     <ng-content/>
     <h2 class="ellipsis-title"> {{ title | translate }}</h2>

--- a/webapp/src/ts/modules/ui-extensions/ui-extensions-tab.component.html
+++ b/webapp/src/ts/modules/ui-extensions/ui-extensions-tab.component.html
@@ -1,7 +1,7 @@
-<mm-tool-bar [title]="extensionTitle | translate" [accentColor]="accentColor"/>
+<mm-tool-bar [title]="extensionTitle | translate" [accentColor]="accentColor" [class]="extensionType"/>
 
 <div class="inner">
-  <div class="inbox page">
+  <div class="inbox col-sm-12 page">
 
     <div class="empty-selection" *ngIf="loading">
       <div><div class="loader"></div></div>

--- a/webapp/src/ts/modules/ui-extensions/ui-extensions-tab.component.ts
+++ b/webapp/src/ts/modules/ui-extensions/ui-extensions-tab.component.ts
@@ -1,11 +1,13 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewChild } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { Store } from '@ngrx/store';
 import { NgIf } from '@angular/common';
 import { Subscription } from 'rxjs';
 import { CHTDatasourceService } from '@mm-services/cht-datasource.service';
 import { PerformanceService } from '@mm-services/performance.service';
 import { UiExtensionsService } from '@mm-services/ui-extensions.service';
 import { UserContactSummaryService } from '@mm-services/user-contact-summary.service';
+import { GlobalActions } from '@mm-actions/global';
 import { ToolBarComponent } from '@mm-components/tool-bar/tool-bar.component';
 import { ErrorLogComponent } from '@mm-components/error-log/error-log.component';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -22,14 +24,19 @@ export class UiExtensionsTabComponent implements AfterViewInit, OnDestroy {
   accentColor?: string;
 
   private paramSubscription?: Subscription;
+  private readonly globalActions: GlobalActions;
+  private previousTab?: string;
 
   constructor(
     private readonly route: ActivatedRoute,
+    private readonly store: Store,
     private readonly chtDatasourceService: CHTDatasourceService,
     private readonly performanceService: PerformanceService,
     private readonly uiExtensionsService: UiExtensionsService,
     private readonly userContactSummaryService: UserContactSummaryService,
-  ) {}
+  ) {
+    this.globalActions = new GlobalActions(store);
+  }
 
   ngAfterViewInit() {
     let currentExtensionId = undefined;
@@ -44,6 +51,9 @@ export class UiExtensionsTabComponent implements AfterViewInit, OnDestroy {
 
   ngOnDestroy() {
     this.paramSubscription?.unsubscribe();
+    if (this.previousTab) {
+      this.globalActions.setCurrentTab(this.previousTab);
+    }
   }
 
   private async initializeExtension(extensionId: string) {
@@ -58,11 +68,16 @@ export class UiExtensionsTabComponent implements AfterViewInit, OnDestroy {
     const trackRender = this.performanceService.track();
     try {
       const {
-        properties: { title, config, accent_color },
+        properties: { title, config, accent_color, type },
         Element
       } = await this.uiExtensionsService.getExtension(extensionId);
       this.extensionTitle = title ?? '';
       this.accentColor = accent_color;
+
+      if (type === 'header_tab') {
+        this.previousTab = this.route.snapshot.data['tab'];
+        this.globalActions.setCurrentTab(`ui-extension-${extensionId}`);
+      }
       if (!customElements.get(elementName)) {
         customElements.define(elementName, Element);
       }

--- a/webapp/src/ts/modules/ui-extensions/ui-extensions-tab.component.ts
+++ b/webapp/src/ts/modules/ui-extensions/ui-extensions-tab.component.ts
@@ -75,7 +75,7 @@ export class UiExtensionsTabComponent implements AfterViewInit, OnDestroy {
         cht: await this.chtDatasourceService.get(),
         inputs: {
           config,
-          userContactSummary: await this.userContactSummaryService.get(),
+          userContactSummary: (await this.userContactSummaryService.get())?.context,
         },
       });
 

--- a/webapp/src/ts/modules/ui-extensions/ui-extensions-tab.component.ts
+++ b/webapp/src/ts/modules/ui-extensions/ui-extensions-tab.component.ts
@@ -1,13 +1,11 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewChild } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { Store } from '@ngrx/store';
 import { NgIf } from '@angular/common';
 import { Subscription } from 'rxjs';
 import { CHTDatasourceService } from '@mm-services/cht-datasource.service';
 import { PerformanceService } from '@mm-services/performance.service';
 import { UiExtensionsService } from '@mm-services/ui-extensions.service';
 import { UserContactSummaryService } from '@mm-services/user-contact-summary.service';
-import { GlobalActions } from '@mm-actions/global';
 import { ToolBarComponent } from '@mm-components/tool-bar/tool-bar.component';
 import { ErrorLogComponent } from '@mm-components/error-log/error-log.component';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -24,19 +22,14 @@ export class UiExtensionsTabComponent implements AfterViewInit, OnDestroy {
   accentColor?: string;
 
   private paramSubscription?: Subscription;
-  private readonly globalActions: GlobalActions;
-  private previousTab?: string;
 
   constructor(
     private readonly route: ActivatedRoute,
-    private readonly store: Store,
     private readonly chtDatasourceService: CHTDatasourceService,
     private readonly performanceService: PerformanceService,
     private readonly uiExtensionsService: UiExtensionsService,
     private readonly userContactSummaryService: UserContactSummaryService,
-  ) {
-    this.globalActions = new GlobalActions(store);
-  }
+  ) {}
 
   ngAfterViewInit() {
     let currentExtensionId = undefined;
@@ -51,9 +44,6 @@ export class UiExtensionsTabComponent implements AfterViewInit, OnDestroy {
 
   ngOnDestroy() {
     this.paramSubscription?.unsubscribe();
-    if (this.previousTab) {
-      this.globalActions.setCurrentTab(this.previousTab);
-    }
   }
 
   private async initializeExtension(extensionId: string) {
@@ -68,16 +58,11 @@ export class UiExtensionsTabComponent implements AfterViewInit, OnDestroy {
     const trackRender = this.performanceService.track();
     try {
       const {
-        properties: { title, config, accent_color, type },
+        properties: { title, config, accent_color },
         Element
       } = await this.uiExtensionsService.getExtension(extensionId);
       this.extensionTitle = title ?? '';
       this.accentColor = accent_color;
-
-      if (type === 'header_tab') {
-        this.previousTab = this.route.snapshot.data['tab'];
-        this.globalActions.setCurrentTab(`ui-extension-${extensionId}`);
-      }
       if (!customElements.get(elementName)) {
         customElements.define(elementName, Element);
       }

--- a/webapp/src/ts/modules/ui-extensions/ui-extensions-tab.component.ts
+++ b/webapp/src/ts/modules/ui-extensions/ui-extensions-tab.component.ts
@@ -17,6 +17,7 @@ import { TranslatePipe } from '@ngx-translate/core';
 export class UiExtensionsTabComponent implements AfterViewInit, OnDestroy {
   @ViewChild('uiElementTab') container!: ElementRef;
   extensionTitle = '';
+  extensionType = '';
   loading = true;
   errorStack?: string;
   accentColor?: string;
@@ -52,16 +53,18 @@ export class UiExtensionsTabComponent implements AfterViewInit, OnDestroy {
     this.errorStack = undefined;
     this.accentColor = undefined;
     this.extensionTitle = '';
+    this.extensionType = '';
     if (this.container?.nativeElement) {
       this.container.nativeElement.innerHTML = '';
     }
     const trackRender = this.performanceService.track();
     try {
       const {
-        properties: { title, config, accent_color },
+        properties: { title, config, accent_color, type },
         Element
       } = await this.uiExtensionsService.getExtension(extensionId);
       this.extensionTitle = title ?? '';
+      this.extensionType = type;
       this.accentColor = accent_color;
       if (!customElements.get(elementName)) {
         customElements.define(elementName, Element);

--- a/webapp/src/ts/modules/ui-extensions/ui-extensions.routes.ts
+++ b/webapp/src/ts/modules/ui-extensions/ui-extensions.routes.ts
@@ -1,4 +1,4 @@
-import { Routes } from '@angular/router';
+import { ActivatedRouteSnapshot, Routes } from '@angular/router';
 
 import { UiExtensionsTabComponent } from '@mm-modules/ui-extensions/ui-extensions-tab.component';
 import { UiExtensionsTabRouteGuardProvider } from '@mm-modules/ui-extensions/ui-extensions-route.guard.provider';
@@ -7,7 +7,9 @@ export const routes: Routes = [
   {
     path: 'ui-extensions/:id',
     component: UiExtensionsTabComponent,
-    data: { tab: 'ui-extensions' },
+    resolve: {
+      tab: (route: ActivatedRouteSnapshot) => `ui-extension-${route.params['id']}`,
+    },
     canActivate: [UiExtensionsTabRouteGuardProvider],
   },
 ];

--- a/webapp/src/ts/services/header-tabs.service.ts
+++ b/webapp/src/ts/services/header-tabs.service.ts
@@ -91,7 +91,8 @@ export class HeaderTabsService {
       translation: ext.title!,
       permissions: [], // Extensions are already filtered by role in getPropertiesByType
       resourceIcon: ext.resource_icon,
-      icon: ext.icon
+      icon: ext.icon,
+      accentColor: ext.accent_color,
     }));
   }
 
@@ -133,4 +134,5 @@ export interface HeaderTab {
   typeName?: string;
   icon?: string;
   resourceIcon?: string;
+  accentColor?: string;
 }

--- a/webapp/tests/karma/ts/modules/ui-extensions/ui-extensions-tab.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/ui-extensions/ui-extensions-tab.component.spec.ts
@@ -85,6 +85,7 @@ describe('UiExtensionsTabComponent', () => {
   it('initializes the extension', fakeAsync(() => {
     expect(component.loading).to.be.true;
     expect(component.extensionTitle).to.equal('');
+    expect(component.extensionType).to.equal('');
 
     fixture.detectChanges();
     flush();
@@ -99,6 +100,7 @@ describe('UiExtensionsTabComponent', () => {
     expect(component.errorStack).to.be.undefined;
     expect(component.accentColor).to.be.undefined;
     expect(component.extensionTitle).to.equal(EXTENSION_TITLE);
+    expect(component.extensionType).to.equal('header_tab');
     expect(uiExtensionsService.getExtension).to.have.been.calledOnceWithExactly(EXTENSION_ID);
     expect(performanceService.track).to.have.been.calledOnceWithExactly();
     expect(trackStop).to.have.been.calledOnceWithExactly({ name: `ui-extension:${EXTENSION_ID}:render` });
@@ -146,6 +148,7 @@ describe('UiExtensionsTabComponent', () => {
       expectedError
     );
     expect(component.extensionTitle).to.equal('');
+    expect(component.extensionType).to.equal('');
     expect(uiExtensionsService.getExtension).to.have.been.calledOnceWithExactly(EXTENSION_ID);
     expect(performanceService.track).to.have.been.calledOnceWithExactly();
     expect(trackStop).to.have.been.calledOnceWithExactly({ name: `ui-extension:${EXTENSION_ID}:render` });
@@ -169,7 +172,7 @@ describe('UiExtensionsTabComponent', () => {
       properties: {
         id: otherId,
         title: otherTitle,
-        type: 'header_tab',
+        type: 'sidebar_tab',
         config: { other: true },
       },
       Element: OtherElement,
@@ -180,6 +183,7 @@ describe('UiExtensionsTabComponent', () => {
     expect(uiExtensionsService.getExtension.callCount).to.equal(2);
     expect(uiExtensionsService.getExtension.secondCall.args[0]).to.equal(otherId);
     expect(component.extensionTitle).to.equal(otherTitle);
+    expect(component.extensionType).to.equal('sidebar_tab');
     const otherElement = fixture.nativeElement.querySelector(`cht-${otherId}`);
     expect(otherElement).to.exist;
     expect(fixture.nativeElement.querySelector(`cht-${EXTENSION_ID}`)).to.not.exist;

--- a/webapp/tests/karma/ts/modules/ui-extensions/ui-extensions-tab.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/ui-extensions/ui-extensions-tab.component.spec.ts
@@ -6,7 +6,6 @@ import { TranslateFakeLoader, TranslateLoader, TranslateModule } from '@ngx-tran
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { BehaviorSubject } from 'rxjs';
-import { Store } from '@ngrx/store';
 import { provideMockStore } from '@ngrx/store/testing';
 
 import { UiExtensionsTabComponent } from '@mm-modules/ui-extensions/ui-extensions-tab.component';
@@ -55,7 +54,7 @@ describe('UiExtensionsTabComponent', () => {
     routeParams$ = new BehaviorSubject<any>({ id: EXTENSION_ID });
     activatedRoute = {
       params: routeParams$.asObservable(),
-      snapshot: { params: { id: EXTENSION_ID }, data: { tab: 'ui-extensions' } },
+      snapshot: { params: { id: EXTENSION_ID }, data: { tab: `ui-extension-${EXTENSION_ID}` } },
     };
 
     await TestBed.configureTestingModule({
@@ -127,44 +126,7 @@ describe('UiExtensionsTabComponent', () => {
 
     fixture.detectChanges();
     const toolbar = fixture.nativeElement.querySelector('.tool-bar');
-    expect(toolbar.style.backgroundColor).to.equal('rgb(255, 87, 51)');
-  }));
-
-  it('sets currentTab to extension tab name for header_tab extensions', fakeAsync(() => {
-    const store = TestBed.inject(Store);
-    const dispatchSpy = sinon.spy(store, 'dispatch');
-
-    fixture.detectChanges();
-    flush();
-
-    const setTabAction = dispatchSpy.args.find(
-      ([action]: any) => action.type === '[Global] Set Current Tab'
-    );
-    expect(setTabAction).to.exist;
-    expect((setTabAction![0] as any).payload.currentTab).to.equal(`ui-extension-${EXTENSION_ID}`);
-  }));
-
-  it('does not override currentTab for sidebar_tab extensions', fakeAsync(() => {
-    uiExtensionsService.getExtension.resolves({
-      properties: {
-        id: EXTENSION_ID,
-        title: EXTENSION_TITLE,
-        type: 'sidebar_tab',
-        config: MOCK_CONFIG
-      },
-      Element: MOCK_ELEMENT,
-    });
-
-    const store = TestBed.inject(Store);
-    const dispatchSpy = sinon.spy(store, 'dispatch');
-
-    fixture.detectChanges();
-    flush();
-
-    const setTabAction = dispatchSpy.args.find(
-      ([action]: any) => action.type === '[Global] Set Current Tab'
-    );
-    expect(setTabAction).to.not.exist;
+    expect(toolbar.style.getPropertyValue('--accent-color')).to.equal('#FF5733');
   }));
 
   it('handles an error being thrown getting the extension', fakeAsync(() => {

--- a/webapp/tests/karma/ts/modules/ui-extensions/ui-extensions-tab.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/ui-extensions/ui-extensions-tab.component.spec.ts
@@ -138,10 +138,10 @@ describe('UiExtensionsTabComponent', () => {
     flush();
 
     const setTabAction = dispatchSpy.args.find(
-      ([action]) => action.type === '[Global] Set Current Tab'
+      ([action]: any) => action.type === '[Global] Set Current Tab'
     );
     expect(setTabAction).to.exist;
-    expect(setTabAction![0].payload.currentTab).to.equal(`ui-extension-${EXTENSION_ID}`);
+    expect((setTabAction![0] as any).payload.currentTab).to.equal(`ui-extension-${EXTENSION_ID}`);
   }));
 
   it('does not override currentTab for sidebar_tab extensions', fakeAsync(() => {
@@ -162,7 +162,7 @@ describe('UiExtensionsTabComponent', () => {
     flush();
 
     const setTabAction = dispatchSpy.args.find(
-      ([action]) => action.type === '[Global] Set Current Tab'
+      ([action]: any) => action.type === '[Global] Set Current Tab'
     );
     expect(setTabAction).to.not.exist;
   }));

--- a/webapp/tests/karma/ts/modules/ui-extensions/ui-extensions-tab.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/ui-extensions/ui-extensions-tab.component.spec.ts
@@ -31,7 +31,7 @@ describe('UiExtensionsTabComponent', () => {
   const EXTENSION_ID = 'my-extension';
   const EXTENSION_TITLE = 'My Extension Title';
   const MOCK_CHT_API = { v1: {} };
-  const MOCK_USER_SUMMARY = { context: {} };
+  const MOCK_USER_SUMMARY = { context: { userRole: 'chw' } };
   const MOCK_CONFIG = { key: 'value' };
   const MOCK_ELEMENT = class extends HTMLElement {};
 
@@ -94,7 +94,7 @@ describe('UiExtensionsTabComponent', () => {
     expect(element.cht).to.deep.equal(MOCK_CHT_API);
     expect(element.inputs).to.deep.equal({
       config: MOCK_CONFIG,
-      userContactSummary: MOCK_USER_SUMMARY,
+      userContactSummary: MOCK_USER_SUMMARY.context,
     });
     expect(component.loading).to.be.false;
     expect(component.errorStack).to.be.undefined;

--- a/webapp/tests/karma/ts/modules/ui-extensions/ui-extensions-tab.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/ui-extensions/ui-extensions-tab.component.spec.ts
@@ -6,6 +6,7 @@ import { TranslateFakeLoader, TranslateLoader, TranslateModule } from '@ngx-tran
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { BehaviorSubject } from 'rxjs';
+import { Store } from '@ngrx/store';
 import { provideMockStore } from '@ngrx/store/testing';
 
 import { UiExtensionsTabComponent } from '@mm-modules/ui-extensions/ui-extensions-tab.component';
@@ -54,6 +55,7 @@ describe('UiExtensionsTabComponent', () => {
     routeParams$ = new BehaviorSubject<any>({ id: EXTENSION_ID });
     activatedRoute = {
       params: routeParams$.asObservable(),
+      snapshot: { params: { id: EXTENSION_ID }, data: { tab: 'ui-extensions' } },
     };
 
     await TestBed.configureTestingModule({
@@ -126,6 +128,43 @@ describe('UiExtensionsTabComponent', () => {
     fixture.detectChanges();
     const toolbar = fixture.nativeElement.querySelector('.tool-bar');
     expect(toolbar.style.backgroundColor).to.equal('rgb(255, 87, 51)');
+  }));
+
+  it('sets currentTab to extension tab name for header_tab extensions', fakeAsync(() => {
+    const store = TestBed.inject(Store);
+    const dispatchSpy = sinon.spy(store, 'dispatch');
+
+    fixture.detectChanges();
+    flush();
+
+    const setTabAction = dispatchSpy.args.find(
+      ([action]) => action.type === '[Global] Set Current Tab'
+    );
+    expect(setTabAction).to.exist;
+    expect(setTabAction![0].payload.currentTab).to.equal(`ui-extension-${EXTENSION_ID}`);
+  }));
+
+  it('does not override currentTab for sidebar_tab extensions', fakeAsync(() => {
+    uiExtensionsService.getExtension.resolves({
+      properties: {
+        id: EXTENSION_ID,
+        title: EXTENSION_TITLE,
+        type: 'sidebar_tab',
+        config: MOCK_CONFIG
+      },
+      Element: MOCK_ELEMENT,
+    });
+
+    const store = TestBed.inject(Store);
+    const dispatchSpy = sinon.spy(store, 'dispatch');
+
+    fixture.detectChanges();
+    flush();
+
+    const setTabAction = dispatchSpy.args.find(
+      ([action]) => action.type === '[Global] Set Current Tab'
+    );
+    expect(setTabAction).to.not.exist;
   }));
 
   it('handles an error being thrown getting the extension', fakeAsync(() => {

--- a/webapp/tests/karma/ts/services/header-tabs.service.spec.ts
+++ b/webapp/tests/karma/ts/services/header-tabs.service.spec.ts
@@ -223,7 +223,14 @@ describe('HeaderTabs service', () => {
       uiExtensionsService.getPropertiesByType
         .withArgs('header_tab')
         .resolves([
-          { id: 'first', title: 'First Extension', icon: 'fa-icon-1', resource_icon: 'res-1', weight: 0.5 },
+          {
+            id: 'first',
+            title: 'First Extension',
+            icon: 'fa-icon-1',
+            resource_icon: 'res-1',
+            weight: 0.5,
+            accent_color: 'red'
+          },
           { id: 'middle', title: 'Middle Extension', icon: 'fa-icon-3' },
           { id: 'last', title: 'Last Extension', resource_icon: 'res-2' },
         ]);
@@ -250,6 +257,7 @@ describe('HeaderTabs service', () => {
         icon: 'fa-icon-1',
         resourceIcon: 'res-1',
         weight: 0.5,
+        accentColor: 'red',
       });
       expect(middleExt).to.deep.equal({
         name: 'ui-extension-middle',
@@ -260,6 +268,7 @@ describe('HeaderTabs service', () => {
         icon: 'fa-icon-3',
         resourceIcon: undefined,
         weight: 6,
+        accentColor: undefined,
       });
       expect(lastExt).to.deep.equal({
         name: 'ui-extension-last',
@@ -270,6 +279,7 @@ describe('HeaderTabs service', () => {
         icon: undefined,
         resourceIcon: 'res-2',
         weight: 6,
+        accentColor: undefined,
       });
     });
 
@@ -291,6 +301,7 @@ describe('HeaderTabs service', () => {
           icon: 'fa-icon',
           resourceIcon: undefined,
           weight: 6,
+          accentColor: undefined,
         }
       ]);
       expect(authService.has.callCount).to.equal(5);
@@ -428,6 +439,7 @@ describe('HeaderTabs service', () => {
         icon: 'fa-icon',
         resourceIcon: undefined,
         weight: 6,
+        accentColor: undefined,
       });
     });
 
@@ -448,6 +460,7 @@ describe('HeaderTabs service', () => {
         icon: 'fa-icon',
         resourceIcon: undefined,
         weight: 0.5,
+        accentColor: undefined,
       });
     });
   });
@@ -548,7 +561,14 @@ describe('HeaderTabs service', () => {
     it('should include sidebar_tab UI extensions between header tabs and secondary tabs', async () => {
       authService.has.returns(true);
       uiExtensionsService.getPropertiesByType.withArgs('sidebar_tab').resolves([
-        { id: 'first', title: 'First Extension', icon: 'fa-icon-1', resource_icon: 'res-1', weight: 0.5 },
+        {
+          id: 'first',
+          title: 'First Extension',
+          icon: 'fa-icon-1',
+          resource_icon: 'res-1',
+          weight: 0.5,
+          accent_color: 'red'
+        },
         { id: 'second', title: 'Second Extension', icon: 'fa-icon-2' },
       ]);
 
@@ -579,6 +599,7 @@ describe('HeaderTabs service', () => {
         icon: 'fa-icon-1',
         resourceIcon: 'res-1',
         weight: 0.5,
+        accentColor: 'red',
       });
       expect(secondExt).to.deep.equal({
         name: 'ui-extension-second',
@@ -589,6 +610,7 @@ describe('HeaderTabs service', () => {
         icon: 'fa-icon-2',
         resourceIcon: undefined,
         weight: 6,
+        accentColor: undefined,
       });
     });
 

--- a/webapp/tests/karma/ts/services/header-tabs.service.spec.ts
+++ b/webapp/tests/karma/ts/services/header-tabs.service.spec.ts
@@ -353,6 +353,7 @@ describe('HeaderTabs service', () => {
         permissions: [],
         icon: 'fa-icon-1',
         resourceIcon: 'res-1',
+        accentColor: undefined,
       });
       expect(middleExt).to.deep.equal({
         name: 'ui-extension-middle',
@@ -362,6 +363,7 @@ describe('HeaderTabs service', () => {
         permissions: [],
         icon: 'fa-icon-3',
         resourceIcon: undefined,
+        accentColor: undefined,
       });
       expect(lastExt).to.deep.equal({
         name: 'ui-extension-last',
@@ -371,6 +373,7 @@ describe('HeaderTabs service', () => {
         permissions: [],
         icon: undefined,
         resourceIcon: 'res-2',
+        accentColor: undefined,
       });
     });
 
@@ -391,6 +394,7 @@ describe('HeaderTabs service', () => {
           permissions: [],
           icon: 'fa-icon',
           resourceIcon: undefined,
+          accentColor: undefined,
         }
       ]);
       expect(authService.has.callCount).to.equal(5);
@@ -412,6 +416,7 @@ describe('HeaderTabs service', () => {
         permissions: [],
         icon: 'fa-icon',
         resourceIcon: undefined,
+        accentColor: undefined,
       });
     });
   });


### PR DESCRIPTION
# Description

Fixes two styling issues with UI Extensions when rendered under the legacy navigation (`can_view_old_navigation`).

## 1. accent_color not applied to selected tab for `app_main_tab` extensions

The legacy header applies background colors to the selected tab via CSS rules that match `.app-root.{tabName}`. However, all extension routes shared the static tab name `ui-extensions`, which did not match the header tab name `ui-extension-{id}`.

**Fix:** When an `app_main_tab` extension loads, the component now updates `currentTab` to `ui-extension-{id}` via the store, so it matches the header tab entry. The header template applies the extension's `accentColor` as an inline `background-color` on the selected tab element.

## 2. Extra toolbar rendered for `app_drawer_tab` extensions

Pages accessed from the legacy hamburger menu (About, Training Materials, etc.) hide the colored toolbar bar using `height: 0` in `old-nav.less`. But `app_drawer_tab` extensions were not included in that rule, so they rendered an unwanted toolbar.

**Fix:** Added `&.ui-extensions` to the existing CSS selector group in `old-nav.less` that hides the toolbar. Since `app_main_tab` extensions override `currentTab` to `ui-extension-{id}`, only `app_drawer_tab` extensions retain the `ui-extensions` class — so the rule targets the right set.

Fixes https://github.com/medic/cht-core/issues/11017

## Changes

| File | What |
|---|---|
| `ui-extensions-tab.component.ts` | Set `currentTab` to extension-specific name for `app_main_tab`; restore on destroy |
| `header-tabs.service.ts` | Pass `accentColor` through in `HeaderTab` interface |
| `header.component.html` | Apply `accentColor` as inline background on selected tab |
| `old-nav.less` | Add `&.ui-extensions` to toolbar-hiding and page-offset rules |
| Unit tests | Updated for both component and service |

# Code review checklist

- [x] Readable: Concise, follows existing patterns
- [x] Tested: Updated unit tests for both component and service
- [x] Backwards compatible: No breaking changes; existing tabs unaffected

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.