### PR TITLE
feat(#10323): allow external media in enketo form notes

### DIFF
--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -233,7 +233,7 @@ app.use(
           `'self'`,
           'data:', // unsafe
           'blob:',
-          '*.openstreetmap.org',// used for enketo geopoint widget
+          '*.openstreetmap.org', // used for enketo geopoint widget
           'https:', 
         ],
         mediaSrc: [

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -227,13 +227,14 @@ app.use(
           `${environment.buildsUrl}/`,
           'maps.googleapis.com' // used for enketo geopoint widget
         ],
-        childSrc: [`'self'`],
+        childSrc: [`'self'`, 'https://www.youtube.com'],
         formAction: [`'self'`],
         imgSrc: [
           `'self'`,
           'data:', // unsafe
           'blob:',
-          '*.openstreetmap.org', // used for enketo geopoint widget
+          '*.openstreetmap.org',// used for enketo geopoint widget
+          'https:', 
         ],
         mediaSrc: [
           `'self'`,


### PR DESCRIPTION
## Description

Updates the Content Security Policy in `api/src/routing.js` to allow external media to be embedded in Enketo form note fields.

**Changes:**
- Added `https://www.youtube.com` to `childSrc` to allow YouTube iframes
- Added `https:` scheme to `imgSrc` to allow externally hosted images

**Testing:**
Verified locally that YouTube iframes now render in form note fields (previously blocked by CSP). External images also load with `https:` scheme.

Relates to #10323