### PR TITLE
fix: log and propagate getUserSettings middleware failures

### DIFF
--- a/api/src/middleware/authorization.js
+++ b/api/src/middleware/authorization.js
@@ -16,7 +16,11 @@ const getUserSettings = (req) => {
     .then(userCtx => {
       req.userCtx = userCtx;
     })
-    .catch(err => err);
+    .catch(err => {
+      logger.error('Error getting user settings: %o', err);
+      req.authErr = err;
+      return err;
+    });
 };
 
 module.exports = {

--- a/api/tests/mocha/middleware/authorization.spec.js
+++ b/api/tests/mocha/middleware/authorization.spec.js
@@ -210,18 +210,24 @@ describe('Authorization middleware', () => {
       testReq.userCtx = { name: 'user' };
       auth.getUserCtx.resolves({ name: 'user' });
       auth.isOnlineOnly.withArgs({ name: 'user' }).returns(false);
-      auth.getUserSettings.withArgs({ name: 'user' }).rejects({ some: 'error' });
+      const testError = { some: 'error' };
+      auth.getUserSettings.withArgs({ name: 'user' }).rejects(testError);
+      const loggerStub = sinon.stub(logger, 'error');
 
       return middleware
         .onlineUserProxy(proxy, testReq, testRes, next)
         .then(() => {
           serverUtils.error.callCount.should.equal(0);
           next.callCount.should.equal(1);
-          next.args[0].should.deep.equal([{ some: 'error' }]);
+          next.args[0].should.deep.equal([testError]);
           proxy.web.callCount.should.equal(0);
           testReq.userCtx.should.deep.equal({ name: 'user' });
+          testReq.authErr.should.equal(testError);
           auth.isOnlineOnly.args[0][0].should.deep.equal({ name: 'user'});
           auth.getUserSettings.args[0][0].should.deep.equal({ name: 'user'});
+          loggerStub.callCount.should.equal(1);
+          loggerStub.args[0][0].should.equal('Error getting user settings: %o');
+          loggerStub.args[0][1].should.equal(testError);
         });
     });
   });
@@ -261,17 +267,23 @@ describe('Authorization middleware', () => {
     it('catches user_settings errors', () => {
       testReq.userCtx = { name: 'user' };
       auth.isOnlineOnly.withArgs({ name: 'user' }).returns(false);
-      auth.getUserSettings.withArgs({ name: 'user' }).rejects({ some: 'error' });
+      const testError = { some: 'error' };
+      auth.getUserSettings.withArgs({ name: 'user' }).rejects(testError);
+      const loggerStub = sinon.stub(logger, 'error');
 
       return middleware
         .onlineUserPassThrough(testReq, testRes, next)
         .then(() => {
           serverUtils.error.callCount.should.equal(0);
           next.callCount.should.equal(1);
-          next.args[0].should.deep.equal([{ some: 'error' }]);
+          next.args[0].should.deep.equal([testError]);
           testReq.userCtx.should.deep.equal({ name: 'user' });
+          testReq.authErr.should.equal(testError);
           auth.isOnlineOnly.args[0][0].should.deep.equal({ name: 'user'});
           auth.getUserSettings.args[0][0].should.deep.equal({ name: 'user'});
+          loggerStub.callCount.should.equal(1);
+          loggerStub.args[0][0].should.equal('Error getting user settings: %o');
+          loggerStub.args[0][1].should.equal(testError);
         });
     });
   });
@@ -446,6 +458,30 @@ describe('Authorization middleware', () => {
           testReq.userCtx.should.deep.equal({ name: 'user', contact_id: 'a' });
           auth.isOnlineOnly.args[0][0].should.deep.equal({ name: 'user'});
           auth.getUserSettings.args[0][0].should.deep.equal({ name: 'user'});
+        });
+    });
+
+    it('catches user_settings errors', () => {
+      testReq.userCtx = { name: 'user' };
+      auth.getUserCtx.resolves({ name: 'user' });
+      auth.isOnlineOnly.withArgs({ name: 'user' }).returns(false);
+      const testError = { some: 'error' };
+      auth.getUserSettings.withArgs({ name: 'user' }).rejects(testError);
+      const loggerStub = sinon.stub(logger, 'error');
+
+      return middleware
+        .getUserSettings(testReq, testRes, next)
+        .then(() => {
+          serverUtils.error.callCount.should.equal(0);
+          next.callCount.should.equal(1);
+          next.args[0].should.deep.equal([testError]);
+          testReq.userCtx.should.deep.equal({ name: 'user' });
+          testReq.authErr.should.equal(testError);
+          auth.isOnlineOnly.args[0][0].should.deep.equal({ name: 'user'});
+          auth.getUserSettings.args[0][0].should.deep.equal({ name: 'user'});
+          loggerStub.callCount.should.equal(1);
+          loggerStub.args[0][0].should.equal('Error getting user settings: %o');
+          loggerStub.args[0][1].should.equal(testError);
         });
     });
   });


### PR DESCRIPTION
Fixes #11051

Previously, if `auth.getUserSettings()` failed, the error was caught and ignored without any log output. The request continued normally, making the failure difficult to detect and debug in production.

## Changes

- added proper error logging for failed `getUserSettings` calls
- stored the error in `req.authErr` to match existing auth middleware behavior
- preserved current middleware flow so requests do not hang
- kept the fix minimal and scoped only to this issue

## Tests

Added regression tests to verify:

- errors are logged correctly
- `req.authErr` is set properly
- middleware continues safely after failures
- online user middleware paths still work correctly

All related authorization middleware tests are passing.