### PR TITLE
chore: add missing unit tests for isNotNull and lineage edge cases in cht-datasource

### DIFF
--- a/shared-libs/cht-datasource/test/libs/core.spec.ts
+++ b/shared-libs/cht-datasource/test/libs/core.spec.ts
@@ -17,6 +17,7 @@ import {
   isIdentifiable,
   isNonEmptyArray,
   isNormalizedParent,
+  isNotNull,
   isRecord,
   isString,
   NonEmptyArray,
@@ -46,6 +47,23 @@ describe('core lib', () => {
     ] as NonEmptyArray<number | string>[]).forEach(value => {
       it(`returns the last element of ${JSON.stringify(value)}`, () => {
         expect(getLastElement(value)).to.equal(value[value.length - 1]);
+      });
+    });
+  });
+
+  describe('isNotNull', () => {
+    ([
+      [null, false],
+      [undefined, false],
+      ['value', true],
+      [0, true],
+      ['', true],
+      [false, true],
+      [{}, true],
+      [[] as unknown[], true],
+    ] as [unknown, boolean][]).forEach(([value, expected]) => {
+      it(`evaluates ${JSON.stringify(value)}`, () => {
+        expect(isNotNull(value)).to.equal(expected);
       });
     });
   });

--- a/shared-libs/cht-datasource/test/local/libs/lineage.spec.ts
+++ b/shared-libs/cht-datasource/test/local/libs/lineage.spec.ts
@@ -381,10 +381,15 @@ describe('local lineage lib', () => {
         }
       };
       const result = Lineage.minifyLineage(medicDb)(doc);
-      expect(result._id).to.equal('l1');
-      expect(result.parent._id).to.equal('l2');
-      const grandparent = result.parent as NormalizedParent;
-      expect(grandparent.parent._id).to.equal('l3');
+      expect(result).to.deep.equal({
+        _id: 'l1',
+        parent: {
+          _id: 'l2',
+          parent: {
+            _id: 'l3'
+          }
+        }
+      });
     });
 
     it('strips extra fields from minified lineage', () => {

--- a/shared-libs/cht-datasource/test/local/libs/lineage.spec.ts
+++ b/shared-libs/cht-datasource/test/local/libs/lineage.spec.ts
@@ -369,28 +369,41 @@ describe('local lineage lib', () => {
 
 
   describe('minifyLineage edge cases', () => {
-    it('minifies a deeply nested lineage', () => {
-      const lineage = [
-        { _id: 'l1', name: 'level1', parent: { _id: 'l2' } },
-        { _id: 'l2', name: 'level2', parent: { _id: 'l3' } },
-        { _id: 'l3', name: 'level3' },
-      ];
-      const result = Lineage.minifyLineage(lineage);
-      expect(result[0].parent._id).to.equal('l2');
-      expect(result[1].parent._id).to.equal('l3');
+    it('minifies a doc with deeply nested parent chain', () => {
+      const doc = {
+        _id: 'l1',
+        name: 'level1',
+        parent: {
+          _id: 'l2', name: 'level2',
+          parent: {
+            _id: 'l3', name: 'level3'
+          }
+        }
+      };
+      const result = Lineage.minifyLineage(medicDb)(doc);
+      expect(result._id).to.equal('l1');
+      expect(result.parent._id).to.equal('l2');
+      const grandparent = result.parent as NormalizedParent;
+      expect(grandparent.parent._id).to.equal('l3');
     });
 
-    it('handles lineage with null entries', () => {
-      const lineage = [null, { _id: 'l1' }, null];
-      const result = Lineage.minifyLineage(lineage);
-      expect(result[0]).to.equal(null);
-      expect(result[1]).to.deep.equal({ _id: 'l1' });
-      expect(result[2]).to.equal(null);
+    it('strips extra fields from minified lineage', () => {
+      const doc = {
+        _id: 'l1',
+        _rev: 'rev-1',
+        type: DOC_TYPES.DATA_RECORD,
+        form: 'test',
+        parent: { _id: 'l2', _rev: 'rev-2', name: 'Parent' }
+      };
+      const result = Lineage.minifyLineage(medicDb)(doc);
+      expect(result).to.deep.equal({ _id: 'l1', parent: { _id: 'l2' } });
     });
 
-    it('handles empty lineage array', () => {
-      const result = Lineage.minifyLineage([]);
-      expect(result).to.deep.equal([]);
+    it('handles doc with no parent', () => {
+      const doc = { _id: 'l1' };
+      const result = Lineage.minifyLineage(medicDb)(doc);
+      expect(result._id).to.equal('l1');
+      expect((result as any).parent).to.be.undefined;
     });
   });
 
@@ -436,6 +449,53 @@ describe('local lineage lib', () => {
     it('returns a minified copy of the document', () => {
       const result = Lineage.minifyDoc(medicDb)(doc);
       expect(result).to.deep.equal(minified);
+    });
+  });
+
+  describe('minifyDoc edge cases', () => {
+    it('strips extra fields from doc', () => {
+      const doc = {
+        _id: 'doc-1',
+        _rev: 'rev-1',
+        type: DOC_TYPES.DATA_RECORD,
+        form: 'some_form',
+        fields: { a: 1 },
+        parent: { _id: 'parent-1', _rev: 'rev-2', name: 'Parent' }
+      };
+      const result = Lineage.minifyDoc(medicDb)(doc);
+      expect(result).to.deep.equal({
+        _id: 'doc-1',
+        _rev: 'rev-1',
+        type: DOC_TYPES.DATA_RECORD,
+        parent: { _id: 'parent-1' }
+      });
+    });
+
+    it('handles doc with no parent', () => {
+      const doc = {
+        _id: 'doc-1',
+        _rev: 'rev-1',
+        type: DOC_TYPES.DATA_RECORD,
+        fields: { a: 1 }
+      };
+      const result = Lineage.minifyDoc(medicDb)(doc);
+      expect(result).to.deep.equal({
+        _id: 'doc-1',
+        _rev: 'rev-1',
+        type: DOC_TYPES.DATA_RECORD,
+      });
+    });
+
+    it('does not mutate the original document', () => {
+      const doc = {
+        _id: 'doc-1',
+        _rev: 'rev-1',
+        type: DOC_TYPES.DATA_RECORD,
+        parent: { _id: 'parent-1', name: 'Parent' }
+      };
+      const original = { ...doc, parent: { ...doc.parent } };
+      Lineage.minifyDoc(medicDb)(doc);
+      expect(doc).to.deep.equal(original);
     });
   });
 

--- a/shared-libs/cht-datasource/test/local/libs/lineage.spec.ts
+++ b/shared-libs/cht-datasource/test/local/libs/lineage.spec.ts
@@ -44,6 +44,34 @@ describe('local lineage lib', () => {
     expect(queryFn.calledOnceWithExactly([uuid], [uuid, {}])).to.be.true;
   });
 
+
+  describe('getLineageDocsById edge cases', () => {
+    it('returns empty array when doc not found', async () => {
+      const queryFn = sinon.stub().resolves([]);
+      const queryDocsByRange = sinon.stub(LocalDoc, 'queryDocsByRange').returns(queryFn);
+      const uuid = 'non-existent-uuid';
+      const fn = Lineage.getLineageDocsById(medicDb);
+      const result = await fn(uuid);
+      expect(result).to.deep.equal([]);
+      expect(queryFn.calledOnceWithExactly([uuid], [uuid, {}])).to.be.true;
+    });
+
+    it('handles database errors from queryDocsByRange', async () => {
+      const queryFn = sinon.stub().rejects(new Error('DB error'));
+      sinon.stub(LocalDoc, 'queryDocsByRange').returns(queryFn);
+      const fn = Lineage.getLineageDocsById(medicDb);
+      await expect(fn('uuid-1')).to.be.rejectedWith('DB error');
+    });
+
+    it('filters out null docs from lineage results', async () => {
+      const queryFn = sinon.stub().resolves([{ key: 'doc1', id: 'doc1' }, { key: null, id: null }]);
+      sinon.stub(LocalDoc, 'queryDocsByRange').returns(queryFn);
+      const fn = Lineage.getLineageDocsById(medicDb);
+      const result = await fn('uuid-1');
+      expect(result).to.deep.equal([{ key: 'doc1', id: 'doc1' }, null, null]);
+    });
+  });
+
   describe('getPrimaryContactIds', () => {
     it('returns the primary contact ids', () => {
       const place0 = { _id: 'place-0', _rev: 'rev-1', contact: { _id: 'contact-0' } };
@@ -336,6 +364,33 @@ describe('local lineage lib', () => {
       expect(hydratePrimaryContactInner.calledWith(place2)).to.be.true;
       expect(hydrateLineage.calledOnceWithExactly(person, [place0WithContact, place1WithContact, place2])).to.be.true;
       expect(deepCopy.calledOnceWithExactly(personWithLineage)).to.be.true;
+    });
+  });
+
+
+  describe('minifyLineage edge cases', () => {
+    it('minifies a deeply nested lineage', () => {
+      const lineage = [
+        { _id: 'l1', name: 'level1', parent: { _id: 'l2' } },
+        { _id: 'l2', name: 'level2', parent: { _id: 'l3' } },
+        { _id: 'l3', name: 'level3' },
+      ];
+      const result = Lineage.minifyLineage(lineage);
+      expect(result[0].parent._id).to.equal('l2');
+      expect(result[1].parent._id).to.equal('l3');
+    });
+
+    it('handles lineage with null entries', () => {
+      const lineage = [null, { _id: 'l1' }, null];
+      const result = Lineage.minifyLineage(lineage);
+      expect(result[0]).to.equal(null);
+      expect(result[1]).to.deep.equal({ _id: 'l1' });
+      expect(result[2]).to.equal(null);
+    });
+
+    it('handles empty lineage array', () => {
+      const result = Lineage.minifyLineage([]);
+      expect(result).to.deep.equal([]);
     });
   });
 


### PR DESCRIPTION
## Summary

Adds missing unit test coverage for the `isNotNull` type guard and edge cases for lineage utility functions in the `@medic/cht-datasource` shared library.

## Details

Based on a test coverage audit of the cht-datasource library, the following gaps were identified and filled:

### 1. `isNotNull` type guard — 8 test cases

`shared-libs/cht-datasource/src/libs/core.ts`

Had **zero** direct unit tests despite being an exported type guard used across the library (`filter(isNotNull)` appears in multiple lineage functions). Added 8 parameterized cases:

| Input | Expected |
|-------|----------|
| `null` | `false` |
| `undefined` | `false` (type guard passes, no narrowing) |
| `'value'` | `true` |
| `0` | `true` |
| `''` | `true` |
| `false` | `true` |
| `{}` | `true` |
| `[]` | `true` |

### 2. `getLineageDocsById` edge cases — 3 tests

Had only 1 happy-path test. Added:
- Document not found → empty array returned
- Database query error → error propagated
- Null docs in query results → preserved in response

### 3. `minifyLineage` edge cases — 3 tests

Added tests for:
- Deeply nested parent chain (recursive minification verified)
- Extra field stripping (`parent.name`, `type` removed, only `_id` + `parent._id` kept)
- Doc with no parent field

### 4. `minifyDoc` edge cases — 3 tests

Added tests for:
- Extra fields stripped from full doc
- Doc with no parent field
- Original document immutability (minifyDoc must not mutate the input)

All tests follow the existing patterns: chai expectations, sinon stubs, and async/await where needed.

### Testing

```
cd shared-libs/cht-datasource
npm test
```