### PR TITLE
fix(#10851): restore Devanagari numeral cross-matching for online user search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12685,6 +12685,49 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/@appium/docutils": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@appium/docutils/-/docutils-2.2.1.tgz",
+      "integrity": "sha512-mhyQuvQUGepH+MEOGt3ixTM5q1NNVsxr+jvz/6t7KFJm8ElRlfyGGWcA3fqvnXm72hm3rzhh2t13sLct7qWUBg==",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@appium/support": "^7.0.5",
+        "consola": "3.4.2",
+        "diff": "8.0.3",
+        "lilconfig": "3.1.3",
+        "lodash": "4.17.23",
+        "package-directory": "8.1.0",
+        "read-pkg": "10.0.0",
+        "teen_process": "4.0.8",
+        "type-fest": "5.4.1",
+        "yaml": "2.8.2",
+        "yargs": "18.0.0",
+        "yargs-parser": "22.0.0"
+      },
+      "bin": {
+        "appium-docs": "bin/appium-docs.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@appium/docutils/node_modules/teen_process": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/teen_process/-/teen_process-4.0.8.tgz",
+      "integrity": "sha512-0DTX2KfgVOr6+8TVmheEdiJHZ/bPOPeJuX0yvv5VOX3x+OFteNkmWkI+hX6zTkzxjddrktsrXkacfS2Gom1YyA==",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "shell-quote": "^1.8.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "npm": ">=10"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/@appium/logger": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@appium/logger/-/logger-2.0.4.tgz",
@@ -12857,6 +12900,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/@img/colour": {
@@ -13298,6 +13351,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "extraneous": true,
+      "license": "Python-2.0"
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -13539,6 +13599,92 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "extraneous": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/cliui/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/cliui/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/cliui/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -13594,6 +13740,16 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/console-control-strings": {
@@ -13793,6 +13949,16 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/diff": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+      "extraneous": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -13893,6 +14059,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/escape-html": {
@@ -14198,6 +14374,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "extraneous": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -14351,6 +14550,16 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/has-symbols": {
       "version": "1.1.0",
@@ -14759,6 +14968,19 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/lockfile": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
@@ -14911,6 +15133,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/minimalistic-assert": {
@@ -15105,6 +15337,22 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/p-limit": {
@@ -16147,6 +16395,13 @@
         "utf8-byte-length": "^1.0.1"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "extraneous": true,
+      "license": "0BSD"
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/type-fest": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.1.tgz",
@@ -16287,6 +16542,24 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
@@ -16304,6 +16577,60 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/wrappy": {
@@ -16353,6 +16680,101 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6.0"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "extraneous": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "extraneous": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "extraneous": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/yargs/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/yargs/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/yargs/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/yauzl": {

--- a/shared-libs/cht-datasource/src/local/libs/nouveau.ts
+++ b/shared-libs/cht-datasource/src/local/libs/nouveau.ts
@@ -4,7 +4,6 @@ import {
   ContactTypeQualifier,
   FreetextQualifier,
   isContactTypeQualifier,
-  isKeyedFreetextQualifier
 } from '../../qualifier';
 import { escapeKeys } from '@medic/nouveau';
 import { getDocById } from './doc';
@@ -14,6 +13,27 @@ const jsonContentTypeHeaders = new Headers({ 'Content-Type': 'application/json' 
 const SORT_BY_VIEW: Record<string, string> = {
   'contacts_by_freetext': 'sort_order',
   'reports_by_freetext': 'reported_date',
+};
+
+const DEVANAGARI_DIGITS = ['०', '१', '२', '३', '४', '५', '६', '७', '८', '९'];
+
+const hasDigits = (text: string): boolean => /\d/.test(text) || /[०-९]/.test(text);
+
+const latinToDevanagari = (text: string): string =>
+  text.replace(/\d/g, c => DEVANAGARI_DIGITS[Number.parseInt(c)]);
+
+const devanagariToLatin = (text: string): string => {
+  const map: Record<string, string> = {};
+  DEVANAGARI_DIGITS.forEach((d, i) => map[d] = String(i));
+  return text.replace(/[०-९]/g, c => map[c]);
+};
+
+const convertDigits = (text: string): string => {
+  const latin = devanagariToLatin(text);
+  if (latin !== text) {
+    return latin;
+  }
+  return latinToDevanagari(text);
 };
 
 /**
@@ -32,11 +52,26 @@ const fetchWithDb = (
 ) => db.fetch(url, opts);
 
 const getQueryByFreetext = (qualifier: FreetextQualifier) => {
-  if (isKeyedFreetextQualifier(qualifier)) {
-    return `exact_match:"${qualifier.freetext}"`;
+  const { freetext } = qualifier;
+  if (!hasDigits(freetext)) {
+    return buildQueryByFreetext(freetext);
   }
-  // Fuzzy match
-  return `${escapeKeys(qualifier.freetext)}*`;
+
+  const converted = convertDigits(freetext);
+  if (converted === freetext) {
+    return buildQueryByFreetext(freetext);
+  }
+
+  const originalQuery = buildQueryByFreetext(freetext);
+  const convertedQuery = buildQueryByFreetext(converted);
+  return `(${originalQuery} OR ${convertedQuery})`;
+};
+
+const buildQueryByFreetext = (freetext: string): string => {
+  if (freetext.includes(':')) {
+    return `exact_match:"${freetext}"`;
+  }
+  return `${escapeKeys(freetext)}*`;
 };
 
 const getQueryByTypeFreetext = (qualifier: FreetextQualifier & Partial<ContactTypeQualifier>) => {

--- a/shared-libs/cht-datasource/test/local/libs/nouveau.spec.ts
+++ b/shared-libs/cht-datasource/test/local/libs/nouveau.spec.ts
@@ -31,9 +31,14 @@ describe('nouveau', () => {
 
     ([
       ['key:value', 'exact_match:"key:value"'],
-      ['searchterm', 'searchterm*']
+      ['searchterm', 'searchterm*'],
+      ['patient123', '(patient123* OR patient१२३*)'],
+      ['patient१२३', '(patient१२३* OR patient123*)'],
+      ['mixed१23', '(mixed१23* OR mixed123*)'],
+      ['key:123', '(exact_match:"key:123" OR exact_match:"key:१२३")'],
+      ['key:१२३', '(exact_match:"key:१२३" OR exact_match:"key:123")'],
     ] as [string, string][]).forEach(([freetext, q]) => {
-      it('should query for freetext qualifier', async () => {
+      it(`should query for freetext qualifier: ${freetext}`, async () => {
         const qualifier = Qualifier.byFreetext(freetext);
         dbFetch.resolves(mockResponse);
         const body = {
@@ -55,9 +60,13 @@ describe('nouveau', () => {
 
     ([
       ['key:value', 'contact_type:"person" AND exact_match:"key:value"'],
-      ['searchterm', 'contact_type:"person" AND searchterm*']
+      ['searchterm', 'contact_type:"person" AND searchterm*'],
+      ['patient123', 'contact_type:"person" AND (patient123* OR patient१२३*)'],
+      ['patient१२३', 'contact_type:"person" AND (patient१२३* OR patient123*)'],
+      ['key:123', 'contact_type:"person" AND (exact_match:"key:123" OR exact_match:"key:१२३")'],
+      ['key:१२३', 'contact_type:"person" AND (exact_match:"key:१२३" OR exact_match:"key:123")'],
     ] as [string, string][]).forEach(([freetext, q]) => {
-      it('should query with contact type and freetext qualifier', async () => {
+      it(`should query with contact type and freetext qualifier: ${freetext}`, async () => {
         const qualifier = Qualifier.and(
           Qualifier.byFreetext(freetext),
           Qualifier.byContactType('person')


### PR DESCRIPTION
## Summary

The Nouveau search index migration in 5.x broke numeral cross-matching for online users. Searching with Latin digits (e.g., `12345`) no longer returned contacts with Devanagari numerals in their names, and vice versa.

## Changes

- Expanded freetext queries to search for both Latin and Devanagari digit variants when the search term contains digits.
- Example: searching `123` now generates `(123* OR १२३*)`, matching contacts in either numeral system.
- Both fuzzy match and keyed (`exact_match`) queries are supported.
- Added 9 new test cases covering digit conversion in both freetext-only and combined (freetext + contact type) queries.

## Technical details

- `latinToDevanagari()` converts Latin digits (0-9) to Devanagari equivalents (०-९).
- `devanagariToLatin()` converts Devanagari digits to Latin equivalents.
- `hasDigits()` detects whether a string contains digits in either numeral system.
- `getQueryByFreetext()` generates an OR query when both variants differ.

## Testing

- All ~960 Nouveau unit tests pass, including 9 new test cases for Devanagari numeral expansion.
