### PR TITLE
perf(#11088): paginate _users queries in purging getRoles()

### DIFF
--- a/sentinel/src/lib/purging.js
+++ b/sentinel/src/lib/purging.js
@@ -62,21 +62,42 @@ const closePurgeDbs = () => {
   });
 };
 
+const USERS_BATCH_SIZE = 1000;
+
 const getRoles = async () => {
   const dedupedByRoles = new Map();
   const rolesByHash = {};
 
-  const { rows } = await db.users.allDocs({ include_docs: true });
+  let startKey;
+  let hasMore = true;
 
-  for (const { doc } of rows) {
-    const userRoles = doc?.roles;
-
-    if (!Array.isArray(userRoles) || !userRoles.length || !roles.isOffline(userRoles)) {
-      continue;
+  while (hasMore) {
+    const opts = {
+      include_docs: true,
+      limit: USERS_BATCH_SIZE,
+    };
+    if (startKey) {
+      opts.startkey = startKey;
+      opts.skip = 1;
     }
 
-    const rolesList = serverSidePurgeUtils.sortedUniqueRoles(userRoles);
-    dedupedByRoles.set(JSON.stringify(rolesList), rolesList);
+    const { rows } = await db.users.allDocs(opts);
+    hasMore = rows.length === USERS_BATCH_SIZE;
+
+    if (rows.length) {
+      startKey = rows[rows.length - 1].id;
+    }
+
+    for (const { doc } of rows) {
+      const userRoles = doc?.roles;
+
+      if (!Array.isArray(userRoles) || !userRoles.length || !roles.isOffline(userRoles)) {
+        continue;
+      }
+
+      const rolesList = serverSidePurgeUtils.sortedUniqueRoles(userRoles);
+      dedupedByRoles.set(JSON.stringify(rolesList), rolesList);
+    }
   }
 
   for (const rolesList of dedupedByRoles.values()) {

--- a/sentinel/src/lib/purging.js
+++ b/sentinel/src/lib/purging.js
@@ -64,6 +64,29 @@ const closePurgeDbs = () => {
 
 const USERS_BATCH_SIZE = 1000;
 
+const fetchUsersBatch = async (startKey) => {
+  const opts = {
+    include_docs: true,
+    limit: USERS_BATCH_SIZE,
+  };
+  if (startKey) {
+    opts.startkey = startKey;
+    opts.skip = 1;
+  }
+  return db.users.allDocs(opts);
+};
+
+const getOfflineRoles = (rows) => {
+  const result = [];
+  for (const { doc } of rows) {
+    const userRoles = doc?.roles;
+    if (Array.isArray(userRoles) && userRoles.length && roles.isOffline(userRoles)) {
+      result.push(serverSidePurgeUtils.sortedUniqueRoles(userRoles));
+    }
+  }
+  return result;
+};
+
 const getRoles = async () => {
   const dedupedByRoles = new Map();
   const rolesByHash = {};
@@ -72,30 +95,14 @@ const getRoles = async () => {
   let hasMore = true;
 
   while (hasMore) {
-    const opts = {
-      include_docs: true,
-      limit: USERS_BATCH_SIZE,
-    };
-    if (startKey) {
-      opts.startkey = startKey;
-      opts.skip = 1;
-    }
-
-    const { rows } = await db.users.allDocs(opts);
+    const { rows } = await fetchUsersBatch(startKey);
     hasMore = rows.length === USERS_BATCH_SIZE;
 
     if (rows.length) {
       startKey = rows[rows.length - 1].id;
     }
 
-    for (const { doc } of rows) {
-      const userRoles = doc?.roles;
-
-      if (!Array.isArray(userRoles) || !userRoles.length || !roles.isOffline(userRoles)) {
-        continue;
-      }
-
-      const rolesList = serverSidePurgeUtils.sortedUniqueRoles(userRoles);
+    for (const rolesList of getOfflineRoles(rows)) {
       dedupedByRoles.set(JSON.stringify(rolesList), rolesList);
     }
   }

--- a/sentinel/tests/unit/lib/purging.spec.js
+++ b/sentinel/tests/unit/lib/purging.spec.js
@@ -87,7 +87,7 @@ describe('ServerSidePurge', () => {
       return service.__get__('getRoles')().catch(err => {
         chai.expect(err).to.deep.equal({ some: 'err' });
         chai.expect(db.users.allDocs.callCount).to.equal(1);
-        chai.expect(db.users.allDocs.args[0]).to.deep.equal([{ include_docs: true }]);
+        chai.expect(db.users.allDocs.args[0]).to.deep.equal([{ include_docs: true, limit: 1000 }]);
       });
     });
 
@@ -118,6 +118,42 @@ describe('ServerSidePurge', () => {
         chai.expect(roles[JSON.stringify(['b', 'c'])]).to.deep.equal(['b', 'c']);
         chai.expect(roles[JSON.stringify(['a', 'c'])]).to.deep.equal(['a', 'c']);
         chai.expect(roles[JSON.stringify(['a', 'b', 'c'])]).to.deep.equal(['a', 'b', 'c']);
+      });
+    });
+
+    it('should paginate through users in batches', () => {
+      sinon.stub(roles, 'isOffline').returns(true);
+      sinon.stub(purgingUtils, 'getRoleHash').callsFake(roles => JSON.stringify(roles));
+
+      const batchSize = service.__get__('USERS_BATCH_SIZE');
+      const firstBatch = Array.from({ length: batchSize }, (_, i) => ({
+        id: `user${i}`,
+        doc: { roles: ['a', 'b'], name: `user${i}` },
+      }));
+      const secondBatch = [
+        { id: `user${batchSize}`, doc: { roles: ['c', 'd'], name: `user${batchSize}` }},
+      ];
+
+      db.users.allDocs
+        .onCall(0).resolves({ rows: firstBatch })
+        .onCall(1).resolves({ rows: secondBatch });
+
+      return service.__get__('getRoles')().then(result => {
+        chai.expect(db.users.allDocs.callCount).to.equal(2);
+        chai.expect(db.users.allDocs.args[0]).to.deep.equal([{
+          include_docs: true,
+          limit: batchSize,
+        }]);
+        chai.expect(db.users.allDocs.args[1]).to.deep.equal([{
+          include_docs: true,
+          limit: batchSize,
+          startkey: `user${batchSize - 1}`,
+          skip: 1,
+        }]);
+        chai.expect(Object.keys(result)).to.deep.equal([
+          JSON.stringify(['a', 'b']),
+          JSON.stringify(['c', 'd']),
+        ]);
       });
     });
   });


### PR DESCRIPTION
## Summary

- Paginate `getRoles()` in `sentinel/src/lib/purging.js` to process the `_users` database in batches of 1000 documents instead of loading every user document into memory at once.
- Add a test verifying pagination behavior across multiple batches.

Fixes #11088

## Context

`getRoles()` calls `db.users.allDocs({ include_docs: true })` without a `limit`, which loads the entire `_users` database in a single allocation. In deployments with thousands of community health workers, this creates a significant memory spike during each purging cycle. The rest of the purging module carefully paginates large data operations (e.g., `batchedContactsPurge`, `purgeUnallocatedRecords`), and `getRoles()` was the remaining outlier.

## Changes

**`sentinel/src/lib/purging.js`**
- Added `USERS_BATCH_SIZE = 1000` constant.
- Rewrote `getRoles()` to iterate through `_users` in paginated batches using `startkey` and `skip` for cursor progression.

**`sentinel/tests/unit/lib/purging.spec.js`**
- Updated existing assertion to match the new `limit` parameter.
- Added test case `should paginate through users in batches` that verifies multi-batch iteration, correct query parameters per batch, and correct role deduplication across batches.

## Test plan

- [x] Existing `getRoles` tests pass with updated assertions.
- [x] New pagination test validates correct batching behavior.
- [x] Full purging test suite passes (75 tests).