### PR TITLE
fix(#11017): fix legacy UI styling for UI extensions

### DIFF
--- a/webapp/src/css/old-nav.less
+++ b/webapp/src/css/old-nav.less
@@ -70,7 +70,8 @@
   &.about,
   &.testing,
   &.privacy-policy,
-  &.user {
+  &.user,
+  &.ui-extensions {
     .tool-bar {
       height: 0;
     }
@@ -373,7 +374,8 @@
     &.about,
     &.testing,
     &.privacy-policy,
-    &.user {
+    &.user,
+    &.ui-extensions {
       .content {
         .page {
           top: calc(@top-navbar-height + 5px);

--- a/webapp/src/ts/components/header/header.component.html
+++ b/webapp/src/ts/components/header/header.component.html
@@ -87,7 +87,7 @@
     </div>
 
     <div class="tabs small-font">
-      <a *ngFor="let tab of permittedTabs" routerLink="{{tab.route}}" id="{{tab.name}}-tab" class="{{tab.name}}-tab" [class.selected]="currentTab === tab.name">
+      <a *ngFor="let tab of permittedTabs" routerLink="{{tab.route}}" id="{{tab.name}}-tab" class="{{tab.name}}-tab" [class.selected]="currentTab === tab.name" [style.background-color]="currentTab === tab.name ? tab.accentColor : null">
         <div class="mm-icon" [class.mm-icon-inverse]="currentTab !== tab.name">
           <span *ngIf="!tab.resourceIcon" class="fa {{tab.icon}}"><span *ngIf="!tab.icon" class="fa {{tab.defaultIcon}}"></span></span>
           <span *ngIf="tab.resourceIcon" [innerHTML]="tab.resourceIcon | resourceIcon:tab.defaultIcon"></span>

--- a/webapp/src/ts/modules/ui-extensions/ui-extensions-tab.component.ts
+++ b/webapp/src/ts/modules/ui-extensions/ui-extensions-tab.component.ts
@@ -1,11 +1,13 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewChild } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { Store } from '@ngrx/store';
 import { NgIf } from '@angular/common';
 import { Subscription } from 'rxjs';
 import { CHTDatasourceService } from '@mm-services/cht-datasource.service';
 import { PerformanceService } from '@mm-services/performance.service';
 import { UiExtensionsService } from '@mm-services/ui-extensions.service';
 import { UserContactSummaryService } from '@mm-services/user-contact-summary.service';
+import { GlobalActions } from '@mm-actions/global';
 import { ToolBarComponent } from '@mm-components/tool-bar/tool-bar.component';
 import { ErrorLogComponent } from '@mm-components/error-log/error-log.component';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -22,14 +24,19 @@ export class UiExtensionsTabComponent implements AfterViewInit, OnDestroy {
   accentColor?: string;
 
   private paramSubscription?: Subscription;
+  private readonly globalActions: GlobalActions;
+  private previousTab?: string;
 
   constructor(
     private readonly route: ActivatedRoute,
+    private readonly store: Store,
     private readonly chtDatasourceService: CHTDatasourceService,
     private readonly performanceService: PerformanceService,
     private readonly uiExtensionsService: UiExtensionsService,
     private readonly userContactSummaryService: UserContactSummaryService,
-  ) {}
+  ) {
+    this.globalActions = new GlobalActions(store);
+  }
 
   ngAfterViewInit() {
     let currentExtensionId = undefined;
@@ -44,6 +51,9 @@ export class UiExtensionsTabComponent implements AfterViewInit, OnDestroy {
 
   ngOnDestroy() {
     this.paramSubscription?.unsubscribe();
+    if (this.previousTab) {
+      this.globalActions.setCurrentTab(this.previousTab);
+    }
   }
 
   private async initializeExtension(extensionId: string) {
@@ -58,11 +68,16 @@ export class UiExtensionsTabComponent implements AfterViewInit, OnDestroy {
     const trackRender = this.performanceService.track();
     try {
       const {
-        properties: { title, config, accent_color },
+        properties: { title, config, accent_color, type },
         Element
       } = await this.uiExtensionsService.getExtension(extensionId);
       this.extensionTitle = title ?? '';
       this.accentColor = accent_color;
+
+      if (type === 'header_tab') {
+        this.previousTab = this.route.snapshot.data['tab'];
+        this.globalActions.setCurrentTab(`ui-extension-${extensionId}`);
+      }
       if (!customElements.get(elementName)) {
         customElements.define(elementName, Element);
       }

--- a/webapp/src/ts/services/header-tabs.service.ts
+++ b/webapp/src/ts/services/header-tabs.service.ts
@@ -141,6 +141,7 @@ export class HeaderTabsService {
       permissions: [], // Extensions are already filtered by role in getPropertiesByType
       resourceIcon: ext.resource_icon,
       icon: ext.icon,
+      accentColor: ext.accent_color,
       weight: ext.weight ?? this.DEFAULT_UI_EXTENSION_WEIGHT
     }));
   }
@@ -200,6 +201,7 @@ export interface SidebarTab {
   permissions: string[];
   icon?: string;
   resourceIcon?: string;
+  accentColor?: string;
 }
 
 export interface HeaderTab extends SidebarTab {

--- a/webapp/tests/karma/karma-unit.conf.js
+++ b/webapp/tests/karma/karma-unit.conf.js
@@ -16,7 +16,7 @@ module.exports = function (config) {
 
   // allow to require xml files as strings
   config.buildWebpack.webpackConfig.module.rules.push({
-    test: /enketo-xml\/.*\.xml$/i,
+    test: /enketo-xml[/\\](.*)\.xml$/i,
     use: 'raw-loader',
   });
 

--- a/webapp/tests/karma/ts/modules/ui-extensions/ui-extensions-tab.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/ui-extensions/ui-extensions-tab.component.spec.ts
@@ -6,6 +6,7 @@ import { TranslateFakeLoader, TranslateLoader, TranslateModule } from '@ngx-tran
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { BehaviorSubject } from 'rxjs';
+import { Store } from '@ngrx/store';
 import { provideMockStore } from '@ngrx/store/testing';
 
 import { UiExtensionsTabComponent } from '@mm-modules/ui-extensions/ui-extensions-tab.component';
@@ -54,6 +55,7 @@ describe('UiExtensionsTabComponent', () => {
     routeParams$ = new BehaviorSubject<any>({ id: EXTENSION_ID });
     activatedRoute = {
       params: routeParams$.asObservable(),
+      snapshot: { params: { id: EXTENSION_ID }, data: { tab: 'ui-extensions' } },
     };
 
     await TestBed.configureTestingModule({
@@ -208,5 +210,42 @@ describe('UiExtensionsTabComponent', () => {
     flush();
 
     expect(uiExtensionsService.getExtension.callCount).to.equal(1);
+  }));
+
+  it('sets currentTab to extension tab name for header_tab extensions', fakeAsync(() => {
+    const store = TestBed.inject(Store);
+    const dispatchSpy = sinon.spy(store, 'dispatch');
+
+    fixture.detectChanges();
+    flush();
+
+    const setTabAction = dispatchSpy.args.find(
+      ([action]: any) => action.type === 'SET_CURRENT_TAB'
+    );
+    expect(setTabAction).to.exist;
+    expect((setTabAction![0] as any).payload.currentTab).to.equal(`ui-extension-${EXTENSION_ID}`);
+  }));
+
+  it('does not override currentTab for sidebar_tab extensions', fakeAsync(() => {
+    uiExtensionsService.getExtension.resolves({
+      properties: {
+        id: EXTENSION_ID,
+        title: EXTENSION_TITLE,
+        type: 'sidebar_tab',
+        config: MOCK_CONFIG
+      },
+      Element: MOCK_ELEMENT,
+    });
+
+    const store = TestBed.inject(Store);
+    const dispatchSpy = sinon.spy(store, 'dispatch');
+
+    fixture.detectChanges();
+    flush();
+
+    const setTabAction = dispatchSpy.args.find(
+      ([action]: any) => action.type === 'SET_CURRENT_TAB'
+    );
+    expect(setTabAction).to.not.exist;
   }));
 });

--- a/webapp/tests/karma/ts/services/header-tabs.service.spec.ts
+++ b/webapp/tests/karma/ts/services/header-tabs.service.spec.ts
@@ -223,7 +223,7 @@ describe('HeaderTabs service', () => {
       uiExtensionsService.getPropertiesByType
         .withArgs('header_tab')
         .resolves([
-          { id: 'first', title: 'First Extension', icon: 'fa-icon-1', resource_icon: 'res-1', weight: 0.5 },
+          { id: 'first', title: 'First Extension', icon: 'fa-icon-1', resource_icon: 'res-1', weight: 0.5, accent_color: '#FF5733' },
           { id: 'middle', title: 'Middle Extension', icon: 'fa-icon-3' },
           { id: 'last', title: 'Last Extension', resource_icon: 'res-2' },
         ]);
@@ -249,6 +249,7 @@ describe('HeaderTabs service', () => {
         permissions: [],
         icon: 'fa-icon-1',
         resourceIcon: 'res-1',
+        accentColor: '#FF5733',
         weight: 0.5,
       });
       expect(middleExt).to.deep.equal({
@@ -259,6 +260,7 @@ describe('HeaderTabs service', () => {
         permissions: [],
         icon: 'fa-icon-3',
         resourceIcon: undefined,
+        accentColor: undefined,
         weight: 6,
       });
       expect(lastExt).to.deep.equal({
@@ -269,6 +271,7 @@ describe('HeaderTabs service', () => {
         permissions: [],
         icon: undefined,
         resourceIcon: 'res-2',
+        accentColor: undefined,
         weight: 6,
       });
     });
@@ -290,6 +293,7 @@ describe('HeaderTabs service', () => {
           permissions: [],
           icon: 'fa-icon',
           resourceIcon: undefined,
+          accentColor: undefined,
           weight: 6,
         }
       ]);
@@ -427,6 +431,7 @@ describe('HeaderTabs service', () => {
         permissions: [],
         icon: 'fa-icon',
         resourceIcon: undefined,
+        accentColor: undefined,
         weight: 6,
       });
     });
@@ -447,6 +452,7 @@ describe('HeaderTabs service', () => {
         permissions: [],
         icon: 'fa-icon',
         resourceIcon: undefined,
+        accentColor: undefined,
         weight: 0.5,
       });
     });
@@ -578,6 +584,7 @@ describe('HeaderTabs service', () => {
         permissions: [],
         icon: 'fa-icon-1',
         resourceIcon: 'res-1',
+        accentColor: undefined,
         weight: 0.5,
       });
       expect(secondExt).to.deep.equal({
@@ -588,6 +595,7 @@ describe('HeaderTabs service', () => {
         permissions: [],
         icon: 'fa-icon-2',
         resourceIcon: undefined,
+        accentColor: undefined,
         weight: 6,
       });
     });


### PR DESCRIPTION
## Summary

Fixes #11017

This updates legacy navigation styling behavior for UI extensions.

Previously, `app_main_tab` extensions did not apply the configured `accent_color` correctly in the old navigation header tabs. Also, `app_drawer_tab` extensions rendered an extra toolbar/header space that was inconsistent with existing legacy drawer pages like About and Training Materials.

## Changes

- fixed legacy header tab accent color rendering for `app_main_tab` extensions
- removed extra toolbar/header spacing for `app_drawer_tab` extensions in legacy navigation
- updated current tab handling for extension routes
- fixed Windows path separator handling in Karma XML loader regex
- added regression and unit test coverage for legacy UI extension tab behavior

## Tests

Added and verified tests for:

- active legacy tab selection behavior
- extension tab initialization
- current tab fallback handling
- sidebar extension behavior
- cleanup handling for extension tabs

Relevant Karma test suites compile and pass successfully.