### PR TITLE
feat(#10908): support ordering header tabs by weight

### DIFF
--- a/tests/e2e/default/navigation/navigation.wdio-spec.js
+++ b/tests/e2e/default/navigation/navigation.wdio-spec.js
@@ -54,6 +54,8 @@ describe('Navigation tests', () => {
       it('should display tab labels, when all tabs are enabled', async () => {
         const tabsButtonLabelsNames = await commonPage.getAllButtonLabelsNames();
         expect(tabsButtonLabelsNames).to.deep.equal(['Messages', 'Tasks', 'Reports', 'People', 'Targets']);
+        const tabsButtonIcons = await commonPage.getAllButtonFaIconClasses();
+        expect(tabsButtonIcons).to.deep.equal(['fa-envelope', 'fa-flag', 'fa-list-alt', 'fa-user', 'fa-bar-chart-o']);
       });
     });
 
@@ -88,6 +90,27 @@ describe('Navigation tests', () => {
         await commonPage.goToPeople('missing');
         await commonPage.goToReports('missing');
         console.log('after loading missing person');
+      });
+
+      it('should display tabs according to header_tabs configuration', async () => {
+        await utils.updateSettings({ header_tabs: {
+          messages: {
+            weight: 44,
+            icon: 'fa-flag',
+          },
+          reports: {
+            weight: 43,
+            icon: 'fa-user',
+          },
+          contacts: {
+            weight: 1,
+            icon: 'fa-bar-chart-o'
+          },
+        } }, { ignoreReload: false });
+        const tabsButtonLabelsNames = await commonPage.getAllButtonLabelsNames();
+        expect(tabsButtonLabelsNames).to.deep.equal(['People', 'Reports', 'Messages']);
+        const tabsButtonIcons = await commonPage.getAllButtonFaIconClasses();
+        expect(tabsButtonIcons).to.deep.equal(['fa-bar-chart-o', 'fa-user', 'fa-flag']);
       });
     });
   });

--- a/tests/e2e/default/old-navigation/old-navigation.wdio-spec.js
+++ b/tests/e2e/default/old-navigation/old-navigation.wdio-spec.js
@@ -12,6 +12,7 @@ const reportsPage = require('@page-objects/default/reports/reports.wdio.page');
 const contactPage = require('@page-objects/default/contacts/contacts.wdio.page');
 const targetAggregatesPage = require('@page-objects/default/targets/target-aggregates.wdio.page');
 const { CONTACT_TYPES } = require('@medic/constants');
+const commonPage = require('@page-objects/default/common/common.wdio.page');
 
 describe('Old Navigation', () => {
   const places = placeFactory.generateHierarchy();
@@ -100,5 +101,41 @@ describe('Old Navigation', () => {
 
   it('should successfully sync', async () => {
     await oldNavigationPage.sync();
+  });
+
+  it('should display tab labels, when all tabs are enabled', async () => {
+    const tabsButtonLabelsNames = await commonPage.getAllButtonLabelsNames();
+    expect(tabsButtonLabelsNames).to.deep.equal(['Messages', 'Tasks', 'Reports', 'People', 'Targets']);
+    const tabsButtonIcons = await commonPage.getAllButtonFaIconClasses();
+    expect(tabsButtonIcons).to.deep.equal(['fa-envelope', 'fa-flag', 'fa-list-alt', 'fa-user', 'fa-bar-chart-o']);
+  });
+
+  it('should display tabs according to permissions and header_tabs configuration', async () => {
+    const permissionsToRemove = [
+      'can_view_analytics',
+      'can_view_analytics_tab',
+      'can_view_tasks',
+      'can_view_tasks_tab'
+    ];
+    await utils.updatePermissions(offlineUser.roles, [], permissionsToRemove, { ignoreReload: true });
+    await utils.updateSettings({ header_tabs: {
+      messages: {
+        weight: 44,
+        icon: 'fa-flag',
+      },
+      reports: {
+        weight: 43,
+        icon: 'fa-user',
+      },
+      contacts: {
+        weight: 1,
+        icon: 'fa-bar-chart-o'
+      },
+    } }, { ignoreReload: false });
+
+    const tabsButtonLabelsNames = await commonPage.getAllButtonLabelsNames();
+    expect(tabsButtonLabelsNames).to.deep.equal(['People', 'Reports', 'Messages']);
+    const tabsButtonIcons = await commonPage.getAllButtonFaIconClasses();
+    expect(tabsButtonIcons).to.deep.equal(['fa-bar-chart-o', 'fa-user', 'fa-flag']);
   });
 });

--- a/tests/page-objects/default/common/common.wdio.page.js
+++ b/tests/page-objects/default/common/common.wdio.page.js
@@ -9,6 +9,7 @@ const getGenericAria = (text) => $(`aria/${text}`);
 
 const tabsSelector = {
   getAllButtonLabels: async () => await $$('.header .tabs .button-label'),
+  getAllButtonIcons: async () => await $$('.header .tabs .mm-icon span.fa:empty'),
   messagesTab: () => $('#messages-tab'),
   taskTab: () => $('#tasks-tab'),
   analyticsTab: () => $('#analytics-tab'),
@@ -536,6 +537,12 @@ const getAllButtonLabelsNames = async () => {
   return await getTextForElements(tabsSelector.getAllButtonLabels);
 };
 
+const getAllButtonFaIconClasses = async () => {
+  const iconElements = await (await tabsSelector.getAllButtonIcons());
+  const iconClasses = await iconElements.map(element => element.getAttribute('class'));
+  return iconClasses.map(classes => classes.split(' ').find(c => c.startsWith('fa-')));
+};
+
 const isMenuOptionEnabled = async (action) => {
   const parent = await kebabMenuSelectors[action]().parentElement().parentElement();
   return await parent.getAttribute('aria-disabled') === 'false';
@@ -662,6 +669,7 @@ module.exports = {
   openAppManagement,
   getTextForElements,
   getAllButtonLabelsNames,
+  getAllButtonFaIconClasses,
   isMenuOptionEnabled,
   isMenuOptionVisible,
   loadNextInfiniteScrollPage,

--- a/webapp/src/ts/components/header/header.component.html
+++ b/webapp/src/ts/components/header/header.component.html
@@ -56,36 +56,6 @@
 
           <li role="separator" class="divider" *ngIf="!replicationStatus.disabled"></li>
 
-          <li role="presentation" mmAuth="can_view_messages,!can_view_messages_tab">
-            <a role="menuitem" tabindex="-1" routerLink="messages">
-              <i class="fa fa-fw fa-envelope"></i>
-              <span>{{'Messages' | translate}}</span>
-            </a>
-          </li>
-          <li role="presentation" mmAuth="can_view_tasks,!can_view_tasks_tab">
-            <a role="menuitem" tabindex="-1" routerLink="tasks">
-              <i class="fa fa-fw fa-flag"></i>
-              <span>{{'Tasks' | translate}}</span>
-            </a>
-          </li>
-          <li role="presentation" mmAuth="can_view_reports,!can_view_reports_tab">
-            <a role="menuitem" tabindex="-1" routerLink="reports">
-              <i class="fa fa-fw fa-list-alt"></i>
-              <span>{{'Reports' | translate}}</span>
-            </a>
-          </li>
-          <li role="presentation" mmAuth="can_view_contacts,!can_view_contacts_tab">
-            <a role="menuitem" tabindex="-1" routerLink="contacts">
-              <i class="fa fa-fw fa-user"></i>
-              <span>{{'Contacts' | translate}}</span>
-            </a>
-          </li>
-          <li role="presentation" mmAuth="can_view_analytics,!can_view_analytics_tab">
-            <a role="menuitem" tabindex="-1" routerLink="analytics" routerLink-opts="{reload: true}">
-              <i class="fa fa-bar-chart-o"></i>
-              <span>{{'Analytics' | translate}}</span>
-            </a>
-          </li>
           <li role="presentation" class="desktop-only" mmAuth [mmAuthAny]="[ 'can_configure', 'can_view_outgoing_messages', 'can_export_all' ]" [mmAuthOnline]="true">
             <a href="{{adminUrl}}" role="menuitem" tabindex="-1" rel="noopener noreferrer">
               <i class="fa fa-fw fa-cog"></i>
@@ -93,46 +63,19 @@
             </a>
           </li>
 
-          <ng-container *ngFor="let ext of uiExtensionOptions">
+          <ng-container *ngFor="let tab of legacyMenuTabs">
             <li>
-              <a role="menuitem" tabindex="-1" [routerLink]="ext.routerLink">
-                <span class="nav-icon" *ngIf="ext.resourceIcon" [innerHTML]="ext.resourceIcon | resourceIcon"></span>
-                <i *ngIf="!ext.resourceIcon" class="fa fa-fw {{ext.icon}}"></i>
-                <span>{{ext.translationKey | translate}}</span>
+              <a role="menuitem" tabindex="-1"
+                 *ngIf="tab.name !== 'privacy-policy' || showPrivacyPolicy"
+                 [routerLink]="tab.route"
+                 (click)="onLegacyMenuClick(tab)">
+                <span class="nav-icon" *ngIf="tab.resourceIcon" [innerHTML]="tab.resourceIcon | resourceIcon"></span>
+                <i *ngIf="!tab.resourceIcon" class="fa fa-fw {{tab.icon || tab.defaultIcon}}"></i>
+                <span>{{tab.translation | translate}}</span>
               </a>
             </li>
           </ng-container>
 
-          <li role="presentation">
-            <a routerLink="trainings" role="menuitem" tabindex="-1">
-              <i class="fa fa-fw fa-graduation-cap"></i>
-              <span>{{'training_materials.page.title' | translate}}</span>
-            </a>
-          </li>
-          <li role="presentation">
-            <a routerLink="about" role="menuitem" tabindex="-1">
-              <i class="fa fa-fw fa-question"></i>
-              <span>{{'about' | translate}}</span>
-            </a>
-          </li>
-          <li role="presentation" mmAuth="can_edit_profile">
-            <a role="menuitem" tabindex="-1" routerLink="user" test-id="user-settings-menu-option">
-              <i class="fa fa-fw fa-user"></i>
-              <span>{{'edit.user.settings' | translate}}</span>
-            </a>
-          </li>
-          <li role="presentation" *ngIf="showPrivacyPolicy">
-            <a role="menuitem" tabindex="-1" routerLink="privacy-policy">
-              <i class="fa fa-fw fa-lock"></i>
-              <span>{{'privacy.policy' | translate}}</span>
-            </a>
-          </li>
-          <li role="presentation">
-            <a role="menuitem" tabindex="-1" (click)="openFeedback()">
-              <i class="fa fa-fw fa-bug"></i>
-              <span>{{'Report Bug' | translate}}</span>
-            </a>
-          </li>
           <li role="presentation" *ngIf="canLogOut">
             <a role="menuitem" tabindex="-1" rel="external" (click)="logout()">
               <i class="fa fa-fw fa-power-off"></i>

--- a/webapp/src/ts/components/header/header.component.html
+++ b/webapp/src/ts/components/header/header.component.html
@@ -63,7 +63,7 @@
             </a>
           </li>
 
-          <ng-container *ngFor="let tab of legacyMenuTabs">
+          <ng-container *ngFor="let tab of headerTabsForLegacySidebar">
             <li>
               <a role="menuitem" tabindex="-1"
                  *ngIf="tab.name !== 'privacy-policy' || showPrivacyPolicy"

--- a/webapp/src/ts/components/header/header.component.ts
+++ b/webapp/src/ts/components/header/header.component.ts
@@ -18,8 +18,7 @@ import { RelativeDatePipe } from '@mm-pipes/date.pipe';
 import { LocalizeNumberPipe } from '@mm-pipes/number.pipe';
 import { HeaderLogoPipe, ResourceIconPipe } from '@mm-pipes/resource-icon.pipe';
 
-import { HeaderTab, HeaderTabsService } from '@mm-services/header-tabs.service';
-import { UiExtensionsService } from '@mm-services/ui-extensions.service';
+import { HeaderTab, HeaderTabsService, SidebarTab } from '@mm-services/header-tabs.service';
 
 export const OLD_NAV_PERMISSION = 'can_view_old_navigation';
 
@@ -38,7 +37,7 @@ export const OLD_NAV_PERMISSION = 'can_view_old_navigation';
     HeaderLogoPipe,
     ResourceIconPipe,
     RelativeDatePipe,
-    LocalizeNumberPipe
+    LocalizeNumberPipe,
   ]
 })
 
@@ -51,7 +50,7 @@ export class HeaderComponent extends BaseMenuComponent implements OnInit, OnDest
   currentTab;
   bubbleCount = {};
   permittedTabs: HeaderTab[] = [];
-  uiExtensionOptions: UiExtMenuOption[] = [];
+  legacyMenuTabs: SidebarTab[] = [];
 
   constructor(
     protected readonly store: Store,
@@ -59,7 +58,6 @@ export class HeaderComponent extends BaseMenuComponent implements OnInit, OnDest
     protected readonly modalService: ModalService,
     protected readonly storageInfoService: StorageInfoService,
     private headerTabsService: HeaderTabsService,
-    private readonly uiExtensionsService: UiExtensionsService,
   ) {
     super(store, dbSyncService, modalService, storageInfoService);
   }
@@ -68,11 +66,20 @@ export class HeaderComponent extends BaseMenuComponent implements OnInit, OnDest
     super.ngOnInit();
     this.additionalSubscriptions();
     this.getHeaderTabs();
-    this.loadUiExtensionOptions();
+    this.headerTabsService
+      .getSidebarTabs()
+      .then(tabs => this.legacyMenuTabs = tabs);
   }
 
   ngOnDestroy() {
     super.ngOnDestroy();
+  }
+
+  onLegacyMenuClick(tab: SidebarTab) {
+    if (tab.name !== 'bug') {
+      return;
+    }
+    this.openFeedback();
   }
 
   private additionalSubscriptions(){
@@ -100,25 +107,4 @@ export class HeaderComponent extends BaseMenuComponent implements OnInit, OnDest
         this.permittedTabs = permittedTabs;
       });
   }
-
-  private loadUiExtensionOptions() {
-    this.uiExtensionsService
-      .getPropertiesByType('sidebar_tab')
-      .then(extensions => {
-        this.uiExtensionOptions = extensions
-          .map(ext => ({
-            routerLink: `ui-extensions/${ext.id}`,
-            translationKey: ext.title!,
-            resourceIcon: ext.resource_icon,
-            icon: ext.icon || 'fa-question-circle',
-          }));
-      });
-  }
-}
-
-interface UiExtMenuOption {
-  routerLink: string;
-  translationKey: string;
-  resourceIcon?: string;
-  icon?: string;
 }

--- a/webapp/src/ts/components/header/header.component.ts
+++ b/webapp/src/ts/components/header/header.component.ts
@@ -37,7 +37,7 @@ export const OLD_NAV_PERMISSION = 'can_view_old_navigation';
     HeaderLogoPipe,
     ResourceIconPipe,
     RelativeDatePipe,
-    LocalizeNumberPipe,
+    LocalizeNumberPipe
   ]
 })
 

--- a/webapp/src/ts/components/header/header.component.ts
+++ b/webapp/src/ts/components/header/header.component.ts
@@ -50,7 +50,7 @@ export class HeaderComponent extends BaseMenuComponent implements OnInit, OnDest
   currentTab;
   bubbleCount = {};
   permittedTabs: HeaderTab[] = [];
-  legacyMenuTabs: SidebarTab[] = [];
+  headerTabsForLegacySidebar: SidebarTab[] = [];
 
   constructor(
     protected readonly store: Store,
@@ -68,7 +68,7 @@ export class HeaderComponent extends BaseMenuComponent implements OnInit, OnDest
     this.getHeaderTabs();
     this.headerTabsService
       .getSidebarTabs()
-      .then(tabs => this.legacyMenuTabs = tabs);
+      .then(tabs => this.headerTabsForLegacySidebar = tabs);
   }
 
   ngOnDestroy() {
@@ -76,10 +76,9 @@ export class HeaderComponent extends BaseMenuComponent implements OnInit, OnDest
   }
 
   onLegacyMenuClick(tab: SidebarTab) {
-    if (tab.name !== 'bug') {
-      return;
+    if (tab.name === 'bug') {
+      this.openFeedback();
     }
-    this.openFeedback();
   }
 
   private additionalSubscriptions(){

--- a/webapp/src/ts/components/sidebar-menu/sidebar-menu.component.html
+++ b/webapp/src/ts/components/sidebar-menu/sidebar-menu.component.html
@@ -62,24 +62,14 @@
       </div>
 
       <div class="nav-section">
-        <ng-container *ngFor="let option of menuOptions">
+        <ng-container *ngFor="let tab of headerTabsForSidebar">
           <a class="nav-item"
-            *ngIf="option.hasPermissions"
-            [routerLink]="option.routerLink"
-            [mmAuth]="option.hasPermissions"
-            (click)="option.click && option.click(); close()">
-            <span class="nav-icon" *ngIf="option.resourceIcon" [innerHTML]="option.resourceIcon | resourceIcon"></span>
-            <mat-icon *ngIf="!option.resourceIcon" [fontIcon]="option.icon"></mat-icon>
-            <span>{{ option.translationKey | translate }}</span>
-          </a>
-
-          <a class="nav-item"
-            *ngIf="!option.hasPermissions && option.canDisplay"
-            [routerLink]="option.routerLink"
-            (click)="option.click && option.click(); close()">
-            <span class="nav-icon" *ngIf="option.resourceIcon" [innerHTML]="option.resourceIcon | resourceIcon"></span>
-            <mat-icon *ngIf="!option.resourceIcon" [fontIcon]="option.icon"></mat-icon>
-            <span>{{ option.translationKey | translate }}</span>
+             *ngIf="tab.name !== 'privacy-policy' || showPrivacyPolicy"
+             [routerLink]="tab.route"
+             (click)="onTabClick(tab)">
+              <span class="nav-icon" *ngIf="tab.resourceIcon" [innerHTML]="tab.resourceIcon | resourceIcon"></span>
+              <mat-icon *ngIf="!tab.resourceIcon" [fontIcon]="tab.icon || tab.defaultIcon"></mat-icon>
+              <span>{{ tab.translation | translate }}</span>
           </a>
         </ng-container>
       </div>

--- a/webapp/src/ts/components/sidebar-menu/sidebar-menu.component.ts
+++ b/webapp/src/ts/components/sidebar-menu/sidebar-menu.component.ts
@@ -1,9 +1,9 @@
-import { Component, OnDestroy, OnInit, ViewChild, Input } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { BaseMenuComponent } from '@mm-components/base-menu/base-menu.component';
 import { MatSidenav, MatSidenavContainer, MatSidenavContent } from '@angular/material/sidenav';
 import { PanelHeaderComponent } from '@mm-components/panel-header/panel-header.component';
-import { NgFor, NgIf, NgClass } from '@angular/common';
-import { RouterLink, NavigationStart, Router } from '@angular/router';
+import { NgClass, NgFor, NgIf } from '@angular/common';
+import { NavigationStart, Router, RouterLink } from '@angular/router';
 import { AuthDirective } from '@mm-directives/auth.directive';
 import { MatIcon } from '@angular/material/icon';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -17,43 +17,10 @@ import { LocationService } from '@mm-services/location.service';
 import { DBSyncService } from '@mm-services/db-sync.service';
 import { ModalService } from '@mm-services/modal.service';
 import { StorageInfoService } from '@mm-services/storage-info.service';
-import { UiExtensionsService } from '@mm-services/ui-extensions.service';
 
 import { filter } from 'rxjs/operators';
 import { Selectors } from '@mm-selectors/index';
-
-const TAB_MENU_OPTIONS = [
-  {
-    routerLink: 'messages',
-    icon: 'fa-envelope',
-    translationKey: 'Messages',
-    hasPermissions: 'can_view_messages,!can_view_messages_tab'
-  },
-  {
-    routerLink: 'tasks',
-    icon: 'fa-flag',
-    translationKey: 'Tasks',
-    hasPermissions: 'can_view_tasks,!can_view_tasks_tab'
-  },
-  {
-    routerLink: 'reports',
-    icon: 'fa-list-alt',
-    translationKey: 'Reports',
-    hasPermissions: 'can_view_reports,!can_view_reports_tab'
-  },
-  {
-    routerLink: 'contacts',
-    icon: 'fa-user',
-    translationKey: 'Contacts',
-    hasPermissions: 'can_view_contacts,!can_view_contacts_tab'
-  },
-  {
-    routerLink: 'analytics',
-    icon: 'fa-bar-chart-o',
-    translationKey: 'Analytics',
-    hasPermissions: 'can_view_analytics,!can_view_analytics_tab',
-  },
-];
+import { HeaderTabsService, SidebarTab } from '@mm-services/header-tabs.service';
 
 @Component({
   selector: 'mm-sidebar-menu',
@@ -79,7 +46,8 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
   @ViewChild('sidebar') sidebar!: MatSidenav;
   private globalActions: GlobalActions;
   replicationStatus;
-  menuOptions: MenuOption[] = [];
+  showPrivacyPolicy: boolean = false;
+  headerTabsForSidebar: SidebarTab[] = [];
   adminAppPath: string = '';
 
   constructor(
@@ -89,7 +57,7 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
     protected modalService: ModalService,
     private router: Router,
     protected readonly storageInfoService: StorageInfoService,
-    private readonly uiExtensionsService: UiExtensionsService,
+    private readonly headerTabsService: HeaderTabsService
   ) {
     super(store, dbSyncService, modalService, storageInfoService);
     this.globalActions = new GlobalActions(store);
@@ -100,6 +68,9 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
     this.adminAppPath = this.locationService.adminPath;
     this.additionalSubscriptions();
     this.subscribeToRouter();
+    this.headerTabsService
+      .getSidebarTabs()
+      .then(tabs => this.headerTabsForSidebar = tabs);
   }
 
   ngOnDestroy() {
@@ -117,6 +88,14 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
     super.replicate();
   }
 
+  onTabClick(tab: SidebarTab) {
+    if (tab.name !== 'bug') {
+      return;
+    }
+    this.openFeedback();
+    this.close();
+  }
+
   private subscribeToRouter() {
     const routerSubscription = this.router.events
       .pipe(filter(event => event instanceof NavigationStart))
@@ -132,73 +111,7 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
 
     const subscribePrivacyPolicy = this.store
       .select(Selectors.getShowPrivacyPolicy)
-      .subscribe(showPrivacyPolicy => this.setMenuOptions(showPrivacyPolicy));
+      .subscribe(showPrivacyPolicy => this.showPrivacyPolicy = showPrivacyPolicy);
     this.subscriptions.add(subscribePrivacyPolicy);
   }
-
-  private async getUiExtensionOptions() {
-    const extensions = await this.uiExtensionsService.getPropertiesByType('sidebar_tab');
-    return extensions
-      .filter(ext => ext.title)
-      .map(ext => ({
-        routerLink: `ui-extensions/${ext.id}`,
-        translationKey: ext.title!,
-        resourceIcon: ext.resource_icon,
-        icon: ext.icon || 'fa-question-circle',
-        canDisplay: true,
-      }));
-  }
-
-  private async setMenuOptions(showPrivacyPolicy: boolean) {
-    this.menuOptions = [
-      ...TAB_MENU_OPTIONS,
-      ...(await this.getUiExtensionOptions()),
-      ...this.getSecondaryOptions(showPrivacyPolicy),
-    ];
-  }
-
-  private getSecondaryOptions(showPrivacyPolicy: boolean) {
-    return [
-      {
-        routerLink: 'trainings',
-        icon: 'fa-graduation-cap',
-        translationKey: 'training_materials.page.title',
-        canDisplay: true,
-      },
-      {
-        routerLink: 'about',
-        icon: 'fa-question',
-        translationKey: 'about',
-        canDisplay: true,
-      },
-      {
-        routerLink: 'user',
-        icon: 'fa-user',
-        translationKey: 'edit.user.settings',
-        hasPermissions: 'can_edit_profile'
-      },
-      {
-        routerLink: 'privacy-policy',
-        icon: 'fa-lock',
-        translationKey: 'privacy.policy',
-        canDisplay: showPrivacyPolicy,
-      },
-      {
-        icon: 'fa-bug',
-        translationKey: 'Report Bug',
-        canDisplay: true,
-        click: () => this.openFeedback()
-      },
-    ];
-  }
-}
-
-interface MenuOption {
-  icon?: string;
-  resourceIcon?: string;
-  translationKey: string;
-  routerLink?: string;
-  hasPermissions?: string;
-  canDisplay?: boolean;
-  click?: () => void;
 }

--- a/webapp/src/ts/components/sidebar-menu/sidebar-menu.component.ts
+++ b/webapp/src/ts/components/sidebar-menu/sidebar-menu.component.ts
@@ -89,10 +89,9 @@ export class SidebarMenuComponent extends BaseMenuComponent implements OnInit, O
   }
 
   onTabClick(tab: SidebarTab) {
-    if (tab.name !== 'bug') {
-      return;
+    if (tab.name === 'bug') {
+      this.openFeedback();
     }
-    this.openFeedback();
     this.close();
   }
 

--- a/webapp/src/ts/services/header-tabs.service.ts
+++ b/webapp/src/ts/services/header-tabs.service.ts
@@ -24,6 +24,7 @@ export class HeaderTabsService {
       typeName: 'message',
       icon: undefined,
       resourceIcon: undefined,
+      weight: 1,
     },
     {
       name: 'tasks',
@@ -34,6 +35,7 @@ export class HeaderTabsService {
       typeName: 'task',
       icon: undefined,
       resourceIcon: undefined,
+      weight: 2,
     },
     {
       name: 'reports',
@@ -44,6 +46,7 @@ export class HeaderTabsService {
       typeName: 'report',
       icon: undefined,
       resourceIcon: undefined,
+      weight: 3,
     },
     {
       name: 'contacts',
@@ -53,6 +56,7 @@ export class HeaderTabsService {
       permissions: ['can_view_contacts', 'can_view_contacts_tab'],
       icon: undefined,
       resourceIcon: undefined,
+      weight: 4,
     },
     {
       name: 'analytics',
@@ -62,8 +66,11 @@ export class HeaderTabsService {
       permissions: ['can_view_analytics', 'can_view_analytics_tab'],
       icon: undefined,
       resourceIcon: undefined,
+      weight: 5,
     }
   ];
+
+  private readonly DEFAULT_UI_EXTENSION_WEIGHT = 6;
 
   private tabs?: HeaderTab[];
 
@@ -74,7 +81,8 @@ export class HeaderTabsService {
       return {
         ...tab,
         icon: tabSettings?.icon?.startsWith('fa-') ? tabSettings.icon : tab.icon,
-        resourceIcon: tabSettings?.resource_icon ? tabSettings.resource_icon : tab.resourceIcon
+        resourceIcon: tabSettings?.resource_icon ? tabSettings.resource_icon : tab.resourceIcon,
+        weight: tabSettings?.weight ?? tab.weight
       };
     });
 
@@ -91,7 +99,8 @@ export class HeaderTabsService {
       translation: ext.title!,
       permissions: [], // Extensions are already filtered by role in getPropertiesByType
       resourceIcon: ext.resource_icon,
-      icon: ext.icon
+      icon: ext.icon,
+      weight: ext.weight ?? this.DEFAULT_UI_EXTENSION_WEIGHT
     }));
   }
 
@@ -106,7 +115,7 @@ export class HeaderTabsService {
         this.getHeaderTabs(),
         this.getUiExtensionTabs()
       ]);
-      this.tabs = [...headerTabs, ...uiExtensionTabs];
+      this.tabs = [...headerTabs, ...uiExtensionTabs].sort((a, b) => a.weight - b.weight);
     }
 
     return this.tabs;
@@ -133,4 +142,5 @@ export interface HeaderTab {
   typeName?: string;
   icon?: string;
   resourceIcon?: string;
+  weight: number;
 }

--- a/webapp/src/ts/services/header-tabs.service.ts
+++ b/webapp/src/ts/services/header-tabs.service.ts
@@ -14,69 +14,110 @@ export class HeaderTabsService {
     private readonly uiExtensionsService: UiExtensionsService
   ) { }
 
+  private readonly MESSAGE_TAB = {
+    name: 'messages',
+    route: 'messages',
+    defaultIcon: 'fa-envelope',
+    translation: 'Messages',
+    typeName: 'message',
+    weight: 1,
+  };
+
+  private readonly TASKS_TAB = {
+    name: 'tasks',
+    route: 'tasks',
+    defaultIcon: 'fa-flag',
+    translation: 'Tasks',
+    typeName: 'task',
+    weight: 2,
+  };
+
+  private readonly REPORTS_TAB = {
+    name: 'reports',
+    route: 'reports',
+    defaultIcon: 'fa-list-alt',
+    translation: 'Reports',
+    typeName: 'report',
+    weight: 3,
+  };
+
+  private readonly CONTACTS_TAB = {
+    name: 'contacts',
+    route: 'contacts',
+    defaultIcon: 'fa-user',
+    translation: 'Contacts',
+    weight: 4,
+  };
+
+  private readonly ANALYTICS_TAB = {
+    name: 'analytics',
+    route: 'analytics',
+    defaultIcon: 'fa-bar-chart-o',
+    translation: 'Analytics',
+    weight: 5,
+  };
+
+  private readonly SIDEBAR_HEADER_TABS: HeaderTab[] = [
+    { ...this.MESSAGE_TAB, permissions: ['can_view_messages', '!can_view_messages_tab'] },
+    { ...this.TASKS_TAB, permissions: ['can_view_tasks', '!can_view_tasks_tab'] },
+    { ...this.REPORTS_TAB, permissions: ['can_view_reports', '!can_view_reports_tab'] },
+    { ...this.CONTACTS_TAB, permissions: ['can_view_contacts', '!can_view_contacts_tab'] },
+    { ...this.ANALYTICS_TAB, permissions: ['can_view_analytics', '!can_view_analytics_tab'] }
+  ];
+
   private readonly DEFAULT_TABS: HeaderTab[] = [
+    { ...this.MESSAGE_TAB, permissions: ['can_view_messages', 'can_view_messages_tab'] },
+    { ...this.TASKS_TAB, permissions: ['can_view_tasks', 'can_view_tasks_tab'] },
+    { ...this.REPORTS_TAB, permissions: ['can_view_reports', 'can_view_reports_tab'] },
+    { ...this.CONTACTS_TAB, permissions: ['can_view_contacts', 'can_view_contacts_tab'] },
+    { ...this.ANALYTICS_TAB, permissions: ['can_view_analytics', 'can_view_analytics_tab'] }
+  ];
+
+  private readonly SIDEBAR_TABS: SidebarTab[] = [
     {
-      name: 'messages',
-      route: 'messages',
-      defaultIcon: 'fa-envelope',
-      translation: 'Messages',
-      permissions: ['can_view_messages', 'can_view_messages_tab'],
-      typeName: 'message',
-      icon: undefined,
-      resourceIcon: undefined,
-      weight: 1,
+      name: 'trainings',
+      route: 'trainings',
+      defaultIcon: 'fa-graduation-cap',
+      translation: 'training_materials.page.title',
+      permissions: [],
     },
     {
-      name: 'tasks',
-      route: 'tasks',
-      defaultIcon: 'fa-flag',
-      translation: 'Tasks',
-      permissions: ['can_view_tasks', 'can_view_tasks_tab'],
-      typeName: 'task',
-      icon: undefined,
-      resourceIcon: undefined,
-      weight: 2,
+      name: 'about',
+      route: 'about',
+      defaultIcon: 'fa-question',
+      translation: 'about',
+      permissions: [],
     },
     {
-      name: 'reports',
-      route: 'reports',
-      defaultIcon: 'fa-list-alt',
-      translation: 'Reports',
-      permissions: ['can_view_reports', 'can_view_reports_tab'],
-      typeName: 'report',
-      icon: undefined,
-      resourceIcon: undefined,
-      weight: 3,
-    },
-    {
-      name: 'contacts',
-      route: 'contacts',
+      name: 'user',
+      route: 'user',
       defaultIcon: 'fa-user',
-      translation: 'Contacts',
-      permissions: ['can_view_contacts', 'can_view_contacts_tab'],
-      icon: undefined,
-      resourceIcon: undefined,
-      weight: 4,
+      translation: 'edit.user.settings',
+      permissions: ['can_edit_profile'],
     },
     {
-      name: 'analytics',
-      route: 'analytics',
-      defaultIcon: 'fa-bar-chart-o',
-      translation: 'Analytics',
-      permissions: ['can_view_analytics', 'can_view_analytics_tab'],
-      icon: undefined,
-      resourceIcon: undefined,
-      weight: 5,
-    }
+      name: 'privacy-policy',
+      route: 'privacy-policy',
+      defaultIcon: 'fa-lock',
+      translation: 'privacy.policy',
+      permissions: [],
+    },
+    {
+      name: 'bug',
+      defaultIcon: 'fa-bug',
+      translation: 'Report Bug',
+      permissions: [],
+    },
   ];
 
   private readonly DEFAULT_UI_EXTENSION_WEIGHT = 6;
 
   private tabs?: HeaderTab[];
+  private sidebarTabs?: SidebarTab[];
 
-  private async getHeaderTabs() {
+  private async getHeaderTabs(tabs: HeaderTab[]) {
     const { header_tabs } = await this.settingsService.get();
-    const headerTabs = this.DEFAULT_TABS.map(tab => {
+    const headerTabs = tabs.map(tab => {
       const tabSettings = header_tabs?.[tab.name];
       return {
         ...tab,
@@ -90,8 +131,8 @@ export class HeaderTabsService {
     return headerTabs.filter((tab, index) => tabAuthorization[index]);
   }
 
-  private async getUiExtensionTabs() {
-    const extensions = await this.uiExtensionsService.getPropertiesByType('header_tab');
+  private async getUiExtensionTabs(type: string) {
+    const extensions = await this.uiExtensionsService.getPropertiesByType(type);
     return extensions.map(ext => ({
       name: `ui-extension-${ext.id}`,
       route: `ui-extensions/${ext.id}`,
@@ -104,6 +145,23 @@ export class HeaderTabsService {
     }));
   }
 
+  async getSidebarTabs(): Promise<SidebarTab[]> {
+    if (!this.sidebarTabs) {
+      const [headerTabs, uiExtensionTabs] = await Promise.all([
+        this.getHeaderTabs(this.SIDEBAR_HEADER_TABS),
+        this.getUiExtensionTabs('sidebar_tab')
+      ]);
+      // sidebar_tab extensions should always come after the headers
+      this.sidebarTabs = [
+        ...headerTabs.sort((a, b) => a.weight - b.weight),
+        ...uiExtensionTabs,
+        ...this.SIDEBAR_TABS
+      ];
+    }
+
+    return this.sidebarTabs;
+  }
+
   /**
    * Returns the list of authorized header tabs according to the current user's permissions.
    *
@@ -112,8 +170,8 @@ export class HeaderTabsService {
   async getAuthorizedTabs(): Promise<HeaderTab[]> {
     if (!this.tabs) {
       const [headerTabs, uiExtensionTabs] = await Promise.all([
-        this.getHeaderTabs(),
-        this.getUiExtensionTabs()
+        this.getHeaderTabs(this.DEFAULT_TABS),
+        this.getUiExtensionTabs('header_tab')
       ]);
       this.tabs = [...headerTabs, ...uiExtensionTabs].sort((a, b) => a.weight - b.weight);
     }
@@ -133,14 +191,18 @@ export class HeaderTabsService {
   }
 }
 
-export interface HeaderTab {
+export interface SidebarTab {
   name: string;
-  route: string;
+  route?: string;
   defaultIcon: string;
   translation: string;
   permissions: string[];
-  typeName?: string;
   icon?: string;
   resourceIcon?: string;
+}
+
+export interface HeaderTab extends SidebarTab {
+  route: string;
+  typeName?: string;
   weight: number;
 }

--- a/webapp/src/ts/services/header-tabs.service.ts
+++ b/webapp/src/ts/services/header-tabs.service.ts
@@ -151,9 +151,10 @@ export class HeaderTabsService {
         this.getHeaderTabs(this.SIDEBAR_HEADER_TABS),
         this.getUiExtensionTabs('sidebar_tab')
       ]);
+      headerTabs.sort((a, b) => a.weight - b.weight);
       // sidebar_tab extensions should always come after the headers
       this.sidebarTabs = [
-        ...headerTabs.sort((a, b) => a.weight - b.weight),
+        ...headerTabs,
         ...uiExtensionTabs,
         ...this.SIDEBAR_TABS
       ];

--- a/webapp/src/ts/services/header-tabs.service.ts
+++ b/webapp/src/ts/services/header-tabs.service.ts
@@ -110,7 +110,7 @@ export class HeaderTabsService {
     },
   ];
 
-  private readonly DEFAULT_UI_EXTENSION_WEIGHT = 6;
+  private readonly DEFAULT_UI_EXTENSION_WEIGHT = this.DEFAULT_TABS.length + 1;
 
   private tabs?: HeaderTab[];
   private sidebarTabs?: SidebarTab[];

--- a/webapp/src/ts/services/ui-extensions.service.ts
+++ b/webapp/src/ts/services/ui-extensions.service.ts
@@ -13,6 +13,7 @@ interface UiExtensionProperties {
   readonly title?: string;
   readonly config?: Record<string, unknown>;
   readonly accent_color?: string;
+  readonly weight?: number;
 }
 
 interface UiExtension {
@@ -70,7 +71,20 @@ export class UiExtensionsService {
 
   async getPropertiesByType(type: string): Promise<UiExtensionProperties[]> {
     await this.init();
-    return this.extensionProperties.filter(extension => extension.type === type);
+    return this.extensionProperties
+      .filter(extension => extension.type === type)
+      .sort((a, b) => {
+        if (a.weight !== undefined && b.weight !== undefined) {
+          return a.weight - b.weight;
+        }
+        if (a.weight !== undefined) {
+          return -1;
+        }
+        if (b.weight !== undefined) {
+          return 1;
+        }
+        return a.id.localeCompare(b.id);
+      });
   }
 
   async getProperties(id: string): Promise<UiExtensionProperties> {

--- a/webapp/tests/karma/ts/app.component.spec.ts
+++ b/webapp/tests/karma/ts/app.component.spec.ts
@@ -54,6 +54,7 @@ import { StorageInfoService } from '@mm-services/storage-info.service';
 import { TasksNotificationService } from '@mm-services/task-notifications.service';
 import { PREFIXES } from '@medic/constants';
 import { UiExtensionsService } from '@mm-services/ui-extensions.service';
+import { HeaderTabsService } from '@mm-services/header-tabs.service';
 
 describe('AppComponent', () => {
   let component: AppComponent;
@@ -98,6 +99,7 @@ describe('AppComponent', () => {
   let storageInfoService;
   let tasksNotificationService;
   let uiExtensionsService;
+  let headerTabsService;
   // End Services
 
   let globalActions;
@@ -200,6 +202,10 @@ describe('AppComponent', () => {
     formService = { setUserContext: sinon.stub() };
     updateServiceWorkerService = { update: sinon.stub() };
     uiExtensionsService = { getPropertiesByType: sinon.stub().resolves([]) };
+    headerTabsService = {
+      getAuthorizedTabs: sinon.stub().resolves([]),
+      getSidebarTabs: sinon.stub().resolves([]),
+    };
     consoleErrorStub = sinon.stub(console, 'error');
 
     const mockedSelectors = [
@@ -256,6 +262,7 @@ describe('AppComponent', () => {
           { provide: Router, useValue: router },
           { provide: TasksNotificationService, useValue: tasksNotificationService },
           { provide: UiExtensionsService, useValue: uiExtensionsService },
+          { provide: HeaderTabsService, useValue: headerTabsService },
         ]
       })
       .overrideComponent(SidebarMenuComponent, {

--- a/webapp/tests/karma/ts/components/header/header.component.spec.ts
+++ b/webapp/tests/karma/ts/components/header/header.component.spec.ts
@@ -194,7 +194,7 @@ describe('Header Component', () => {
       expect(component.legacyMenuTabs).to.deep.equal([]);
     });
 
-    it('should populate legacyMenuTabs from headerTabsService.getSidebarTabs()', async () => {
+    it('should populate legacyMenuTabs', async () => {
       const sidebarTabs = [
         {
           name: 'messages',
@@ -224,7 +224,7 @@ describe('Header Component', () => {
       fixture.detectChanges();
       await fixture.whenStable();
 
-      expect(headerTabsService.getSidebarTabs.callCount).to.equal(1);
+      expect(headerTabsService.getSidebarTabs).to.have.been.calledOnceWithExactly();
       expect(component.legacyMenuTabs).to.deep.equal(sidebarTabs);
     });
   });
@@ -240,7 +240,7 @@ describe('Header Component', () => {
         permissions: [],
       });
 
-      expect(modalService.show.calledOnce).to.be.true;
+      expect(modalService.show).to.have.been.calledOnce;
       expect(modalService.show.args[0][0]).to.equal(FeedbackComponent);
     });
 
@@ -255,7 +255,7 @@ describe('Header Component', () => {
         permissions: [],
       });
 
-      expect(modalService.show.called).to.be.false;
+      expect(modalService.show).to.not.have.been.called;
     });
   });
 

--- a/webapp/tests/karma/ts/components/header/header.component.spec.ts
+++ b/webapp/tests/karma/ts/components/header/header.component.spec.ts
@@ -191,7 +191,7 @@ describe('Header Component', () => {
       await fixture.whenStable();
 
       expect(headerTabsService.getSidebarTabs.callCount).to.equal(1);
-      expect(component.legacyMenuTabs).to.deep.equal([]);
+      expect(component.headerTabsForLegacySidebar).to.deep.equal([]);
     });
 
     it('should populate legacyMenuTabs', async () => {
@@ -225,7 +225,7 @@ describe('Header Component', () => {
       await fixture.whenStable();
 
       expect(headerTabsService.getSidebarTabs).to.have.been.calledOnceWithExactly();
-      expect(component.legacyMenuTabs).to.deep.equal(sidebarTabs);
+      expect(component.headerTabsForLegacySidebar).to.deep.equal(sidebarTabs);
     });
   });
 

--- a/webapp/tests/karma/ts/components/header/header.component.spec.ts
+++ b/webapp/tests/karma/ts/components/header/header.component.spec.ts
@@ -11,9 +11,9 @@ import { DBSyncService } from '@mm-services/db-sync.service';
 import { ModalService } from '@mm-services/modal.service';
 import { StorageInfoService } from '@mm-services/storage-info.service';
 import { HeaderTabsService } from '@mm-services/header-tabs.service';
-import { UiExtensionsService } from '@mm-services/ui-extensions.service';
 import { CustomResourceService } from '@mm-services/custom-resource.service';
 import { ChangesService } from '@mm-services/changes.service';
+import { FeedbackComponent } from '@mm-modals/feedback/feedback.component';
 import { Selectors } from '@mm-selectors/index';
 
 describe('Header Component', () => {
@@ -24,7 +24,6 @@ describe('Header Component', () => {
   let modalService;
   let storageInfoService;
   let headerTabsService;
-  let uiExtensionsService;
   let customResourceService;
   let changesService;
 
@@ -41,10 +40,8 @@ describe('Header Component', () => {
         { name: 'messages', defaultIcon: 'fa-envelope' },
         { name: 'tasks', defaultIcon: 'fa-flag', typeName: 'task' },
         { name: 'reports', defaultIcon: 'fa-list-alt', typeName: 'report' },
-      ])
-    };
-    uiExtensionsService = {
-      getPropertiesByType: sinon.stub().resolves([]),
+      ]),
+      getSidebarTabs: sinon.stub().resolves([])
     };
     customResourceService = {
       getAppTitle: sinon.stub().resolves('App Title'),
@@ -75,7 +72,6 @@ describe('Header Component', () => {
           { provide: ModalService, useValue: modalService },
           { provide: StorageInfoService, useValue: storageInfoService },
           { provide: HeaderTabsService, useValue: headerTabsService },
-          { provide: UiExtensionsService, useValue: uiExtensionsService },
           { provide: CustomResourceService, useValue: customResourceService },
           { provide: ChangesService, useValue: changesService },
         ]
@@ -189,39 +185,77 @@ describe('Header Component', () => {
     expect(unsubscribeSpy.callCount).to.equal(1);
   });
 
-  describe('UI extension options', () => {
-    it('should initialize uiExtensionOptions as empty array', async () => {
+  describe('legacy menu tabs', () => {
+    it('should initialize legacyMenuTabs as empty array', async () => {
       fixture.detectChanges();
       await fixture.whenStable();
 
-      expect(uiExtensionsService.getPropertiesByType).to.have.been.calledOnceWithExactly('sidebar_tab');
-      expect(component.uiExtensionOptions).to.deep.equal([]);
+      expect(headerTabsService.getSidebarTabs.callCount).to.equal(1);
+      expect(component.legacyMenuTabs).to.deep.equal([]);
     });
 
-    it('should load sidebar_tab extensions and map them to menu options', async () => {
-      uiExtensionsService.getPropertiesByType.resolves([
-        { id: 'ext1', type: 'sidebar_tab', title: 'Hello Extension', resource_icon: 'hello-icon' },
-        { id: 'ext2', type: 'sidebar_tab', title: 'Goodbye Extension', icon: 'fa-goodbye' },
-      ]);
+    it('should populate legacyMenuTabs from headerTabsService.getSidebarTabs()', async () => {
+      const sidebarTabs = [
+        {
+          name: 'messages',
+          route: 'messages',
+          defaultIcon: 'fa-envelope',
+          translation: 'Messages',
+          permissions: ['can_view_messages', '!can_view_messages_tab'],
+        },
+        {
+          name: 'ui-extension-first',
+          route: 'ui-extensions/first',
+          defaultIcon: 'fa-question-circle',
+          translation: 'First Extension',
+          permissions: [],
+          icon: 'fa-icon-1',
+          resourceIcon: 'res-1',
+        },
+        {
+          name: 'bug',
+          defaultIcon: 'fa-bug',
+          translation: 'Report Bug',
+          permissions: [],
+        },
+      ];
+      headerTabsService.getSidebarTabs.resolves(sidebarTabs);
 
       fixture.detectChanges();
       await fixture.whenStable();
 
-      expect(uiExtensionsService.getPropertiesByType).to.have.been.calledOnceWithExactly('sidebar_tab');
-      expect(component.uiExtensionOptions).to.deep.equal([
-        {
-          routerLink: 'ui-extensions/ext1',
-          translationKey: 'Hello Extension',
-          resourceIcon: 'hello-icon',
-          icon: 'fa-question-circle'
-        },
-        {
-          routerLink: 'ui-extensions/ext2',
-          translationKey: 'Goodbye Extension',
-          resourceIcon: undefined,
-          icon: 'fa-goodbye'
-        },
-      ]);
+      expect(headerTabsService.getSidebarTabs.callCount).to.equal(1);
+      expect(component.legacyMenuTabs).to.deep.equal(sidebarTabs);
+    });
+  });
+
+  describe('onLegacyMenuClick()', () => {
+    it('should open the feedback modal when the bug tab is clicked', () => {
+      fixture.detectChanges();
+
+      component.onLegacyMenuClick({
+        name: 'bug',
+        defaultIcon: 'fa-bug',
+        translation: 'Report Bug',
+        permissions: [],
+      });
+
+      expect(modalService.show.calledOnce).to.be.true;
+      expect(modalService.show.args[0][0]).to.equal(FeedbackComponent);
+    });
+
+    it('should not open the feedback modal for any other tab', () => {
+      fixture.detectChanges();
+
+      component.onLegacyMenuClick({
+        name: 'messages',
+        route: 'messages',
+        defaultIcon: 'fa-envelope',
+        translation: 'Messages',
+        permissions: [],
+      });
+
+      expect(modalService.show.called).to.be.false;
     });
   });
 

--- a/webapp/tests/karma/ts/components/sidebar-menu/sidebar-menu.component.spec.ts
+++ b/webapp/tests/karma/ts/components/sidebar-menu/sidebar-menu.component.spec.ts
@@ -90,11 +90,13 @@ describe('SidebarMenuComponent', () => {
     expect(unsubscribeSpy.calledOnce).to.be.true;
   });
 
-  it('should initialise the admin app path', () => {
+  it('should initialise the component', () => {
     expect(component.adminAppPath).to.equal('/admin/');
+    expect(component.headerTabsForSidebar).to.deep.equal([]);
+    expect(component.showPrivacyPolicy).to.be.false;
   });
 
-  it('should populate headerTabsForSidebar from headerTabsService', async () => {
+  it('should populate headerTabsForSidebar', async () => {
     const sidebarTabs: SidebarTab[] = [
       {
         name: 'messages',
@@ -118,14 +120,6 @@ describe('SidebarMenuComponent', () => {
 
     expect(headerTabsService.getSidebarTabs).to.have.been.calledOnceWithExactly();
     expect(component.headerTabsForSidebar).to.deep.equal(sidebarTabs);
-  });
-
-  it('should initialize headerTabsForSidebar as empty array before loading', () => {
-    expect(component.headerTabsForSidebar).to.deep.equal([]);
-  });
-
-  it('should default showPrivacyPolicy to false', () => {
-    expect(component.showPrivacyPolicy).to.be.false;
   });
 
   it('should update showPrivacyPolicy when the selector emits', () => {
@@ -177,9 +171,9 @@ describe('SidebarMenuComponent', () => {
         permissions: [],
       });
 
-      expect(modalService.show.calledOnce).to.be.true;
+      expect(modalService.show).to.have.been.calledOnce;
       expect(modalService.show.args[0][0]).to.deep.equal(FeedbackComponent);
-      expect(closeStub.calledOnce).to.be.true;
+      expect(closeStub).to.have.been.calledOnceWithExactly();
     });
 
     it('should close the sidebar for any other tab', () => {
@@ -193,8 +187,8 @@ describe('SidebarMenuComponent', () => {
         permissions: [],
       });
 
-      expect(modalService.show.called).to.be.false;
-      expect(closeStub.calledOnce).to.be.true;
+      expect(modalService.show).to.not.have.been.called;
+      expect(closeStub).to.have.been.calledOnceWithExactly();
     });
   });
 });

--- a/webapp/tests/karma/ts/components/sidebar-menu/sidebar-menu.component.spec.ts
+++ b/webapp/tests/karma/ts/components/sidebar-menu/sidebar-menu.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { MatSidenavModule } from '@angular/material/sidenav';
@@ -6,7 +6,7 @@ import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { TranslateFakeLoader, TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import sinon from 'sinon';
-import { assert, expect } from 'chai';
+import { expect } from 'chai';
 
 import { SidebarMenuComponent } from '@mm-components/sidebar-menu/sidebar-menu.component';
 import { LocationService } from '@mm-services/location.service';
@@ -18,7 +18,7 @@ import { AuthService } from '@mm-services/auth.service';
 import { GlobalActions } from '@mm-actions/global';
 import { LogoutConfirmComponent } from '@mm-modals/logout/logout-confirm.component';
 import { FeedbackComponent } from '@mm-modals/feedback/feedback.component';
-import { UiExtensionsService } from '@mm-services/ui-extensions.service';
+import { HeaderTabsService, SidebarTab } from '@mm-services/header-tabs.service';
 import { CustomResourceService } from '@mm-services/custom-resource.service';
 import { ChangesService } from '@mm-services/changes.service';
 import { Selectors } from '@mm-selectors/index';
@@ -30,7 +30,7 @@ describe('SidebarMenuComponent', () => {
   let dbSyncService;
   let modalService;
   let authService;
-  let uiExtensionsService;
+  let headerTabsService;
   let customResourceService;
   let changesService;
   let store: MockStore;
@@ -54,7 +54,7 @@ describe('SidebarMenuComponent', () => {
           { provide: DBSyncService, useValue: dbSyncService },
           { provide: ModalService, useValue: modalService },
           { provide: AuthService, useValue: authService },
-          { provide: UiExtensionsService, useValue: uiExtensionsService },
+          { provide: HeaderTabsService, useValue: headerTabsService },
           { provide: CustomResourceService, useValue: customResourceService },
           { provide: ChangesService, useValue: changesService },
         ],
@@ -73,9 +73,7 @@ describe('SidebarMenuComponent', () => {
     dbSyncService = { sync: sinon.stub() };
     modalService = { show: sinon.stub() };
     authService = { has: sinon.stub(), online: sinon.stub() };
-    uiExtensionsService = {
-      getPropertiesByType: sinon.stub().resolves([]),
-    };
+    headerTabsService = { getSidebarTabs: sinon.stub().resolves([]) };
     customResourceService = { getImg: sinon.stub().returns('') };
     changesService = { subscribe: sinon.stub().returns({ unsubscribe: sinon.stub() }) };
 
@@ -92,70 +90,49 @@ describe('SidebarMenuComponent', () => {
     expect(unsubscribeSpy.calledOnce).to.be.true;
   });
 
-  it('should initialise component with menu options', () => {
+  it('should initialise the admin app path', () => {
     expect(component.adminAppPath).to.equal('/admin/');
+  });
 
-    expect(component.menuOptions).excluding('click').to.deep.equal([
+  it('should populate headerTabsForSidebar from headerTabsService', async () => {
+    const sidebarTabs: SidebarTab[] = [
       {
-        routerLink: 'messages',
-        icon: 'fa-envelope',
-        translationKey: 'Messages',
-        hasPermissions: 'can_view_messages,!can_view_messages_tab'
+        name: 'messages',
+        route: 'messages',
+        defaultIcon: 'fa-envelope',
+        translation: 'Messages',
+        permissions: ['can_view_messages', '!can_view_messages_tab'],
       },
       {
-        routerLink: 'tasks',
-        icon: 'fa-flag',
-        translationKey: 'Tasks',
-        hasPermissions: 'can_view_tasks,!can_view_tasks_tab'
+        name: 'bug',
+        defaultIcon: 'fa-bug',
+        translation: 'Report Bug',
+        permissions: [],
       },
-      {
-        routerLink: 'reports',
-        icon: 'fa-list-alt',
-        translationKey: 'Reports',
-        hasPermissions: 'can_view_reports,!can_view_reports_tab'
-      },
-      {
-        routerLink: 'contacts',
-        icon: 'fa-user',
-        translationKey: 'Contacts',
-        hasPermissions: 'can_view_contacts,!can_view_contacts_tab'
-      },
-      {
-        routerLink: 'analytics',
-        icon: 'fa-bar-chart-o',
-        translationKey: 'Analytics',
-        hasPermissions: 'can_view_analytics,!can_view_analytics_tab',
-      },
-      {
-        routerLink: 'trainings',
-        icon: 'fa-graduation-cap',
-        translationKey: 'training_materials.page.title',
-        canDisplay: true,
-      },
-      {
-        routerLink: 'about',
-        icon: 'fa-question',
-        translationKey: 'about',
-        canDisplay: true,
-      },
-      {
-        routerLink: 'user',
-        icon: 'fa-user',
-        translationKey: 'edit.user.settings',
-        hasPermissions: 'can_edit_profile'
-      },
-      {
-        routerLink: 'privacy-policy',
-        icon: 'fa-lock',
-        translationKey: 'privacy.policy',
-        canDisplay: false,
-      },
-      {
-        icon: 'fa-bug',
-        translationKey: 'Report Bug',
-        canDisplay: true,
-      },
-    ]);
+    ];
+    headerTabsService.getSidebarTabs.resetHistory();
+    headerTabsService.getSidebarTabs.resolves(sidebarTabs);
+
+    await TestBed.resetTestingModule();
+    await createComponent();
+
+    expect(headerTabsService.getSidebarTabs).to.have.been.calledOnceWithExactly();
+    expect(component.headerTabsForSidebar).to.deep.equal(sidebarTabs);
+  });
+
+  it('should initialize headerTabsForSidebar as empty array before loading', () => {
+    expect(component.headerTabsForSidebar).to.deep.equal([]);
+  });
+
+  it('should default showPrivacyPolicy to false', () => {
+    expect(component.showPrivacyPolicy).to.be.false;
+  });
+
+  it('should update showPrivacyPolicy when the selector emits', () => {
+    store.overrideSelector(Selectors.getShowPrivacyPolicy, true);
+    store.refreshState();
+
+    expect(component.showPrivacyPolicy).to.be.true;
   });
 
   it('should close sidebar menu', () => {
@@ -189,122 +166,35 @@ describe('SidebarMenuComponent', () => {
     expect(modalService.show.args[0][0]).to.deep.equal(LogoutConfirmComponent);
   });
 
-  it('should show report bug modal', () => {
-    const reportBug = component.menuOptions.find(option => option.translationKey === 'Report Bug');
+  describe('onTabClick()', () => {
+    it('should show the feedback modal and close the sidebar when the bug tab is clicked', () => {
+      const closeStub = sinon.stub(GlobalActions.prototype, 'closeSidebarMenu');
 
-    if (!reportBug?.click) {
-      assert.fail('should have report bug option');
-      return;
-    }
+      component.onTabClick({
+        name: 'bug',
+        defaultIcon: 'fa-bug',
+        translation: 'Report Bug',
+        permissions: [],
+      });
 
-    reportBug.click();
-
-    expect(modalService.show.calledOnce).to.be.true;
-    expect(modalService.show.args[0][0]).to.deep.equal(FeedbackComponent);
-  });
-
-  describe('UI Extension options (sidebar_tab)', () => {
-    beforeEach(async () => {
-      uiExtensionsService.getPropertiesByType.resolves([
-        { id: 'ext-reports', type: 'sidebar_tab', title: 'custom.reports', resource_icon: 'reports-icon' },
-        { id: 'ext-map', type: 'sidebar_tab', title: 'custom.map', icon: 'fa-user' },
-      ]);
-
-      await TestBed.resetTestingModule();
-      await createComponent();
+      expect(modalService.show.calledOnce).to.be.true;
+      expect(modalService.show.args[0][0]).to.deep.equal(FeedbackComponent);
+      expect(closeStub.calledOnce).to.be.true;
     });
 
-    it('should populate ui extension options from registered extensions', () => {
-      expect(uiExtensionsService.getPropertiesByType.args).to.deep.equal([['sidebar_tab'], ['sidebar_tab']]);
+    it('should not open the feedback modal or close the sidebar for any other tab', () => {
+      const closeStub = sinon.stub(GlobalActions.prototype, 'closeSidebarMenu');
 
-      expect(component.menuOptions).excluding('click').to.deep.equal([
-        {
-          routerLink: 'messages',
-          icon: 'fa-envelope',
-          translationKey: 'Messages',
-          hasPermissions: 'can_view_messages,!can_view_messages_tab'
-        },
-        {
-          routerLink: 'tasks',
-          icon: 'fa-flag',
-          translationKey: 'Tasks',
-          hasPermissions: 'can_view_tasks,!can_view_tasks_tab'
-        },
-        {
-          routerLink: 'reports',
-          icon: 'fa-list-alt',
-          translationKey: 'Reports',
-          hasPermissions: 'can_view_reports,!can_view_reports_tab'
-        },
-        {
-          routerLink: 'contacts',
-          icon: 'fa-user',
-          translationKey: 'Contacts',
-          hasPermissions: 'can_view_contacts,!can_view_contacts_tab'
-        },
-        {
-          routerLink: 'analytics',
-          icon: 'fa-bar-chart-o',
-          translationKey: 'Analytics',
-          hasPermissions: 'can_view_analytics,!can_view_analytics_tab',
-        },
-        {
-          translationKey: 'custom.reports',
-          routerLink: 'ui-extensions/ext-reports',
-          resourceIcon: 'reports-icon',
-          icon: 'fa-question-circle',
-          canDisplay: true,
-        },
-        {
-          translationKey: 'custom.map',
-          routerLink: 'ui-extensions/ext-map',
-          resourceIcon: undefined,
-          icon: 'fa-user',
-          canDisplay: true,
-        },
-        {
-          routerLink: 'trainings',
-          icon: 'fa-graduation-cap',
-          translationKey: 'training_materials.page.title',
-          canDisplay: true,
-        },
-        {
-          routerLink: 'about',
-          icon: 'fa-question',
-          translationKey: 'about',
-          canDisplay: true,
-        },
-        {
-          routerLink: 'user',
-          icon: 'fa-user',
-          translationKey: 'edit.user.settings',
-          hasPermissions: 'can_edit_profile'
-        },
-        {
-          routerLink: 'privacy-policy',
-          icon: 'fa-lock',
-          translationKey: 'privacy.policy',
-          canDisplay: false,
-        },
-        {
-          icon: 'fa-bug',
-          translationKey: 'Report Bug',
-          canDisplay: true,
-        },
-      ]);
+      component.onTabClick({
+        name: 'messages',
+        route: 'messages',
+        defaultIcon: 'fa-envelope',
+        translation: 'Messages',
+        permissions: [],
+      });
+
+      expect(modalService.show.called).to.be.false;
+      expect(closeStub.called).to.be.false;
     });
-
-    it('should rebuild menuOptions preserving extension positions when privacy policy changes', fakeAsync(() => {
-      expect(uiExtensionsService.getPropertiesByType.args).to.deep.equal([['sidebar_tab'], ['sidebar_tab']]);
-      store.overrideSelector(Selectors.getShowPrivacyPolicy, true);
-      store.refreshState();
-      flush();
-
-      const privacyPolicy = component.menuOptions.find(opt => opt.routerLink === 'privacy-policy');
-      expect(privacyPolicy?.canDisplay).to.be.true;
-      expect(uiExtensionsService.getPropertiesByType.args).to.deep.equal([
-        ['sidebar_tab'], ['sidebar_tab'], ['sidebar_tab']
-      ]);
-    }));
   });
 });

--- a/webapp/tests/karma/ts/components/sidebar-menu/sidebar-menu.component.spec.ts
+++ b/webapp/tests/karma/ts/components/sidebar-menu/sidebar-menu.component.spec.ts
@@ -182,7 +182,7 @@ describe('SidebarMenuComponent', () => {
       expect(closeStub.calledOnce).to.be.true;
     });
 
-    it('should not open the feedback modal or close the sidebar for any other tab', () => {
+    it('should close the sidebar for any other tab', () => {
       const closeStub = sinon.stub(GlobalActions.prototype, 'closeSidebarMenu');
 
       component.onTabClick({
@@ -194,7 +194,7 @@ describe('SidebarMenuComponent', () => {
       });
 
       expect(modalService.show.called).to.be.false;
-      expect(closeStub.called).to.be.false;
+      expect(closeStub.calledOnce).to.be.true;
     });
   });
 });

--- a/webapp/tests/karma/ts/services/header-tabs.service.spec.ts
+++ b/webapp/tests/karma/ts/services/header-tabs.service.spec.ts
@@ -452,4 +452,164 @@ describe('HeaderTabs service', () => {
       });
     });
   });
+
+  describe('getSidebarTabs()', () => {
+    const SIDEBAR_SECONDARY_TABS = [
+      {
+        name: 'trainings',
+        route: 'trainings',
+        defaultIcon: 'fa-graduation-cap',
+        translation: 'training_materials.page.title',
+        permissions: [],
+      },
+      {
+        name: 'about',
+        route: 'about',
+        defaultIcon: 'fa-question',
+        translation: 'about',
+        permissions: [],
+      },
+      {
+        name: 'user',
+        route: 'user',
+        defaultIcon: 'fa-user',
+        translation: 'edit.user.settings',
+        permissions: ['can_edit_profile'],
+      },
+      {
+        name: 'privacy-policy',
+        route: 'privacy-policy',
+        defaultIcon: 'fa-lock',
+        translation: 'privacy.policy',
+        permissions: [],
+      },
+      {
+        name: 'bug',
+        defaultIcon: 'fa-bug',
+        translation: 'Report Bug',
+        permissions: [],
+      },
+    ];
+
+    it('should return only the secondary sidebar tabs when no header_tab permissions are granted', async () => {
+      authService.has.returns(false);
+
+      const tabs = await service.getSidebarTabs();
+
+      expect(tabs).to.deep.equal(SIDEBAR_SECONDARY_TABS);
+      expect(uiExtensionsService.getPropertiesByType).to.have.been.calledOnceWithExactly('sidebar_tab');
+    });
+
+    it('should include header tabs with negated tab permissions, sorted by weight, before secondary tabs', async () => {
+      authService.has.withArgs(['can_view_messages', '!can_view_messages_tab']).returns(true);
+      authService.has.withArgs(['can_view_tasks', '!can_view_tasks_tab']).returns(false);
+      authService.has.withArgs(['can_view_reports', '!can_view_reports_tab']).returns(true);
+      authService.has.withArgs(['can_view_contacts', '!can_view_contacts_tab']).returns(false);
+      authService.has.withArgs(['can_view_analytics', '!can_view_analytics_tab']).returns(true);
+
+      const tabs = await service.getSidebarTabs();
+
+      expect(tabs.map(t => t.name)).to.deep.equal([
+        'messages',
+        'reports',
+        'analytics',
+        'trainings',
+        'about',
+        'user',
+        'privacy-policy',
+        'bug',
+      ]);
+    });
+
+    it('should sort header tabs by weight before appending secondary tabs', async () => {
+      settingsService.get.resolves({
+        header_tabs: {
+          analytics: { weight: 0 },
+          messages: { weight: 100 },
+        }
+      });
+      authService.has.returns(true);
+
+      const tabs = await service.getSidebarTabs();
+
+      expect(tabs.map(t => t.name)).to.deep.equal([
+        'analytics',
+        'tasks',
+        'reports',
+        'contacts',
+        'messages',
+        'trainings',
+        'about',
+        'user',
+        'privacy-policy',
+        'bug',
+      ]);
+    });
+
+    it('should include sidebar_tab UI extensions between header tabs and secondary tabs', async () => {
+      authService.has.returns(true);
+      uiExtensionsService.getPropertiesByType.withArgs('sidebar_tab').resolves([
+        { id: 'first', title: 'First Extension', icon: 'fa-icon-1', resource_icon: 'res-1' },
+        { id: 'second', title: 'Second Extension', icon: 'fa-icon-2' },
+      ]);
+
+      const tabs = await service.getSidebarTabs();
+
+      expect(tabs.map(t => t.name)).to.deep.equal([
+        'messages',
+        'tasks',
+        'reports',
+        'contacts',
+        'analytics',
+        'ui-extension-first',
+        'ui-extension-second',
+        'trainings',
+        'about',
+        'user',
+        'privacy-policy',
+        'bug',
+      ]);
+
+      const firstExt = tabs.find(t => t.name === 'ui-extension-first');
+      expect(firstExt).to.deep.equal({
+        name: 'ui-extension-first',
+        route: 'ui-extensions/first',
+        defaultIcon: 'fa-question-circle',
+        translation: 'First Extension',
+        permissions: [],
+        icon: 'fa-icon-1',
+        resourceIcon: 'res-1',
+        weight: 6,
+      });
+    });
+
+    it('should query sidebar_tab extensions, not header_tab extensions', async () => {
+      await service.getSidebarTabs();
+
+      expect(uiExtensionsService.getPropertiesByType).to.have.been.calledOnceWithExactly('sidebar_tab');
+    });
+
+    it('should cache sidebar tabs after first call', async () => {
+      await service.getSidebarTabs();
+      await service.getSidebarTabs();
+      await service.getSidebarTabs();
+
+      expect(settingsService.get.callCount).to.equal(1);
+      expect(uiExtensionsService.getPropertiesByType.callCount).to.equal(1);
+    });
+
+    it('should always include secondary tabs regardless of authorization', async () => {
+      authService.has.returns(false);
+
+      const tabs = await service.getSidebarTabs();
+
+      expect(tabs.map(t => t.name)).to.deep.equal([
+        'trainings',
+        'about',
+        'user',
+        'privacy-policy',
+        'bug',
+      ]);
+    });
+  });
 });

--- a/webapp/tests/karma/ts/services/header-tabs.service.spec.ts
+++ b/webapp/tests/karma/ts/services/header-tabs.service.spec.ts
@@ -51,6 +51,7 @@ describe('HeaderTabs service', () => {
           typeName: 'message',
           icon: undefined,
           resourceIcon: undefined,
+          weight: 1,
         },
         {
           name: 'reports',
@@ -61,6 +62,7 @@ describe('HeaderTabs service', () => {
           typeName: 'report',
           icon: undefined,
           resourceIcon: undefined,
+          weight: 3,
         },
         {
           name: 'analytics',
@@ -70,6 +72,7 @@ describe('HeaderTabs service', () => {
           permissions: ['can_view_analytics', 'can_view_analytics_tab'],
           icon: undefined,
           resourceIcon: undefined,
+          weight: 5,
         }
       ]);
     });
@@ -102,6 +105,7 @@ describe('HeaderTabs service', () => {
           typeName: 'task',
           icon: undefined,
           resourceIcon: undefined,
+          weight: 2,
         },
         {
           name: 'contacts',
@@ -111,6 +115,7 @@ describe('HeaderTabs service', () => {
           permissions: ['can_view_contacts', 'can_view_contacts_tab'],
           icon: undefined,
           resourceIcon: undefined,
+          weight: 4,
         },
         {
           name: 'analytics',
@@ -120,6 +125,7 @@ describe('HeaderTabs service', () => {
           permissions: ['can_view_analytics', 'can_view_analytics_tab'],
           icon: undefined,
           resourceIcon: undefined,
+          weight: 5,
         }
       ]);
     });
@@ -148,14 +154,14 @@ describe('HeaderTabs service', () => {
       expect(analyticsTab!.typeName).to.be.undefined;
     });
 
-    it('should replace icons from settings when provided', async () => {
+    it('should replace icons and weight from settings when provided', async () => {
       settingsService.get.resolves({
         header_tabs: {
-          messages: { resource_icon: 'pomegranate-icon' },
+          messages: { resource_icon: 'pomegranate-icon', weight: 10 },
           tasks: { icon: 'fa-apple' },
           contacts: { resource_icon: 'pear-icon', icon: 'not-fa-pear-icon' },
           reports: { resource_icon: 'pineapple-icon', icon: 'not-fa-pineapple-icon' },
-          analytics: { resource_icon: 'mango-icon', icon: 'fa-mango-icon' },
+          analytics: { resource_icon: 'mango-icon', icon: 'fa-mango-icon', weight: 9 },
         }
       });
       authService.has.withArgs(['can_view_messages', 'can_view_messages_tab']).returns(true);
@@ -168,16 +174,6 @@ describe('HeaderTabs service', () => {
 
       expect(tabs).to.deep.equal([
         {
-          name: 'messages',
-          route: 'messages',
-          defaultIcon: 'fa-envelope',
-          translation: 'Messages',
-          permissions: ['can_view_messages', 'can_view_messages_tab'],
-          typeName: 'message',
-          icon: undefined,
-          resourceIcon: 'pomegranate-icon',
-        },
-        {
           name: 'tasks',
           route: 'tasks',
           defaultIcon: 'fa-flag',
@@ -186,6 +182,7 @@ describe('HeaderTabs service', () => {
           typeName: 'task',
           icon: 'fa-apple',
           resourceIcon: undefined,
+          weight: 2,
         },
         {
           name: 'contacts',
@@ -195,6 +192,7 @@ describe('HeaderTabs service', () => {
           permissions: ['can_view_contacts', 'can_view_contacts_tab'],
           icon: undefined,
           resourceIcon: 'pear-icon',
+          weight: 4,
         },
         {
           name: 'analytics',
@@ -204,8 +202,99 @@ describe('HeaderTabs service', () => {
           permissions: ['can_view_analytics', 'can_view_analytics_tab'],
           icon: 'fa-mango-icon',
           resourceIcon: 'mango-icon',
-        }
+          weight: 9,
+        },
+        {
+          name: 'messages',
+          route: 'messages',
+          defaultIcon: 'fa-envelope',
+          translation: 'Messages',
+          permissions: ['can_view_messages', 'can_view_messages_tab'],
+          typeName: 'message',
+          icon: undefined,
+          resourceIcon: 'pomegranate-icon',
+          weight: 10,
+        },
       ]);
+
+      it('should include UI extension tabs', async () => {
+        authService.has.returns(true);
+        uiExtensionsService.getPropertiesByType
+          .withArgs('header_tab')
+          .resolves([
+            { id: 'first', title: 'First Extension', icon: 'fa-icon-1', resource_icon: 'res-1', weight: 0.5 },
+            { id: 'middle', title: 'Middle Extension', icon: 'fa-icon-3' },
+            { id: 'last', title: 'Last Extension', resource_icon: 'res-2' },
+          ]);
+
+        const tabs = await service.getAuthorizedTabs();
+
+        expect(tabs.map(t => t.name)).to.deep.equal([
+          'messages',
+          'tasks',
+          'reports',
+          'contacts',
+          'analytics',
+          'ui-extension-first',
+          'ui-extension-middle',
+          'ui-extension-last',
+        ]);
+
+        const [firstExt,,,,,, middleExt, lastExt] = tabs;
+        expect(firstExt).to.deep.equal({
+          name: 'ui-extension-first',
+          route: 'ui-extensions/first',
+          defaultIcon: 'fa-question-circle',
+          translation: 'First Extension',
+          permissions: [],
+          icon: 'fa-icon-1',
+          resourceIcon: 'res-1',
+          weight: 0.5,
+        });
+        expect(middleExt).to.deep.equal({
+          name: 'ui-extension-middle',
+          route: 'ui-extensions/middle',
+          defaultIcon: 'fa-question-circle',
+          translation: 'Middle Extension',
+          permissions: [],
+          icon: 'fa-icon-3',
+          resourceIcon: undefined,
+          weight: 6,
+        });
+        expect(lastExt).to.deep.equal({
+          name: 'ui-extension-last',
+          route: 'ui-extensions/last',
+          defaultIcon: 'fa-question-circle',
+          translation: 'Last Extension',
+          permissions: [],
+          icon: undefined,
+          resourceIcon: 'res-2',
+          weight: 6,
+        });
+      });
+
+      it('should include UI extensions even when no default tabs are authorized', async () => {
+        authService.has.returns(false);
+        uiExtensionsService.getPropertiesByType.withArgs('header_tab').resolves([
+          { id: 'ext', title: 'Extension', icon: 'fa-icon' },
+        ]);
+
+        const tabs = await service.getAuthorizedTabs();
+
+        expect(tabs).to.deep.equal([
+          {
+            name: 'ui-extension-ext',
+            route: 'ui-extensions/ext',
+            defaultIcon: 'fa-question-circle',
+            translation: 'Extension',
+            permissions: [],
+            icon: 'fa-icon',
+            resourceIcon: undefined,
+            weight: 6,
+          }
+        ]);
+        expect(authService.has.callCount).to.equal(5);
+      });
     });
 
     it('should cache tabs after first call', async () => {
@@ -238,6 +327,7 @@ describe('HeaderTabs service', () => {
         typeName: 'message',
         icon: undefined,
         resourceIcon: undefined,
+        weight: 1,
       });
     });
 
@@ -259,6 +349,7 @@ describe('HeaderTabs service', () => {
         typeName: 'report',
         icon: undefined,
         resourceIcon: undefined,
+        weight: 3,
       });
     });
 
@@ -287,6 +378,7 @@ describe('HeaderTabs service', () => {
         permissions: ['can_view_contacts', 'can_view_contacts_tab'],
         icon: undefined,
         resourceIcon: undefined,
+        weight: 4,
       });
     });
 
@@ -316,84 +408,8 @@ describe('HeaderTabs service', () => {
         permissions: ['can_view_analytics', 'can_view_analytics_tab'],
         icon: 'fa-mango-icon',
         resourceIcon: 'mango-icon',
+        weight: 5,
       });
-    });
-  });
-
-  describe('Custom UI Extensions', () => {
-    it('should append UI extension tabs after the default tabs', async () => {
-      authService.has.returns(true);
-      uiExtensionsService.getPropertiesByType
-        .withArgs('header_tab')
-        .resolves([
-          { id: 'first', title: 'First Extension', icon: 'fa-icon-1', resource_icon: 'res-1' },
-          { id: 'middle', title: 'Middle Extension', icon: 'fa-icon-3' },
-          { id: 'last', title: 'Last Extension', resource_icon: 'res-2' },
-        ]);
-
-      const tabs = await service.getAuthorizedTabs();
-
-      expect(tabs.map(t => t.name)).to.deep.equal([
-        'messages',
-        'tasks',
-        'reports',
-        'contacts',
-        'analytics',
-        'ui-extension-first',
-        'ui-extension-middle',
-        'ui-extension-last',
-      ]);
-
-      const [,,,,,firstExt, middleExt, lastExt] = tabs;
-      expect(firstExt).to.deep.equal({
-        name: 'ui-extension-first',
-        route: 'ui-extensions/first',
-        defaultIcon: 'fa-question-circle',
-        translation: 'First Extension',
-        permissions: [],
-        icon: 'fa-icon-1',
-        resourceIcon: 'res-1',
-      });
-      expect(middleExt).to.deep.equal({
-        name: 'ui-extension-middle',
-        route: 'ui-extensions/middle',
-        defaultIcon: 'fa-question-circle',
-        translation: 'Middle Extension',
-        permissions: [],
-        icon: 'fa-icon-3',
-        resourceIcon: undefined,
-      });
-      expect(lastExt).to.deep.equal({
-        name: 'ui-extension-last',
-        route: 'ui-extensions/last',
-        defaultIcon: 'fa-question-circle',
-        translation: 'Last Extension',
-        permissions: [],
-        icon: undefined,
-        resourceIcon: 'res-2',
-      });
-    });
-
-    it('should include UI extensions even when no default tabs are authorized', async () => {
-      authService.has.returns(false);
-      uiExtensionsService.getPropertiesByType.withArgs('header_tab').resolves([
-        { id: 'ext', title: 'Extension', icon: 'fa-icon' },
-      ]);
-
-      const tabs = await service.getAuthorizedTabs();
-
-      expect(tabs).to.deep.equal([
-        {
-          name: 'ui-extension-ext',
-          route: 'ui-extensions/ext',
-          defaultIcon: 'fa-question-circle',
-          translation: 'Extension',
-          permissions: [],
-          icon: 'fa-icon',
-          resourceIcon: undefined,
-        }
-      ]);
-      expect(authService.has.callCount).to.equal(5);
     });
 
     it('should return UI extension tab as primary when no default tabs are authorized', async () => {
@@ -412,6 +428,27 @@ describe('HeaderTabs service', () => {
         permissions: [],
         icon: 'fa-icon',
         resourceIcon: undefined,
+        weight: 6,
+      });
+    });
+
+    it('should return UI extension tab as primary when it has the lowest weight', async () => {
+      authService.has.returns(true);
+      uiExtensionsService.getPropertiesByType.withArgs('header_tab').resolves([
+        { id: 'ext', title: 'Extension', icon: 'fa-icon', weight: 0.5 },
+      ]);
+
+      const tab = await service.getPrimaryTab();
+
+      expect(tab).to.deep.equal({
+        name: 'ui-extension-ext',
+        route: 'ui-extensions/ext',
+        defaultIcon: 'fa-question-circle',
+        translation: 'Extension',
+        permissions: [],
+        icon: 'fa-icon',
+        resourceIcon: undefined,
+        weight: 0.5,
       });
     });
   });

--- a/webapp/tests/karma/ts/services/header-tabs.service.spec.ts
+++ b/webapp/tests/karma/ts/services/header-tabs.service.spec.ts
@@ -548,7 +548,7 @@ describe('HeaderTabs service', () => {
     it('should include sidebar_tab UI extensions between header tabs and secondary tabs', async () => {
       authService.has.returns(true);
       uiExtensionsService.getPropertiesByType.withArgs('sidebar_tab').resolves([
-        { id: 'first', title: 'First Extension', icon: 'fa-icon-1', resource_icon: 'res-1' },
+        { id: 'first', title: 'First Extension', icon: 'fa-icon-1', resource_icon: 'res-1', weight: 0.5 },
         { id: 'second', title: 'Second Extension', icon: 'fa-icon-2' },
       ]);
 
@@ -569,7 +569,7 @@ describe('HeaderTabs service', () => {
         'privacy-policy',
         'bug',
       ]);
-      const [,,,,, firstExt] = tabs;
+      const [,,,,, firstExt, secondExt] = tabs;
       expect(firstExt).to.deep.equal({
         name: 'ui-extension-first',
         route: 'ui-extensions/first',
@@ -578,6 +578,16 @@ describe('HeaderTabs service', () => {
         permissions: [],
         icon: 'fa-icon-1',
         resourceIcon: 'res-1',
+        weight: 0.5,
+      });
+      expect(secondExt).to.deep.equal({
+        name: 'ui-extension-second',
+        route: 'ui-extensions/second',
+        defaultIcon: 'fa-question-circle',
+        translation: 'Second Extension',
+        permissions: [],
+        icon: 'fa-icon-2',
+        resourceIcon: undefined,
         weight: 6,
       });
     });

--- a/webapp/tests/karma/ts/services/header-tabs.service.spec.ts
+++ b/webapp/tests/karma/ts/services/header-tabs.service.spec.ts
@@ -216,85 +216,85 @@ describe('HeaderTabs service', () => {
           weight: 10,
         },
       ]);
+    });
 
-      it('should include UI extension tabs', async () => {
-        authService.has.returns(true);
-        uiExtensionsService.getPropertiesByType
-          .withArgs('header_tab')
-          .resolves([
-            { id: 'first', title: 'First Extension', icon: 'fa-icon-1', resource_icon: 'res-1', weight: 0.5 },
-            { id: 'middle', title: 'Middle Extension', icon: 'fa-icon-3' },
-            { id: 'last', title: 'Last Extension', resource_icon: 'res-2' },
-          ]);
-
-        const tabs = await service.getAuthorizedTabs();
-
-        expect(tabs.map(t => t.name)).to.deep.equal([
-          'messages',
-          'tasks',
-          'reports',
-          'contacts',
-          'analytics',
-          'ui-extension-first',
-          'ui-extension-middle',
-          'ui-extension-last',
+    it('should include UI extension tabs', async () => {
+      authService.has.returns(true);
+      uiExtensionsService.getPropertiesByType
+        .withArgs('header_tab')
+        .resolves([
+          { id: 'first', title: 'First Extension', icon: 'fa-icon-1', resource_icon: 'res-1', weight: 0.5 },
+          { id: 'middle', title: 'Middle Extension', icon: 'fa-icon-3' },
+          { id: 'last', title: 'Last Extension', resource_icon: 'res-2' },
         ]);
 
-        const [firstExt,,,,,, middleExt, lastExt] = tabs;
-        expect(firstExt).to.deep.equal({
-          name: 'ui-extension-first',
-          route: 'ui-extensions/first',
+      const tabs = await service.getAuthorizedTabs();
+
+      expect(tabs.map(t => t.name)).to.deep.equal([
+        'messages',
+        'tasks',
+        'reports',
+        'contacts',
+        'analytics',
+        'ui-extension-first',
+        'ui-extension-middle',
+        'ui-extension-last',
+      ]);
+
+      const [firstExt,,,,,, middleExt, lastExt] = tabs;
+      expect(firstExt).to.deep.equal({
+        name: 'ui-extension-first',
+        route: 'ui-extensions/first',
+        defaultIcon: 'fa-question-circle',
+        translation: 'First Extension',
+        permissions: [],
+        icon: 'fa-icon-1',
+        resourceIcon: 'res-1',
+        weight: 0.5,
+      });
+      expect(middleExt).to.deep.equal({
+        name: 'ui-extension-middle',
+        route: 'ui-extensions/middle',
+        defaultIcon: 'fa-question-circle',
+        translation: 'Middle Extension',
+        permissions: [],
+        icon: 'fa-icon-3',
+        resourceIcon: undefined,
+        weight: 6,
+      });
+      expect(lastExt).to.deep.equal({
+        name: 'ui-extension-last',
+        route: 'ui-extensions/last',
+        defaultIcon: 'fa-question-circle',
+        translation: 'Last Extension',
+        permissions: [],
+        icon: undefined,
+        resourceIcon: 'res-2',
+        weight: 6,
+      });
+    });
+
+    it('should include UI extensions even when no default tabs are authorized', async () => {
+      authService.has.returns(false);
+      uiExtensionsService.getPropertiesByType.withArgs('header_tab').resolves([
+        { id: 'ext', title: 'Extension', icon: 'fa-icon' },
+      ]);
+
+      const tabs = await service.getAuthorizedTabs();
+
+      expect(tabs).to.deep.equal([
+        {
+          name: 'ui-extension-ext',
+          route: 'ui-extensions/ext',
           defaultIcon: 'fa-question-circle',
-          translation: 'First Extension',
+          translation: 'Extension',
           permissions: [],
-          icon: 'fa-icon-1',
-          resourceIcon: 'res-1',
-          weight: 0.5,
-        });
-        expect(middleExt).to.deep.equal({
-          name: 'ui-extension-middle',
-          route: 'ui-extensions/middle',
-          defaultIcon: 'fa-question-circle',
-          translation: 'Middle Extension',
-          permissions: [],
-          icon: 'fa-icon-3',
+          icon: 'fa-icon',
           resourceIcon: undefined,
           weight: 6,
-        });
-        expect(lastExt).to.deep.equal({
-          name: 'ui-extension-last',
-          route: 'ui-extensions/last',
-          defaultIcon: 'fa-question-circle',
-          translation: 'Last Extension',
-          permissions: [],
-          icon: undefined,
-          resourceIcon: 'res-2',
-          weight: 6,
-        });
-      });
-
-      it('should include UI extensions even when no default tabs are authorized', async () => {
-        authService.has.returns(false);
-        uiExtensionsService.getPropertiesByType.withArgs('header_tab').resolves([
-          { id: 'ext', title: 'Extension', icon: 'fa-icon' },
-        ]);
-
-        const tabs = await service.getAuthorizedTabs();
-
-        expect(tabs).to.deep.equal([
-          {
-            name: 'ui-extension-ext',
-            route: 'ui-extensions/ext',
-            defaultIcon: 'fa-question-circle',
-            translation: 'Extension',
-            permissions: [],
-            icon: 'fa-icon',
-            resourceIcon: undefined,
-            weight: 6,
-          }
-        ]);
-        expect(authService.has.callCount).to.equal(5);
-      });
+        }
+      ]);
+      expect(authService.has.callCount).to.equal(5);
     });
 
     it('should cache tabs after first call', async () => {

--- a/webapp/tests/karma/ts/services/header-tabs.service.spec.ts
+++ b/webapp/tests/karma/ts/services/header-tabs.service.spec.ts
@@ -231,12 +231,12 @@ describe('HeaderTabs service', () => {
       const tabs = await service.getAuthorizedTabs();
 
       expect(tabs.map(t => t.name)).to.deep.equal([
+        'ui-extension-first',
         'messages',
         'tasks',
         'reports',
         'contacts',
         'analytics',
-        'ui-extension-first',
         'ui-extension-middle',
         'ui-extension-last',
       ]);

--- a/webapp/tests/karma/ts/services/header-tabs.service.spec.ts
+++ b/webapp/tests/karma/ts/services/header-tabs.service.spec.ts
@@ -240,7 +240,6 @@ describe('HeaderTabs service', () => {
         'ui-extension-middle',
         'ui-extension-last',
       ]);
-
       const [firstExt,,,,,, middleExt, lastExt] = tabs;
       expect(firstExt).to.deep.equal({
         name: 'ui-extension-first',
@@ -555,6 +554,7 @@ describe('HeaderTabs service', () => {
 
       const tabs = await service.getSidebarTabs();
 
+      expect(uiExtensionsService.getPropertiesByType).to.have.been.calledOnceWithExactly('sidebar_tab');
       expect(tabs.map(t => t.name)).to.deep.equal([
         'messages',
         'tasks',
@@ -569,8 +569,7 @@ describe('HeaderTabs service', () => {
         'privacy-policy',
         'bug',
       ]);
-
-      const firstExt = tabs.find(t => t.name === 'ui-extension-first');
+      const [,,,,, firstExt] = tabs;
       expect(firstExt).to.deep.equal({
         name: 'ui-extension-first',
         route: 'ui-extensions/first',
@@ -583,12 +582,6 @@ describe('HeaderTabs service', () => {
       });
     });
 
-    it('should query sidebar_tab extensions, not header_tab extensions', async () => {
-      await service.getSidebarTabs();
-
-      expect(uiExtensionsService.getPropertiesByType).to.have.been.calledOnceWithExactly('sidebar_tab');
-    });
-
     it('should cache sidebar tabs after first call', async () => {
       await service.getSidebarTabs();
       await service.getSidebarTabs();
@@ -596,20 +589,6 @@ describe('HeaderTabs service', () => {
 
       expect(settingsService.get.callCount).to.equal(1);
       expect(uiExtensionsService.getPropertiesByType.callCount).to.equal(1);
-    });
-
-    it('should always include secondary tabs regardless of authorization', async () => {
-      authService.has.returns(false);
-
-      const tabs = await service.getSidebarTabs();
-
-      expect(tabs.map(t => t.name)).to.deep.equal([
-        'trainings',
-        'about',
-        'user',
-        'privacy-policy',
-        'bug',
-      ]);
     });
   });
 });

--- a/webapp/tests/karma/ts/services/ui-extensions.service.spec.ts
+++ b/webapp/tests/karma/ts/services/ui-extensions.service.spec.ts
@@ -145,6 +145,58 @@ describe('UiExtensionsService', () => {
 
       expect(result).to.deep.equal([]);
     });
+
+    it('should sort weighted extensions before unweighted ones', async () => {
+      const extensions = [
+        { id: 'ext-a', type: 'tab' },
+        { id: 'ext-b', type: 'tab', weight: 5 },
+      ];
+      http.get.returns(of(extensions));
+
+      const result = await service.getPropertiesByType('tab');
+
+      expect(result.map(e => e.id)).to.deep.equal(['ext-b', 'ext-a']);
+    });
+
+    it('should sort weighted extensions ascending by weight', async () => {
+      const extensions = [
+        { id: 'ext-a', type: 'tab', weight: 10 },
+        { id: 'ext-b', type: 'tab', weight: 1 },
+        { id: 'ext-c', type: 'tab', weight: 5 },
+      ];
+      http.get.returns(of(extensions));
+
+      const result = await service.getPropertiesByType('tab');
+
+      expect(result.map(e => e.id)).to.deep.equal(['ext-b', 'ext-c', 'ext-a']);
+    });
+
+    it('should sort unweighted extensions alphabetically by id', async () => {
+      const extensions = [
+        { id: 'ext-c', type: 'tab' },
+        { id: 'ext-a', type: 'tab' },
+        { id: 'ext-b', type: 'tab' },
+      ];
+      http.get.returns(of(extensions));
+
+      const result = await service.getPropertiesByType('tab');
+
+      expect(result.map(e => e.id)).to.deep.equal(['ext-a', 'ext-b', 'ext-c']);
+    });
+
+    it('should sort weighted before unweighted, each group sorted internally', async () => {
+      const extensions = [
+        { id: 'ext-c', type: 'tab' },
+        { id: 'ext-d', type: 'tab', weight: 10 },
+        { id: 'ext-a', type: 'tab' },
+        { id: 'ext-e', type: 'tab', weight: 1 },
+      ];
+      http.get.returns(of(extensions));
+
+      const result = await service.getPropertiesByType('tab');
+
+      expect(result.map(e => e.id)).to.deep.equal(['ext-e', 'ext-d', 'ext-a', 'ext-c']);
+    });
   });
 
   describe('getProperties()', () => {


### PR DESCRIPTION
# Description

Closes #10908 

This PR adds support for ordering the main interface headers tabs according to the `weight` property configured in the [header_tabs app settings](https://docs.communityhealthtoolkit.org/building/reference/app-settings/header_tabs/).  Additionally, the `header_tab` UI Extensions can also have a `weight` property that is used when factoring in the ordering of all the tabs. This ordering is honored both in the new and in the old UI.

There was considerable duplication and complexity around the sidebar menu options between the new and the old UI.  I have refactored the handling of these options to follow similar patterns with what we have for the main header tabs.

Documentation for the new config will be added in https://github.com/medic/cht-docs/pull/2213

## AI disclosure

Most of the unit test updates were made by Claude. I have reviewed all changes.

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [X] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [X] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [X] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [X] Tested: Unit and/or e2e where appropriate
- [X] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [X] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

