### PR TITLE
refactor(webapp): replace any types in auth directive and training-card guard

### DIFF
--- a/webapp/src/ts/directives/auth.directive.ts
+++ b/webapp/src/ts/directives/auth.directive.ts
@@ -2,12 +2,27 @@ import * as _ from 'lodash-es';
 import { Directive, Input, HostBinding, OnChanges } from '@angular/core';
 import { AuthService } from '../services/auth.service';
 
+/**
+ * A single property accepted by `mmAuthAny`. Reflects the runtime branches
+ * in the directive's `dynamicChecks`:
+ *   - `true`            -> short-circuit allow (line: mmAuthAny.some(p => p === true))
+ *   - string            -> a single permission name
+ *   - string[]          -> an AND-group of permission names (flattened via _.flattenDeep)
+ */
+type AuthAnyValue = boolean | string | string[];
+
+/**
+ * `mmAuthAny` accepts either a single AuthAnyValue (auto-wrapped to a one-element array
+ * at runtime) or an array of them representing OR-of-AND-groups.
+ */
+type AuthAnyInput = AuthAnyValue | AuthAnyValue[];
+
 @Directive({
   selector: '[mmAuth]'
 })
 export class AuthDirective implements OnChanges {
   @Input() mmAuth?: string;
-  @Input() mmAuthAny?: any;
+  @Input() mmAuthAny?: AuthAnyInput;
   @Input() mmAuthOnline?: boolean;
 
   private hidden = true;

--- a/webapp/src/ts/training-card.guard.provider.ts
+++ b/webapp/src/ts/training-card.guard.provider.ts
@@ -9,7 +9,7 @@ import { Selectors } from '@mm-selectors/index';
 @Injectable({
   providedIn: 'root'
 })
-export class TrainingCardDeactivationGuardProvider implements CanDeactivate<any> {
+export class TrainingCardDeactivationGuardProvider implements CanDeactivate<unknown> {
   private readonly globalActions: GlobalActions;
 
   constructor(private readonly store: Store) {
@@ -17,7 +17,7 @@ export class TrainingCardDeactivationGuardProvider implements CanDeactivate<any>
   }
 
   canDeactivate(
-    component: any,
+    component: unknown,
     currentRoute: ActivatedRouteSnapshot,
     currentState: RouterStateSnapshot,
     nextState: RouterStateSnapshot,


### PR DESCRIPTION
Part of #10883.

## Changes

- `webapp/src/ts/directives/auth.directive.ts`: replace `mmAuthAny?: any` with a narrow union (`AuthAnyValue | AuthAnyValue[]`) that reflects the runtime branches in `dynamicChecks` — a value is either `true` (short-circuit allow), a single permission name, or an AND-group of permission names; the input accepts a single value or an array of them representing OR-of-AND-groups.
- `webapp/src/ts/training-card.guard.provider.ts`: replace `CanDeactivate<any>` and `component: any` with `unknown`. The guard does not use the component parameter — `unknown` matches the actual contract without resorting to `any`.

## No behavior change

Pure typing change. No runtime logic touched. The new types match all existing call sites.
