### PR TITLE
feat(#11018): rebuild service worker on UI extension changes

### DIFF
--- a/api/src/services/config-watcher.js
+++ b/api/src/services/config-watcher.js
@@ -184,6 +184,10 @@ const listen = () => {
     if (extensionLibs.isLibChange(change)) {
       return handleLibsChanges();
     }
+
+    if (change.id.startsWith('ui-extension:')) {
+      return updateServiceWorker();
+    }
   });
 };
 

--- a/api/src/services/config-watcher.js
+++ b/api/src/services/config-watcher.js
@@ -17,6 +17,7 @@ const config = require('../config');
 const environment = require('@medic/environment');
 const dataContext = require('./data-context');
 const extensionLibs = require('./extension-libs');
+const uiExtension = require('./ui-extension');
 const deployInfo = require('./deploy-info');
 
 const MEDIC_DDOC_ID = '_design/medic';
@@ -127,10 +128,6 @@ const handleBrandingChanges = () => {
     .then(() => updateServiceWorker());
 };
 
-const handleLibsChanges = () => {
-  return updateServiceWorker();
-};
-
 const updateManifest = () => {
   return manifest.generate().catch(err => {
     logger.error('Failed to generate manifest: %o', err);
@@ -182,10 +179,10 @@ const listen = () => {
     }
 
     if (extensionLibs.isLibChange(change)) {
-      return handleLibsChanges();
+      return updateServiceWorker();
     }
 
-    if (change.id.startsWith('ui-extension:')) {
+    if (uiExtension.isExtensionChange(change)) {
       return updateServiceWorker();
     }
   });

--- a/api/src/services/ui-extension.js
+++ b/api/src/services/ui-extension.js
@@ -13,6 +13,8 @@ const getExtensionDoc = (name) => {
 };
 
 module.exports = {
+  isExtensionChange: ({ id }) => id.startsWith(PREFIX),
+
   getScript: async (name) => {
     const doc = await getExtensionDoc(name);
     const attachment = doc?._attachments?.['extension.js'];

--- a/api/tests/mocha/services/config-watcher.spec.js
+++ b/api/tests/mocha/services/config-watcher.spec.js
@@ -325,5 +325,29 @@ describe('Configuration', () => {
 
     });
 
+    describe('ui extension changes', () => {
+
+      it('generates service worker when a ui-extension doc is created', () => {
+        generateServiceWorker.run.resolves();
+        return dbWatcher.medic.args[0][0]({ id: 'ui-extension:my-ext' }).then(() => {
+          chai.expect(generateServiceWorker.run.callCount).to.equal(1);
+        });
+      });
+
+      it('generates service worker when a ui-extension doc is updated', () => {
+        generateServiceWorker.run.resolves();
+        return dbWatcher.medic.args[0][0]({ id: 'ui-extension:another-ext' }).then(() => {
+          chai.expect(generateServiceWorker.run.callCount).to.equal(1);
+        });
+      });
+
+      it('does not generate service worker for unrelated doc changes', () => {
+        generateServiceWorker.run.resolves();
+        dbWatcher.medic.args[0][0]({ id: 'some-other-doc' });
+        chai.expect(generateServiceWorker.run.callCount).to.equal(0);
+      });
+
+    });
+
   });
 });

--- a/api/tests/mocha/services/config-watcher.spec.js
+++ b/api/tests/mocha/services/config-watcher.spec.js
@@ -9,6 +9,7 @@ const dbWatcher = require('../../../src/services/db-watcher');
 const settingsService = require('../../../src/services/settings');
 const translations = require('../../../src/translations');
 const extensionLibsService = require('../../../src/services/extension-libs');
+const uiExtensionService = require('../../../src/services/ui-extension');
 const generateServiceWorker = require('../../../src/generate-service-worker');
 const generateXform = require('../../../src/services/generate-xform');
 const config = require('../../../src/config');
@@ -28,6 +29,7 @@ describe('Configuration', () => {
     sinon.stub(generateServiceWorker, 'run');
     sinon.stub(manifest, 'generate');
     sinon.stub(extensionLibsService, 'isLibChange').returns(false);
+    sinon.stub(uiExtensionService, 'isExtensionChange').returns(false);
     sinon.spy(config, 'set');
     sinon.spy(config, 'setTranslationCache');
     sinon.spy(config, 'setTransitionsLib');
@@ -327,16 +329,11 @@ describe('Configuration', () => {
 
     describe('ui extension changes', () => {
 
-      it('generates service worker when a ui-extension doc is created', () => {
+      it('generates service worker when a ui-extension doc change is detected', () => {
+        uiExtensionService.isExtensionChange.returns(true);
         generateServiceWorker.run.resolves();
         return dbWatcher.medic.args[0][0]({ id: 'ui-extension:my-ext' }).then(() => {
-          chai.expect(generateServiceWorker.run.callCount).to.equal(1);
-        });
-      });
-
-      it('generates service worker when a ui-extension doc is updated', () => {
-        generateServiceWorker.run.resolves();
-        return dbWatcher.medic.args[0][0]({ id: 'ui-extension:another-ext' }).then(() => {
+          chai.expect(uiExtensionService.isExtensionChange.calledWith({ id: 'ui-extension:my-ext' })).to.be.true;
           chai.expect(generateServiceWorker.run.callCount).to.equal(1);
         });
       });

--- a/api/tests/mocha/services/ui-extension.spec.js
+++ b/api/tests/mocha/services/ui-extension.spec.js
@@ -14,6 +14,16 @@ describe('UI Extension service', () => {
 
   afterEach(() => sinon.restore());
 
+  describe('isExtensionChange', () => {
+    it('is falsy for unrelated doc', () => {
+      expect(service.isExtensionChange({ id: 'some-other-doc' })).to.be.false;
+    });
+
+    it('returns true for a ui-extension doc', () => {
+      expect(service.isExtensionChange({ id: 'ui-extension:my-ext' })).to.be.true;
+    });
+  });
+
   describe('getScript', () => {
     it('handles undefined doc', async () => {
       dbGet.resolves(undefined);


### PR DESCRIPTION
## Description

Fixes https://github.com/medic/cht-core/issues/11018

When a `ui-extension:*` document is created or updated in CouchDB, the service worker is now rebuilt automatically. This ensures that new or modified UI extensions are available to users without requiring a server restart.

## Changes

- Added a `ui-extension:` prefix check in `config-watcher.listen()` that triggers `updateServiceWorker()` when a UI extension doc changes
- Added unit tests covering create, update, and unrelated doc scenarios

## Test plan

- [ ] Create a new `ui-extension:*` doc in medic database and verify the service worker is regenerated
- [ ] Update an existing `ui-extension:*` doc and verify the service worker is regenerated
- [ ] Verify unrelated doc changes do not trigger a service worker rebuild
- [ ] Unit tests pass: `npx mocha api/tests/mocha/services/config-watcher.spec.js --exit`