### PR TITLE
test: verify SonarCloud gate after removing redundant cast (#10884)

### DIFF
--- a/webapp/src/ts/modals/edit-user/update-password.component.ts
+++ b/webapp/src/ts/modals/edit-user/update-password.component.ts
@@ -65,9 +65,9 @@ export class UpdatePasswordComponent {
     try {
       const user:any = await this.userSettingsService.get();
       const username = user.name;
-      await this.updatePasswordService.update(username, currentPassword, newPassword);
+      await this.updatePasswordService.update(username, currentPassword!, newPassword!);
       try {
-        await this.userLoginService.login(username, newPassword);
+        await this.userLoginService.login(username, newPassword!);
       } catch (err) {
         if (err.status === 302) {
           this.close();

--- a/webapp/src/ts/services/cache.service.ts
+++ b/webapp/src/ts/services/cache.service.ts
@@ -26,14 +26,14 @@ interface CacheEntry<T = unknown, C = CacheChange> {
   providedIn: 'root'
 })
 export class CacheService {
-  private caches: CacheEntry[] = [];
+  private readonly caches: CacheEntry[] = [];
 
   constructor(private changesService:ChangesService) {
     this.changesService.subscribe({
       key: 'cache',
       callback: (change) => {
         this.caches.forEach((cache) => {
-          if (cache.invalidate && cache.invalidate(change)) {
+          if (cache.invalidate?.(change)) {
             cache.docs = null;
             cache.pending = false;
           }

--- a/webapp/src/ts/services/cache.service.ts
+++ b/webapp/src/ts/services/cache.service.ts
@@ -5,20 +5,20 @@ import {ChangesService} from '@mm-services/changes.service';
 type CacheCallback<T = unknown> = (err: unknown, result?: T) => void;
 
 export interface CacheChange {
-  id?: string;
+  id: string;
   doc?: { _id?: string; [key: string]: unknown };
   [key: string]: unknown;
 }
 
-interface CacheRegisterOptions<T = unknown, C = CacheChange> {
+interface CacheRegisterOptions<T = unknown> {
   get: (done: CacheCallback<T>) => void;
-  invalidate?: (change: C) => boolean;
+  invalidate?: (change: CacheChange) => boolean;
 }
 
-interface CacheEntry<T = unknown, C = CacheChange> {
+interface CacheEntry<T = unknown> {
   docs: T | null;
   pending: boolean;
-  invalidate?: (change: C) => boolean;
+  invalidate?: (change: CacheChange) => boolean;
   callbacks: CacheCallback<T>[];
 }
 
@@ -33,6 +33,9 @@ export class CacheService {
       key: 'cache',
       callback: (change) => {
         this.caches.forEach((cache) => {
+          // Optional chaining is required: `invalidate` is documented as optional (see register
+          // docstring), but the original AngularJS call site was unguarded. Without `?.` the
+          // runtime would crash on any consumer that omits invalidate.
           if (cache.invalidate?.(change)) {
             cache.docs = null;
             cache.pending = false;
@@ -54,8 +57,8 @@ export class CacheService {
    *     If no invalidate function is provided the cache will never
    *     invalidate.
    */
-  register<T = unknown, C = CacheChange>(options: CacheRegisterOptions<T, C>) {
-    const cache: CacheEntry<T, C> = {
+  register<T = unknown>(options: CacheRegisterOptions<T>) {
+    const cache: CacheEntry<T> = {
       docs: null,
       pending: false,
       invalidate: options.invalidate,

--- a/webapp/src/ts/services/cache.service.ts
+++ b/webapp/src/ts/services/cache.service.ts
@@ -65,6 +65,8 @@ export class CacheService {
       callbacks: []
     };
 
+    // T is erased here so heterogeneous entries can share `caches: CacheEntry[]`;
+    // the cast widens CacheEntry<T> to the default CacheEntry, it does not hide a bug.
     this.caches.push(cache as CacheEntry);
 
     return (callback: CacheCallback<T>) => {

--- a/webapp/src/ts/services/cache.service.ts
+++ b/webapp/src/ts/services/cache.service.ts
@@ -2,23 +2,32 @@ import {Injectable} from '@angular/core';
 
 import {ChangesService} from '@mm-services/changes.service';
 
+type CacheCallback<T = unknown> = (err: unknown, result?: T) => void;
+
+interface CacheRegisterOptions<T = unknown, C = unknown> {
+  get: (done: CacheCallback<T>) => void;
+  invalidate?: (change: C) => boolean;
+}
+
+interface CacheEntry<T = unknown, C = unknown> {
+  docs: T | null;
+  pending: boolean;
+  invalidate?: (change: C) => boolean;
+  callbacks: CacheCallback<T>[];
+}
+
 @Injectable({
   providedIn: 'root'
 })
 export class CacheService {
-  private caches: {
-    docs: any;
-    pending: boolean;
-    invalidate: any;
-    callbacks: any[];
-  }[] = [];
+  private caches: CacheEntry[] = [];
 
   constructor(private changesService:ChangesService) {
     this.changesService.subscribe({
       key: 'cache',
       callback: (change) => {
         this.caches.forEach((cache) => {
-          if (cache.invalidate(change)) {
+          if (cache.invalidate && cache.invalidate(change)) {
             cache.docs = null;
             cache.pending = false;
           }
@@ -39,17 +48,17 @@ export class CacheService {
    *     If no invalidate function is provided the cache will never
    *     invalidate.
    */
-  register(options) {
-    const cache = {
+  register<T = unknown, C = unknown>(options: CacheRegisterOptions<T, C>) {
+    const cache: CacheEntry<T, C> = {
       docs: null,
       pending: false,
       invalidate: options.invalidate,
-      callbacks: [] as any[]
+      callbacks: []
     };
 
-    this.caches.push(cache);
+    this.caches.push(cache as CacheEntry);
 
-    return (callback) => {
+    return (callback: CacheCallback<T>) => {
       if (cache.docs) {
         return callback(null, cache.docs);
       }
@@ -61,10 +70,10 @@ export class CacheService {
       options.get((err, result) => {
         cache.pending = false;
         if (!err) {
-          cache.docs = result;
+          cache.docs = result ?? null;
         }
-        cache.callbacks.forEach((callback) => {
-          callback(err, result);
+        cache.callbacks.forEach((cb) => {
+          cb(err, result);
         });
         cache.callbacks = [];
       });

--- a/webapp/src/ts/services/cache.service.ts
+++ b/webapp/src/ts/services/cache.service.ts
@@ -4,12 +4,18 @@ import {ChangesService} from '@mm-services/changes.service';
 
 type CacheCallback<T = unknown> = (err: unknown, result?: T) => void;
 
-interface CacheRegisterOptions<T = unknown, C = unknown> {
+export interface CacheChange {
+  id?: string;
+  doc?: { _id?: string; [key: string]: unknown };
+  [key: string]: unknown;
+}
+
+interface CacheRegisterOptions<T = unknown, C = CacheChange> {
   get: (done: CacheCallback<T>) => void;
   invalidate?: (change: C) => boolean;
 }
 
-interface CacheEntry<T = unknown, C = unknown> {
+interface CacheEntry<T = unknown, C = CacheChange> {
   docs: T | null;
   pending: boolean;
   invalidate?: (change: C) => boolean;
@@ -48,7 +54,7 @@ export class CacheService {
    *     If no invalidate function is provided the cache will never
    *     invalidate.
    */
-  register<T = unknown, C = unknown>(options: CacheRegisterOptions<T, C>) {
+  register<T = unknown, C = CacheChange>(options: CacheRegisterOptions<T, C>) {
     const cache: CacheEntry<T, C> = {
       docs: null,
       pending: false,

--- a/webapp/src/ts/services/cache.service.ts
+++ b/webapp/src/ts/services/cache.service.ts
@@ -65,9 +65,9 @@ export class CacheService {
       callbacks: []
     };
 
-    // T is erased here so heterogeneous entries can share `caches: CacheEntry[]`;
-    // the cast widens CacheEntry<T> to the default CacheEntry, it does not hide a bug.
-    this.caches.push(cache as CacheEntry);
+    // T is intentionally erased here: the shared `caches: CacheEntry[]` holds entries
+    // registered with different T by multiple consumers.
+    this.caches.push(cache);
 
     return (callback: CacheCallback<T>) => {
       if (cache.docs) {

--- a/webapp/src/ts/services/contacts.service.ts
+++ b/webapp/src/ts/services/contacts.service.ts
@@ -26,7 +26,7 @@ export class ContactsService {
       .then(types => {
         const cacheByType = {};
         types.forEach(type => {
-          cacheByType[type.id as string] = this.cacheService.register({
+          cacheByType[type.id as string] = this.cacheService.register<Record<string, unknown>[]>({
             get: (callback) => {
               return this.dbService
                 .get()

--- a/webapp/src/ts/services/extract-lineage.service.ts
+++ b/webapp/src/ts/services/extract-lineage.service.ts
@@ -1,8 +1,12 @@
 import { Injectable } from '@angular/core';
 
+// Shape-compatible with NormalizedParent from `@medic/cht-datasource/libs/core`
+// (`readonly _id: string` + `readonly parent?: NormalizedParent`). Kept local
+// because NormalizedParent is marked @internal and not re-exported from the
+// cht-datasource public API; converge once the shared type is exposed.
 interface ContactLineage {
-  _id?: string;
-  parent?: ContactLineage;
+  readonly _id: string;
+  readonly parent?: ContactLineage;
 }
 
 @Injectable({
@@ -17,18 +21,9 @@ export class ExtractLineageService {
     if (!contact) {
       return contact;
     }
-
-    const result: ContactLineage = { _id: contact._id };
-    let minified = result;
-
-    while (contact.parent) {
-      const next: ContactLineage = { _id: contact.parent._id };
-      minified.parent = next;
-      minified = next;
-      contact = contact.parent;
-    }
-
-    return result;
+    return contact.parent
+      ? { _id: contact._id, parent: this.extract(contact.parent) as ContactLineage }
+      : { _id: contact._id };
   }
 
   removeUserFacility(lineage: string[], userLineageLevel: string): string[] | undefined {

--- a/webapp/src/ts/services/extract-lineage.service.ts
+++ b/webapp/src/ts/services/extract-lineage.service.ts
@@ -1,5 +1,10 @@
 import { Injectable } from '@angular/core';
 
+interface ContactLineage {
+  _id?: string;
+  parent?: ContactLineage;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -8,17 +13,18 @@ export class ExtractLineageService {
   constructor() {
   }
 
-  extract(contact) {
+  extract(contact: ContactLineage | null | undefined): ContactLineage | null | undefined {
     if (!contact) {
       return contact;
     }
 
-    const result: any = { _id: contact._id };
+    const result: ContactLineage = { _id: contact._id };
     let minified = result;
 
     while (contact.parent) {
-      minified.parent = { _id: contact.parent._id };
-      minified = minified.parent;
+      const next: ContactLineage = { _id: contact.parent._id };
+      minified.parent = next;
+      minified = next;
       contact = contact.parent;
     }
 

--- a/webapp/src/ts/services/extract-lineage.service.ts
+++ b/webapp/src/ts/services/extract-lineage.service.ts
@@ -22,7 +22,7 @@ export class ExtractLineageService {
       return contact;
     }
     return contact.parent
-      ? { _id: contact._id, parent: this.extract(contact.parent) as ContactLineage }
+      ? { _id: contact._id, parent: this.extract(contact.parent) ?? undefined }
       : { _id: contact._id };
   }
 

--- a/webapp/src/ts/services/settings.service.ts
+++ b/webapp/src/ts/services/settings.service.ts
@@ -15,7 +15,7 @@ export class SettingsService {
     private db: DbService,
     private cacheService: CacheService
   ) {
-    this.cache = this.cacheService.register({
+    this.cache = this.cacheService.register<Record<string, unknown>>({
       get: (callback) => {
         this.db.get()
           .get(this.SETTINGS_ID)

--- a/webapp/src/ts/services/update-password.service.ts
+++ b/webapp/src/ts/services/update-password.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 
 @Injectable({
   providedIn: 'root'
@@ -20,11 +20,11 @@ export class UpdatePasswordService {
    */
   update(username, currentPassword, newPassword): Promise<Object> {
     const url = '/api/v1/users/' + username;
-    const headers: any = {
+    const headers = new HttpHeaders({
       'Content-Type': 'application/json',
       Accept: 'application/json',
       Authorization: 'Basic ' + window.btoa(username + ':' + currentPassword)
-    };
+    });
     const updates = { password: newPassword };
     return this.http.post(url, updates, { headers }).toPromise() as Promise<Object>;
   }

--- a/webapp/src/ts/services/update-password.service.ts
+++ b/webapp/src/ts/services/update-password.service.ts
@@ -18,7 +18,7 @@ export class UpdatePasswordService {
    * @param      {string} currentPassword  Password for Basic Auth
    * @param      {string} newPassword      Password to set
    */
-  update(username, currentPassword, newPassword): Promise<Object> {
+  update(username: string, currentPassword: string, newPassword: string): Promise<Object> {
     const url = '/api/v1/users/' + username;
     const headers = new HttpHeaders({
       'Content-Type': 'application/json',

--- a/webapp/src/ts/services/user-contact-summary.service.ts
+++ b/webapp/src/ts/services/user-contact-summary.service.ts
@@ -32,7 +32,7 @@ export class UserContactSummaryService {
   ) {
     this.store.select(Selectors.getForms).subscribe(forms => this.forms = forms);
 
-    this.cache = this.cacheService.register({
+    this.cache = this.cacheService.register<Record<string, unknown>>({
       get: async (callback:Function) => {
         try {
           const summary = await this.loadSummary();

--- a/webapp/src/ts/services/user-login.service.ts
+++ b/webapp/src/ts/services/user-login.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { LocationService } from '@mm-services/location.service';
 
 @Injectable({
@@ -22,10 +22,10 @@ export class UserLoginService {
 
     const url = '/' + this.location.dbName + '/login';
 
-    const headers: any = {
+    const headers = new HttpHeaders({
       'Content-Type': 'application/json',
       Accept: 'application/json',
-    };
+    });
 
     const data = JSON.stringify({
       user: username,

--- a/webapp/src/ts/services/user-login.service.ts
+++ b/webapp/src/ts/services/user-login.service.ts
@@ -18,7 +18,7 @@ export class UserLoginService {
    * @param {String} username username of the user to be logged in.
    * @param {String} password password of the user.
    */
-  login(username, password): Promise<Object> {
+  login(username: string, password: string): Promise<Object> {
 
     const url = '/' + this.location.dbName + '/login';
 

--- a/webapp/src/ts/services/user-settings.service.ts
+++ b/webapp/src/ts/services/user-settings.service.ts
@@ -20,7 +20,7 @@ export class UserSettingsService {
     private languageService:LanguageService,
     private sessionService:SessionService,
   ) {
-    this.cache = this.cacheService.register({
+    this.cache = this.cacheService.register<Record<string, unknown>>({
       get: callback => {
         const docId = this.userDocId();
         this.dbService.get()

--- a/webapp/tests/karma/ts/services/cache.service.spec.ts
+++ b/webapp/tests/karma/ts/services/cache.service.spec.ts
@@ -44,7 +44,7 @@ describe('Cache Service', () => {
   });
 
   it('returns results from get', (done) => {
-    const docs = [ { _id: 1 } ];
+    const docs = [ { _id: '1' } ];
     service.register({
       get: (callback) => {
         callback(null, docs);
@@ -56,7 +56,7 @@ describe('Cache Service', () => {
   });
 
   it('calls multiple callbacks', (done) => {
-    const docs = [ { _id: 1 } ];
+    const docs = [ { _id: '1' } ];
     let callback;
     let count = 0;
     const cache = service.register({
@@ -77,7 +77,7 @@ describe('Cache Service', () => {
   });
 
   it('caches the result', (done) => {
-    const docs = [ { _id: 1 } ];
+    const docs = [ { _id: '1' } ];
     let callback;
     let count = 0;
     const cache = service.register({
@@ -99,8 +99,8 @@ describe('Cache Service', () => {
   });
 
   it('invalidates the cache on doc update', (done) => {
-    const initial = [ { _id: 1, name: 'gareth' } ];
-    const updated = [ { _id: 1, name: 'alex' } ];
+    const initial = [ { _id: '1', name: 'gareth' } ];
+    const updated = [ { _id: '1', name: 'alex' } ];
     let count = 0;
     const cache = service.register({
       get: (callback) => {
@@ -121,7 +121,7 @@ describe('Cache Service', () => {
       expect(err).to.equal(null);
       expect(results).to.deep.equal(initial);
     });
-    changesCallback({ id: 1, changes: [ { rev: '5-xyz' } ] });
+    changesCallback({ id: '1', changes: [ { rev: '5-xyz' } ] });
     cache((err, results) => {
       expect(err).to.equal(null);
       expect(results).to.deep.equal(updated);
@@ -130,9 +130,9 @@ describe('Cache Service', () => {
   });
 
   it('invalidates the cache on new doc', (done) => {
-    const newDoc = { _id: 2, name: 'alex' };
-    const initial = [ { _id: 1, name: 'gareth' } ];
-    const updated = [ { _id: 1, name: 'gareth' }, newDoc ];
+    const newDoc = { _id: '2', name: 'alex' };
+    const initial = [ { _id: '1', name: 'gareth' } ];
+    const updated = [ { _id: '1', name: 'gareth' }, newDoc ];
     let count = 0;
     const cache = service.register({
       get: (callback) => {
@@ -164,8 +164,8 @@ describe('Cache Service', () => {
   });
 
   it('does not invalidate the cache when filter fails', (done) => {
-    const newDoc = { _id: 2, name: 'alex' };
-    const initial = [ { _id: 1, name: 'gareth' } ];
+    const newDoc = { _id: '2', name: 'alex' };
+    const initial = [ { _id: '1', name: 'gareth' } ];
     let count = 0;
     const cache = service.register({
       get: (callback) => {

--- a/webapp/tests/karma/ts/services/cache.service.spec.ts
+++ b/webapp/tests/karma/ts/services/cache.service.spec.ts
@@ -129,6 +129,23 @@ describe('Cache Service', () => {
     });
   });
 
+  it('does not crash and does not invalidate when invalidate is omitted', (done) => {
+    const docs = [ { _id: '1' } ];
+    const cache = service.register({
+      get: (callback) => callback(null, docs)
+    });
+    cache((err, results) => {
+      expect(err).to.equal(null);
+      expect(results).to.deep.equal(docs);
+      expect(() => changesCallback({ id: '1', changes: [ { rev: '1-xyz' } ] })).not.to.throw();
+      cache((err2, results2) => {
+        expect(err2).to.equal(null);
+        expect(results2).to.deep.equal(docs);
+        done();
+      });
+    });
+  });
+
   it('invalidates the cache on new doc', (done) => {
     const newDoc = { _id: '2', name: 'alex' };
     const initial = [ { _id: '1', name: 'gareth' } ];


### PR DESCRIPTION
**Throwaway / DO NOT MERGE / DO NOT REVIEW.**

Exists only to confirm that removing the redundant `as CacheEntry` cast in `webapp/src/ts/services/cache.service.ts` clears the SonarCloud `new_violations` quality gate that is currently failing on #10884.

Base = this branch is #10884's branch (`osc/10883-replace-any-types`) plus the single-line cast removal. Will be closed and the branch deleted once the gate result is confirmed.