### PR TITLE
build: delete previous docs cache before new entry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -269,6 +269,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+      actions: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -281,6 +282,12 @@ jobs:
       - run: node scripts/build/cli npmCiModules
       - name: Build Documentation
         run: npm run build-documentation
+      - name: Delete previous docs cache
+        if: github.ref == 'refs/heads/master'
+        continue-on-error: true   # cache entry might not exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh cache delete cht-datasource-docs --repo ${{ github.repository }}
       - name: Cache generated docs
         if: github.ref == 'refs/heads/master'
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5


### PR DESCRIPTION
# Description

Fixes problem of new versions of the docs (both [cht-datasource](https://docs.communityhealthtoolkit.org/cht-datasource/) and [OpenAPI](https://docs.communityhealthtoolkit.org/building/reference/api/) not being committed to [the GitHub pages Repo](https://github.com/medic/cht-datasource).  A new commit should automatically be created when there is any docs changes in the `master` build.

The problem is with the [caching](https://github.com/medic/cht-core/blob/985b26b2a80048d0e8e88a410877802e949bebab/.github/workflows/build.yml#L284) in the `build-geenerated-docs` job.  When I originally updated that job to use the GitHub actions cache, I thought that adding an entry to the cache with an existing key (e.g. `cht-datasource-docs`) would just _overwrite_ the existing cache entry for that key.  However the job would actually never update the cache because of:

> Failed to save: Unable to reserve cache with key cht-datasource-docs, another job may be creating this cache.
> Warning: Cache save failed.

Now, I realize that was a mistake and have [confirmed in the docs](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#cache-action-usage) that:

> You cannot change the contents of an existing cache. Instead, you can create a new cache with a new key.

One option is to just use a unique value for each build run (e.g. the commit hash) so there is never an existing cache entry.  The downside of that is that the cached values would just continue to stack up as more commits come in. Cache entries [are not evicted](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#usage-limits-and-eviction-policy) until 7 days after they are last used or until we hit the 10GB limit.  Practically speaking this _should_ not be a huge concern right now, but it could mess with other caching we want to do later and is just an unnecessary use of resources.

Instead, in this PR I have decided to keep the fixed `cht-datasource-docs` key and just delete any existing entry before adding a new one to the cache.

## AI Disclosure

The basic configuration update here is a suggestion from Claude that I have validated both via the official documentation as well as by manually running the `gh cache delete` command locally and confirming that it deletes the cache successfully and enables subsequent runs of CI job to properly deploy changes to 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->

- [X] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [X] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

