### PR TITLE
fix: handle zero-value LMP dates in pregnancy registration

### DIFF
--- a/shared-libs/transitions/src/transitions/registration.js
+++ b/shared-libs/transitions/src/transitions/registration.js
@@ -145,49 +145,49 @@ const getDaysSinceDOB = doc => {
  * property names atm.
  */
 const getWeeksSinceLMP = doc => {
-  const props = ['weeks_since_lmp', 'last_menstrual_period', 'lmp'];
-  for (const prop of props) {
-    if (doc.fields) {
-      const val = doc.fields[prop];
-      if (val !== undefined && val !== null && String(val).trim() !== '') {
-        const lmp = Number(val);
-        if (!isNaN(lmp)) {
-          return lmp;
-        }
-      }
-    }
+  const fields = doc?.fields;
+  if (!fields) {
+    return;
   }
+  const props = ['weeks_since_lmp', 'last_menstrual_period', 'lmp'];
+  const foundProp = props.find(prop => {
+    const val = fields[prop];
+    return val !== undefined && val !== null && String(val).trim() !== '';
+  });
+  if (foundProp === undefined) {
+    return;
+  }
+  const lmp = Number(fields[foundProp]);
+  return Number.isNaN(lmp) ? undefined : lmp;
 };
 
-/*
-* Given a doc, try to get the exact LMP date
-*/
 const getLMPDate = doc => {
-  const props = ['lmp_date', 'date_lmp'];
-  for (const prop of props) {
-    if (doc.fields && doc.fields[prop] !== undefined && doc.fields[prop] !== null) {
-      const lmp = parseInt(doc.fields[prop]);
-      if (!isNaN(lmp)) {//milliseconds since epoch
-        return lmp;
-      }
-    }
+  const fields = doc?.fields;
+  if (!fields) {
+    return;
   }
+  const props = ['lmp_date', 'date_lmp'];
+  const foundProp = props.find(prop => fields[prop] !== undefined && fields[prop] !== null);
+  if (foundProp === undefined) {
+    return;
+  }
+  const lmp = Number.parseInt(fields[foundProp], 10);
+  return Number.isNaN(lmp) ? undefined : lmp;
 };
 
 const setExpectedBirthDate = doc => {
   let start;
   const lmpDate = getLMPDate(doc);
-  if (lmpDate !== undefined && lmpDate !== null) {
+  if (typeof lmpDate === 'number') {
     start = moment(lmpDate);
   } else {
     const lmp = getWeeksSinceLMP(doc);
-    if (lmp !== undefined && lmp !== null) {
-      start = moment(doc.reported_date).startOf('day');
-      start.subtract(lmp, 'weeks');
+    if (typeof lmp === 'number') {
+      start = moment(doc.reported_date).startOf('day').subtract(lmp, 'weeks');
     }
   }
 
-  if (!start) {// means baby was already born, chw just wants a registration.
+  if (!start) {
     doc.lmp_date = null;
     doc.expected_date = null;
     return;

--- a/shared-libs/transitions/src/transitions/registration.js
+++ b/shared-libs/transitions/src/transitions/registration.js
@@ -147,9 +147,14 @@ const getDaysSinceDOB = doc => {
 const getWeeksSinceLMP = doc => {
   const props = ['weeks_since_lmp', 'last_menstrual_period', 'lmp'];
   for (const prop of props) {
-    const lmp = Number(doc.fields && doc.fields[prop]);
-    if (!isNaN(lmp)) {
-      return lmp;
+    if (doc.fields) {
+      const val = doc.fields[prop];
+      if (val !== undefined && val !== null && String(val).trim() !== '') {
+        const lmp = Number(val);
+        if (!isNaN(lmp)) {
+          return lmp;
+        }
+      }
     }
   }
 };
@@ -160,9 +165,11 @@ const getWeeksSinceLMP = doc => {
 const getLMPDate = doc => {
   const props = ['lmp_date', 'date_lmp'];
   for (const prop of props) {
-    const lmp = doc.fields && doc.fields[prop] && parseInt(doc.fields[prop]);
-    if (!isNaN(lmp)) {//milliseconds since epoch
-      return lmp;
+    if (doc.fields && doc.fields[prop] !== undefined && doc.fields[prop] !== null) {
+      const lmp = parseInt(doc.fields[prop]);
+      if (!isNaN(lmp)) {//milliseconds since epoch
+        return lmp;
+      }
     }
   }
 };
@@ -170,11 +177,11 @@ const getLMPDate = doc => {
 const setExpectedBirthDate = doc => {
   let start;
   const lmpDate = getLMPDate(doc);
-  if (lmpDate) {
+  if (lmpDate !== undefined && lmpDate !== null) {
     start = moment(lmpDate);
   } else {
     const lmp = getWeeksSinceLMP(doc);
-    if (lmp) {
+    if (lmp !== undefined && lmp !== null) {
       start = moment(doc.reported_date).startOf('day');
       start.subtract(lmp, 'weeks');
     }

--- a/shared-libs/transitions/test/unit/pregnancy_registration.js
+++ b/shared-libs/transitions/test/unit/pregnancy_registration.js
@@ -150,11 +150,30 @@ describe('pregnancy registration with weeks since LMP', () => {
     assert(transition.filter({ doc, info: {} }));
   });
 
-  it('setExpectedBirthDate sets lmp_date and expected_date to null when lmp 0', () => {
-    const doc = { fields: { lmp: 0 }, type: DOC_TYPES.DATA_RECORD };
+  it('setExpectedBirthDate sets lmp_date and expected_date correctly when lmp is 0', () => {
+    const reported_date = moment('2000-01-01');
+    const doc = { fields: { lmp: 0 }, reported_date: reported_date.valueOf(), type: DOC_TYPES.DATA_RECORD };
     transition.setExpectedBirthDate(doc);
-    assert.equal(doc.lmp_date, null);
-    assert.equal(doc.expected_date, null);
+    const start = reported_date.clone().startOf('day');
+    assert.equal(doc.lmp_date, start.toISOString());
+    assert.equal(doc.expected_date, start.clone().add(40, 'weeks').toISOString());
+  });
+
+  it('setExpectedBirthDate sets lmp_date and expected_date to null when lmp is null or undefined or empty', () => {
+    const doc1 = { fields: { lmp: null }, type: DOC_TYPES.DATA_RECORD };
+    transition.setExpectedBirthDate(doc1);
+    assert.equal(doc1.lmp_date, null);
+    assert.equal(doc1.expected_date, null);
+
+    const doc2 = { fields: { lmp: undefined }, type: DOC_TYPES.DATA_RECORD };
+    transition.setExpectedBirthDate(doc2);
+    assert.equal(doc2.lmp_date, null);
+    assert.equal(doc2.expected_date, null);
+
+    const doc3 = { fields: { lmp: '' }, type: DOC_TYPES.DATA_RECORD };
+    transition.setExpectedBirthDate(doc3);
+    assert.equal(doc3.lmp_date, null);
+    assert.equal(doc3.expected_date, null);
   });
 
   it('setExpectedBirthDate sets lmp_date and expected_date correctly for lmp: 10', () => {
@@ -247,7 +266,7 @@ describe('pregnancy registration with weeks since LMP', () => {
   });
 
 
-  it('zero lmp value only registers patient', () => {
+  it('zero lmp value registers patient and sets expected birth date', () => {
     sinon.stub(utils, 'getContactUuid').resolves(undefined);
     sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
     sinon.stub(contactTypeUtils, 'isParentOf').returns(true);
@@ -267,7 +286,7 @@ describe('pregnancy registration with weeks since LMP', () => {
 
     return transition.onMatch({ doc: doc }).then(function(changed) {
       assert.equal(changed, true);
-      assert.equal(doc.lmp_date, null);
+      assert.equal(doc.lmp_date, moment(doc.reported_date).startOf('day').toISOString());
       assert.equal(doc.patient_id, 12345);
       assert.equal(doc.tasks, undefined);
       assert.equal(db.medic.post.callCount, 1);
@@ -522,6 +541,22 @@ describe('pregnancy registration with exact LMP date', () => {
     assert(doc.lmp_date);
     assert.equal(doc.lmp_date, eightWeeksAgo.clone().toISOString());
     assert.equal(doc.expected_date, eightWeeksAgo.clone().add(40, 'weeks').toISOString());
+  });
+
+  it('setExpectedBirthDate sets lmp_date and expected_date correctly for lmp_date = 0', () => {
+    const doc = {
+      fields:
+      {
+        lmp_date: 0
+      },
+      reported_date: today.valueOf(),
+      type: DOC_TYPES.DATA_RECORD
+    };
+
+    transition.setExpectedBirthDate(doc);
+    assert(doc.lmp_date);
+    assert.equal(doc.lmp_date, moment(0).toISOString());
+    assert.equal(doc.expected_date, moment(0).add(40, 'weeks').toISOString());
   });
 
   it('valid adds lmp_date and patient_id', () => {


### PR DESCRIPTION
This fixes an issue where pregnancies registered with weeks_since_lmp = 0 incorrectly cleared lmp_date and expected_date because the transition logic relied on truthy checks.

Changes

replaced loose truthy checks with explicit null/undefined validation
fixed handling for lmp = 0 and lmp_date = 0 values
preserved existing behavior for missing or empty inputs
added regression coverage for zero-week pregnancy registrations
added validation coverage for null, undefined, and empty string cases

Impact

Pregnancies registered at exactly 0 weeks since LMP now correctly generate lmp_date and expected_date, ensuring ANC schedules are created properly while keeping existing registration behavior unchanged.

Fixes #11070