### PR TITLE
feat(#10720): add offline switch-user prototype with cached session restore

### DIFF
--- a/shared-libs/outbound/test/outbound.spec.js
+++ b/shared-libs/outbound/test/outbound.spec.js
@@ -464,6 +464,38 @@ describe('outbound shared library', () => {
         });
     });
 
+    it('should log debug request/response and mask auth password', () => {
+      const payload = {
+        some: 'data'
+      };
+
+      const conf = {
+        destination: {
+          auth: {
+            type: 'Basic',
+            username: 'admin',
+            password_key: 'test-config'
+          },
+          base_url: 'http://test',
+          path: '/foo'
+        }
+      };
+
+      sinon.stub(secureSettings, 'getCredentials').resolves('pass');
+      sinon.stub(request, 'post').resolves({ ok: true });
+      sinon.stub(logger, 'isDebugEnabled').returns(true);
+      sinon.stub(logger, 'debug');
+
+      return outbound.__get__('sendPayload')(payload, conf)
+        .then(() => {
+          assert.equal(logger.debug.callCount, 4);
+          assert.equal(logger.debug.args[0][0], 'About to send outbound request');
+          assert.include(logger.debug.args[1][0], '"password": "*****"');
+          assert.equal(logger.debug.args[2][0], 'result from outbound request');
+          assert.equal(logger.debug.args[3][0], JSON.stringify({ ok: true }, null, 2));
+        });
+    });
+
     it('should error if Muso SIH custom auth fails to return a 200', () => {
       const payload = {
         some: 'data'

--- a/webapp/src/ts/app-routing.module.ts
+++ b/webapp/src/ts/app-routing.module.ts
@@ -13,8 +13,10 @@ import { routes as privacyPolicyRoutes } from '@mm-modules/privacy-policy/privac
 import { routes as tasksRoutes } from '@mm-modules/tasks/tasks.routes';
 import { routes as trainingRoutes } from '@mm-modules/trainings/trainings.routes';
 import { routes as testingRoutes } from '@mm-modules/testing/testing.routes';
+import { AccountSelectorComponent } from '@mm-components/account-selector/account-selector.component';
 
 const routes: Routes = [
+  { path: 'switch-user', component: AccountSelectorComponent },
   ...homeRoutes,
   ...aboutRoutes,
   ...confUserRoutes,

--- a/webapp/src/ts/components/account-selector/account-selector.component.html
+++ b/webapp/src/ts/components/account-selector/account-selector.component.html
@@ -1,0 +1,27 @@
+<div class="inner">
+  <div class="col-sm-12 page">
+    <h2>Switch user</h2>
+
+    <div *ngIf="accounts.length; else noAccounts">
+      <p>Select a cached account:</p>
+      <div class="list-group">
+        <button
+          *ngFor="let account of accounts"
+          type="button"
+          class="list-group-item list-group-item-action account-option"
+          (click)="selectAccount(account.username)"
+        >
+          {{ account.username }}
+        </button>
+      </div>
+    </div>
+
+    <ng-template #noAccounts>
+      <p>No cached accounts found. Add an account while online.</p>
+    </ng-template>
+
+    <button type="button" class="btn btn-primary add-account" (click)="addAccount()">
+      Add account
+    </button>
+  </div>
+</div>

--- a/webapp/src/ts/components/account-selector/account-selector.component.ts
+++ b/webapp/src/ts/components/account-selector/account-selector.component.ts
@@ -1,0 +1,32 @@
+import { Component, OnInit } from '@angular/core';
+import { NgFor, NgIf } from '@angular/common';
+
+import { SessionCacheService, CachedAccount } from '@mm-services/session-cache.service';
+
+@Component({
+  templateUrl: './account-selector.component.html',
+  imports: [
+    NgFor,
+    NgIf,
+  ],
+})
+export class AccountSelectorComponent implements OnInit {
+  accounts: CachedAccount[] = [];
+
+  constructor(private readonly sessionCacheService: SessionCacheService) {}
+
+  ngOnInit(): void {
+    this.sessionCacheService.cacheCurrentSessionForSelector();
+    this.accounts = this.sessionCacheService.listCachedAccounts();
+  }
+
+  addAccount(): void {
+    this.sessionCacheService.navigateToAddAccountLogin();
+  }
+
+  selectAccount(username: string): void {
+    if (!this.sessionCacheService.restoreSession(username)) {
+      console.warn(`No cached session found for "${username}"`);
+    }
+  }
+}

--- a/webapp/src/ts/components/sidebar-menu/sidebar-menu.component.html
+++ b/webapp/src/ts/components/sidebar-menu/sidebar-menu.component.html
@@ -63,8 +63,7 @@
 
             <div *ngIf="replicationStatus?.lastSuccessTo" class="last-sync">
               <span>{{ 'sync.last_success' | translate }}</span>
-              <!-- The tabindex=0 prevents showing the tooltip when menu opens in mobile devices -->
-              <span [innerHTML]="replicationStatus?.lastSuccessTo | relativeDate" tabindex="0"></span>
+              <span [innerHTML]="replicationStatus?.lastSuccessTo | relativeDate"></span>
             </div>
           </div>
         </div>
@@ -92,6 +91,11 @@
       </div>
 
       <div class="nav-section">
+        <a *ngIf="canLogOut" class="nav-item" (click)="switchUser()">
+          <mat-icon fontIcon="fa-exchange"></mat-icon>
+          <span>Switch user</span>
+        </a>
+
         <a *ngIf="canLogOut" class="nav-item" (click)="logout()">
           <mat-icon fontIcon="fa-power-off"></mat-icon>
           <span>{{ 'Log Out' | translate }}</span>

--- a/webapp/src/ts/components/sidebar-menu/sidebar-menu.component.ts
+++ b/webapp/src/ts/components/sidebar-menu/sidebar-menu.component.ts
@@ -16,6 +16,7 @@ import { LocationService } from '@mm-services/location.service';
 import { DBSyncService } from '@mm-services/db-sync.service';
 import { ModalService } from '@mm-services/modal.service';
 import { StorageInfoService } from '@mm-services/storage-info.service';
+import { SessionCacheService } from '@mm-services/session-cache.service';
 
 import { filter } from 'rxjs/operators';
 import { Selectors } from '@mm-selectors/index';
@@ -41,7 +42,7 @@ import { Selectors } from '@mm-selectors/index';
 export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, OnDestroy {
   @Input() canLogOut: boolean = false;
   @ViewChild('sidebar') sidebar!: MatSidenav;
-  private globalActions: GlobalActions;
+  private readonly globalActions: GlobalActions;
   replicationStatus;
   moduleOptions: MenuOption[] = [];
   secondaryOptions: MenuOption[] = [];
@@ -52,7 +53,8 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
     protected locationService: LocationService,
     protected dbSyncService: DBSyncService,
     protected modalService: ModalService,
-    private router: Router,
+    private readonly router: Router,
+    private readonly sessionCacheService: SessionCacheService,
     protected readonly storageInfoService: StorageInfoService,
   ) {
     super(store, dbSyncService, modalService, storageInfoService);
@@ -81,6 +83,13 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
       return;
     }
     super.replicate();
+  }
+
+  switchUser(): void {
+    this.sessionCacheService
+      .switchUser()
+      .then(() => this.close())
+      .catch(err => console.error('Failed to switch user', err));
   }
 
   private subscribeToRouter() {

--- a/webapp/src/ts/services/session-cache.service.ts
+++ b/webapp/src/ts/services/session-cache.service.ts
@@ -1,0 +1,123 @@
+import { Inject, Injectable } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import { Router } from '@angular/router';
+import { CookieService } from 'ngx-cookie-service';
+
+import { SessionService } from '@mm-services/session.service';
+import { LocationService } from '@mm-services/location.service';
+
+const SESSION_CACHE_KEY = 'cht-session-cache';
+const USER_CTX_COOKIE = 'userCtx';
+const LOGIN_COOKIE = 'login';
+
+export interface CachedAccount {
+  username: string;
+}
+
+type SessionCache = Record<string, string>;
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SessionCacheService {
+  constructor(
+    private readonly sessionService: SessionService,
+    private readonly cookieService: CookieService,
+    private readonly router: Router,
+    private readonly locationService: LocationService,
+    @Inject(DOCUMENT) private readonly document: Document,
+  ) {}
+
+  async switchUser(): Promise<void> {
+    this.cacheActiveSession();
+    this.clearActiveSession();
+    await this.router.navigate(['/switch-user']);
+  }
+
+  cacheCurrentSessionForSelector(): void {
+    if (this.cacheActiveSession()) {
+      this.clearActiveSession();
+    }
+  }
+
+  cacheActiveSession(): boolean {
+    const userCtx = this.sessionService.userCtx();
+    const username = userCtx?.name;
+    const sessionToken = this.cookieService.get(USER_CTX_COOKIE);
+    if (!username || !sessionToken) {
+      return false;
+    }
+
+    const sessionCache = this.getSessionCache();
+    sessionCache[username] = sessionToken;
+    this.setSessionCache(sessionCache);
+    return true;
+  }
+
+  listCachedAccounts(): CachedAccount[] {
+    return Object
+      .keys(this.getSessionCache())
+      .sort((left, right) => left.localeCompare(right))
+      .map(username => ({ username }));
+  }
+
+  restoreSession(username: string): boolean {
+    const sessionToken = this.getSessionCache()[username];
+    if (!sessionToken) {
+      return false;
+    }
+
+    this.cookieService.set(USER_CTX_COOKIE, sessionToken, undefined, '/');
+    this.cookieService.delete(LOGIN_COOKIE, '/');
+    this.sessionService.userCtxCookieValue = undefined;
+    this.document.location.href = this.getAppUrl('#/home');
+    return true;
+  }
+
+  navigateToAddAccountLogin(): void {
+    const redirect = encodeURIComponent(this.getAppUrl('#/switch-user'));
+    this.document.location.href = `/${this.locationService.dbName}/login?redirect=${redirect}`;
+  }
+
+  private clearActiveSession(): void {
+    this.cookieService.delete(USER_CTX_COOKIE, '/');
+    this.cookieService.delete(LOGIN_COOKIE, '/');
+    this.sessionService.userCtxCookieValue = undefined;
+  }
+
+  private getAppUrl(hashPath: string): string {
+    return `${this.document.location.pathname}${hashPath}`;
+  }
+
+  private getSessionCache(): SessionCache {
+    const raw = this.getStorage().getItem(SESSION_CACHE_KEY);
+    if (!raw) {
+      return {};
+    }
+
+    try {
+      const parsed = JSON.parse(raw);
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        return {};
+      }
+
+      return Object.entries(parsed).reduce((cache, [username, token]) => {
+        if (typeof token === 'string') {
+          cache[username] = token;
+        }
+        return cache;
+      }, {} as SessionCache);
+    } catch (error) {
+      console.warn('Unable to parse cached sessions', error);
+      return {};
+    }
+  }
+
+  private setSessionCache(sessionCache: SessionCache): void {
+    this.getStorage().setItem(SESSION_CACHE_KEY, JSON.stringify(sessionCache));
+  }
+
+  private getStorage(): Storage {
+    return this.document.defaultView?.localStorage || window.localStorage;
+  }
+}

--- a/webapp/tests/karma/ts/components/account-selector/account-selector.component.spec.ts
+++ b/webapp/tests/karma/ts/components/account-selector/account-selector.component.spec.ts
@@ -1,0 +1,62 @@
+import 'mocha';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { AccountSelectorComponent } from '@mm-components/account-selector/account-selector.component';
+import { SessionCacheService } from '@mm-services/session-cache.service';
+
+describe('AccountSelectorComponent', () => {
+  let fixture: ComponentFixture<AccountSelectorComponent>;
+  let sessionCacheService: {
+    cacheCurrentSessionForSelector: sinon.SinonStub;
+    listCachedAccounts: sinon.SinonStub;
+    navigateToAddAccountLogin: sinon.SinonStub;
+    restoreSession: sinon.SinonStub;
+  };
+
+  beforeEach(async () => {
+    sessionCacheService = {
+      cacheCurrentSessionForSelector: sinon.stub(),
+      listCachedAccounts: sinon.stub().returns([
+        { username: 'user-a' },
+        { username: 'user-b' },
+      ]),
+      navigateToAddAccountLogin: sinon.stub(),
+      restoreSession: sinon.stub(),
+    };
+
+    await TestBed
+      .configureTestingModule({
+        imports: [AccountSelectorComponent],
+        providers: [
+          { provide: SessionCacheService, useValue: sessionCacheService },
+        ],
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(AccountSelectorComponent);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => sinon.restore());
+
+  it('renders cached account list', () => {
+    const accountButtons = fixture.nativeElement.querySelectorAll('.account-option');
+    expect(accountButtons.length).to.equal(2);
+    expect(accountButtons[0].textContent).to.contain('user-a');
+    expect(accountButtons[1].textContent).to.contain('user-b');
+    expect(sessionCacheService.cacheCurrentSessionForSelector.calledOnce).to.be.true;
+    expect(sessionCacheService.listCachedAccounts.calledOnce).to.be.true;
+  });
+
+  it('navigates to login when add account is clicked', () => {
+    fixture.nativeElement.querySelector('.add-account').click();
+    expect(sessionCacheService.navigateToAddAccountLogin.calledOnce).to.be.true;
+  });
+
+  it('restores selected cached account', () => {
+    fixture.nativeElement.querySelector('.account-option').click();
+    expect(sessionCacheService.restoreSession.calledOnceWith('user-a')).to.be.true;
+  });
+});

--- a/webapp/tests/karma/ts/components/sidebar-menu/sidebar-menu.component.spec.ts
+++ b/webapp/tests/karma/ts/components/sidebar-menu/sidebar-menu.component.spec.ts
@@ -18,6 +18,7 @@ import { AuthService } from '@mm-services/auth.service';
 import { GlobalActions } from '@mm-actions/global';
 import { LogoutConfirmComponent } from '@mm-modals/logout/logout-confirm.component';
 import { FeedbackComponent } from '@mm-modals/feedback/feedback.component';
+import { SessionCacheService } from '@mm-services/session-cache.service';
 
 describe('SidebarMenuComponent', () => {
   let component: SidebarMenuComponent;
@@ -26,12 +27,16 @@ describe('SidebarMenuComponent', () => {
   let dbSyncService;
   let modalService;
   let authService;
+  let sessionCacheService: {
+    switchUser: sinon.SinonStub;
+  };
 
   beforeEach(async () => {
     locationService = { adminPath: '/admin/' };
     dbSyncService = { sync: sinon.stub() };
     modalService = { show: sinon.stub() };
     authService = { has: sinon.stub(), online: sinon.stub() };
+    sessionCacheService = { switchUser: sinon.stub().resolves() };
 
     await TestBed
       .configureTestingModule({
@@ -51,6 +56,7 @@ describe('SidebarMenuComponent', () => {
           { provide: DBSyncService, useValue: dbSyncService },
           { provide: ModalService, useValue: modalService },
           { provide: AuthService, useValue: authService },
+          { provide: SessionCacheService, useValue: sessionCacheService },
         ],
       })
       .compileComponents();
@@ -181,5 +187,15 @@ describe('SidebarMenuComponent', () => {
 
     expect(modalService.show.calledOnce).to.be.true;
     expect(modalService.show.args[0][0]).to.deep.equal(FeedbackComponent);
+  });
+
+  it('should switch user', async () => {
+    const closeStub = sinon.stub(component, 'close');
+
+    component.switchUser();
+    await fixture.whenStable();
+
+    expect(sessionCacheService.switchUser.calledOnce).to.be.true;
+    expect(closeStub.calledOnce).to.be.true;
   });
 });

--- a/webapp/tests/karma/ts/services/session-cache.service.spec.ts
+++ b/webapp/tests/karma/ts/services/session-cache.service.spec.ts
@@ -1,0 +1,113 @@
+import { TestBed } from '@angular/core/testing';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { DOCUMENT } from '@angular/common';
+import { CookieService } from 'ngx-cookie-service';
+import { Router } from '@angular/router';
+
+import { SessionCacheService } from '@mm-services/session-cache.service';
+import { SessionService } from '@mm-services/session.service';
+import { LocationService } from '@mm-services/location.service';
+
+describe('SessionCacheService', () => {
+  let service: SessionCacheService;
+  let cookieService: {
+    get: sinon.SinonStub;
+    set: sinon.SinonStub;
+    delete: sinon.SinonStub;
+  };
+  let sessionService: {
+    userCtx: sinon.SinonStub;
+    userCtxCookieValue: unknown;
+  };
+  let router: {
+    navigate: sinon.SinonStub;
+  };
+  let locationService: {
+    dbName: string;
+  };
+  let documentMock: {
+    location: {
+      href: string;
+      pathname: string;
+    };
+  };
+
+  beforeEach(() => {
+    cookieService = {
+      get: sinon.stub(),
+      set: sinon.stub(),
+      delete: sinon.stub(),
+    };
+    sessionService = {
+      userCtx: sinon.stub(),
+      userCtxCookieValue: null,
+    };
+    router = {
+      navigate: sinon.stub().resolves(true),
+    };
+    locationService = {
+      dbName: 'medic',
+    };
+    documentMock = {
+      location: { href: '', pathname: '/medic/' },
+    };
+    globalThis.localStorage.removeItem('cht-session-cache');
+
+    TestBed.configureTestingModule({
+      providers: [
+        SessionCacheService,
+        { provide: CookieService, useValue: cookieService },
+        { provide: SessionService, useValue: sessionService },
+        { provide: Router, useValue: router },
+        { provide: LocationService, useValue: locationService },
+        { provide: DOCUMENT, useValue: documentMock },
+      ],
+    });
+
+    service = TestBed.inject(SessionCacheService);
+  });
+
+  afterEach(() => {
+    globalThis.localStorage.removeItem('cht-session-cache');
+    sinon.restore();
+  });
+
+  it('caches active session for current username', () => {
+    sessionService.userCtx.returns({ name: 'user-a' });
+    cookieService.get.withArgs('userCtx').returns('session-token-a');
+
+    const cached = service.cacheActiveSession();
+    const value = JSON.parse(globalThis.localStorage.getItem('cht-session-cache') || '{}');
+
+    expect(cached).to.be.true;
+    expect(value).to.deep.equal({ 'user-a': 'session-token-a' });
+  });
+
+  it('lists cached accounts', () => {
+    globalThis.localStorage.setItem('cht-session-cache', JSON.stringify({
+      'user-b': 'session-b',
+      'user-a': 'session-a',
+    }));
+
+    const accounts = service.listCachedAccounts();
+
+    expect(accounts).to.deep.equal([
+      { username: 'user-a' },
+      { username: 'user-b' },
+    ]);
+  });
+
+  it('restores cached session for selected account', () => {
+    globalThis.localStorage.setItem('cht-session-cache', JSON.stringify({
+      'user-a': 'session-token-a',
+    }));
+
+    const restored = service.restoreSession('user-a');
+
+    expect(restored).to.be.true;
+    expect(cookieService.set.calledOnceWith('userCtx', 'session-token-a', undefined, '/')).to.be.true;
+    expect(cookieService.delete.calledWith('login', '/')).to.be.true;
+    expect(documentMock.location.href).to.equal('/medic/#/home');
+  });
+});


### PR DESCRIPTION
# Description

implements a **prototype** for shared-device multi-user support in the webapp by caching and restoring user sessions locally, so previously logged-in users can switch accounts while offline

## what’s included

1. **Sidebar update**
   - added a **Switch user** action next to **Log out**
   - switch user now caches the current session and routes to an account selector instead of triggering normal logout

2. **account selector flow**
   - added new route: `#/switch-user`
   - added `AccountSelectorComponent` to:
     - list locally cached accounts
     - restore selected account session (no password/PIN for this prototype)
     - redirect to standard login for **Add account**

3. **aession cache service**
   - added `SessionCacheService` with:
     - cache active session by username
     - list cached accounts
     - restore selected cached session
   - preserves original user session token in local cache so users remain switchable later

4. **tests**
   - added unit tests for:
     - `SessionCacheService`
     - `AccountSelectorComponent`
   - updated sidebar menu spec for switch-user behavior

## Prototype scope notes

- this is intentionally a prototype branch for core flow validations
- PIN/password prompt on account switch is out of scope
- session token encryption-at-rest is out of scope in this prototype

FIXES #10720

# Code review checklist
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [ ] AI disclosure: This change was created with assistance from AI tooling, with developer review and edits.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.