### PR TITLE
fix(#11090): remove password from rate limiter lookup keys

### DIFF
--- a/api/src/services/rate-limit.js
+++ b/api/src/services/rate-limit.js
@@ -26,15 +26,9 @@ const getKeys = (req) => {
   if (req.body?.user) {
     keys.push(req.body.user);
   }
-  if (req.body?.password) {
-    keys.push(req.body.password);
-  }
   const basicAuth = auth.basicAuthCredentials(req);
   if (basicAuth?.username) {
     keys.push(basicAuth.username);
-  }
-  if (basicAuth?.password) {
-    keys.push(basicAuth.password);
   }
   return keys;
 };

--- a/api/tests/mocha/services/rate-limit.spec.js
+++ b/api/tests/mocha/services/rate-limit.spec.js
@@ -59,28 +59,24 @@ describe('rate-limit service', () => {
       auth.basicAuthCredentials.returns({ username: 'basicuser', password: 'basicpass' });
       rateLimit.get.withArgs('quay').resolves();
       rateLimit.get.withArgs('key').resolves({ remainingPoints: 1 });
-      rateLimit.get.withArgs('kee').resolves({ remainingPoints: 1 });
       rateLimit.get.withArgs('basicuser').resolves({ remainingPoints: 1 });
-      rateLimit.get.withArgs('basicpass').resolves({ remainingPoints: 1 });
       const actual = await service.isLimited(req);
       chai.expect(actual).to.be.false;
-      chai.expect(rateLimit.get.callCount).to.equal(5);
+      chai.expect(rateLimit.get.callCount).to.equal(3);
     });
 
-    it('returns false when any limit reached', async () => {
+    it('returns true when any limit reached', async () => {
       const req = {
         ip: 'quay',
         body: { user: 'key', password: 'kee' }
       };
       auth.basicAuthCredentials.returns({ username: 'basicuser', password: 'basicpass' });
       rateLimit.get.withArgs('quay').resolves();
-      rateLimit.get.withArgs('key').resolves({ remainingPoints: 1 });
-      rateLimit.get.withArgs('kee').resolves({ remainingPoints: 0 });
+      rateLimit.get.withArgs('key').resolves({ remainingPoints: 0 });
       rateLimit.get.withArgs('basicuser').resolves({ remainingPoints: 1 });
-      rateLimit.get.withArgs('basicpass').resolves({ remainingPoints: 1 });
       const actual = await service.isLimited(req);
       chai.expect(actual).to.be.true;
-      chai.expect(rateLimit.get.callCount).to.equal(3); // it short circuits when the first key is found to be limited
+      chai.expect(rateLimit.get.callCount).to.equal(2);
     });
 
   });
@@ -95,12 +91,10 @@ describe('rate-limit service', () => {
       auth.basicAuthCredentials.returns({ username: 'basicuser', password: 'basicpass' });
       rateLimit.consume.resolves();
       await service.consume(req);
-      chai.expect(rateLimit.consume.callCount).to.equal(5);
+      chai.expect(rateLimit.consume.callCount).to.equal(3);
       chai.expect(rateLimit.consume.args[0][0]).to.equal('quay');
       chai.expect(rateLimit.consume.args[1][0]).to.equal('key');
-      chai.expect(rateLimit.consume.args[2][0]).to.equal('kee');
-      chai.expect(rateLimit.consume.args[3][0]).to.equal('basicuser');
-      chai.expect(rateLimit.consume.args[4][0]).to.equal('basicpass');
+      chai.expect(rateLimit.consume.args[2][0]).to.equal('basicuser');
     });
 
     it('ignores rejections', async () => {
@@ -110,9 +104,8 @@ describe('rate-limit service', () => {
       };
       rateLimit.consume.withArgs('quay').rejects(); // rate limit exceeded
       rateLimit.consume.withArgs('key').resolves();
-      rateLimit.consume.withArgs('kee').resolves();
       await service.consume(req);
-      chai.expect(rateLimit.consume.callCount).to.equal(3);
+      chai.expect(rateLimit.consume.callCount).to.equal(2);
     });
 
   });


### PR DESCRIPTION
## Summary

- Remove the raw password from the set of keys used by the login rate limiter, preventing cross-account lockout when multiple users share the same password.
- Update tests to reflect the reduced key set (IP + username only).

Fixes #11090
Related to #10705

## Context

The rate limiter in `api/src/services/rate-limit.js` uses multiple keys per request: IP, username, and password. When any single key exhausts its 10-attempt budget within 10 seconds, all subsequent requests matching that key are blocked.

Because the raw password is used as a key, all accounts sharing the same password share a rate limit bucket. An attacker can lock out every account with a given password by sending 10 failed login requests with any username and that password. This is especially relevant in CHT deployments where administrators provision devices for community health workers and password patterns may overlap.

The combination of IP + username is sufficient to prevent brute-force attacks against individual accounts.

## Changes

**`api/src/services/rate-limit.js`**
- Removed `req.body.password` and `basicAuth.password` from `getKeys()`.

**`api/tests/mocha/services/rate-limit.spec.js`**
- Updated `isLimited` tests: adjusted call counts and removed password key assertions.
- Updated `consume` tests: adjusted call counts and removed password key assertions.

## Test plan

- [ ] All 7 rate-limit service tests pass.
- [ ] All 5 rate-limiter middleware tests pass.
- [ ] Rate limiting still works correctly by IP and username.