### PR TITLE
fix(#9491): fail fast with helpful error when nginx container fails to start

### DIFF
--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -949,6 +949,10 @@ const listenForApi = async () => {
   throw new Error('API failed to start after 3 minutes');
 };
 
+const NGINX_PORT_HINT =
+  'Ports 80 and/or 443 are often already in use; stop the other service or set NGINX_HTTP_PORT ' +
+  'and NGINX_HTTPS_PORT (see tests/constants.js for HTTPS).';
+
 const waitForNginxContainerRunning = async () => {
   if (!isDocker()) {
     return;
@@ -956,39 +960,44 @@ const waitForNginxContainerRunning = async () => {
   const containerName = getContainerName('nginx');
   const maxTries = 30;
   for (let i = 0; i < maxTries; i++) {
-    let status;
+    let state;
     try {
-      status = await runCommand(
-        `docker inspect -f '{{.State.Status}}' ${containerName}`,
+      const rawState = await runCommand(
+        `docker inspect -f '{{json .State}}' ${containerName}`,
         { verbose: false }
       );
-    } catch {
+      state = JSON.parse(rawState);
+    } catch (err) {
       throw new Error(
-        `Expected nginx container "${containerName}" was not found after docker compose up. ` +
-        'Ports 80 and/or 443 are often already in use; stop the other service or set NGINX_HTTP_PORT ' +
-        'and NGINX_HTTPS_PORT (see tests/constants.js for HTTPS).'
+        `Expected nginx container "${containerName}" was not found after docker compose up ` +
+        `(${err.message}). ${NGINX_PORT_HINT}`
       );
     }
 
-    const trimmedStatus = status.trim();
-
-    if (trimmedStatus === 'exited' || trimmedStatus === 'dead') {
+    // A failed port bind leaves the container in `created` state (never exited/dead) with the
+    // real reason in `State.Error`, so check it explicitly to fail fast on the issue #9491 case.
+    if (state.Error) {
       throw new Error(
-        `nginx container "${containerName}" failed to start (status: ${trimmedStatus}). ` +
-        'Ports 80 and/or 443 are often already in use; stop the other service or set NGINX_HTTP_PORT ' +
-        'and NGINX_HTTPS_PORT (see tests/constants.js for HTTPS).'
+        `nginx container "${containerName}" failed to start: ${state.Error} ` +
+        `(exitCode: ${state.ExitCode}). ${NGINX_PORT_HINT}`
       );
     }
 
-    if (trimmedStatus === 'running') {
+    if (state.Status === 'exited' || state.Status === 'dead') {
+      throw new Error(
+        `nginx container "${containerName}" failed to start ` +
+        `(status: ${state.Status}, exitCode: ${state.ExitCode}). ${NGINX_PORT_HINT}`
+      );
+    }
+
+    if (state.Status === 'running') {
       return;
     }
 
     await delayPromise(1000);
   }
   throw new Error(
-    `nginx container "${containerName}" did not become running within ${maxTries} tries. ` +
-    'Ports 80 and/or 443 are often already in use; stop the other service or set NGINX_HTTP_PORT and NGINX_HTTPS_PORT.'
+    `nginx container "${containerName}" did not become running within ${maxTries} tries. ${NGINX_PORT_HINT}`
   );
 };
 

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -987,7 +987,7 @@ const waitForNginxContainerRunning = async () => {
     await delayPromise(1000);
   }
   throw new Error(
-    `nginx container "${containerName}" did not become running within ${maxTries}s. ` +
+    `nginx container "${containerName}" did not become running within ${maxTries} tries. ` +
     'Ports 80 and/or 443 are often already in use; stop the other service or set NGINX_HTTP_PORT and NGINX_HTTPS_PORT.'
   );
 };

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -949,6 +949,49 @@ const listenForApi = async () => {
   throw new Error('API failed to start after 3 minutes');
 };
 
+const waitForNginxContainerRunning = async () => {
+  if (!isDocker()) {
+    return;
+  }
+  const containerName = getContainerName('nginx');
+  const maxTries = 30;
+  for (let i = 0; i < maxTries; i++) {
+    let status;
+    try {
+      status = await runCommand(
+        `docker inspect -f '{{.State.Status}}' ${containerName}`,
+        { verbose: false }
+      );
+    } catch {
+      throw new Error(
+        `Expected nginx container "${containerName}" was not found after docker compose up. ` +
+        'Ports 80 and/or 443 are often already in use; stop the other service or set NGINX_HTTP_PORT ' +
+        'and NGINX_HTTPS_PORT (see tests/constants.js for HTTPS).'
+      );
+    }
+
+    const trimmedStatus = status.trim();
+
+    if (trimmedStatus === 'exited' || trimmedStatus === 'dead') {
+      throw new Error(
+        `nginx container "${containerName}" failed to start (status: ${trimmedStatus}). ` +
+        'Ports 80 and/or 443 are often already in use; stop the other service or set NGINX_HTTP_PORT ' +
+        'and NGINX_HTTPS_PORT (see tests/constants.js for HTTPS).'
+      );
+    }
+
+    if (trimmedStatus === 'running') {
+      return;
+    }
+
+    await delayPromise(1000);
+  }
+  throw new Error(
+    `nginx container "${containerName}" did not become running within ${maxTries}s. ` +
+    'Ports 80 and/or 443 are often already in use; stop the other service or set NGINX_HTTP_PORT and NGINX_HTTPS_PORT.'
+  );
+};
+
 const dockerComposeCmd = (params) => {
   const composeFiles = COMPOSE_FILES.map(file => ['-f', getTestComposeFilePath(file)]).flat();
   composeFiles.push('-f', COMPOSE_OVERRIDE_FILE);
@@ -1296,6 +1339,7 @@ const startServices = async () => {
   env.COUCHDB_NOUVEAU_DATA = makeTempDir('ci-nouveaudata');
 
   await dockerComposeCmd('up -d');
+  await waitForNginxContainerRunning();
   const services = await dockerComposeCmd('ps -q');
   if (!services.length) {
     throw new Error('Errors when starting services');


### PR DESCRIPTION
# Description

Fixes #9491. This continues the work by @SnehaChaursia in #10816, which became inactive. See that PR for the original description and the full change.

This revision only adds the fixes for the review feedback left on #10816:

- **Detect the port conflict case via `State.Error`** (the issue #9491 scenario). The original check looked only at `Status`, which never catches this case: a failed port bind leaves the container in `created` (not `exited`/`dead`), so the old code burned all 30 retries before a generic timeout fired. Inspecting the full `State` and checking `State.Error` fails fast with the real reason.
- Surface the underlying `docker inspect` error when the container is missing, and include `ExitCode` in failure messages.
- De-duplicate the repeated port hint into a single constant.

# Code review checklist
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages.
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: verified the new branching end to end against real Docker container states (port conflict `created`, `running`, `exited`, missing container)
- [ ] Internationalised: All user facing text
- [x] Backwards compatible: test only Docker path; k3d unchanged (`isDocker()` guard)
- [ ] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:fix/9491-e2e-nginx-fail-fast-v2/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:fix/9491-e2e-nginx-fail-fast-v2/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:fix/9491-e2e-nginx-fail-fast-v2/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
