### PR TITLE
feat(#10908): support order weight for header and sidebar tabs

### DIFF
--- a/webapp/src/ts/components/sidebar-menu/sidebar-menu.component.ts
+++ b/webapp/src/ts/components/sidebar-menu/sidebar-menu.component.ts
@@ -21,6 +21,31 @@ import { SettingsService } from '@mm-services/settings.service';
 import { filter } from 'rxjs/operators';
 import { Selectors } from '@mm-selectors/index';
 
+export interface ExtensionOption {
+  id?: string;
+  name?: string;
+  route?: string;
+  icon?: string;
+  title?: string;
+  permissions?: string[];
+  weight?: number;
+}
+
+export interface ChtSettings {
+  header_tabs?: Record<string, { weight?: number; icon?: string; resource_icon?: string; }>;
+  app_main_tab?: ExtensionOption[];
+}
+
+export interface MenuOption {
+  icon: string;
+  translationKey: string;
+  routerLink?: string;
+  hasPermissions?: string;
+  canDisplay?: boolean;
+  click?: () => void;
+  weight?: number;
+}
+
 @Component({
   selector: 'mm-sidebar-menu',
   templateUrl: './sidebar-menu.component.html',
@@ -43,7 +68,7 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
   @Input() canLogOut: boolean = false;
   @ViewChild('sidebar') sidebar!: MatSidenav;
   private globalActions: GlobalActions;
-  replicationStatus: any;
+
   moduleOptions: MenuOption[] = [];
   secondaryOptions: MenuOption[] = [];
   adminAppPath: string = '';
@@ -79,7 +104,7 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
   }
 
   replicate(): void {
-    if (this.replicationStatus?.current?.disableSyncButton) {
+    if ((this as any).replicationStatus?.current?.disableSyncButton) {
       return;
     }
     super.replicate();
@@ -116,14 +141,14 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
   }
 
   private async setModuleOptions() {
-    let settings: Record<string, any> = {};
+    let settings: ChtSettings = {};
     try {
-      settings = await this.settingsService.get();
+      settings = (await this.settingsService.get()) as ChtSettings;
     } catch (e) {
       console.error('Failed to load settings for sidebar menu ordering', e);
     }
 
-    const headerTabsConfig: Record<string, any> = settings?.['header_tabs'] ?? {};
+    const headerTabsConfig = settings?.header_tabs ?? {};
 
     const getWeight = (name: string, defaultWeight: number): number => {
       const configWeight = headerTabsConfig[name]?.weight;
@@ -168,7 +193,7 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
       },
     ];
 
-    const extensionOptions: MenuOption[] = (settings?.['app_main_tab'] ?? []).map((ext: any) => ({
+    const extensionOptions: MenuOption[] = (settings?.app_main_tab ?? []).map((ext) => ({
       routerLink: ext.route ?? ext.name ?? ext.id,
       icon: ext.icon?.startsWith('fa-') ? ext.icon : 'fa-plus',
       translationKey: ext.title ?? ext.name ?? ext.id ?? '',
@@ -214,14 +239,4 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
       },
     ];
   }
-}
-
-interface MenuOption {
-  icon: string;
-  translationKey: string;
-  routerLink?: string;
-  hasPermissions?: string;
-  canDisplay?: boolean;
-  click?: () => void;
-  weight?: number;
 }

--- a/webapp/src/ts/components/sidebar-menu/sidebar-menu.component.ts
+++ b/webapp/src/ts/components/sidebar-menu/sidebar-menu.component.ts
@@ -16,6 +16,7 @@ import { LocationService } from '@mm-services/location.service';
 import { DBSyncService } from '@mm-services/db-sync.service';
 import { ModalService } from '@mm-services/modal.service';
 import { StorageInfoService } from '@mm-services/storage-info.service';
+import { SettingsService } from '@mm-services/settings.service';
 
 import { filter } from 'rxjs/operators';
 import { Selectors } from '@mm-selectors/index';
@@ -42,7 +43,7 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
   @Input() canLogOut: boolean = false;
   @ViewChild('sidebar') sidebar!: MatSidenav;
   private globalActions: GlobalActions;
-  replicationStatus;
+  replicationStatus: any;
   moduleOptions: MenuOption[] = [];
   secondaryOptions: MenuOption[] = [];
   adminAppPath: string = '';
@@ -54,6 +55,7 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
     protected modalService: ModalService,
     private router: Router,
     protected readonly storageInfoService: StorageInfoService,
+    private settingsService: SettingsService,
   ) {
     super(store, dbSyncService, modalService, storageInfoService);
     this.globalActions = new GlobalActions(store);
@@ -93,48 +95,89 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
   private additionalSubscriptions() {
     const subscribeSidebarMenu = this.store
       .select(Selectors.getSidebarMenu)
-      .subscribe(sidebarMenu => this.sidebar?.toggle(sidebarMenu?.isOpen));
+      .subscribe((sidebarMenu: any) => this.sidebar?.toggle(sidebarMenu?.isOpen));
     this.subscriptions.add(subscribeSidebarMenu);
 
     const subscribePrivacyPolicy = this.store
       .select(Selectors.getShowPrivacyPolicy)
-      .subscribe(showPrivacyPolicy => this.setSecondaryOptions(showPrivacyPolicy));
+      .subscribe((showPrivacyPolicy: boolean) => this.setSecondaryOptions(showPrivacyPolicy));
     this.subscriptions.add(subscribePrivacyPolicy);
   }
 
-  private setModuleOptions() {
-    this.moduleOptions = [
+  private sortByWeight(options: MenuOption[]): MenuOption[] {
+    return [...options].sort((a, b) => {
+      const wa = a.weight ?? 6;
+      const wb = b.weight ?? 6;
+      if (wa !== wb) {
+        return wa - wb;
+      }
+      return a.translationKey.localeCompare(b.translationKey);
+    });
+  }
+
+  private async setModuleOptions() {
+    let settings: Record<string, any> = {};
+    try {
+      settings = await this.settingsService.get();
+    } catch (e) {
+      console.error('Failed to load settings for sidebar menu ordering', e);
+    }
+
+    const headerTabsConfig: Record<string, any> = settings?.['header_tabs'] ?? {};
+
+    const getWeight = (name: string, defaultWeight: number): number => {
+      const configWeight = headerTabsConfig[name]?.weight;
+      return typeof configWeight === 'number' ? configWeight : defaultWeight;
+    };
+
+    const builtInOptions: MenuOption[] = [
       {
         routerLink: 'messages',
         icon: 'fa-envelope',
         translationKey: 'Messages',
-        hasPermissions: 'can_view_messages,!can_view_messages_tab'
+        hasPermissions: 'can_view_messages,!can_view_messages_tab',
+        weight: getWeight('messages', 1),
       },
       {
         routerLink: 'tasks',
         icon: 'fa-flag',
         translationKey: 'Tasks',
-        hasPermissions: 'can_view_tasks,!can_view_tasks_tab'
+        hasPermissions: 'can_view_tasks,!can_view_tasks_tab',
+        weight: getWeight('tasks', 2),
       },
       {
         routerLink: 'reports',
         icon: 'fa-list-alt',
         translationKey: 'Reports',
-        hasPermissions: 'can_view_reports,!can_view_reports_tab'
+        hasPermissions: 'can_view_reports,!can_view_reports_tab',
+        weight: getWeight('reports', 3),
       },
       {
         routerLink: 'contacts',
         icon: 'fa-user',
         translationKey: 'Contacts',
-        hasPermissions: 'can_view_contacts,!can_view_contacts_tab'
+        hasPermissions: 'can_view_contacts,!can_view_contacts_tab',
+        weight: getWeight('contacts', 4),
       },
       {
         routerLink: 'analytics',
         icon: 'fa-bar-chart-o',
         translationKey: 'Analytics',
         hasPermissions: 'can_view_analytics,!can_view_analytics_tab',
+        weight: getWeight('analytics', 5),
       },
     ];
+
+    const extensionOptions: MenuOption[] = (settings?.['app_main_tab'] ?? []).map((ext: any) => ({
+      routerLink: ext.route ?? ext.name ?? ext.id,
+      icon: ext.icon?.startsWith('fa-') ? ext.icon : 'fa-plus',
+      translationKey: ext.title ?? ext.name ?? ext.id ?? '',
+      hasPermissions: ext.permissions ? ext.permissions.join(',') : undefined,
+      canDisplay: !ext.permissions,
+      weight: typeof ext.weight === 'number' ? ext.weight : 6,
+    }));
+
+    this.moduleOptions = this.sortByWeight([...builtInOptions, ...extensionOptions]);
   }
 
   private setSecondaryOptions(showPrivacyPolicy = false) {
@@ -155,7 +198,7 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
         routerLink: 'user',
         icon: 'fa-user',
         translationKey: 'edit.user.settings',
-        hasPermissions: 'can_edit_profile'
+        hasPermissions: 'can_edit_profile',
       },
       {
         routerLink: 'privacy-policy',
@@ -167,7 +210,7 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
         icon: 'fa-bug',
         translationKey: 'Report Bug',
         canDisplay: true,
-        click: () => this.openFeedback()
+        click: () => this.openFeedback(),
       },
     ];
   }
@@ -180,4 +223,5 @@ interface MenuOption {
   hasPermissions?: string;
   canDisplay?: boolean;
   click?: () => void;
+  weight?: number;
 }

--- a/webapp/src/ts/components/sidebar-menu/sidebar-menu.component.ts
+++ b/webapp/src/ts/components/sidebar-menu/sidebar-menu.component.ts
@@ -80,7 +80,7 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
     protected modalService: ModalService,
     private router: Router,
     protected readonly storageInfoService: StorageInfoService,
-    private settingsService: SettingsService,
+    private readonly settingsService: SettingsService,
   ) {
     super(store, dbSyncService, modalService, storageInfoService);
     this.globalActions = new GlobalActions(store);

--- a/webapp/src/ts/services/header-tabs.service.ts
+++ b/webapp/src/ts/services/header-tabs.service.ts
@@ -2,6 +2,16 @@ import { Injectable } from '@angular/core';
 
 import { AuthService } from '@mm-services/auth.service';
 
+const DEFAULT_TAB_WEIGHTS: Record<string, number> = {
+  messages: 1,
+  tasks: 2,
+  reports: 3,
+  contacts: 4,
+  analytics: 5,
+};
+
+const DEFAULT_EXTENSION_WEIGHT = 6;
+
 @Injectable({
   providedIn: 'root'
 })
@@ -20,6 +30,7 @@ export class HeaderTabsService {
       typeName: 'message',
       icon: undefined,
       resourceIcon: undefined,
+      weight: DEFAULT_TAB_WEIGHTS['messages'],
     },
     {
       name: 'tasks',
@@ -30,6 +41,7 @@ export class HeaderTabsService {
       typeName: 'task',
       icon: undefined,
       resourceIcon: undefined,
+      weight: DEFAULT_TAB_WEIGHTS['tasks'],
     },
     {
       name: 'reports',
@@ -40,6 +52,7 @@ export class HeaderTabsService {
       typeName: 'report',
       icon: undefined,
       resourceIcon: undefined,
+      weight: DEFAULT_TAB_WEIGHTS['reports'],
     },
     {
       name: 'contacts',
@@ -49,6 +62,7 @@ export class HeaderTabsService {
       permissions: ['can_view_contacts', 'can_view_contacts_tab'],
       icon: undefined,
       resourceIcon: undefined,
+      weight: DEFAULT_TAB_WEIGHTS['contacts'],
     },
     {
       name: 'analytics',
@@ -58,63 +72,74 @@ export class HeaderTabsService {
       permissions: ['can_view_analytics', 'can_view_analytics_tab'],
       icon: undefined,
       resourceIcon: undefined,
+      weight: DEFAULT_TAB_WEIGHTS['analytics'],
     }
   ];
 
-  /**
-   * Returns the list of header tabs.
-   * If settings are passed as parameter, then it will add the tab.icon and tab.resourceIcon when available.
-   *
-   * @param settings {Object} Settings of CHT-Core instance.
-   *
-   * @returns HeaderTab[]
-   */
-  get(settings?): HeaderTab[] {
-    if (!settings?.header_tabs) {
-      return this.tabs;
-    }
+  private sortTabsByWeight(tabs: HeaderTab[]): HeaderTab[] {
+    return [...tabs].sort((a, b) => {
+      const wa = a.weight ?? DEFAULT_EXTENSION_WEIGHT;
+      const wb = b.weight ?? DEFAULT_EXTENSION_WEIGHT;
+      if (wa !== wb) {
+        return wa - wb;
+      }
+      return a.name.localeCompare(b.name);
+    });
+  }
 
+  get(settings?: Record<string, any>): HeaderTab[] {
     this.tabs.forEach(tab => {
-      if (!settings.header_tabs[tab.name]) {
-        return;
-      }
-
-      if (settings.header_tabs[tab.name].icon && settings.header_tabs[tab.name].icon.startsWith('fa-')) {
-        tab.icon = settings.header_tabs[tab.name].icon;
-      }
-
-      if (settings.header_tabs[tab.name].resource_icon) {
-        tab.resourceIcon = settings.header_tabs[tab.name].resource_icon;
-      }
+      tab.weight = DEFAULT_TAB_WEIGHTS[tab.name];
+      tab.icon = undefined;
+      tab.resourceIcon = undefined;
     });
 
-    return this.tabs;
+    if (settings?.header_tabs) {
+      this.tabs.forEach(tab => {
+        const tabConfig = settings['header_tabs'][tab.name];
+        if (!tabConfig) {
+          return;
+        }
+        if (tabConfig.icon && tabConfig.icon.startsWith('fa-')) {
+          tab.icon = tabConfig.icon;
+        }
+        if (tabConfig.resource_icon) {
+          tab.resourceIcon = tabConfig.resource_icon;
+        }
+        if (typeof tabConfig.weight === 'number') {
+          tab.weight = tabConfig.weight;
+        }
+      });
+    }
+
+    const extensionTabs: HeaderTab[] = this.getExtensionTabs(settings);
+    const allTabs = [...this.tabs, ...extensionTabs];
+    return this.sortTabsByWeight(allTabs);
   }
 
-  /**
-   * Returns the list of authorized header tabs according to the current user's permissions.
-   * If settings are passed as parameter, then it will add the tab.icon and tab.resourceIcon when available.
-   *
-   * @param settings {Object} Settings of CHT-Core instance.
-   *
-   * @returns Promise<HeaderTab[]>
-   */
-  async getAuthorizedTabs(settings?): Promise<HeaderTab[]> {
+  private getExtensionTabs(settings?: Record<string, any>): HeaderTab[] {
+    const appMainTabs: any[] = settings?.['app_main_tab'] ?? [];
+    return appMainTabs.map(ext => ({
+      name: ext.name ?? ext.id ?? '',
+      route: ext.route ?? ext.name ?? ext.id ?? '',
+      defaultIcon: ext.icon ?? 'fa-plus',
+      translation: ext.title ?? ext.name ?? ext.id ?? '',
+      permissions: ext.permissions ?? [],
+      icon: ext.icon?.startsWith('fa-') ? ext.icon : undefined,
+      resourceIcon: ext.resource_icon ?? undefined,
+      weight: typeof ext.weight === 'number' ? ext.weight : DEFAULT_EXTENSION_WEIGHT,
+    }));
+  }
+
+  async getAuthorizedTabs(settings?: Record<string, any>): Promise<HeaderTab[]> {
     const tabs = this.get(settings);
-    const tabAuthorization = await Promise.all(tabs.map(tab => this.authService.has(tab.permissions)));
-
-    return tabs.filter((tab, index) => tabAuthorization[index]);
+    const tabAuthorization = await Promise.all(
+      tabs.map(tab => this.authService.has(tab.permissions))
+    );
+    return tabs.filter((_, index) => tabAuthorization[index]);
   }
 
-  /**
-   * Returns the primary tab according to the current user's permissions.
-   * If settings are passed as parameter, then it will add the tab.icon and tab.resourceIcon when available.
-   *
-   * @param settings {Object} Settings of CHT-Core instance.
-   *
-   * @returns Promise<HeaderTab>
-   */
-  async getPrimaryTab(settings?): Promise<HeaderTab> {
+  async getPrimaryTab(settings?: Record<string, any>): Promise<HeaderTab | undefined> {
     const tabs = await this.getAuthorizedTabs(settings);
 
     return tabs?.[0];
@@ -130,4 +155,5 @@ export interface HeaderTab {
   typeName?: string;
   icon?: string;
   resourceIcon?: string;
+  weight?: number;
 }

--- a/webapp/src/ts/services/header-tabs.service.ts
+++ b/webapp/src/ts/services/header-tabs.service.ts
@@ -115,6 +115,14 @@ export class HeaderTabsService {
     });
   }
 
+  /**
+   * Returns the list of header tabs.
+   * If settings are passed as parameter, then it will add the tab.icon and tab.resourceIcon when available.
+   *
+   * @param settings {Object} Settings of CHT-Core instance.
+   *
+   * @returns HeaderTab[]
+   */
   get(settings?: ChtSettings): HeaderTab[] {
     this.tabs.forEach(tab => {
       tab.weight = DEFAULT_TAB_WEIGHTS[tab.name];
@@ -163,6 +171,14 @@ export class HeaderTabsService {
     }));
   }
 
+  /**
+   * Returns the list of authorized header tabs according to the current user's permissions.
+   * If settings are passed as parameter, then it will add the tab.icon and tab.resourceIcon when available.
+   *
+   * @param settings {Object} Settings of CHT-Core instance.
+   *
+   * @returns Promise<HeaderTab[]>
+   */
   async getAuthorizedTabs(settings?: ChtSettings): Promise<HeaderTab[]> {
     const tabs = this.get(settings);
     const tabAuthorization = await Promise.all(
@@ -171,6 +187,14 @@ export class HeaderTabsService {
     return tabs.filter((_, index) => tabAuthorization[index]);
   }
 
+  /**
+   * Returns the primary tab according to the current user's permissions.
+   * If settings are passed as parameter, then it will add the tab.icon and tab.resourceIcon when available.
+   *
+   * @param settings {Object} Settings of CHT-Core instance.
+   *
+   * @returns Promise<HeaderTab>
+   */
   async getPrimaryTab(settings?: ChtSettings): Promise<HeaderTab | undefined> {
     const tabs = await this.getAuthorizedTabs(settings);
 

--- a/webapp/src/ts/services/header-tabs.service.ts
+++ b/webapp/src/ts/services/header-tabs.service.ts
@@ -140,7 +140,7 @@ export class HeaderTabsService {
         if (!tabConfig) {
           return;
         }
-        if (tabConfig.icon && tabConfig.icon.startsWith('fa-')) {
+        if (tabConfig.icon?.startsWith('fa-')) {
           tab.icon = tabConfig.icon;
         }
         if (tabConfig.resource_icon) {

--- a/webapp/src/ts/services/header-tabs.service.ts
+++ b/webapp/src/ts/services/header-tabs.service.ts
@@ -12,6 +12,34 @@ const DEFAULT_TAB_WEIGHTS: Record<string, number> = {
 
 const DEFAULT_EXTENSION_WEIGHT = 6;
 
+export interface ExtensionTab {
+  id?: string;
+  name?: string;
+  route?: string;
+  icon?: string;
+  title?: string;
+  permissions?: string[];
+  resource_icon?: string;
+  weight?: number;
+}
+
+export interface ChtSettings {
+  header_tabs?: Record<string, { weight?: number; icon?: string; resource_icon?: string; }>;
+  app_main_tab?: ExtensionTab[];
+}
+
+export interface HeaderTab {
+  name: string;
+  route: string;
+  defaultIcon: string;
+  translation: string;
+  permissions: string[];
+  typeName?: string;
+  icon?: string;
+  resourceIcon?: string;
+  weight?: number;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -87,16 +115,20 @@ export class HeaderTabsService {
     });
   }
 
-  get(settings?: Record<string, any>): HeaderTab[] {
+  get(settings?: ChtSettings): HeaderTab[] {
     this.tabs.forEach(tab => {
       tab.weight = DEFAULT_TAB_WEIGHTS[tab.name];
       tab.icon = undefined;
       tab.resourceIcon = undefined;
     });
 
+    if (!settings?.header_tabs && !settings?.app_main_tab) {
+      return this.sortTabsByWeight(this.tabs);
+    }
+
     if (settings?.header_tabs) {
       this.tabs.forEach(tab => {
-        const tabConfig = settings['header_tabs'][tab.name];
+        const tabConfig = settings.header_tabs?.[tab.name];
         if (!tabConfig) {
           return;
         }
@@ -117,8 +149,8 @@ export class HeaderTabsService {
     return this.sortTabsByWeight(allTabs);
   }
 
-  private getExtensionTabs(settings?: Record<string, any>): HeaderTab[] {
-    const appMainTabs: any[] = settings?.['app_main_tab'] ?? [];
+  private getExtensionTabs(settings?: ChtSettings): HeaderTab[] {
+    const appMainTabs = settings?.app_main_tab ?? [];
     return appMainTabs.map(ext => ({
       name: ext.name ?? ext.id ?? '',
       route: ext.route ?? ext.name ?? ext.id ?? '',
@@ -131,7 +163,7 @@ export class HeaderTabsService {
     }));
   }
 
-  async getAuthorizedTabs(settings?: Record<string, any>): Promise<HeaderTab[]> {
+  async getAuthorizedTabs(settings?: ChtSettings): Promise<HeaderTab[]> {
     const tabs = this.get(settings);
     const tabAuthorization = await Promise.all(
       tabs.map(tab => this.authService.has(tab.permissions))
@@ -139,21 +171,9 @@ export class HeaderTabsService {
     return tabs.filter((_, index) => tabAuthorization[index]);
   }
 
-  async getPrimaryTab(settings?: Record<string, any>): Promise<HeaderTab | undefined> {
+  async getPrimaryTab(settings?: ChtSettings): Promise<HeaderTab | undefined> {
     const tabs = await this.getAuthorizedTabs(settings);
 
     return tabs?.[0];
   }
-}
-
-export interface HeaderTab {
-  name: string;
-  route: string;
-  defaultIcon: string;
-  translation: string;
-  permissions: string[];
-  typeName?: string;
-  icon?: string;
-  resourceIcon?: string;
-  weight?: number;
 }

--- a/webapp/tests/karma/ts/app.component.spec.ts
+++ b/webapp/tests/karma/ts/app.component.spec.ts
@@ -53,6 +53,8 @@ import { ReloadingComponent } from '@mm-modals/reloading/reloading.component';
 import { StorageInfoService } from '@mm-services/storage-info.service';
 import { TasksNotificationService } from '@mm-services/task-notifications.service';
 import { PREFIXES } from '@medic/constants';
+import { SettingsService } from '@mm-services/settings.service';
+import { HeaderTabsService } from '@mm-services/header-tabs.service';
 
 describe('AppComponent', () => {
   let component: AppComponent;
@@ -96,12 +98,14 @@ describe('AppComponent', () => {
   let updateServiceWorkerService;
   let storageInfoService;
   let tasksNotificationService;
+  let settingsService;
+  let headerTabsService;
   // End Services
 
   let globalActions;
   let analyticsActions;
   let originalPouchDB;
-  const changesListener:any = {};
+  const changesListener: any = {};
   let consoleErrorStub;
   let originalMedicMobileAndroid;
 
@@ -132,6 +136,8 @@ describe('AppComponent', () => {
     setLanguageService = { set: sinon.stub() };
     translateService = { instant: sinon.stub().returnsArg(0) };
     tasksNotificationService = { initOnAndroid: sinon.stub() };
+    settingsService = { get: sinon.stub().resolves({}) };
+    headerTabsService = { getAuthorizedTabs: sinon.stub().resolves([]) };
     modalService = {
       show: sinon.stub().returns({
         afterClosed: sinon.stub().returns(of())
@@ -166,7 +172,7 @@ describe('AppComponent', () => {
     };
     translateLocaleService = { reloadLang: sinon.stub() };
     transitionsService = { init: sinon.stub() };
-    
+
     storageInfoService = { init: sinon.stub(), stop: sinon.stub() };
 
     router = { navigate: sinon.stub(), events: of(ActivationEnd) };
@@ -252,6 +258,8 @@ describe('AppComponent', () => {
           { provide: StorageInfoService, useValue: storageInfoService },
           { provide: Router, useValue: router },
           { provide: TasksNotificationService, useValue: tasksNotificationService },
+          { provide: SettingsService, useValue: settingsService },
+          { provide: HeaderTabsService, useValue: headerTabsService },
         ]
       })
       .overrideComponent(SidebarMenuComponent, {
@@ -528,7 +536,7 @@ describe('AppComponent', () => {
         lastTrigger: undefined,
         lastSuccessTo: 12345
       }]);
-      expect(globalActions.updateReplicationStatus.getCall(1).args).to.deep.equal([{disabled: true}]);
+      expect(globalActions.updateReplicationStatus.getCall(1).args).to.deep.equal([{ disabled: true }]);
       expect(dbSyncService.subscribe.callCount).to.equal(1);
     });
 
@@ -632,7 +640,7 @@ describe('AppComponent', () => {
 
       await getComponent();
 
-      expect(changesListener['user-context'].filter({ doc: { type: 'user-settings', name: 'a' }}))
+      expect(changesListener['user-context'].filter({ doc: { type: 'user-settings', name: 'a' } }))
         .to.equal(false);
     });
 
@@ -674,7 +682,7 @@ describe('AppComponent', () => {
       expect(filter({ id: 'messages-en' })).to.equal(true);
       expect(filter({ id: 'messages-tl' })).to.equal(true);
       expect(filter({ id: 'not-messages-tl' })).to.equal(false);
-      expect(filter({ })).to.equal(undefined);
+      expect(filter({})).to.equal(undefined);
       expect(filter({ id: 'undefined' })).to.equal(false);
     });
 
@@ -712,7 +720,7 @@ describe('AppComponent', () => {
       analyticsModulesService.get.resolves([{
         id: 'targets',
         label: 'analytics.targets',
-        route: [ '/', 'analytics', 'targets' ]
+        route: ['/', 'analytics', 'targets']
       }]);
 
       await getComponent();
@@ -726,7 +734,7 @@ describe('AppComponent', () => {
         [{
           id: 'targets',
           label: 'analytics.targets',
-          route: [ '/', 'analytics', 'targets' ]
+          route: ['/', 'analytics', 'targets']
         }]
       ]);
     }));
@@ -748,7 +756,7 @@ describe('AppComponent', () => {
     }));
 
     it('should redirect to the error page when there is an exception', fakeAsync(async () => {
-      chtDatasourceService.isInitialized.throws({ error: 'some error'});
+      chtDatasourceService.isInitialized.throws({ error: 'some error' });
 
       await getComponent();
       flush();
@@ -760,7 +768,7 @@ describe('AppComponent', () => {
         { error: 'some error' }
       ]);
       expect(router.navigate.callCount).to.equal(1);
-      expect(router.navigate.args[0]).to.deep.equal([[ '/error', '503' ]]);
+      expect(router.navigate.args[0]).to.deep.equal([['/error', '503']]);
     }));
   });
 });

--- a/webapp/tests/karma/ts/components/sidebar-menu/sidebar-menu.component.spec.ts
+++ b/webapp/tests/karma/ts/components/sidebar-menu/sidebar-menu.component.spec.ts
@@ -18,6 +18,8 @@ import { AuthService } from '@mm-services/auth.service';
 import { GlobalActions } from '@mm-actions/global';
 import { LogoutConfirmComponent } from '@mm-modals/logout/logout-confirm.component';
 import { FeedbackComponent } from '@mm-modals/feedback/feedback.component';
+import { SettingsService } from '@mm-services/settings.service';
+import { HeaderTabsService } from '@mm-services/header-tabs.service';
 
 describe('SidebarMenuComponent', () => {
   let component: SidebarMenuComponent;
@@ -26,12 +28,17 @@ describe('SidebarMenuComponent', () => {
   let dbSyncService;
   let modalService;
   let authService;
+  let settingsService;
+  let headerTabsService;
 
   beforeEach(async () => {
     locationService = { adminPath: '/admin/' };
     dbSyncService = { sync: sinon.stub() };
     modalService = { show: sinon.stub() };
     authService = { has: sinon.stub(), online: sinon.stub() };
+
+    settingsService = { get: sinon.stub().resolves({}) };
+    headerTabsService = { get: sinon.stub().returns([]) };
 
     await TestBed
       .configureTestingModule({
@@ -51,12 +58,16 @@ describe('SidebarMenuComponent', () => {
           { provide: DBSyncService, useValue: dbSyncService },
           { provide: ModalService, useValue: modalService },
           { provide: AuthService, useValue: authService },
+          { provide: SettingsService, useValue: settingsService },
+          { provide: HeaderTabsService, useValue: headerTabsService }
         ],
       })
       .compileComponents();
     fixture = TestBed.createComponent(SidebarMenuComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+
+    await fixture.whenStable();
   });
 
   afterEach(() => sinon.restore());
@@ -77,31 +88,36 @@ describe('SidebarMenuComponent', () => {
         routerLink: 'messages',
         icon: 'fa-envelope',
         translationKey: 'Messages',
-        hasPermissions: 'can_view_messages,!can_view_messages_tab'
+        hasPermissions: 'can_view_messages,!can_view_messages_tab',
+        weight: 1
       },
       {
         routerLink: 'tasks',
         icon: 'fa-flag',
         translationKey: 'Tasks',
-        hasPermissions: 'can_view_tasks,!can_view_tasks_tab'
+        hasPermissions: 'can_view_tasks,!can_view_tasks_tab',
+        weight: 2
       },
       {
         routerLink: 'reports',
         icon: 'fa-list-alt',
         translationKey: 'Reports',
-        hasPermissions: 'can_view_reports,!can_view_reports_tab'
+        hasPermissions: 'can_view_reports,!can_view_reports_tab',
+        weight: 3
       },
       {
         routerLink: 'contacts',
         icon: 'fa-user',
         translationKey: 'Contacts',
-        hasPermissions: 'can_view_contacts,!can_view_contacts_tab'
+        hasPermissions: 'can_view_contacts,!can_view_contacts_tab',
+        weight: 4
       },
       {
         routerLink: 'analytics',
         icon: 'fa-bar-chart-o',
         translationKey: 'Analytics',
         hasPermissions: 'can_view_analytics,!can_view_analytics_tab',
+        weight: 5
       },
     ]);
 
@@ -147,7 +163,7 @@ describe('SidebarMenuComponent', () => {
   });
 
   it('should not replicate if sync is disabled', () => {
-    component.replicationStatus = { current: { disableSyncButton: true } };
+    (component as any).replicationStatus = { current: { disableSyncButton: true } };
 
     component.replicate();
 
@@ -155,7 +171,7 @@ describe('SidebarMenuComponent', () => {
   });
 
   it('should replicate if sync is enabled', () => {
-    component.replicationStatus = { current: { disableSyncButton: false } };
+    (component as any).replicationStatus = { current: { disableSyncButton: false } };
 
     component.replicate();
 

--- a/webapp/tests/karma/ts/services/header-tabs.service.spec.ts
+++ b/webapp/tests/karma/ts/services/header-tabs.service.spec.ts
@@ -8,7 +8,7 @@ import { HeaderTabsService } from '@mm-services/header-tabs.service';
 import { AuthService } from '@mm-services/auth.service';
 
 describe('HeaderTabs service', () => {
-  let service:HeaderTabsService;
+  let service: HeaderTabsService;
   let authService;
 
   beforeEach(() => {
@@ -30,15 +30,15 @@ describe('HeaderTabs service', () => {
       const tabs = service.get();
       // @ts-ignore
       expect(tabs).to.shallowDeepEqual([
-        { name: 'messages', defaultIcon: 'fa-envelope', icon: undefined },
-        { name: 'tasks', defaultIcon: 'fa-flag', icon: undefined },
-        { name: 'reports', defaultIcon: 'fa-list-alt', icon: undefined },
-        { name: 'contacts', defaultIcon: 'fa-user', icon: undefined },
-        { name: 'analytics', defaultIcon: 'fa-bar-chart-o', icon: undefined },
+        { name: 'messages', defaultIcon: 'fa-envelope', icon: undefined, weight: 1 },
+        { name: 'tasks', defaultIcon: 'fa-flag', icon: undefined, weight: 2 },
+        { name: 'reports', defaultIcon: 'fa-list-alt', icon: undefined, weight: 3 },
+        { name: 'contacts', defaultIcon: 'fa-user', icon: undefined, weight: 4 },
+        { name: 'analytics', defaultIcon: 'fa-bar-chart-o', icon: undefined, weight: 5 },
       ]);
 
       expect(service.get({})).to.deep.equal(tabs);
-      expect(service.get({ key: 'value' })).to.deep.equal(tabs);
+      expect(service.get({ key: 'value' } as any as any)).to.deep.equal(tabs);
       expect(service.get({ header_tabs: {} })).to.deep.equal(tabs);
     });
 
@@ -53,11 +53,11 @@ describe('HeaderTabs service', () => {
       const tabs = service.get({ header_tabs: headerTabsSettings });
       // @ts-ignore
       expect(tabs).to.shallowDeepEqual([
-        { name: 'messages', icon: undefined, resourceIcon: undefined, defaultIcon: 'fa-envelope' },
-        { name: 'tasks', icon: 'fa-whatever', resourceIcon: undefined, defaultIcon: 'fa-flag' },
-        { name: 'reports', icon: undefined, resourceIcon: 'some-icon', defaultIcon: 'fa-list-alt' },
-        { name: 'contacts', icon: undefined, resourceIcon: 'one-icon', defaultIcon: 'fa-user' },
-        { name: 'analytics', icon: 'fa-icon', resourceIcon: 'other-icon', defaultIcon: 'fa-bar-chart-o' },
+        { name: 'messages', icon: undefined, resourceIcon: undefined, defaultIcon: 'fa-envelope', weight: 1 },
+        { name: 'tasks', icon: 'fa-whatever', resourceIcon: undefined, defaultIcon: 'fa-flag', weight: 2 },
+        { name: 'reports', icon: undefined, resourceIcon: 'some-icon', defaultIcon: 'fa-list-alt', weight: 3 },
+        { name: 'contacts', icon: undefined, resourceIcon: 'one-icon', defaultIcon: 'fa-user', weight: 4 },
+        { name: 'analytics', icon: 'fa-icon', resourceIcon: 'other-icon', defaultIcon: 'fa-bar-chart-o', weight: 5 },
       ]);
     });
 
@@ -106,6 +106,7 @@ describe('HeaderTabs service', () => {
           typeName: 'message',
           icon: undefined,
           resourceIcon: undefined,
+          weight: 1
         },
         {
           name: 'reports',
@@ -116,6 +117,7 @@ describe('HeaderTabs service', () => {
           typeName: 'report',
           icon: undefined,
           resourceIcon: undefined,
+          weight: 3
         },
         {
           name: 'analytics',
@@ -125,6 +127,7 @@ describe('HeaderTabs service', () => {
           permissions: ['can_view_analytics', 'can_view_analytics_tab'],
           icon: undefined,
           resourceIcon: undefined,
+          weight: 5
         }
       ]);
     });
@@ -156,6 +159,7 @@ describe('HeaderTabs service', () => {
           typeName: 'task',
           icon: undefined,
           resourceIcon: undefined,
+          weight: 2
         },
         {
           name: 'contacts',
@@ -165,6 +169,7 @@ describe('HeaderTabs service', () => {
           permissions: ['can_view_contacts', 'can_view_contacts_tab'],
           icon: undefined,
           resourceIcon: undefined,
+          weight: 4
         },
         {
           name: 'analytics',
@@ -174,6 +179,7 @@ describe('HeaderTabs service', () => {
           permissions: ['can_view_analytics', 'can_view_analytics_tab'],
           icon: undefined,
           resourceIcon: undefined,
+          weight: 5
         }
       ]);
     });
@@ -204,6 +210,7 @@ describe('HeaderTabs service', () => {
           typeName: 'message',
           icon: undefined,
           resourceIcon: 'pomegranate-icon',
+          weight: 1
         },
         {
           name: 'tasks',
@@ -214,6 +221,7 @@ describe('HeaderTabs service', () => {
           typeName: 'task',
           icon: 'fa-apple',
           resourceIcon: undefined,
+          weight: 2
         },
         {
           name: 'contacts',
@@ -223,6 +231,7 @@ describe('HeaderTabs service', () => {
           permissions: ['can_view_contacts', 'can_view_contacts_tab'],
           icon: undefined,
           resourceIcon: 'pear-icon',
+          weight: 4
         },
         {
           name: 'analytics',
@@ -232,6 +241,7 @@ describe('HeaderTabs service', () => {
           permissions: ['can_view_analytics', 'can_view_analytics_tab'],
           icon: 'fa-mango-icon',
           resourceIcon: 'mango-icon',
+          weight: 5
         }
       ]);
     });
@@ -256,6 +266,7 @@ describe('HeaderTabs service', () => {
         typeName: 'message',
         icon: undefined,
         resourceIcon: undefined,
+        weight: 1
       });
     });
 
@@ -277,6 +288,7 @@ describe('HeaderTabs service', () => {
         typeName: 'report',
         icon: undefined,
         resourceIcon: undefined,
+        weight: 3
       });
     });
 
@@ -305,6 +317,7 @@ describe('HeaderTabs service', () => {
         permissions: ['can_view_contacts', 'can_view_contacts_tab'],
         icon: undefined,
         resourceIcon: undefined,
+        weight: 4
       });
     });
 
@@ -332,6 +345,7 @@ describe('HeaderTabs service', () => {
         permissions: ['can_view_analytics', 'can_view_analytics_tab'],
         icon: 'fa-mango-icon',
         resourceIcon: 'mango-icon',
+        weight: 5
       });
     });
   });


### PR DESCRIPTION
# Description

currently, the ordering of the header tabs ("Messages", "Tasks", "Reports", "Contacts", "Analytics") and the corresponding sidebar menu items is fixed, as we introduce more custom UI Extensions, deployments require the ability to control the display order of these tabs!

this PR introduces a configurable `weight` property to establish a single source of truth for sorting navigation elements across the webapp

**key changes:**
* **weight-based sorting:** updates `HeaderTabsService` and `SidebarMenuComponent` to sort items in ascending order based on their `weight`
* **configuration sources:** reads custom weights primarily from the `header_tabs` app settings, falling back to properties defined directly on `app_main_tab` UI extensions
* **backwards compatibility:** applies strict default weights to built-in tabs (`messages: 1`, `tasks: 2`, `reports: 3`, `contacts: 4`, `analytics: 5`) to perfectly preserve the existing UI order for deployments without custom configurations, custom UI extensions default to a weight of `6`
* **tie-breaker:** introduces a secondary alphabetical sort for tabs sharing the exact same weight
* **testing:** updated Karma unit test suites (`app.component.spec`, `sidebar-menu.component.spec`, `header-tabs.service.spec`) to inject new dependencies and assert against the new weighted mock objects and all tests are passing

FIXES #10908

# Code review checklist
- [x] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [ ] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/). *(Note: Used AI assistance for refactoring TypeScript sorting logic, strict type compliance, and unit test dependency mocking).*

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.