### PR TITLE
fix(#9381): accept_case_reports transition fails to persist doc changes

### DIFF
--- a/shared-libs/transitions/src/transitions/accept_case_reports.js
+++ b/shared-libs/transitions/src/transitions/accept_case_reports.js
@@ -95,7 +95,7 @@ module.exports = {
         }
         addMessagesToDoc(doc, config, registrations);
         updatePlaceUuid(doc, registrations);
-        return silenceRegistrations(doc, config, registrations);
+        return silenceRegistrations(doc, config, registrations).then(() => true);
       });
     });
 

--- a/shared-libs/transitions/test/unit/transitions/accept_case_reports.js
+++ b/shared-libs/transitions/test/unit/transitions/accept_case_reports.js
@@ -250,7 +250,7 @@ describe('accept_case_reports', () => {
       });
     });
 
-    it('adds place id from registration', () => {
+    it('adds place id from registration and returns truthy', () => {
       config.get.returns([{
         form: 'x',
         messages: [{
@@ -274,7 +274,8 @@ describe('accept_case_reports', () => {
         }
       };
 
-      return transition.onMatch({ doc }).then(() => {
+      return transition.onMatch({ doc }).then(changed => {
+        changed.should.equal(true);
         doc.fields.place_uuid.should.equal('abc');
         doc.tasks.length.should.equal(1);
         doc.tasks[0].messages.length.should.equal(1);


### PR DESCRIPTION
## Summary

The `accept_case_reports` transition's `onMatch` function returns the result of `silenceRegistrations()`, which resolves to `undefined`. The transitions framework treats falsy return values as "no changes," so document modifications (messages, `place_uuid`) are never persisted to the database.

## Changes

- Appended `.then(() => true)` to the `silenceRegistrations` call to ensure a truthy return value when the transition completes successfully.
- Updated the unit test to assert the truthy return value.

## Testing

- All 14 `accept_case_reports` transition unit tests pass.
- The fix matches the pattern used by `accept_patient_reports` and `registration` transitions, which already return `true` on success.
