### PR TITLE
Support Bikram Sambat month intervals for Targets and UHC

### DIFF
--- a/shared-libs/calendar-interval/package.json
+++ b/shared-libs/calendar-interval/package.json
@@ -7,5 +7,8 @@
     "test": "nyc --nycrcPath='../nyc.config.js' mocha ./test"
   },
   "author": "",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "dependencies": {
+    "bikram-sambat": "^1.8.0"
+  }
 }

--- a/shared-libs/calendar-interval/src/index.js
+++ b/shared-libs/calendar-interval/src/index.js
@@ -1,4 +1,5 @@
 const moment = require('moment');
+const bikramSambat = require('bikram-sambat');
 
 const normalizeStartDate = (intervalStartDate) => {
   intervalStartDate = parseInt(intervalStartDate);
@@ -28,18 +29,18 @@ const getMinimumEndDate = (intervalStartDate, nextMonth, relativeDate) => {
     .valueOf();
 };
 
-const getInterval = (intervalStartDate, referenceDate = moment()) => {
+const getGregorianInterval = (intervalStartDate, referenceDate) => {
   intervalStartDate = normalizeStartDate(intervalStartDate);
   if (intervalStartDate === 1) {
     return {
-      start: referenceDate.startOf('month').valueOf(),
-      end: referenceDate.endOf('month').valueOf()
+      start: referenceDate.clone().startOf('month').valueOf(),
+      end: referenceDate.clone().endOf('month').valueOf()
     };
   }
 
   if (intervalStartDate <= referenceDate.date()) {
     return {
-      start: referenceDate.date(intervalStartDate).startOf('day').valueOf(),
+      start: referenceDate.clone().date(intervalStartDate).startOf('day').valueOf(),
       end: getMinimumEndDate(intervalStartDate, true, referenceDate)
     };
   }
@@ -50,7 +51,66 @@ const getInterval = (intervalStartDate, referenceDate = moment()) => {
   };
 };
 
-const getPreviousInterval = (intervalStartDate, referenceDate = moment()) => {
+const bsMonthNav = (year, month, delta) => {
+  month += delta;
+  if (month > 12) {
+    month = 1;
+    year++;
+  } else if (month < 1) {
+    month = 12;
+    year--;
+  }
+  return { year, month };
+};
+
+const getBikramSambatInterval = (intervalStartDate, referenceDate) => {
+  intervalStartDate = normalizeStartDate(intervalStartDate);
+  const refBs = bikramSambat.toBik(referenceDate.toDate());
+
+  let startBs;
+  let endBs;
+
+  if (intervalStartDate === 1) {
+    startBs = { year: refBs.year, month: refBs.month, day: 1 };
+    endBs = { year: refBs.year, month: refBs.month, day: bikramSambat.daysInMonth(refBs.year, refBs.month) };
+  } else if (intervalStartDate <= refBs.day) {
+    const next = bsMonthNav(refBs.year, refBs.month, 1);
+    const daysInNext = bikramSambat.daysInMonth(next.year, next.month);
+    startBs = { year: refBs.year, month: refBs.month, day: intervalStartDate };
+    endBs = { year: next.year, month: next.month, day: Math.min(intervalStartDate - 1, daysInNext) };
+  } else {
+    const prev = bsMonthNav(refBs.year, refBs.month, -1);
+    const daysInPrev = bikramSambat.daysInMonth(prev.year, prev.month);
+    const daysInCurrent = bikramSambat.daysInMonth(refBs.year, refBs.month);
+    startBs = { year: prev.year, month: prev.month, day: Math.min(intervalStartDate, daysInPrev) };
+    endBs = { year: refBs.year, month: refBs.month, day: Math.min(intervalStartDate - 1, daysInCurrent) };
+  }
+
+  const startG = bikramSambat.toGreg(startBs.year, startBs.month, startBs.day);
+  const endG = bikramSambat.toGreg(endBs.year, endBs.month, endBs.day);
+
+  return {
+    start: moment([startG.year, startG.month - 1, startG.day]).startOf('day').valueOf(),
+    end: moment([endG.year, endG.month - 1, endG.day]).endOf('day').valueOf()
+  };
+};
+
+const getInterval = (intervalStartDate, referenceDate, useBikramSambat) => {
+  if (useBikramSambat) {
+    return getBikramSambatInterval(intervalStartDate, referenceDate);
+  }
+  return getGregorianInterval(intervalStartDate, referenceDate);
+};
+
+const getPreviousInterval = (intervalStartDate, referenceDate, useBikramSambat) => {
+  if (useBikramSambat) {
+    const bs = bikramSambat.toBik(referenceDate.toDate());
+    const prev = bsMonthNav(bs.year, bs.month, -1);
+    const prevDay = Math.min(bs.day, bikramSambat.daysInMonth(prev.year, prev.month));
+    const prevRefG = bikramSambat.toGreg(prev.year, prev.month, prevDay);
+    return getInterval(intervalStartDate, moment(new Date(prevRefG.year, prevRefG.month - 1, prevRefG.day)), true);
+  }
+
   referenceDate = referenceDate.clone().subtract(1, 'month');
   return getInterval(intervalStartDate, referenceDate);
 };
@@ -58,30 +118,41 @@ const getPreviousInterval = (intervalStartDate, referenceDate = moment()) => {
 module.exports = {
   // Returns the timestamps of the start and end of the current calendar interval
   // @param {Number} [intervalStartDate=1] - day of month when interval starts (1 - 31)
+  // @param {Date|Boolean} [referenceDate] - optional reference date, or useBikramSambat if boolean
+  // @param {Boolean} [useBikramSambat=false] - whether to use Bikram Sambat calendar
   //
   // if `intervalStartDate` exceeds month's day count, the start/end of following/current month is returned
-  // f.e. `intervalStartDate` === 31 would generate next intervals :
-  // [12-31 -> 01-30], [01-31 -> 02-[28|29]], [03-01 -> 03-30], [03-31 -> 04-30], [05-01 -> 05-30], [05-31 - 06-30]
-  getCurrent: (intervalStartDate) => getInterval(intervalStartDate),
+  getCurrent: (intervalStartDate, referenceDate, useBikramSambat) => {
+    if (typeof referenceDate === 'boolean') {
+      useBikramSambat = referenceDate;
+      referenceDate = undefined;
+    }
+    return getInterval(intervalStartDate, referenceDate ? moment(referenceDate) : moment(), useBikramSambat);
+  },
 
   /** Returns the timestamps of the start and the end of the previous calendar interval
    *  intervalStartDate: Number. Day of the month when interval starts
    *  referenceDate: Date.
+   *  useBikramSambat: Boolean.
    */
-  getPrevious: (intervalStartDate, referenceDate) => {
-    if (referenceDate) {
-      return getPreviousInterval(intervalStartDate, moment(referenceDate));
+  getPrevious: (intervalStartDate, referenceDate, useBikramSambat) => {
+    if (typeof referenceDate === 'boolean') {
+      useBikramSambat = referenceDate;
+      referenceDate = undefined;
     }
-    return getPreviousInterval(intervalStartDate);
+    return getPreviousInterval(intervalStartDate, referenceDate ? moment(referenceDate) : moment(), useBikramSambat);
   },
 
   /**
    * Returns the timestamps of the start and end of the a calendar interval that contains a reference date
    * @param {Number} [intervalStartDate=1] - day of month when interval starts (1 - 31)
    * @param {Number} timestamp - the reference date the interval should include
+   * @param {Boolean} [useBikramSambat=false] - whether to use Bikram Sambat calendar
    * @returns { start: number, end: number } - timestamps that define the calendar interval
    */
-  getInterval: (intervalStartDate, timestamp) => getInterval(intervalStartDate, moment(timestamp)),
+  getInterval: (intervalStartDate, timestamp, useBikramSambat) => {
+    return getInterval(intervalStartDate, moment(timestamp), useBikramSambat);
+  },
 
   isEqual: (intervalA, intervalB) => !!intervalA &&
                                      intervalA?.start === intervalB?.start &&

--- a/shared-libs/calendar-interval/test/bs-support.spec.js
+++ b/shared-libs/calendar-interval/test/bs-support.spec.js
@@ -1,0 +1,196 @@
+const { expect } = require('chai');
+const moment = require('moment');
+const service = require('../src/index');
+
+describe('CalendarInterval with Bikram Sambat', () => {
+
+  describe('getCurrent (BS mode)', () => {
+    it('returns 1st to end of current BS month when month start is 1', () => {
+      // 2024-04-20 AD is 2081-01-08 BS
+      const referenceDate = moment('2024-04-20');
+      const interval = service.getCurrent(1, referenceDate, true);
+      
+      // Baisakh 1, 2081 -> 2024-04-13 AD
+      expect(moment(interval.start).format('YYYY-MM-DD')).to.equal('2024-04-13');
+      // Baisakh has 31 days. Baisakh 31, 2081 -> 2024-05-13 AD
+      expect(moment(interval.end).format('YYYY-MM-DD')).to.equal('2024-05-13');
+    });
+
+    it('returns n-th of current BS month when n <= today BS (intervalStartDate > 1)', () => {
+      // 2024-04-25 AD is 2081-01-13 BS
+      const referenceDate = moment('2024-04-25');
+      const interval = service.getCurrent(10, referenceDate, true);
+      
+      // Start: Baisakh 10, 2081 -> 2024-04-22 AD
+      expect(moment(interval.start).format('YYYY-MM-DD')).to.equal('2024-04-22');
+      // End: Jestha 9, 2081 -> 2024-05-22 AD
+      expect(moment(interval.end).format('YYYY-MM-DD')).to.equal('2024-05-22');
+    });
+
+    it('returns n-th of previous BS month when n > today BS (previous interval rollover)', () => {
+      // 2024-04-20 AD is 2081-01-08 BS
+      const referenceDate = moment('2024-04-20');
+      const interval = service.getCurrent(10, referenceDate, true);
+      
+      // Start: Chaitra 10, 2080 -> 2024-03-23 AD
+      expect(moment(interval.start).format('YYYY-MM-DD')).to.equal('2024-03-23');
+      // End: Baisakh 9, 2081 -> 2024-04-21 AD
+      expect(moment(interval.end).format('YYYY-MM-DD')).to.equal('2024-04-21');
+    });
+
+    it('handles BS year transitions correctly (end of year rollover)', () => {
+      // 2024-04-12 AD is 2080-12-30 BS (last day of year)
+      const referenceDate = moment('2024-04-12');
+      const interval = service.getCurrent(1, referenceDate, true);
+      
+      // Start: Chaitra 1, 2080 -> 2024-03-14 AD
+      expect(moment(interval.start).format('YYYY-MM-DD')).to.equal('2024-03-14');
+      // End: Chaitra 30, 2080 -> 2024-04-12 AD
+      expect(moment(interval.end).format('YYYY-MM-DD')).to.equal('2024-04-12');
+    });
+
+    it('handles BS year transitions correctly (cross year boundary with n > 1)', () => {
+      // 2024-04-05 AD is 2080-12-23 BS
+      const referenceDate = moment('2024-04-05');
+      const interval = service.getCurrent(25, referenceDate, true);
+      
+      // Start: Falgun 25, 2080 -> 2024-03-08 AD
+      expect(moment(interval.start).format('YYYY-MM-DD')).to.equal('2024-03-08');
+      // End: Chaitra 24, 2080 -> 2024-04-06 AD
+      expect(moment(interval.end).format('YYYY-MM-DD')).to.equal('2024-04-06');
+      
+      // Now let's test a date early in Baisakh
+      // 2024-04-15 AD is 2081-01-03 BS
+      const referenceDate2 = moment('2024-04-15');
+      const interval10 = service.getCurrent(10, referenceDate2, true);
+      
+      // Start should be Chaitra 10, 2080 -> 2024-03-23 AD
+      expect(moment(interval10.start).format('YYYY-MM-DD')).to.equal('2024-03-23');
+      // End should be Baisakh 9, 2081 -> 2024-04-21 AD
+      expect(moment(interval10.end).format('YYYY-MM-DD')).to.equal('2024-04-21');
+
+      // Now let's test a date late in Chaitra with n <= day to cover month > 12 branch
+      // 2024-04-05 AD is 2080-12-23 BS
+      const referenceDate3 = moment('2024-04-05');
+      const interval10_2 = service.getCurrent(10, referenceDate3, true);
+      // Start should be Chaitra 10, 2080 -> 2024-03-23 AD
+      expect(moment(interval10_2.start).format('YYYY-MM-DD')).to.equal('2024-03-23');
+      // End should be Baisakh 9, 2081 -> 2024-04-21 AD
+      expect(moment(interval10_2.end).format('YYYY-MM-DD')).to.equal('2024-04-21');
+    });
+
+    it('clamps intervalStartDate to end of month if it exceeds month length', () => {
+      // Some BS months have 29 days, some 32. Let's test a month with 30 days.
+      // Chaitra 2080 has 30 days.
+      // 2024-04-10 AD is 2080-12-28 BS.
+      const referenceDate = moment('2024-04-10');
+      
+      // Requesting start on the 31st should clamp to 30th since Chaitra has 30 days
+      const interval = service.getCurrent(31, referenceDate, true);
+      
+      // Start: Falgun 30, 2080 -> 2024-03-13 AD (Falgun has 30 days)
+      expect(moment(interval.start).format('YYYY-MM-DD')).to.equal('2024-03-13');
+      // End: Chaitra 30, 2080 -> 2024-04-12 AD
+      expect(moment(interval.end).format('YYYY-MM-DD')).to.equal('2024-04-12');
+    });
+  });
+
+  describe('getPrevious (BS mode)', () => {
+    it('returns the previous BS month when month start is 1', () => {
+      // 2024-04-20 AD is 2081-01-08 BS
+      const referenceDate = moment('2024-04-20');
+      const previous = service.getPrevious(1, referenceDate, true);
+      
+      // Previous month is Chaitra 2080. Start: Chaitra 1, 2080 -> 2024-03-14 AD
+      expect(moment(previous.start).format('YYYY-MM-DD')).to.equal('2024-03-14');
+      // End: Chaitra 30, 2080 -> 2024-04-12 AD
+      expect(moment(previous.end).format('YYYY-MM-DD')).to.equal('2024-04-12');
+    });
+
+    it('returns the previous interval across year boundaries', () => {
+      // 2024-05-14 AD is 2081-02-01 BS (Jestha 1)
+      const referenceDate = moment('2024-05-14');
+      const previous = service.getPrevious(1, referenceDate, true);
+      
+      // Previous month is Baisakh 2081. Start: Baisakh 1, 2081 -> 2024-04-13 AD
+      expect(moment(previous.start).format('YYYY-MM-DD')).to.equal('2024-04-13');
+      // End: Baisakh 31, 2081 -> 2024-05-13 AD
+      expect(moment(previous.end).format('YYYY-MM-DD')).to.equal('2024-05-13');
+
+      // Now get previous of Baisakh 1
+      const refBaisakh = moment('2024-04-13');
+      const prevOfBaisakh = service.getPrevious(1, refBaisakh, true);
+      
+      // Previous month is Chaitra 2080. Start: Chaitra 1, 2080 -> 2024-03-14 AD
+      expect(moment(prevOfBaisakh.start).format('YYYY-MM-DD')).to.equal('2024-03-14');
+    });
+  });
+
+  describe('Gregorian fallback behavior (Config OFF)', () => {
+    it('returns standard Gregorian interval when useBikramSambat is false', () => {
+      // 2024-04-20 AD
+      const referenceDate = moment('2024-04-20');
+      const interval = service.getCurrent(1, referenceDate, false);
+      
+      // Start should be 2024-04-01
+      expect(moment(interval.start).format('YYYY-MM-DD')).to.equal('2024-04-01');
+      // End should be 2024-04-30
+      expect(moment(interval.end).format('YYYY-MM-DD')).to.equal('2024-04-30');
+    });
+
+    it('returns standard Gregorian previous interval when useBikramSambat is false', () => {
+      const referenceDate = moment('2024-04-20');
+      const previous = service.getPrevious(1, referenceDate, false);
+      
+      // Start should be 2024-03-01
+      expect(moment(previous.start).format('YYYY-MM-DD')).to.equal('2024-03-01');
+      // End should be 2024-03-31
+      expect(moment(previous.end).format('YYYY-MM-DD')).to.equal('2024-03-31');
+    });
+  });
+
+  describe('Timezone boundaries', () => {
+    it('generates start and end timestamps safely at start and end of day', () => {
+      // 2024-04-20 AD is 2081-01-08 BS
+      const referenceDate = moment('2024-04-20T15:00:00Z');
+      const interval = service.getCurrent(1, referenceDate, true);
+      
+      // Baisakh 1, 2081 -> 2024-04-13 AD
+      const expectedStart = moment('2024-04-13').startOf('day').valueOf();
+      const expectedEnd = moment('2024-05-13').endOf('day').valueOf();
+      
+      expect(interval.start).to.equal(expectedStart);
+      expect(interval.end).to.equal(expectedEnd);
+    });
+  });
+
+  describe('Edge case coverage for 100% branch coverage', () => {
+    it('isEqual missing branches', () => {
+      expect(service.isEqual({ start: 1, end: 2 }, { start: 1, end: 3 })).to.be.false;
+      expect(service.isEqual({ start: 1, end: 2 }, { start: 2, end: 2 })).to.be.false;
+      expect(service.isEqual(null, null)).to.be.false;
+    });
+
+    it('getCurrent boolean overload missing coverage', () => {
+      const interval = service.getCurrent(1, true); // omitted referenceDate
+      expect(interval.start).to.be.a('number');
+    });
+
+    it('getPrevious missing coverage', () => {
+      const interval = service.getPrevious(1, true); // omitted referenceDate
+      expect(interval.start).to.be.a('number');
+    });
+
+    it('getInterval missing coverage', () => {
+      const interval = service.getInterval(1, moment().valueOf(), true);
+      expect(interval.start).to.be.a('number');
+    });
+
+    it('handles negative month delta correctly', () => {
+      // month < 1 branch coverage check
+      const referenceDate = moment('2024-04-13'); // Baisakh 1 (month 1)
+      const prev = service.getPrevious(1, referenceDate, true);
+      expect(moment(prev.start).format('YYYY-MM-DD')).to.equal('2024-03-14');
+    });
+  });
+});

--- a/shared-libs/rules-engine/src/rules-state-store.js
+++ b/shared-libs/rules-engine/src/rules-state-store.js
@@ -56,6 +56,7 @@ const self = {
    * @param {Object} settings.contact User's hydrated contact document
    * @param {Object} settings.user User's user-settings document
    * @param {number} settings.monthStartDate reporting interval start date
+   * @param {boolean} settings.useBikramSambatMonths whether to use BS calendar for intervals
    * @param {Object} stateChangeCallback Callback which is invoked whenever the state changes.
    *    Receives the updated state as the only parameter.
    */
@@ -69,6 +70,7 @@ const self = {
       contactState: {},
       targetState: targetState.createEmptyState(settings.targets),
       monthStartDate: settings.monthStartDate,
+      useBikramSambatMonths: settings.useBikramSambatMonths,
     };
     currentUserContact = settings.contact;
     currentUserSettings = settings.user;
@@ -122,6 +124,7 @@ const self = {
         contactState: {},
         targetState: targetState.createEmptyState(settings.targets),
         monthStartDate: settings.monthStartDate,
+        useBikramSambatMonths: settings.useBikramSambatMonths,
       };
       currentUserContact = settings.contact;
       currentUserSettings = settings.user;
@@ -147,7 +150,7 @@ const self = {
       return;
     }
 
-    const reportingInterval = calendarInterval.getCurrent(state.monthStartDate);
+    const reportingInterval = calendarInterval.getCurrent(state.monthStartDate, state.useBikramSambatMonths);
     const defaultExpiry = calculatedAt + EXPIRE_CALCULATION_AFTER_MS;
 
     for (const contactId of contactIds) {
@@ -266,7 +269,7 @@ const self = {
    * @returns {Boolean} result.isUpdated True if the aggregate has been update compared to previous stored value.
    */
   aggregateStoredTargetEmissions: async (filterInterval) => {
-    const currentInterval = calendarInterval.getCurrent(state.monthStartDate);
+    const currentInterval = calendarInterval.getCurrent(state.monthStartDate, state.useBikramSambatMonths);
     const interval = filterInterval || currentInterval;
     const storeAggregate = calendarInterval.isEqual(interval, currentInterval);
 

--- a/webapp/src/ts/services/calendar-interval.service.ts
+++ b/webapp/src/ts/services/calendar-interval.service.ts
@@ -8,8 +8,8 @@ export class CalendarIntervalService {
 
   constructor() { }
 
-  getCurrent(startDate:number) {
-    return CalendarInterval.getCurrent(startDate);
+  getCurrent(startDate:number, useBikramSambatMonths?: boolean) {
+    return CalendarInterval.getCurrent(startDate, useBikramSambatMonths);
   }
 
   /**
@@ -19,8 +19,9 @@ export class CalendarIntervalService {
    * the calendar interval of 2023-08-03 -> 2023-09-02
    * @param startDate {number} interval start day - 1-31
    * @param timestamp {number} date that should be included by the interval
+   * @param useBikramSambatMonths {boolean} whether to use BS calendar
    */
-  getInterval(startDate:number, timestamp:number) {
-    return CalendarInterval.getInterval(startDate, timestamp);
+  getInterval(startDate:number, timestamp:number, useBikramSambatMonths?: boolean) {
+    return CalendarInterval.getInterval(startDate, timestamp, useBikramSambatMonths);
   }
 }

--- a/webapp/src/ts/services/rules-engine.service.ts
+++ b/webapp/src/ts/services/rules-engine.service.ts
@@ -230,6 +230,7 @@ export class RulesEngineService implements OnDestroy {
       user: rulesEngineContext.userSettingsDoc,
       rulesAreDeclarative: !!rulesEngineContext.settingsDoc?.tasks?.isDeclarative,
       monthStartDate: this.uhcSettingsService.getMonthStartDate(rulesEngineContext.settingsDoc),
+      useBikramSambatMonths: this.uhcSettingsService.shouldEnableBikramSambatMonths(rulesEngineContext.settingsDoc),
       chtScriptApi: rulesEngineContext.chtScriptApi
     };
   }
@@ -538,7 +539,12 @@ export class RulesEngineService implements OnDestroy {
     this.cancelDebounce(this.FRESHNESS_KEY);
     await this.waitForDebounce(this.CHANGE_WATCHER_KEY);
 
-    const relevantInterval = this.calendarIntervalService.getCurrent(this.uhcMonthStartDate);
+    const settings = await this.settingsService.get();
+    const useBikramSambatMonths = this.uhcSettingsService.shouldEnableBikramSambatMonths(settings);
+    const relevantInterval = this.calendarIntervalService.getCurrent(
+      this.uhcMonthStartDate,
+      useBikramSambatMonths
+    );
     const targets = await this.rulesEngineCore
       .fetchTargets(relevantInterval)
       .on('queued', () => trackPerformanceQueueing = this.performanceService.track())
@@ -568,7 +574,8 @@ export class RulesEngineService implements OnDestroy {
     monthsAgo = 1
   ): string {
     const uhcMonthStartDate = this.uhcSettingsService.getMonthStartDate(settings);
-    const currentInterval = this.calendarIntervalService.getCurrent(uhcMonthStartDate);
+    const useBikramSambatMonths = this.uhcSettingsService.shouldEnableBikramSambatMonths(settings);
+    const currentInterval = this.calendarIntervalService.getCurrent(uhcMonthStartDate, useBikramSambatMonths);
 
     if (reportingPeriod === ReportingPeriod.CURRENT) {
       return moment(currentInterval.end)
@@ -577,7 +584,11 @@ export class RulesEngineService implements OnDestroy {
     }
 
     const previousMonthDate = moment(currentInterval.end).subtract(monthsAgo, 'months');
-    const previousInterval = this.calendarIntervalService.getInterval(uhcMonthStartDate, previousMonthDate.valueOf());
+    const previousInterval = this.calendarIntervalService.getInterval(
+      uhcMonthStartDate,
+      previousMonthDate.valueOf(),
+      useBikramSambatMonths
+    );
     return moment(previousInterval.end)
       .locale('en')
       .format(this.INTERVAL_TAG_FORMAT);

--- a/webapp/src/ts/services/uhc-settings.service.ts
+++ b/webapp/src/ts/services/uhc-settings.service.ts
@@ -7,13 +7,11 @@ export class UHCSettingsService {
   constructor() {}
 
   getMonthStartDate(settings) {
-    return settings &&
-      settings.uhc &&
-      (
-        settings.uhc.month_start_date ||
-        settings.uhc.visit_count &&
-        settings.uhc.visit_count.month_start_date
-      );
+    return settings?.uhc?.month_start_date ?? settings?.uhc?.visit_count?.month_start_date;
+  }
+
+  shouldEnableBikramSambatMonths(settings: Record<string, any>): boolean {
+    return !!settings?.uhc?.visit_count?.use_bikram_sambat_months;
   }
 
   getVisitCountSettings(settings?) {
@@ -24,6 +22,7 @@ export class UHCSettingsService {
     return {
       monthStartDate: this.getMonthStartDate(settings),
       visitCountGoal: settings.uhc.visit_count.visit_count_goal,
+      useBikramSambatMonths: this.shouldEnableBikramSambatMonths(settings),
     };
   }
 

--- a/webapp/src/ts/services/uhc-stats.service.ts
+++ b/webapp/src/ts/services/uhc-stats.service.ts
@@ -65,7 +65,7 @@ export class UHCStatsService {
       return;
     }
 
-    return CalendarInterval.getCurrent(visitCountSettings.monthStartDate);
+    return CalendarInterval.getCurrent(visitCountSettings.monthStartDate, visitCountSettings.useBikramSambatMonths);
   }
 
   async getHomeVisitStats(contact, visitCountSettings: VisitCountSettings): Promise<VisitStats | undefined> {
@@ -106,6 +106,7 @@ type DateRange = {
 interface VisitCountSettings {
   monthStartDate?: number; // Ex: 26
   visitCountGoal?: number;
+  useBikramSambatMonths?: boolean;
 }
 
 interface VisitStats {


### PR DESCRIPTION
Title:
Support Bikram Sambat month intervals for Targets and UHC

Description:

## Summary

This change adds support for using Bikram Sambat (BS) month boundaries when calculating Targets and UHC reporting intervals.

Currently interval calculations are based on Gregorian month boundaries, with optional offsets using `month_start_date`. This update introduces an optional configuration path that allows deployments using the Nepali calendar to align reporting intervals with BS months instead.

## Changes

* added BS-aware interval calculation support in `@medic/calendar-interval`
* updated rules engine interval handling to use BS month boundaries when configured
* integrated BS interval support into Targets and UHC calculations
* exposed configuration flow through existing settings services
* added interval tests covering BS month calculations and rollover behavior

## Configuration

```json
{
  "uhc": {
    "visit_count": {
      "use_bikram_sambat_months": true
    }
  }
}
```

When disabled or omitted, existing Gregorian behavior remains unchanged.

## Notes

This implementation keeps the existing interval storage format and preserves backward compatibility for deployments using Gregorian month calculations.

The changes are scoped to interval generation and reporting calculations without modifying existing target document structures.

Related issues:

* #10652
* #10707
* #6797

