### PR TITLE
chore(#11048): modernize version parsing regex with named capture groups

### DIFF
--- a/admin/src/js/services/version.js
+++ b/admin/src/js/services/version.js
@@ -21,13 +21,13 @@ angular.module('services').factory('Version',
 
       if (versionMatch) {
         const version = {
-          major: parseInt(versionMatch.groups.major),
-          minor: parseInt(versionMatch.groups.minor),
-          patch: parseInt(versionMatch.groups.patch)
+          major: Number.parseInt(versionMatch.groups.major),
+          minor: Number.parseInt(versionMatch.groups.minor),
+          patch: Number.parseInt(versionMatch.groups.patch)
         };
 
         if (versionMatch.groups.beta !== undefined) {
-          version.beta = parseInt(versionMatch.groups.beta);
+          version.beta = Number.parseInt(versionMatch.groups.beta);
         }
 
         if (versionMatch.groups.featureRelease !== undefined) {

--- a/admin/src/js/services/version.js
+++ b/admin/src/js/services/version.js
@@ -16,24 +16,22 @@ angular.module('services').factory('Version',
     };
 
     const versionInformation = function(versionString) {
-      // TODO: replace this regex with named capture groups once we deprecate node 8
-      // /^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?<featureRelease>-FR(?:-\w+)+)?(?:-beta\.(?<beta>\d+))?$/
       const versionMatch = versionString &&
-          versionString.match(/^(\d+)\.(\d+)\.(\d+)(-FR(?:-\w+)+)?(?:-beta\.(\d+))?(\.(\d+))?$/);
+          versionString.match(/^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?<featureRelease>-FR(?:-\w+)+)?(?:-beta\.(?<beta>\d+))?(?:\.(?<build>\d+))?$/);
 
       if (versionMatch) {
         const version = {
-          major: parseInt(versionMatch[1]),
-          minor: parseInt(versionMatch[2]),
-          patch: parseInt(versionMatch[3])
+          major: parseInt(versionMatch.groups.major),
+          minor: parseInt(versionMatch.groups.minor),
+          patch: parseInt(versionMatch.groups.patch)
         };
 
-        if (versionMatch[5] !== undefined) {
-          version.beta = parseInt(versionMatch[5]);
+        if (versionMatch.groups.beta !== undefined) {
+          version.beta = parseInt(versionMatch.groups.beta);
         }
 
-        if (versionMatch[4] !== undefined) {
-          version.featureRelease = versionMatch[4].slice(1); // remove leading dash '-'
+        if (versionMatch.groups.featureRelease !== undefined) {
+          version.featureRelease = versionMatch.groups.featureRelease.slice(1); // remove leading dash '-'
 
           if (version.beta) {
             version.featureRelease += '-beta';


### PR DESCRIPTION
## Summary

Refactors the version parsing regex in `admin/src/js/services/version.js` to use ES2018 named capture groups, and replaces global `parseInt` with `Number.parseInt` to satisfy SonarCloud rule S7773.

## Details

### The technical debt

The `versionInformation` function contained this TODO comment:

```js
// TODO: replace this regex with named capture groups once we deprecate node 8
```

Node 8 has been EOL since December 2019. The codebase already targets Node 18+. This PR finally cleans up that decade-old debt.

### Changes

**1. Named capture groups** — replaced numbered positional groups with descriptive names:

| Before | After |
|--------|-------|
| `(\\d+)` | `(?<major>\\d+)` |
| `versionMatch[1]` | `versionMatch.groups.major` |

This makes the regex self-documenting: you can read `groups.major`, `groups.minor`, `groups.patch`, `groups.beta`, `groups.featureRelease`, `groups.build` at the call site instead of guessing what `versionMatch[4]` means.

**2. Added `build` capture group** — the old regex had `(\\.(\\d+))?` (group 7) for the trailing build number like `4.15.1.12345`, but it was never extracted into the version object. The new regex properly names it `(?<build>\\d+)`.

**3. SonarCloud compliance** — replaced all 4 `parseInt` calls with `Number.parseInt` to fix quality gate failure (rule S7773).

### Impact

Zero behavioral change. All existing unit tests pass. The fix is purely about code maintainability and readability.

### Testing

```
cd admin
npm test -- --grep 'Version'
```

Closes #11048