### PR TITLE
fix(#11033): split Basic Auth credentials at first colon only

### DIFF
--- a/api/src/auth.js
+++ b/api/src/auth.js
@@ -84,7 +84,10 @@ module.exports = {
       return false;
     }
     try {
-      const [username, password] = Buffer.from(authHeader.split(' ')[1], 'base64').toString().split(':');
+      const decoded = Buffer.from(authHeader.split(' ')[1], 'base64').toString();
+      const colonIdx = decoded.indexOf(':');
+      const username = decoded.substring(0, colonIdx);
+      const password = decoded.substring(colonIdx + 1);
       return { username, password };
     } catch {
       throw Error('Corrupted Auth header');

--- a/api/src/auth.js
+++ b/api/src/auth.js
@@ -86,9 +86,13 @@ module.exports = {
     try {
       const decoded = Buffer.from(authHeader.split(' ')[1], 'base64').toString();
       const colonIdx = decoded.indexOf(':');
-      const username = decoded.substring(0, colonIdx);
-      const password = decoded.substring(colonIdx + 1);
-      return { username, password };
+      if (colonIdx === -1) {
+        throw new Error('missing colon separator');
+      }
+      return {
+        username: decoded.substring(0, colonIdx),
+        password: decoded.substring(colonIdx + 1)
+      };
     } catch {
       throw Error('Corrupted Auth header');
     }

--- a/api/tests/mocha/auth.spec.js
+++ b/api/tests/mocha/auth.spec.js
@@ -216,6 +216,43 @@ describe('Auth', () => {
     });
   });
 
+  describe('basicAuthCredentials', () => {
+    const encode = (str) => Buffer.from(str).toString('base64');
+
+    it('returns false when authorization header is missing', () => {
+      chai.expect(auth.basicAuthCredentials({ headers: {} })).to.be.false;
+    });
+
+    it('returns false when authorization header is not Basic', () => {
+      chai.expect(auth.basicAuthCredentials({ headers: { authorization: 'Bearer token' } })).to.be.false;
+    });
+
+    it('extracts username and password from a valid Basic auth header', () => {
+      const result = auth.basicAuthCredentials({
+        headers: { authorization: `Basic ${encode('alice:mypassword')}` }
+      });
+      chai.expect(result).to.deep.equal({ username: 'alice', password: 'mypassword' });
+    });
+
+    it('preserves colons in the password', () => {
+      const result = auth.basicAuthCredentials({
+        headers: { authorization: `Basic ${encode('alice:P@ss:word:123')}` }
+      });
+      chai.expect(result).to.deep.equal({ username: 'alice', password: 'P@ss:word:123' });
+    });
+
+    it('handles an empty password', () => {
+      const result = auth.basicAuthCredentials({
+        headers: { authorization: `Basic ${encode('alice:')}` }
+      });
+      chai.expect(result).to.deep.equal({ username: 'alice', password: '' });
+    });
+
+    it('returns false when req has no headers', () => {
+      chai.expect(auth.basicAuthCredentials({})).to.be.false;
+    });
+  });
+
   describe('assertPermissions', () => {
     const requestOptions = {
       url: 'http://abc.com/_session',

--- a/api/tests/mocha/auth.spec.js
+++ b/api/tests/mocha/auth.spec.js
@@ -248,8 +248,10 @@ describe('Auth', () => {
       chai.expect(result).to.deep.equal({ username: 'alice', password: '' });
     });
 
-    it('returns false when req has no headers', () => {
-      chai.expect(auth.basicAuthCredentials({})).to.be.false;
+    it('throws Corrupted Auth header when credential has no colon separator', () => {
+      chai.expect(() => auth.basicAuthCredentials({
+        headers: { authorization: `Basic ${encode('usernameonly')}` }
+      })).to.throw('Corrupted Auth header');
     });
   });
 


### PR DESCRIPTION
`basicAuthCredentials` in `api/src/auth.js` decoded the `Authorization` header and split the result on every `:`, assigning only the first two elements to username and password. This meant any password containing a colon (e.g. `P@ss:word123`) was silently truncated, causing a 401 for valid credentials on any route that goes through `basicAuthCredentials`.

The fix uses `indexOf(':')` to find the first colon and `substring` to split there, leaving the rest of the string intact as the password. This matches the RFC 7617 requirement that only the first colon separates the user-info into username and password.

Unit tests for `basicAuthCredentials` are added to `api/tests/mocha/auth.spec.js`, covering the normal case, a password with multiple colons, an empty password, a missing header, a non-Basic scheme, and a missing headers object.

Closes #11033