### PR TITLE
fix(#11118): update version handling for feature-release branches

### DIFF
--- a/scripts/build/versions.js
+++ b/scripts/build/versions.js
@@ -10,11 +10,15 @@ const {
   INTERNAL_CONTRIBUTOR,
 } = process.env;
 
+const FEATURE_RELEASE_BRANCH_PATTERN = /^\d+\.\d+\.\d+-FR-.+/;
+
 const escapeBranchName = (branch) => branch?.replace(/[^A-Za-z0-9.-]/g, '-');
+const isFeatureReleaseBranch = (branch) => FEATURE_RELEASE_BRANCH_PATTERN.test(branch);
 
 const getBranchVersion = (release) => {
   const branch = BRANCH === 'master' ? 'alpha' : escapeBranchName(BRANCH);
-  const base = `${packageJson.version}-${branch}`;
+  // Feature-release branches (e.g. 5.1.2-FR-foo) already carry their own version
+  const base = isFeatureReleaseBranch(branch) ? branch : `${packageJson.version}-${branch}`;
   return release ? base : `${base}.${BUILD_NUMBER}`;
 };
 

--- a/tests/integration/api/routing.spec.js
+++ b/tests/integration/api/routing.spec.js
@@ -186,12 +186,16 @@ describe('routing', () => {
         const { BRANCH, TAG } = process.env;
         const isBranchBuild = BRANCH && !TAG;
 
+        // for tags, build_info.version is the tag (semver-valid).
+        // for branches, build_info.version is the escaped branch name: when that itself is
+        // valid semver (e.g. feature-release branches like 5.1.2-FR-foo) the api returns it,
+        // otherwise it falls back to build_info.build (which always carries the build number).
+        const branchVersion = semver.valid(ddoc.build_info.version) || ddoc.build_info.build;
         const deployInfo = {
           ...ddoc.deploy_info,
           ...ddoc.build_info,
-          version: isBranchBuild ? ddoc.build_info.build : ddoc.build_info.version
+          version: isBranchBuild ? branchVersion : ddoc.build_info.version
         };
-        // for historical reasons, for a branch the version in the ddoc is the branch name.
         expect(deployInfoOnline).to.deep.equal(deployInfo);
         expect(deployInfoOffline).to.deep.equal(deployInfo);
       });


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: build|feat|fix|perf|refactor|test|chore

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

closes #11118 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [ ] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:11118-fix-for-fr-releases/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:11118-fix-for-fr-releases/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:11118-fix-for-fr-releases/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

