### PR TITLE
fix(#11019): reload extension content when navigating between tabs

### DIFF
--- a/webapp/src/ts/modules/ui-extensions/ui-extensions-tab.component.ts
+++ b/webapp/src/ts/modules/ui-extensions/ui-extensions-tab.component.ts
@@ -1,6 +1,7 @@
-import { AfterViewInit, Component, ElementRef, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewChild } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { NgIf } from '@angular/common';
+import { Subscription } from 'rxjs';
 import { CHTDatasourceService } from '@mm-services/cht-datasource.service';
 import { PerformanceService } from '@mm-services/performance.service';
 import { UiExtensionsService } from '@mm-services/ui-extensions.service';
@@ -13,12 +14,14 @@ import { TranslatePipe } from '@ngx-translate/core';
   templateUrl: './ui-extensions-tab.component.html',
   imports: [ToolBarComponent, ErrorLogComponent, TranslatePipe, NgIf]
 })
-export class UiExtensionsTabComponent implements AfterViewInit {
+export class UiExtensionsTabComponent implements AfterViewInit, OnDestroy {
   @ViewChild('uiElementTab') container!: ElementRef;
   extensionTitle = '';
   loading = true;
   errorStack?: string;
   accentColor?: string;
+
+  private paramSubscription?: Subscription;
 
   constructor(
     private readonly route: ActivatedRoute,
@@ -30,11 +33,29 @@ export class UiExtensionsTabComponent implements AfterViewInit {
 
   async ngAfterViewInit() {
     await this.initializeExtension();
+    this.paramSubscription = this.route.params.subscribe(async (params) => {
+      const currentTag = this.container?.nativeElement?.firstElementChild?.tagName?.toLowerCase();
+      const newTag = `cht-${params['id'].toLowerCase()}`;
+      if (currentTag && currentTag !== newTag) {
+        await this.initializeExtension();
+      }
+    });
+  }
+
+  ngOnDestroy() {
+    this.paramSubscription?.unsubscribe();
   }
 
   private async initializeExtension() {
     const extensionId = this.route.snapshot.params['id'];
     const elementName = `cht-${extensionId.toLowerCase()}`;
+    this.loading = true;
+    this.errorStack = undefined;
+    this.accentColor = undefined;
+    this.extensionTitle = '';
+    if (this.container?.nativeElement) {
+      this.container.nativeElement.innerHTML = '';
+    }
     const trackRender = this.performanceService.track();
     try {
       const {

--- a/webapp/src/ts/modules/ui-extensions/ui-extensions-tab.component.ts
+++ b/webapp/src/ts/modules/ui-extensions/ui-extensions-tab.component.ts
@@ -31,14 +31,14 @@ export class UiExtensionsTabComponent implements AfterViewInit, OnDestroy {
     private readonly userContactSummaryService: UserContactSummaryService,
   ) {}
 
-  async ngAfterViewInit() {
-    await this.initializeExtension();
+  ngAfterViewInit() {
+    let currentExtensionId = undefined;
     this.paramSubscription = this.route.params.subscribe(async (params) => {
-      const currentTag = this.container?.nativeElement?.firstElementChild?.tagName?.toLowerCase();
-      const newTag = `cht-${params['id'].toLowerCase()}`;
-      if (currentTag && currentTag !== newTag) {
-        await this.initializeExtension();
+      if (currentExtensionId === params['id']) {
+        return;
       }
+      currentExtensionId = params['id'];
+      this.initializeExtension(params['id']);
     });
   }
 
@@ -46,8 +46,7 @@ export class UiExtensionsTabComponent implements AfterViewInit, OnDestroy {
     this.paramSubscription?.unsubscribe();
   }
 
-  private async initializeExtension() {
-    const extensionId = this.route.snapshot.params['id'];
+  private async initializeExtension(extensionId: string) {
     const elementName = `cht-${extensionId.toLowerCase()}`;
     this.loading = true;
     this.errorStack = undefined;

--- a/webapp/tests/karma/ts/modules/ui-extensions/ui-extensions-tab.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/ui-extensions/ui-extensions-tab.component.spec.ts
@@ -5,7 +5,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { TranslateFakeLoader, TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { Subject } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 import { provideMockStore } from '@ngrx/store/testing';
 
 import { UiExtensionsTabComponent } from '@mm-modules/ui-extensions/ui-extensions-tab.component';
@@ -25,7 +25,7 @@ describe('UiExtensionsTabComponent', () => {
   let performanceService;
   let userContactSummaryService;
   let trackStop;
-  let routeParams$: Subject<any>;
+  let routeParams$: BehaviorSubject<any>;
   let activatedRoute;
 
   const EXTENSION_ID = 'my-extension';
@@ -51,9 +51,8 @@ describe('UiExtensionsTabComponent', () => {
         Element: MOCK_ELEMENT,
       }),
     };
-    routeParams$ = new Subject();
+    routeParams$ = new BehaviorSubject<any>({ id: EXTENSION_ID });
     activatedRoute = {
-      snapshot: { params: { id: EXTENSION_ID } },
       params: routeParams$.asObservable(),
     };
 
@@ -158,29 +157,29 @@ describe('UiExtensionsTabComponent', () => {
     flush();
 
     expect(uiExtensionsService.getExtension.callCount).to.equal(1);
+    expect(uiExtensionsService.getExtension.firstCall.args[0]).to.equal(EXTENSION_ID);
     const firstElement = fixture.nativeElement.querySelector(`cht-${EXTENSION_ID}`);
     expect(firstElement).to.exist;
 
-    const OTHER_ID = 'other-extension';
-    const OTHER_TITLE = 'Other Extension';
+    const otherId = 'other-extension';
+    const otherTitle = 'Other Extension';
     const OtherElement = class extends HTMLElement {};
     uiExtensionsService.getExtension.resolves({
       properties: {
-        id: OTHER_ID,
-        title: OTHER_TITLE,
+        id: otherId,
+        title: otherTitle,
         type: 'app_main_tab',
         config: { other: true },
       },
       Element: OtherElement,
     });
-    activatedRoute.snapshot.params = { id: OTHER_ID };
-    routeParams$.next({ id: OTHER_ID });
+    routeParams$.next({ id: otherId });
     flush();
 
     expect(uiExtensionsService.getExtension.callCount).to.equal(2);
-    expect(uiExtensionsService.getExtension.secondCall.args[0]).to.equal(OTHER_ID);
-    expect(component.extensionTitle).to.equal(OTHER_TITLE);
-    const otherElement = fixture.nativeElement.querySelector(`cht-${OTHER_ID}`);
+    expect(uiExtensionsService.getExtension.secondCall.args[0]).to.equal(otherId);
+    expect(component.extensionTitle).to.equal(otherTitle);
+    const otherElement = fixture.nativeElement.querySelector(`cht-${otherId}`);
     expect(otherElement).to.exist;
     expect(fixture.nativeElement.querySelector(`cht-${EXTENSION_ID}`)).to.not.exist;
   }));
@@ -201,11 +200,11 @@ describe('UiExtensionsTabComponent', () => {
     fixture.detectChanges();
     flush();
 
+    expect(uiExtensionsService.getExtension.callCount).to.equal(1);
+
     component.ngOnDestroy();
 
-    const OTHER_ID = 'other-extension';
-    activatedRoute.snapshot.params = { id: OTHER_ID };
-    routeParams$.next({ id: OTHER_ID });
+    routeParams$.next({ id: 'other-extension' });
     flush();
 
     expect(uiExtensionsService.getExtension.callCount).to.equal(1);

--- a/webapp/tests/karma/ts/modules/ui-extensions/ui-extensions-tab.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/ui-extensions/ui-extensions-tab.component.spec.ts
@@ -5,6 +5,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { TranslateFakeLoader, TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { expect } from 'chai';
 import sinon from 'sinon';
+import { Subject } from 'rxjs';
 import { provideMockStore } from '@ngrx/store/testing';
 
 import { UiExtensionsTabComponent } from '@mm-modules/ui-extensions/ui-extensions-tab.component';
@@ -24,6 +25,8 @@ describe('UiExtensionsTabComponent', () => {
   let performanceService;
   let userContactSummaryService;
   let trackStop;
+  let routeParams$: Subject<any>;
+  let activatedRoute;
 
   const EXTENSION_ID = 'my-extension';
   const EXTENSION_TITLE = 'My Extension Title';
@@ -48,6 +51,11 @@ describe('UiExtensionsTabComponent', () => {
         Element: MOCK_ELEMENT,
       }),
     };
+    routeParams$ = new Subject();
+    activatedRoute = {
+      snapshot: { params: { id: EXTENSION_ID } },
+      params: routeParams$.asObservable(),
+    };
 
     await TestBed.configureTestingModule({
       imports: [
@@ -58,7 +66,7 @@ describe('UiExtensionsTabComponent', () => {
       ],
       providers: [
         provideMockStore(),
-        { provide: ActivatedRoute, useValue: { snapshot: { params: { id: EXTENSION_ID } } } },
+        { provide: ActivatedRoute, useValue: activatedRoute },
         { provide: UiExtensionsService, useValue: uiExtensionsService },
         { provide: CHTDatasourceService, useValue: chtDatasourceService },
         { provide: PerformanceService, useValue: performanceService },
@@ -143,5 +151,63 @@ describe('UiExtensionsTabComponent', () => {
     expect(trackStop).to.have.been.calledOnceWithExactly({ name: `ui-extension:${EXTENSION_ID}:render` });
     expect(chtDatasourceService.get).to.not.have.been.called;
     expect(userContactSummaryService.get).to.not.have.been.called;
+  }));
+
+  it('re-initializes when route params change to a different extension', fakeAsync(() => {
+    fixture.detectChanges();
+    flush();
+
+    expect(uiExtensionsService.getExtension.callCount).to.equal(1);
+    const firstElement = fixture.nativeElement.querySelector(`cht-${EXTENSION_ID}`);
+    expect(firstElement).to.exist;
+
+    const OTHER_ID = 'other-extension';
+    const OTHER_TITLE = 'Other Extension';
+    const OtherElement = class extends HTMLElement {};
+    uiExtensionsService.getExtension.resolves({
+      properties: {
+        id: OTHER_ID,
+        title: OTHER_TITLE,
+        type: 'app_main_tab',
+        config: { other: true },
+      },
+      Element: OtherElement,
+    });
+    activatedRoute.snapshot.params = { id: OTHER_ID };
+    routeParams$.next({ id: OTHER_ID });
+    flush();
+
+    expect(uiExtensionsService.getExtension.callCount).to.equal(2);
+    expect(uiExtensionsService.getExtension.secondCall.args[0]).to.equal(OTHER_ID);
+    expect(component.extensionTitle).to.equal(OTHER_TITLE);
+    const otherElement = fixture.nativeElement.querySelector(`cht-${OTHER_ID}`);
+    expect(otherElement).to.exist;
+    expect(fixture.nativeElement.querySelector(`cht-${EXTENSION_ID}`)).to.not.exist;
+  }));
+
+  it('does not re-initialize when route params emit the same extension id', fakeAsync(() => {
+    fixture.detectChanges();
+    flush();
+
+    expect(uiExtensionsService.getExtension.callCount).to.equal(1);
+
+    routeParams$.next({ id: EXTENSION_ID });
+    flush();
+
+    expect(uiExtensionsService.getExtension.callCount).to.equal(1);
+  }));
+
+  it('cleans up param subscription on destroy', fakeAsync(() => {
+    fixture.detectChanges();
+    flush();
+
+    component.ngOnDestroy();
+
+    const OTHER_ID = 'other-extension';
+    activatedRoute.snapshot.params = { id: OTHER_ID };
+    routeParams$.next({ id: OTHER_ID });
+    flush();
+
+    expect(uiExtensionsService.getExtension.callCount).to.equal(1);
   }));
 });


### PR DESCRIPTION
## Description

Fixes https://github.com/medic/cht-core/issues/11019

When navigating between multiple UI extension tabs, the `UiExtensionsTabComponent` was not re-rendering because Angular reuses the same component instance for `ui-extensions/:id` — only the `:id` param changes. Since extension initialization only ran in `ngAfterViewInit` (which fires once), the original extension's content stayed visible even after the URL changed.

## Changes

- Subscribe to `ActivatedRoute.params` in `ngAfterViewInit` to detect when the `:id` parameter changes
- When a different extension is navigated to, clear the container and re-run `initializeExtension()` with the new id
- Reset component state (loading, error, title, accent color) before each initialization
- Unsubscribe from params on component destroy to prevent memory leaks
- Added tests for navigation between extensions, same-id no-op, and cleanup on destroy

## Test plan

- [ ] Configure two or more UI extensions as `app_main_tab`
- [ ] Navigate from one extension tab to another via header tabs
- [ ] Verify the target extension's content renders correctly
- [ ] Navigate back to the first extension and verify it renders again
- [ ] Verify the loading spinner shows during each transition
- [ ] Unit tests pass