### PR TITLE
chore: replace "two birds with one stone" idiom in analytics comment

### DIFF
--- a/webapp/src/ts/modules/analytics/analytics-target-aggregates-detail.component.ts
+++ b/webapp/src/ts/modules/analytics/analytics-target-aggregates-detail.component.ts
@@ -97,7 +97,7 @@ export class AnalyticsTargetAggregatesDetailComponent implements OnInit, OnDestr
     ).subscribe(([params, inited, loaded]) => {
       if (loaded && inited && params) {
         setTimeout(() => {
-          // two birds with one stone
+          // accomplish two things at once
           // both this component and the parent (analytics-target-aggregates) need to be updated
           this.getAggregatesDetail(params.id);
         });


### PR DESCRIPTION
chore: replace "two birds with one stone" idiom in analytics comment

Replaces the lead comment on line 100 of
`webapp/src/ts/modules/analytics/analytics-target-aggregates-detail.component.ts`
with a literal description that matches the explanatory comment on the
next line ("both this component and the parent … need to be updated").
Comment-only — no behaviour change, no test impact. Happy to close if
this isn't a fit.
