### PR TITLE
feat(#10694): adds tasks page free text search functionality

### DIFF
--- a/tests/e2e/default/tasks/tasks-search.wdio-spec.js
+++ b/tests/e2e/default/tasks/tasks-search.wdio-spec.js
@@ -1,0 +1,104 @@
+const utils = require('@utils');
+const sentinelUtils = require('@utils/sentinel');
+const loginPage = require('@page-objects/default/login/login.wdio.page');
+const commonPage = require('@page-objects/default/common/common.wdio.page');
+const tasksPage = require('@page-objects/default/tasks/tasks.wdio.page');
+const searchPage = require('@page-objects/default/search/search.wdio.page');
+const userFactory = require('@factories/cht/users/users');
+const placeFactory = require('@factories/cht/contacts/place');
+const personFactory = require('@factories/cht/contacts/person');
+const { CONTACT_TYPES } = require('@medic/constants');
+
+describe('Tasks Free Text Search', () => {
+
+  const places = placeFactory.generateHierarchy();
+  const clinic = places.get(CONTACT_TYPES.CLINIC);
+  const healthCenter = places.get(CONTACT_TYPES.HEALTH_CENTER);
+
+  const chwContact = personFactory.build({
+    name: 'Megan Spice',
+    phone: '+12068881234',
+    place: healthCenter._id,
+    parent: healthCenter,
+  });
+
+  const chw = userFactory.build({
+    username: 'offlineuser_tasks_search',
+    isOffline: true,
+    place: healthCenter._id,
+    contact: chwContact._id,
+  });
+
+  const patientWithAccents = personFactory.build({
+    name: 'Élodie Patient',
+    patient_id: 'patient_elodie',
+    parent: clinic,
+    reported_date: Date.now(),
+  });
+
+  const patientPlain = personFactory.build({
+    name: 'Bob Patient',
+    patient_id: 'patient_bob',
+    parent: clinic,
+    reported_date: Date.now(),
+  });
+
+  before(async () => {
+    await utils.saveDocs([
+      ...places.values(),
+      chwContact,
+      patientWithAccents,
+      patientPlain,
+    ]);
+    await utils.createUsers([ chw ]);
+    await sentinelUtils.waitForSentinel();
+
+    // Compile task configuration via API before login.
+    // Avoid `sync: true` here because that requires interacting with the UI hamburger menu.
+    await tasksPage.compileTasks('tasks-breadcrumbs-config.js', false);
+    await loginPage.login(chw);
+    await commonPage.tabsSelector.analyticsTab().waitForDisplayed();
+    await commonPage.sync();
+  });
+
+  after(async () => {
+    await utils.deleteUsers([ chw ]);
+    await utils.revertDb([/^form:/], true);
+    await utils.revertSettings(true);
+  });
+
+  it('filters tasks by contact name (diacritics-insensitive) and clears search', async () => {
+    await commonPage.goToTasks();
+
+    const initialCount = await tasksPage.getTaskListCount();
+    expect(initialCount).to.be.greaterThan(0);
+
+    await searchPage.performSearch('elodie');
+    await browser.waitUntil(async () => (await tasksPage.getTaskListCount()) !== initialCount, {
+      timeout: 10000,
+      timeoutMsg: 'Expected task list to be filtered after search'
+    });
+
+    const filteredInfos = await tasksPage.getTasksListInfos(await tasksPage.getTasks());
+    expect(filteredInfos.length).to.be.greaterThan(0);
+    filteredInfos.forEach(info => expect(info.contactName).to.equal(patientWithAccents.name));
+
+    await searchPage.clearSearch();
+    await browser.waitUntil(async () => (await tasksPage.getTaskListCount()) === initialCount, {
+      timeout: 10000,
+      timeoutMsg: 'Expected task list to be restored after clearing search'
+    });
+  });
+
+  it('filters tasks by task title substring', async () => {
+    await commonPage.goToTasks();
+    await searchPage.performSearch('person_create');
+
+    const infos = await tasksPage.getTasksListInfos(await tasksPage.getTasks());
+    expect(infos.length).to.be.greaterThan(0);
+    infos.forEach(info => expect(info.formTitle).to.contain('person_create'));
+
+    await searchPage.clearSearch();
+  });
+});
+

--- a/tests/e2e/default/tasks/tasks-search.wdio-spec.js
+++ b/tests/e2e/default/tasks/tasks-search.wdio-spec.js
@@ -11,7 +11,6 @@ const { CONTACT_TYPES } = require('@medic/constants');
 
 describe('Tasks Free Text Search', () => {
   const places = placeFactory.generateHierarchy();
-  const districtHospital = places.get('district_hospital');
   const healthCenter = places.get('health_center');
   const clinic = places.get(CONTACT_TYPES.CLINIC);
 

--- a/tests/e2e/default/tasks/tasks-search.wdio-spec.js
+++ b/tests/e2e/default/tasks/tasks-search.wdio-spec.js
@@ -167,6 +167,13 @@ describe('Tasks Free Text Search', () => {
     });
 
     await tasksPage.resetFilters();
+    await browser.waitUntil(async () => (await tasksPage.getTasks()).length === searchCount, {
+      timeout: 10000,
+      timeoutMsg: 'Expected reset to restore the search-only result while keeping the search'
+    });
+    const afterResetInfos = await tasksPage.getTasksListInfos(await tasksPage.getTasks());
+    afterResetInfos.forEach(info => expect(info.contactName).to.equal('Margaret Williams'));
+
     await searchPage.clearSearch();
     await browser.waitUntil(async () => (await tasksPage.getTasks()).length === totalCount);
   });

--- a/tests/e2e/default/tasks/tasks-search.wdio-spec.js
+++ b/tests/e2e/default/tasks/tasks-search.wdio-spec.js
@@ -1,44 +1,51 @@
 const utils = require('@utils');
-const sentinelUtils = require('@utils/sentinel');
 const loginPage = require('@page-objects/default/login/login.wdio.page');
-const commonPage = require('@page-objects/default/common/common.wdio.page');
-const tasksPage = require('@page-objects/default/tasks/tasks.wdio.page');
-const searchPage = require('@page-objects/default/search/search.wdio.page');
 const userFactory = require('@factories/cht/users/users');
 const placeFactory = require('@factories/cht/contacts/place');
 const personFactory = require('@factories/cht/contacts/person');
+const tasksPage = require('@page-objects/default/tasks/tasks.wdio.page');
+const searchPage = require('@page-objects/default/search/search.wdio.page');
+const sentinelUtils = require('@utils/sentinel');
+const commonPage = require('@page-objects/default/common/common.wdio.page');
 const { CONTACT_TYPES } = require('@medic/constants');
 
 describe('Tasks Free Text Search', () => {
-
   const places = placeFactory.generateHierarchy();
+  const districtHospital = places.get('district_hospital');
+  const healthCenter = places.get('health_center');
   const clinic = places.get(CONTACT_TYPES.CLINIC);
-  const healthCenter = places.get(CONTACT_TYPES.HEALTH_CENTER);
 
   const chwContact = personFactory.build({
-    name: 'Megan Spice',
-    phone: '+12068881234',
+    name: 'CHW Search User',
+    phone: '+12068881235',
     place: healthCenter._id,
     parent: healthCenter,
   });
 
   const chw = userFactory.build({
-    username: 'offlineuser_tasks_search',
+    username: 'offlineuser_search_tasks',
     isOffline: true,
     place: healthCenter._id,
     contact: chwContact._id,
   });
 
-  const patientWithAccents = personFactory.build({
-    name: 'Élodie Patient',
-    patient_id: 'patient_elodie',
+  const patient1 = personFactory.build({
+    name: 'Margaret Williams',
+    patient_id: 'patient_search_1',
     parent: clinic,
     reported_date: Date.now(),
   });
 
-  const patientPlain = personFactory.build({
-    name: 'Bob Patient',
-    patient_id: 'patient_bob',
+  const patient2 = personFactory.build({
+    name: 'Rajesh Kumar',
+    patient_id: 'patient_search_2',
+    parent: clinic,
+    reported_date: Date.now(),
+  });
+
+  const patientWithAccents = personFactory.build({
+    name: 'Élodie Laurent',
+    patient_id: 'patient_search_3',
     parent: clinic,
     reported_date: Date.now(),
   });
@@ -47,58 +54,128 @@ describe('Tasks Free Text Search', () => {
     await utils.saveDocs([
       ...places.values(),
       chwContact,
+      patient1,
+      patient2,
       patientWithAccents,
-      patientPlain,
     ]);
-    await utils.createUsers([ chw ]);
+    await utils.createUsers([chw]);
+    await tasksPage.compileTasks('tasks-filter-config.js', false);
     await sentinelUtils.waitForSentinel();
-
-    // Compile task configuration via API before login.
-    // Avoid `sync: true` here because that requires interacting with the UI hamburger menu.
-    await tasksPage.compileTasks('tasks-breadcrumbs-config.js', false);
     await loginPage.login(chw);
-    await commonPage.tabsSelector.analyticsTab().waitForDisplayed();
-    await commonPage.sync();
   });
 
   after(async () => {
-    await utils.deleteUsers([ chw ]);
-    await utils.revertDb([/^form:/], true);
-    await utils.revertSettings(true);
+    await utils.deleteUsers([chw]);
   });
 
-  it('filters tasks by contact name (diacritics-insensitive) and clears search', async () => {
+  beforeEach(async () => {
     await commonPage.goToTasks();
+    await browser.waitUntil(async () => (await tasksPage.getTasks()).length > 0);
+  });
 
-    const initialCount = await tasksPage.getTaskListCount();
-    expect(initialCount).to.be.greaterThan(0);
+  it('should filter tasks by contact name', async () => {
+    const allTasks = await tasksPage.getTasks();
+    const totalCount = allTasks.length;
+    expect(totalCount).to.be.greaterThan(0);
+
+    await searchPage.performSearch('Margaret');
+
+    const filteredTasks = await tasksPage.getTasks();
+    const filteredInfos = await tasksPage.getTasksListInfos(filteredTasks);
+    expect(filteredInfos.length).to.be.greaterThan(0);
+    expect(filteredInfos.length).to.be.lessThan(totalCount);
+    filteredInfos.forEach(info => {
+      expect(info.contactName).to.equal('Margaret Williams');
+    });
+
+    await searchPage.clearSearch();
+    await browser.waitUntil(async () => (await tasksPage.getTasks()).length === totalCount);
+  });
+
+  it('should match contact names ignoring diacritics', async () => {
+    const allTasks = await tasksPage.getTasks();
+    const totalCount = allTasks.length;
 
     await searchPage.performSearch('elodie');
-    await browser.waitUntil(async () => (await tasksPage.getTaskListCount()) !== initialCount, {
-      timeout: 10000,
-      timeoutMsg: 'Expected task list to be filtered after search'
-    });
 
-    const filteredInfos = await tasksPage.getTasksListInfos(await tasksPage.getTasks());
+    const filteredTasks = await tasksPage.getTasks();
+    const filteredInfos = await tasksPage.getTasksListInfos(filteredTasks);
     expect(filteredInfos.length).to.be.greaterThan(0);
-    filteredInfos.forEach(info => expect(info.contactName).to.equal(patientWithAccents.name));
+    filteredInfos.forEach(info => {
+      expect(info.contactName).to.equal('Élodie Laurent');
+    });
 
     await searchPage.clearSearch();
-    await browser.waitUntil(async () => (await tasksPage.getTaskListCount()) === initialCount, {
-      timeout: 10000,
-      timeoutMsg: 'Expected task list to be restored after clearing search'
-    });
+    await browser.waitUntil(async () => (await tasksPage.getTasks()).length === totalCount);
   });
 
-  it('filters tasks by task title substring', async () => {
-    await commonPage.goToTasks();
-    await searchPage.performSearch('person_create');
+  it('should filter tasks by task title', async () => {
+    const allTasks = await tasksPage.getTasks();
+    const totalCount = allTasks.length;
 
-    const infos = await tasksPage.getTasksListInfos(await tasksPage.getTasks());
-    expect(infos.length).to.be.greaterThan(0);
-    infos.forEach(info => expect(info.formTitle).to.contain('person_create'));
+    await searchPage.performSearch('Assessment');
+
+    const filteredTasks = await tasksPage.getTasks();
+    const filteredInfos = await tasksPage.getTasksListInfos(filteredTasks);
+    expect(filteredInfos.length).to.be.greaterThan(0);
+    expect(filteredInfos.length).to.be.lessThan(totalCount);
+    filteredInfos.forEach(info => {
+      expect(info.formTitle).to.equal('Assessment');
+    });
 
     await searchPage.clearSearch();
+    await browser.waitUntil(async () => (await tasksPage.getTasks()).length === totalCount);
+  });
+
+  it('should show no tasks when search has no match', async () => {
+    await searchPage.performSearch('xyznonexistent');
+
+    const noTasksMessage = await tasksPage.isTaskElementDisplayed('p', 'No tasks found');
+    expect(noTasksMessage).to.be.true;
+
+    await searchPage.clearSearch();
+    await browser.waitUntil(async () => (await tasksPage.getTasks()).length > 0);
+  });
+
+  it('should restore full task list when search is cleared', async () => {
+    const allTasks = await tasksPage.getTasks();
+    const totalCount = allTasks.length;
+
+    await searchPage.performSearch('Rajesh');
+    const filteredTasks = await tasksPage.getTasks();
+    expect(filteredTasks.length).to.be.lessThan(totalCount);
+
+    await searchPage.clearSearch();
+    await browser.waitUntil(async () => (await tasksPage.getTasks()).length === totalCount);
+
+    const restoredTasks = await tasksPage.getTasks();
+    expect(restoredTasks.length).to.equal(totalCount);
+  });
+
+  it('should combine search with sidebar filters', async () => {
+    const allTasks = await tasksPage.getTasks();
+    const totalCount = allTasks.length;
+
+    await searchPage.performSearch('Margaret');
+    const searchFiltered = await tasksPage.getTasks();
+    const searchCount = searchFiltered.length;
+
+    await tasksPage.openSidebarFilter();
+    await tasksPage.filterByTaskType('Home Visit');
+    await commonPage.waitForPageLoaded();
+
+    const combinedTasks = await tasksPage.getTasks();
+    const combinedInfos = await tasksPage.getTasksListInfos(combinedTasks);
+
+    expect(combinedInfos.length).to.be.greaterThan(0);
+    expect(combinedInfos.length).to.be.at.most(searchCount);
+    combinedInfos.forEach(info => {
+      expect(info.contactName).to.equal('Margaret Williams');
+      expect(info.formTitle).to.equal('Home Visit');
+    });
+
+    await tasksPage.resetFilters();
+    await searchPage.clearSearch();
+    await browser.waitUntil(async () => (await tasksPage.getTasks()).length === totalCount);
   });
 });
-

--- a/tests/e2e/default/tasks/tasks-search.wdio-spec.js
+++ b/tests/e2e/default/tasks/tasks-search.wdio-spec.js
@@ -63,10 +63,6 @@ describe('Tasks Free Text Search', () => {
     await loginPage.login(chw);
   });
 
-  after(async () => {
-    await utils.deleteUsers([chw]);
-  });
-
   beforeEach(async () => {
     await commonPage.goToTasks();
     await browser.waitUntil(async () => (await tasksPage.getTasks()).length > 0);
@@ -146,9 +142,6 @@ describe('Tasks Free Text Search', () => {
 
     await searchPage.clearSearch();
     await browser.waitUntil(async () => (await tasksPage.getTasks()).length === totalCount);
-
-    const restoredTasks = await tasksPage.getTasks();
-    expect(restoredTasks.length).to.equal(totalCount);
   });
 
   it('should combine search with sidebar filters', async () => {

--- a/tests/page-objects/default/reports/reports.wdio.page.js
+++ b/tests/page-objects/default/reports/reports.wdio.page.js
@@ -61,7 +61,7 @@ const reviewDialogSelectors = {
 };
 
 const sidebarFilterSelectors = {
-  openBtn: () => $('mm-search-bar .open-filter'),
+  openBtn: () => $('mm-search-bar .open-filter, .mm-search-bar-container .btn.open-filter'),
   resetBtn: () => $('.sidebar-reset'),
   dateAccordionHeader: () => $('#date-filter-accordion mat-expansion-panel-header'),
   dateAccordionBody: () => $('#date-filter-accordion mat-panel-description'),

--- a/tests/page-objects/default/tasks/tasks.wdio.page.js
+++ b/tests/page-objects/default/tasks/tasks.wdio.page.js
@@ -9,7 +9,7 @@ const FORM_TITLE_SELECTOR = `${TASK_FORM_SELECTOR} h3#form-title`;
 const NO_SELECTED_TASK_SELECTOR = '.empty-selection';
 
 const sidebarFilterSelectors = {
-  openBtn: () => $('mm-search-bar .open-filter'),
+  openBtn: () => $('mm-search-bar .open-filter, .mm-search-bar-container .btn.open-filter'),
   resetBtn: () => $('.sidebar-reset'),
   overdueAccordionHeader: () => $('#overdue-filter-accordion mat-expansion-panel-header'),
   overdueAccordionBody: () => $('#overdue-filter-accordion mat-panel-description'),

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -34,6 +34,7 @@
         "eurodigit": "^3.1.3",
         "fastest-levenshtein": "1.0.16",
         "font-awesome": "^4.7.0",
+        "fuse.js": "^7.3.0",
         "jquery": "3.5.1",
         "lodash-es": "^4.18.1",
         "moment-locales-webpack-plugin": "^1.2.0",
@@ -8388,6 +8389,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.3.0.tgz",
+      "integrity": "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
       }
     },
     "node_modules/gensync": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -48,6 +48,7 @@
     "eurodigit": "^3.1.3",
     "fastest-levenshtein": "1.0.16",
     "font-awesome": "^4.7.0",
+    "fuse.js": "^7.3.0",
     "jquery": "3.5.1",
     "lodash-es": "^4.18.1",
     "moment-locales-webpack-plugin": "^1.2.0",

--- a/webapp/src/ts/modules/tasks/tasks-sidebar-filter.component.ts
+++ b/webapp/src/ts/modules/tasks/tasks-sidebar-filter.component.ts
@@ -121,7 +121,7 @@ export class TasksSidebarFilterComponent implements OnInit, AfterViewInit, OnDes
       return;
     }
     this.isResettingFilters = true;
-    this.globalActions.clearFilters();
+    this.globalActions.clearFilters('search');
     this.clearFilters();
     this.isResettingFilters = false;
     this.applyFilters();

--- a/webapp/src/ts/modules/tasks/tasks.component.html
+++ b/webapp/src/ts/modules/tasks/tasks.component.html
@@ -2,7 +2,7 @@
   <mm-search-bar
     (toggleFilter)="toggleFilter()"
     [showFilter]="true"
-    [showFreetext]="false">
+    [showFreetext]="true">
   </mm-search-bar>
 </mm-tool-bar>
 

--- a/webapp/src/ts/modules/tasks/tasks.component.ts
+++ b/webapp/src/ts/modules/tasks/tasks.component.ts
@@ -134,6 +134,7 @@ export class TasksComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.trackLoadPerformance = this.performanceService.track();
+    this.globalActions.clearFilters();
     this.tasksActions.setSelectedTask(null);
     this.subscribeToStore();
     this.subscribeToChanges();

--- a/webapp/src/ts/reducers/global.ts
+++ b/webapp/src/ts/reducers/global.ts
@@ -293,4 +293,5 @@ export interface TasksFilters {
   taskOverdue?: boolean;
   taskTypes?: { selected: string[] };
   facilities?: { selected: string[] };
+  search?: string;
 }

--- a/webapp/src/ts/selectors/index.ts
+++ b/webapp/src/ts/selectors/index.ts
@@ -6,6 +6,48 @@ interface TaskWithLineage extends TaskEmission {
   lineageIds: string[];
 }
 
+const normalizeSearchText = (value?: string): string => {
+  if (!value) {
+    return '';
+  }
+
+  return value
+    .toString()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim();
+};
+
+const splitSearchTerms = (search?: string): string[] => {
+  const normalized = normalizeSearchText(search);
+  return normalized ? normalized.split(/\s+/).filter(Boolean) : [];
+};
+
+const fuzzyMatch = (text?: string, term?: string): boolean => {
+  if (!term) {
+    return true;
+  }
+
+  const normalizedText = normalizeSearchText(text);
+  if (!normalizedText) {
+    return false;
+  }
+
+  if (normalizedText.includes(term)) {
+    return true;
+  }
+
+  let termIndex = 0;
+  for (let i = 0; i < normalizedText.length && termIndex < term.length; i++) {
+    if (normalizedText[i] === term[termIndex]) {
+      termIndex += 1;
+    }
+  }
+
+  return termIndex === term.length;
+};
+
 const getGlobalState = (state): GlobalState => state.global || {};
 
 const applyTasksFilters = (tasks: TaskWithLineage[], filters: TasksFilters = {}): TaskWithLineage[] => {
@@ -24,6 +66,25 @@ const applyTasksFilters = (tasks: TaskWithLineage[], filters: TasksFilters = {})
     filtered = filtered.filter(task => {
       return task.lineageIds.some(id => filters.facilities?.selected.includes(id));
     });
+  }
+
+  if (filters.search) {
+    const terms = splitSearchTerms(filters.search);
+    if (terms.length) {
+      filtered = filtered.filter(task => {
+        const candidates = [
+          task?.contact?.name,
+          ...(task?.lineage || []),
+          task?.title,
+        ].filter(Boolean);
+
+        if (!candidates.length) {
+          return false;
+        }
+
+        return terms.every(term => candidates.some(candidate => fuzzyMatch(candidate, term)));
+      });
+    }
   }
 
   return filtered;

--- a/webapp/src/ts/selectors/index.ts
+++ b/webapp/src/ts/selectors/index.ts
@@ -88,11 +88,9 @@ const applyTasksFilters = (tasks: TaskWithLineage[], filters: TasksFilters = {})
     });
   }
 
-  if (filters.search) {
-    const normalizedSearch = normalizeText(filters.search);
-    if (normalizedSearch) {
-      filtered = filterTasksBySearch(filtered, normalizedSearch);
-    }
+  const normalizedSearch = normalizeText(filters.search);
+  if (normalizedSearch) {
+    filtered = filterTasksBySearch(filtered, normalizedSearch);
   }
 
   return filtered;

--- a/webapp/src/ts/selectors/index.ts
+++ b/webapp/src/ts/selectors/index.ts
@@ -1,16 +1,18 @@
 import { createSelector } from '@ngrx/store';
 import { GlobalState, TasksFilters } from '@mm-reducers/global';
 import { TaskEmission } from '@mm-services/rules-engine.service';
+import Fuse from 'fuse.js';
 
 interface TaskWithLineage extends TaskEmission {
   lineageIds: string[];
 }
 
-const normalizeSearchText = (value?: string): string => {
+const getGlobalState = (state): GlobalState => state.global || {};
+
+const normalizeText = (value?: string): string => {
   if (!value) {
     return '';
   }
-
   return value
     .toString()
     .toLowerCase()
@@ -19,36 +21,37 @@ const normalizeSearchText = (value?: string): string => {
     .trim();
 };
 
-const splitSearchTerms = (search?: string): string[] => {
-  const normalized = normalizeSearchText(search);
-  return normalized ? normalized.split(/\s+/).filter(Boolean) : [];
-};
-
-const fuzzyMatch = (text?: string, term?: string): boolean => {
-  if (!term) {
+const taskMatchesSearch = (task: TaskWithLineage, search: string): boolean => {
+  if (!search?.trim()) {
     return true;
   }
 
-  const normalizedText = normalizeSearchText(text);
-  if (!normalizedText) {
+  const normalizedSearch = normalizeText(search);
+
+  const candidates = [
+    task?.contact?.name,
+    ...(task?.lineage || []),
+    task?.title,
+  ].filter(Boolean) as string[];
+
+  if (!candidates.length) {
     return false;
   }
 
-  if (normalizedText.includes(term)) {
+  const substringMatch = candidates.some(c => normalizeText(c).includes(normalizedSearch));
+  if (substringMatch) {
     return true;
   }
 
-  let termIndex = 0;
-  for (let i = 0; i < normalizedText.length && termIndex < term.length; i++) {
-    if (normalizedText[i] === term[termIndex]) {
-      termIndex += 1;
-    }
-  }
+  const fuse = new Fuse(candidates, {
+    threshold: 0.2,       
+    distance: 50,
+    minMatchCharLength: 3, 
+    ignoreLocation: true,
+  });
 
-  return termIndex === term.length;
+  return fuse.search(search).length > 0;
 };
-
-const getGlobalState = (state): GlobalState => state.global || {};
 
 const applyTasksFilters = (tasks: TaskWithLineage[], filters: TasksFilters = {}): TaskWithLineage[] => {
   let filtered = tasks;
@@ -69,22 +72,7 @@ const applyTasksFilters = (tasks: TaskWithLineage[], filters: TasksFilters = {})
   }
 
   if (filters.search) {
-    const terms = splitSearchTerms(filters.search);
-    if (terms.length) {
-      filtered = filtered.filter(task => {
-        const candidates = [
-          task?.contact?.name,
-          ...(task?.lineage || []),
-          task?.title,
-        ].filter(Boolean);
-
-        if (!candidates.length) {
-          return false;
-        }
-
-        return terms.every(term => candidates.some(candidate => fuzzyMatch(candidate, term)));
-      });
-    }
+    filtered = filtered.filter(task => taskMatchesSearch(task, filters.search!));
   }
 
   return filtered;

--- a/webapp/src/ts/selectors/index.ts
+++ b/webapp/src/ts/selectors/index.ts
@@ -41,32 +41,33 @@ const FUSE_OPTIONS = {
 };
 
 const filterTasksBySearch = (tasks: TaskWithLineage[], normalizedSearch: string): TaskWithLineage[] => {
-  // First pass: fast substring match on normalized text
   const substringMatched: TaskWithLineage[] = [];
-  const remaining: TaskWithLineage[] = [];
+  const remainingWithCandidates: { task: TaskWithLineage; candidates: string[] }[] = [];
 
   for (const task of tasks) {
     const candidates = getSearchCandidates(task);
     if (candidates.some(c => normalizeText(c).includes(normalizedSearch))) {
       substringMatched.push(task);
     } else if (candidates.length) {
-      remaining.push(task);
+      remainingWithCandidates.push({ task, candidates });
     }
   }
 
-  // Second pass: fuzzy match only on tasks that didn't match by substring.
-  // Build one Fuse index over all remaining candidates to avoid per-task overhead.
-  if (normalizedSearch.length >= FUSE_OPTIONS.minMatchCharLength && remaining.length) {
-    const entries = remaining.flatMap((task, idx) =>
-      getSearchCandidates(task).map(candidate => ({ candidate, idx }))
-    );
-    const fuse = new Fuse(entries, { ...FUSE_OPTIONS, keys: ['candidate'] });
-    const fuzzyMatchIndices = new Set(fuse.search(normalizedSearch).map(r => r.item.idx));
-    const fuzzyMatched = remaining.filter((_, idx) => fuzzyMatchIndices.has(idx));
-    return [...substringMatched, ...fuzzyMatched];
+  if (normalizedSearch.length < FUSE_OPTIONS.minMatchCharLength || !remainingWithCandidates.length) {
+    return substringMatched;
   }
 
-  return substringMatched;
+  // Build one Fuse index over all remaining candidates to avoid per-task overhead.
+  const entries = remainingWithCandidates.flatMap(
+    ({ candidates }, idx) => candidates.map(candidate => ({ candidate, idx }))
+  );
+  const fuse = new Fuse(entries, { ...FUSE_OPTIONS, keys: ['candidate'] });
+  const fuzzyMatchIndices = new Set(fuse.search(normalizedSearch).map(r => r.item.idx));
+  const fuzzyMatched = remainingWithCandidates
+    .filter((_, idx) => fuzzyMatchIndices.has(idx))
+    .map(({ task }) => task);
+
+  return [...substringMatched, ...fuzzyMatched];
 };
 
 const applyTasksFilters = (tasks: TaskWithLineage[], filters: TasksFilters = {}): TaskWithLineage[] => {

--- a/webapp/src/ts/selectors/index.ts
+++ b/webapp/src/ts/selectors/index.ts
@@ -16,17 +16,18 @@ const normalizeText = (value?: string): string => {
   return value
     .toString()
     .toLowerCase()
+    // NFD decomposition splits accented characters into base + combining diacritical marks,
+    // and the regex then strips those combining marks (Unicode range U+0300–U+036F),
+    // so that e.g. 'Élodie' becomes 'elodie' and can be matched without accents.
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, '')
     .trim();
 };
 
-const taskMatchesSearch = (task: TaskWithLineage, search: string): boolean => {
-  if (!search?.trim()) {
+const taskMatchesSearch = (task: TaskWithLineage, normalizedSearch: string): boolean => {
+  if (!normalizedSearch) {
     return true;
   }
-
-  const normalizedSearch = normalizeText(search);
 
   const candidates = [
     task?.contact?.name,
@@ -44,13 +45,17 @@ const taskMatchesSearch = (task: TaskWithLineage, search: string): boolean => {
   }
 
   const fuse = new Fuse(candidates, {
+    // threshold: 0 = exact match only, 1 = match anything.
     threshold: 0.2,       
+    // distance: limits how far from the start of the string a match can be found.
     distance: 50,
+    // Require at least 3 characters to trigger fuzzy matching,
     minMatchCharLength: 3, 
+    // ignoreLocation: true means the match can appear anywhere in the string,
     ignoreLocation: true,
   });
 
-  return fuse.search(search).length > 0;
+  return fuse.search(normalizedSearch).length > 0;
 };
 
 const applyTasksFilters = (tasks: TaskWithLineage[], filters: TasksFilters = {}): TaskWithLineage[] => {
@@ -72,7 +77,10 @@ const applyTasksFilters = (tasks: TaskWithLineage[], filters: TasksFilters = {})
   }
 
   if (filters.search) {
-    filtered = filtered.filter(task => taskMatchesSearch(task, filters.search!));
+    const normalizedSearch = normalizeText(filters.search);
+    if (normalizedSearch) {
+      filtered = filtered.filter(task => taskMatchesSearch(task, normalizedSearch));
+    }
   }
 
   return filtered;

--- a/webapp/src/ts/selectors/index.ts
+++ b/webapp/src/ts/selectors/index.ts
@@ -9,6 +9,10 @@ interface TaskWithLineage extends TaskEmission {
 
 const getGlobalState = (state): GlobalState => state.global || {};
 
+// Strips diacritical marks and lowercases the input so that accented
+// characters like "Élodie" can be matched by searching "elodie".
+// NFD decomposition splits accented characters into base + combining marks,
+// and the regex strips the combining marks (Unicode range U+0300-U+036F).
 const normalizeText = (value?: string): string => {
   if (!value) {
     return '';
@@ -16,46 +20,53 @@ const normalizeText = (value?: string): string => {
   return value
     .toString()
     .toLowerCase()
-    // NFD decomposition splits accented characters into base + combining diacritical marks,
-    // and the regex then strips those combining marks (Unicode range U+0300–U+036F),
-    // so that e.g. 'Élodie' becomes 'elodie' and can be matched without accents.
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, '')
     .trim();
 };
 
-const taskMatchesSearch = (task: TaskWithLineage, normalizedSearch: string): boolean => {
-  if (!normalizedSearch) {
-    return true;
-  }
-
-  const candidates = [
+const getSearchCandidates = (task: TaskWithLineage): string[] => {
+  return [
     task?.contact?.name,
     ...(task?.lineage || []),
     task?.title,
   ].filter(Boolean) as string[];
+};
 
-  if (!candidates.length) {
-    return false;
+const FUSE_OPTIONS = {
+  threshold: 0.2,        // 0 = exact, 1 = match anything; 0.2 allows minor typos
+  distance: 50,          // how far from expected position a match can appear
+  minMatchCharLength: 3, // skip fuzzy matching for very short queries
+  ignoreLocation: true,  // match can appear anywhere in the string
+};
+
+const filterTasksBySearch = (tasks: TaskWithLineage[], normalizedSearch: string): TaskWithLineage[] => {
+  // First pass: fast substring match on normalized text
+  const substringMatched: TaskWithLineage[] = [];
+  const remaining: TaskWithLineage[] = [];
+
+  for (const task of tasks) {
+    const candidates = getSearchCandidates(task);
+    if (candidates.some(c => normalizeText(c).includes(normalizedSearch))) {
+      substringMatched.push(task);
+    } else if (candidates.length) {
+      remaining.push(task);
+    }
   }
 
-  const substringMatch = candidates.some(c => normalizeText(c).includes(normalizedSearch));
-  if (substringMatch) {
-    return true;
+  // Second pass: fuzzy match only on tasks that didn't match by substring.
+  // Build one Fuse index over all remaining candidates to avoid per-task overhead.
+  if (normalizedSearch.length >= FUSE_OPTIONS.minMatchCharLength && remaining.length) {
+    const entries = remaining.flatMap((task, idx) =>
+      getSearchCandidates(task).map(candidate => ({ candidate, idx }))
+    );
+    const fuse = new Fuse(entries, { ...FUSE_OPTIONS, keys: ['candidate'] });
+    const fuzzyMatchIndices = new Set(fuse.search(normalizedSearch).map(r => r.item.idx));
+    const fuzzyMatched = remaining.filter((_, idx) => fuzzyMatchIndices.has(idx));
+    return [...substringMatched, ...fuzzyMatched];
   }
 
-  const fuse = new Fuse(candidates, {
-    // threshold: 0 = exact match only, 1 = match anything.
-    threshold: 0.2,       
-    // distance: limits how far from the start of the string a match can be found.
-    distance: 50,
-    // Require at least 3 characters to trigger fuzzy matching,
-    minMatchCharLength: 3, 
-    // ignoreLocation: true means the match can appear anywhere in the string,
-    ignoreLocation: true,
-  });
-
-  return fuse.search(normalizedSearch).length > 0;
+  return substringMatched;
 };
 
 const applyTasksFilters = (tasks: TaskWithLineage[], filters: TasksFilters = {}): TaskWithLineage[] => {
@@ -79,7 +90,7 @@ const applyTasksFilters = (tasks: TaskWithLineage[], filters: TasksFilters = {})
   if (filters.search) {
     const normalizedSearch = normalizeText(filters.search);
     if (normalizedSearch) {
-      filtered = filtered.filter(task => taskMatchesSearch(task, normalizedSearch));
+      filtered = filterTasksBySearch(filtered, normalizedSearch);
     }
   }
 

--- a/webapp/src/ts/selectors/index.ts
+++ b/webapp/src/ts/selectors/index.ts
@@ -58,8 +58,9 @@ const filterTasksBySearch = (tasks: TaskWithLineage[], normalizedSearch: string)
   }
 
   // Build one Fuse index over all remaining candidates to avoid per-task overhead.
+  // Normalize the indexed text too, so fuzzy matching is diacritic-insensitive like the substring pass.
   const entries = remainingWithCandidates.flatMap(
-    ({ candidates }, idx) => candidates.map(candidate => ({ candidate, idx }))
+    ({ candidates }, idx) => candidates.map(candidate => ({ candidate: normalizeText(candidate), idx }))
   );
   const fuse = new Fuse(entries, { ...FUSE_OPTIONS, keys: ['candidate'] });
   const fuzzyMatchIndices = new Set(fuse.search(normalizedSearch).map(r => r.item.idx));

--- a/webapp/src/ts/selectors/index.ts
+++ b/webapp/src/ts/selectors/index.ts
@@ -34,10 +34,9 @@ const getSearchCandidates = (task: TaskWithLineage): string[] => {
 };
 
 const FUSE_OPTIONS = {
-  threshold: 0.2,        // 0 = exact, 1 = match anything; 0.2 allows minor typos
-  distance: 50,          // how far from expected position a match can appear
-  minMatchCharLength: 3, // skip fuzzy matching for very short queries
-  ignoreLocation: true,  // match can appear anywhere in the string
+  threshold: 0.2,        // 0 = exact match, 1 = matches anything; 0.2 tolerates minor typos
+  ignoreLocation: true,  // a match can appear anywhere in the string
+  minMatchCharLength: 3,
 };
 
 const filterTasksBySearch = (tasks: TaskWithLineage[], normalizedSearch: string): TaskWithLineage[] => {

--- a/webapp/tests/karma/ts/modules/tasks/tasks-sidebar-filter.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/tasks/tasks-sidebar-filter.component.spec.ts
@@ -93,7 +93,7 @@ describe('TasksSidebarFilterComponent', () => {
 
     component.resetFilters();
 
-    expect(clearFiltersStub.calledOnce).to.be.true;
+    expect(clearFiltersStub.calledOnceWithExactly('search')).to.be.true;
     expect(searchEmitSpy.calledOnce).to.be.true;
     expect(telemetryService.record.calledTwice).to.be.true;
     expect(telemetryService.record.args[0][0]).to.equal('tasks:filter:apply');

--- a/webapp/tests/karma/ts/modules/tasks/tasks.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/tasks/tasks.component.spec.ts
@@ -11,6 +11,7 @@ import { ChangesService } from '@mm-services/changes.service';
 import { ContactTypesService } from '@mm-services/contact-types.service';
 import { RulesEngineService } from '@mm-services/rules-engine.service';
 import { TasksActions } from '@mm-actions/tasks';
+import { GlobalActions } from '@mm-actions/global';
 import { PerformanceService } from '@mm-services/performance.service';
 import { TasksComponent } from '@mm-modules/tasks/tasks.component';
 import { NavigationComponent } from '@mm-components/navigation/navigation.component';
@@ -113,6 +114,14 @@ describe('TasksComponent', () => {
     expect(setTasksLoaded.callCount).to.equal(1);
     expect(setTasksLoaded.args[0]).to.deep.equal([false]);
     expect(clearTaskGroup.callCount).to.equal(1);
+  });
+
+  it('should clear global filters on init so a search from another tab does not leak in', async () => {
+    const clearFilters = sinon.stub(GlobalActions.prototype, 'clearFilters');
+
+    await getComponent(); // triggers ngOnInit via detectChanges
+
+    expect(clearFilters.calledOnceWithExactly()).to.be.true;
   });
 
   it('initial state before resolving tasks', async () => {

--- a/webapp/tests/karma/ts/selectors/index.spec.ts
+++ b/webapp/tests/karma/ts/selectors/index.spec.ts
@@ -729,9 +729,18 @@ describe('Selectors', () => {
       it('should combine search with other filters', () => {
         const tasksState = {
           tasksList: [
-            { _id: 'task1', title: 'Home Visit', overdue: true, contact: { name: 'Alice' }, lineage: [], lineageIds: ['c1'] },
-            { _id: 'task2', title: 'Home Visit', overdue: false, contact: { name: 'Alice' }, lineage: [], lineageIds: ['c2'] },
-            { _id: 'task3', title: 'Assessment', overdue: true, contact: { name: 'Bob' }, lineage: [], lineageIds: ['c3'] },
+            {
+              _id: 'task1', title: 'Home Visit', overdue: true,
+              contact: { name: 'Alice' }, lineage: [], lineageIds: ['c1'],
+            },
+            {
+              _id: 'task2', title: 'Home Visit', overdue: false,
+              contact: { name: 'Alice' }, lineage: [], lineageIds: ['c2'],
+            },
+            {
+              _id: 'task3', title: 'Assessment', overdue: true,
+              contact: { name: 'Bob' }, lineage: [], lineageIds: ['c3'],
+            },
           ],
         };
 

--- a/webapp/tests/karma/ts/selectors/index.spec.ts
+++ b/webapp/tests/karma/ts/selectors/index.spec.ts
@@ -609,6 +609,93 @@ describe('Selectors', () => {
         const result = Selectors.getFilteredTasksList.projector(tasksState, globalState);
         expect(result).to.deep.equal([]);
       });
+
+      it('should filter by freetext matching contact name, lineage, or title', () => {
+        const tasksState = {
+          tasksList: [
+            {
+              _id: 'task1',
+              title: 'Follow up',
+              contact: { name: 'Alice Johnson' },
+              lineage: ['Village Alpha'],
+              lineageIds: ['contact1']
+            },
+            {
+              _id: 'task2',
+              title: 'Vaccination',
+              contact: { name: 'Bob Smith' },
+              lineage: ['Village Beta'],
+              lineageIds: ['contact2']
+            },
+            {
+              _id: 'task3',
+              title: 'ANC Visit',
+              contact: { name: 'Carol' },
+              lineage: ['Village Gamma'],
+              lineageIds: ['contact3']
+            },
+          ],
+        };
+
+        const globalStateByName = { filters: { search: 'alice' } } as any;
+        const resultByName = Selectors.getFilteredTasksList.projector(tasksState, globalStateByName);
+        expect(resultByName).to.deep.equal([tasksState.tasksList[0]]);
+
+        const globalStateByLineage = { filters: { search: 'beta' } } as any;
+        const resultByLineage = Selectors.getFilteredTasksList.projector(tasksState, globalStateByLineage);
+        expect(resultByLineage).to.deep.equal([tasksState.tasksList[1]]);
+
+        const globalStateByTitle = { filters: { search: 'anc' } } as any;
+        const resultByTitle = Selectors.getFilteredTasksList.projector(tasksState, globalStateByTitle);
+        expect(resultByTitle).to.deep.equal([tasksState.tasksList[2]]);
+      });
+
+      it('should support fuzzy matching and multiple terms', () => {
+        const tasksState = {
+          tasksList: [
+            {
+              _id: 'task1',
+              title: 'Follow up',
+              contact: { name: 'John Doe' },
+              lineage: ['Village Beta'],
+              lineageIds: ['contact1']
+            },
+            {
+              _id: 'task2',
+              title: 'Vaccination',
+              contact: { name: 'Jane Roe' },
+              lineage: ['Village Alpha'],
+              lineageIds: ['contact2']
+            },
+          ],
+        };
+
+        const fuzzyState = { filters: { search: 'jhn' } } as any;
+        const fuzzyResult = Selectors.getFilteredTasksList.projector(tasksState, fuzzyState);
+        expect(fuzzyResult).to.deep.equal([tasksState.tasksList[0]]);
+
+        const multiTermState = { filters: { search: 'john beta' } } as any;
+        const multiTermResult = Selectors.getFilteredTasksList.projector(tasksState, multiTermState);
+        expect(multiTermResult).to.deep.equal([tasksState.tasksList[0]]);
+      });
+
+      it('should normalize diacritics in search', () => {
+        const tasksState = {
+          tasksList: [
+            {
+              _id: 'task1',
+              title: 'Follow up',
+              contact: { name: 'Élodie' },
+              lineage: ['Village Alpha'],
+              lineageIds: ['contact1']
+            },
+          ],
+        };
+
+        const globalState = { filters: { search: 'elodie' } } as any;
+        const result = Selectors.getFilteredTasksList.projector(tasksState, globalState);
+        expect(result).to.deep.equal([tasksState.tasksList[0]]);
+      });
     });
   });
 });

--- a/webapp/tests/karma/ts/selectors/index.spec.ts
+++ b/webapp/tests/karma/ts/selectors/index.spec.ts
@@ -650,6 +650,39 @@ describe('Selectors', () => {
         expect(resultByTitle).to.deep.equal([tasksState.tasksList[2]]);
       });
 
+      it('should support search with Nepali and Arabic characters', () => {
+        const tasksState = {
+          tasksList: [
+            {
+              _id: 'task1',
+              title: 'Follow up',
+              contact: { name: 'रामकुमारी' },   
+              lineage: ['गाउँपालिका'],           
+              lineageIds: ['contact1']
+            },
+            {
+              _id: 'task2',
+              title: 'ANC Visit',
+              contact: { name: 'فاطمة' },        
+              lineage: ['مستشفى المدينة'],       
+              lineageIds: ['contact2']
+            },
+          ],
+        };
+
+        const nepaliState = { filters: { search: 'रामकुमारी' } } as any;
+        const nepaliResult = Selectors.getFilteredTasksList.projector(tasksState, nepaliState);
+        expect(nepaliResult).to.deep.equal([tasksState.tasksList[0]]);
+
+        const arabicState = { filters: { search: 'فاطمة' } } as any;
+        const arabicResult = Selectors.getFilteredTasksList.projector(tasksState, arabicState);
+        expect(arabicResult).to.deep.equal([tasksState.tasksList[1]]);
+
+        const crossScriptState = { filters: { search: 'فاطمة' } } as any;
+        const crossScriptResult = Selectors.getFilteredTasksList.projector(tasksState, crossScriptState);
+        expect(crossScriptResult).to.deep.equal([tasksState.tasksList[1]]);
+      });
+
       it('should normalize diacritics in search', () => {
         const tasksState = {
           tasksList: [

--- a/webapp/tests/karma/ts/selectors/index.spec.ts
+++ b/webapp/tests/karma/ts/selectors/index.spec.ts
@@ -650,35 +650,6 @@ describe('Selectors', () => {
         expect(resultByTitle).to.deep.equal([tasksState.tasksList[2]]);
       });
 
-      it('should support fuzzy matching and multiple terms', () => {
-        const tasksState = {
-          tasksList: [
-            {
-              _id: 'task1',
-              title: 'Follow up',
-              contact: { name: 'John Doe' },
-              lineage: ['Village Beta'],
-              lineageIds: ['contact1']
-            },
-            {
-              _id: 'task2',
-              title: 'Vaccination',
-              contact: { name: 'Jane Roe' },
-              lineage: ['Village Alpha'],
-              lineageIds: ['contact2']
-            },
-          ],
-        };
-
-        const fuzzyState = { filters: { search: 'jhn' } } as any;
-        const fuzzyResult = Selectors.getFilteredTasksList.projector(tasksState, fuzzyState);
-        expect(fuzzyResult).to.deep.equal([tasksState.tasksList[0]]);
-
-        const multiTermState = { filters: { search: 'john beta' } } as any;
-        const multiTermResult = Selectors.getFilteredTasksList.projector(tasksState, multiTermState);
-        expect(multiTermResult).to.deep.equal([tasksState.tasksList[0]]);
-      });
-
       it('should normalize diacritics in search', () => {
         const tasksState = {
           tasksList: [

--- a/webapp/tests/karma/ts/selectors/index.spec.ts
+++ b/webapp/tests/karma/ts/selectors/index.spec.ts
@@ -700,6 +700,45 @@ describe('Selectors', () => {
         const result = Selectors.getFilteredTasksList.projector(tasksState, globalState);
         expect(result).to.deep.equal([tasksState.tasksList[0]]);
       });
+
+      it('should return all tasks when search is empty', () => {
+        const tasksState = {
+          tasksList: [
+            { _id: 'task1', title: 'Follow up', contact: { name: 'Alice' }, lineage: [], lineageIds: ['c1'] },
+            { _id: 'task2', title: 'ANC Visit', contact: { name: 'Bob' }, lineage: [], lineageIds: ['c2'] },
+          ],
+        };
+
+        const globalState = { filters: { search: '' } } as any;
+        const result = Selectors.getFilteredTasksList.projector(tasksState, globalState);
+        expect(result).to.deep.equal(tasksState.tasksList);
+      });
+
+      it('should return empty array when no tasks match the search', () => {
+        const tasksState = {
+          tasksList: [
+            { _id: 'task1', title: 'Follow up', contact: { name: 'Alice' }, lineage: ['Village'], lineageIds: ['c1'] },
+          ],
+        };
+
+        const globalState = { filters: { search: 'zzzznotfound' } } as any;
+        const result = Selectors.getFilteredTasksList.projector(tasksState, globalState);
+        expect(result).to.deep.equal([]);
+      });
+
+      it('should combine search with other filters', () => {
+        const tasksState = {
+          tasksList: [
+            { _id: 'task1', title: 'Home Visit', overdue: true, contact: { name: 'Alice' }, lineage: [], lineageIds: ['c1'] },
+            { _id: 'task2', title: 'Home Visit', overdue: false, contact: { name: 'Alice' }, lineage: [], lineageIds: ['c2'] },
+            { _id: 'task3', title: 'Assessment', overdue: true, contact: { name: 'Bob' }, lineage: [], lineageIds: ['c3'] },
+          ],
+        };
+
+        const globalState = { filters: { search: 'alice', taskOverdue: true } } as any;
+        const result = Selectors.getFilteredTasksList.projector(tasksState, globalState);
+        expect(result).to.deep.equal([tasksState.tasksList[0]]);
+      });
     });
   });
 });

--- a/webapp/tests/karma/ts/selectors/index.spec.ts
+++ b/webapp/tests/karma/ts/selectors/index.spec.ts
@@ -701,6 +701,59 @@ describe('Selectors', () => {
         expect(result).to.deep.equal([tasksState.tasksList[0]]);
       });
 
+      it('should fuzzy-match contact names with minor typos', () => {
+        const tasksState = {
+          tasksList: [
+            {
+              _id: 'task1',
+              title: 'ANC Visit',
+              contact: { name: 'Alice Johnson' },
+              lineage: ['Village Alpha'],
+              lineageIds: ['c1']
+            },
+            {
+              _id: 'task2',
+              title: 'Vaccination',
+              contact: { name: 'Bob Smith' },
+              lineage: ['Village Beta'],
+              lineageIds: ['c2']
+            },
+          ],
+        };
+
+        // 'jonson' is not a substring of any candidate, so this exercises the Fuse fuzzy pass.
+        const globalState = { filters: { search: 'jonson' } } as any;
+        const result = Selectors.getFilteredTasksList.projector(tasksState, globalState);
+        expect(result).to.deep.equal([tasksState.tasksList[0]]);
+      });
+
+      it('should fuzzy-match diacritic names ignoring accents', () => {
+        const tasksState = {
+          tasksList: [
+            {
+              _id: 'task1',
+              title: 'Follow up',
+              contact: { name: 'Élodie Laurent' },
+              lineage: ['Village Alpha'],
+              lineageIds: ['c1']
+            },
+            {
+              _id: 'task2',
+              title: 'Vaccination',
+              contact: { name: 'Bob Smith' },
+              lineage: ['Village Beta'],
+              lineageIds: ['c2']
+            },
+          ],
+        };
+
+        // 'elodei' transposes letters AND drops the accent, so it only matches once the Fuse
+        // index normalizes its candidates - this guards the diacritic-insensitive fuzzy path.
+        const globalState = { filters: { search: 'elodei' } } as any;
+        const result = Selectors.getFilteredTasksList.projector(tasksState, globalState);
+        expect(result).to.deep.equal([tasksState.tasksList[0]]);
+      });
+
       it('should return all tasks when search is empty', () => {
         const tasksState = {
           tasksList: [

--- a/webapp/tests/karma/ts/selectors/index.spec.ts
+++ b/webapp/tests/karma/ts/selectors/index.spec.ts
@@ -678,9 +678,9 @@ describe('Selectors', () => {
         const arabicResult = Selectors.getFilteredTasksList.projector(tasksState, arabicState);
         expect(arabicResult).to.deep.equal([tasksState.tasksList[1]]);
 
-        const crossScriptState = { filters: { search: 'فاطمة' } } as any;
-        const crossScriptResult = Selectors.getFilteredTasksList.projector(tasksState, crossScriptState);
-        expect(crossScriptResult).to.deep.equal([tasksState.tasksList[1]]);
+        const byLineageState = { filters: { search: 'गाउँपालिका' } } as any;
+        const byLineageResult = Selectors.getFilteredTasksList.projector(tasksState, byLineageState);
+        expect(byLineageResult).to.deep.equal([tasksState.tasksList[0]]);
       });
 
       it('should normalize diacritics in search', () => {
@@ -752,6 +752,31 @@ describe('Selectors', () => {
         const globalState = { filters: { search: 'elodei' } } as any;
         const result = Selectors.getFilteredTasksList.projector(tasksState, globalState);
         expect(result).to.deep.equal([tasksState.tasksList[0]]);
+      });
+
+      it('should return substring matches before fuzzy matches', () => {
+        const tasksState = {
+          tasksList: [
+            {
+              _id: 'task1',
+              title: 'Follow up',
+              contact: { name: 'Alice Johnson' }, // matches 'jonson' only by fuzzy
+              lineage: ['Village Alpha'],
+              lineageIds: ['c1']
+            },
+            {
+              _id: 'task2',
+              title: 'Vaccination',
+              contact: { name: 'Bob Jonson' }, // matches 'jonson' by substring
+              lineage: ['Village Beta'],
+              lineageIds: ['c2']
+            },
+          ],
+        };
+        
+        const globalState = { filters: { search: 'jonson' } } as any;
+        const result = Selectors.getFilteredTasksList.projector(tasksState, globalState);
+        expect(result).to.deep.equal([tasksState.tasksList[1], tasksState.tasksList[0]]);
       });
 
       it('should return all tasks when search is empty', () => {


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: build|feat|fix|perf|refactor|test|chore

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Closes #10694.

This adds free text search to the Tasks page. The search bar's freetext input — previously disabled on this page — is now enabled, letting users filter their task list by contact name, lineage, or task title. Typing a query writes it into the global filters state, where a memoized NgRx selector reactively re-filters the list; no extra query round-trip or page reload is involved.

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [ ] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10694-adds-tasks-page-free-text-search-functionality-/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10694-adds-tasks-page-free-text-search-functionality-/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10694-adds-tasks-page-free-text-search-functionality-/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

