### PR TITLE
feat(#10626): add recursive contact hierarchy delete service

### DIFF
--- a/api/src/services/contact-hierarchy.js
+++ b/api/src/services/contact-hierarchy.js
@@ -1,0 +1,93 @@
+const db = require('../db');
+const logger = require('@medic/logger');
+
+const BATCH_SIZE = 100;
+const MAX_HIERARCHY_SIZE = 5000;
+
+// contacts_by_depth emits a bare [ancestorId] key for a contact and each of its
+// ancestors, so { key: [contactId] } returns one row per member of the subtree.
+const countSubtree = async (contactId) => {
+  const result = await db.medic.query('medic/contacts_by_depth', { key: [contactId] });
+  return result.rows.length;
+};
+
+const getSubtreeContacts = async (contactId) => {
+  const result = await db.medic.query('medic/contacts_by_depth', {
+    key: [contactId],
+    include_docs: true,
+  });
+  return result.rows
+    .map(row => row.doc)
+    .filter(doc => doc && doc.type !== 'tombstone');
+};
+
+// reports_by_subject indexes by both shortcode (patient_id/place_id) and uuid, so a
+// contact's reports are matched by either identifier.
+const getSubjectKeys = (contacts) => {
+  const keys = new Set();
+  contacts.forEach((contact) => {
+    keys.add(contact._id);
+    const shortcode = contact.patient_id || contact.place_id;
+    if (shortcode) {
+      keys.add(shortcode);
+    }
+  });
+  return [...keys];
+};
+
+const getSubjectReports = async (contacts) => {
+  const keys = getSubjectKeys(contacts);
+  const reportsById = new Map();
+  for (let i = 0; i < keys.length; i += BATCH_SIZE) {
+    const result = await db.medic.query('medic-client/reports_by_subject', {
+      keys: keys.slice(i, i + BATCH_SIZE),
+      include_docs: true,
+    });
+    result.rows.forEach(row => row.doc && reportsById.set(row.doc._id, row.doc));
+  }
+  return [...reportsById.values()];
+};
+
+const bulkDelete = async (docs) => {
+  const errors = [];
+  const tombstones = docs.map(doc => ({ ...doc, _deleted: true }));
+  for (let i = 0; i < tombstones.length; i += BATCH_SIZE) {
+    const results = await db.medic.bulkDocs(tombstones.slice(i, i + BATCH_SIZE));
+    results.forEach((result) => {
+      if (result.error) {
+        errors.push({ _id: result.id, error: result.error, reason: result.reason });
+      }
+    });
+  }
+  return errors;
+};
+
+const deleteHierarchy = async (contactId) => {
+  const count = await countSubtree(contactId);
+  if (!count) {
+    return null;
+  }
+  if (count > MAX_HIERARCHY_SIZE) {
+    const error = new Error(
+      `Hierarchy too large to delete via the API (${count} contacts, max ${MAX_HIERARCHY_SIZE}). Use cht-conf instead.`
+    );
+    error.code = 400;
+    throw error;
+  }
+
+  const contacts = await getSubtreeContacts(contactId);
+  const reports = await getSubjectReports(contacts);
+  const errors = await bulkDelete([...contacts, ...reports]);
+
+  logger.info(`Deleted contact ${contactId}: ${contacts.length} contact(s), ${reports.length} report(s)`);
+
+  return {
+    deleted_contacts: contacts.length,
+    deleted_reports: reports.length,
+    errors,
+  };
+};
+
+module.exports = {
+  deleteHierarchy,
+};

--- a/api/tests/mocha/services/contact-hierarchy.spec.js
+++ b/api/tests/mocha/services/contact-hierarchy.spec.js
@@ -1,0 +1,152 @@
+const sinon = require('sinon');
+const { expect } = require('chai');
+const db = require('../../../src/db');
+const service = require('../../../src/services/contact-hierarchy');
+
+const CONTACTS_BY_DEPTH = 'medic/contacts_by_depth';
+const REPORTS_BY_SUBJECT = 'medic-client/reports_by_subject';
+
+const contactDoc = (id, extra = {}) => ({ _id: id, _rev: '1-abc', type: 'person', ...extra });
+const reportDoc = (id) => ({ _id: id, _rev: '1-abc', type: 'data_record', form: 'assessment' });
+const contactRow = (doc) => ({ id: doc._id, key: [doc._id], doc });
+const reportRow = (doc) => ({ id: doc._id, key: 'subject', doc });
+
+describe('contact-hierarchy service', () => {
+  let query;
+  let bulkDocs;
+
+  beforeEach(() => {
+    query = sinon.stub(db.medic, 'query');
+    bulkDocs = sinon.stub(db.medic, 'bulkDocs').resolves([]);
+  });
+
+  afterEach(() => sinon.restore());
+
+  // count query omits include_docs; subtree query sets it.
+  const stubCount = (count) => query
+    .withArgs(CONTACTS_BY_DEPTH, sinon.match(opts => !opts.include_docs))
+    .resolves({ rows: new Array(count).fill({ id: 'x', key: ['x'] }) });
+
+  const stubSubtree = (docs) => query
+    .withArgs(CONTACTS_BY_DEPTH, sinon.match({ include_docs: true }))
+    .resolves({ rows: docs.map(contactRow) });
+
+  const stubReports = (docs) => query
+    .withArgs(REPORTS_BY_SUBJECT, sinon.match.any)
+    .resolves({ rows: docs.map(reportRow) });
+
+  describe('deleteHierarchy', () => {
+    it('returns null when the contact does not exist', async () => {
+      stubCount(0);
+
+      const result = await service.deleteHierarchy('missing');
+
+      expect(result).to.be.null;
+      expect(bulkDocs.called).to.be.false;
+    });
+
+    it('rejects with code 400 when the subtree exceeds the size guard', async () => {
+      stubCount(5001);
+
+      try {
+        await service.deleteHierarchy('huge');
+        expect.fail('expected deleteHierarchy to throw');
+      } catch (err) {
+        expect(err.code).to.equal(400);
+        expect(err.message).to.contain('too large');
+      }
+      expect(bulkDocs.called).to.be.false;
+    });
+
+    it('deletes a single contact with no children or reports', async () => {
+      stubCount(1);
+      stubSubtree([contactDoc('c1', { patient_id: 'SC1' })]);
+      stubReports([]);
+
+      const result = await service.deleteHierarchy('c1');
+
+      expect(result).to.deep.equal({ deleted_contacts: 1, deleted_reports: 0, errors: [] });
+      expect(bulkDocs.calledOnce).to.be.true;
+      const written = bulkDocs.firstCall.args[0];
+      expect(written).to.have.length(1);
+      expect(written[0]._id).to.equal('c1');
+      expect(written[0]._deleted).to.be.true;
+    });
+
+    it('recursively deletes the contact and all of its descendants', async () => {
+      stubCount(3);
+      stubSubtree([contactDoc('root'), contactDoc('child1'), contactDoc('child2')]);
+      stubReports([]);
+
+      const result = await service.deleteHierarchy('root');
+
+      expect(result.deleted_contacts).to.equal(3);
+      const written = bulkDocs.firstCall.args[0];
+      expect(written.map(doc => doc._id)).to.have.members(['root', 'child1', 'child2']);
+      expect(written.every(doc => doc._deleted)).to.be.true;
+    });
+
+    it('filters out tombstone documents from the subtree', async () => {
+      stubCount(2);
+      query
+        .withArgs(CONTACTS_BY_DEPTH, sinon.match({ include_docs: true }))
+        .resolves({ rows: [
+          contactRow(contactDoc('root')),
+          contactRow({ _id: 'old', _rev: '2-abc', type: 'tombstone' }),
+        ] });
+      stubReports([]);
+
+      const result = await service.deleteHierarchy('root');
+
+      expect(result.deleted_contacts).to.equal(1);
+      expect(bulkDocs.firstCall.args[0].map(doc => doc._id)).to.deep.equal(['root']);
+    });
+
+    it('queries reports_by_subject by both uuid and shortcode, and dedupes reports', async () => {
+      const report = reportDoc('r1');
+      stubCount(1);
+      stubSubtree([contactDoc('c1', { patient_id: 'SC1' })]);
+      // same report emitted under both the uuid key and the shortcode key
+      query
+        .withArgs(REPORTS_BY_SUBJECT, sinon.match.any)
+        .resolves({ rows: [reportRow(report), reportRow(report)] });
+
+      const result = await service.deleteHierarchy('c1');
+
+      expect(result.deleted_reports).to.equal(1);
+      const keys = query.withArgs(REPORTS_BY_SUBJECT, sinon.match.any).firstCall.args[1].keys;
+      expect(keys).to.include('c1');
+      expect(keys).to.include('SC1');
+      expect(bulkDocs.firstCall.args[0].map(doc => doc._id)).to.have.members(['c1', 'r1']);
+    });
+
+    it('surfaces per-document bulkDocs errors in the response', async () => {
+      stubCount(1);
+      stubSubtree([contactDoc('c1')]);
+      stubReports([]);
+      bulkDocs.resolves([{ id: 'c1', error: 'conflict', reason: 'Document update conflict' }]);
+
+      const result = await service.deleteHierarchy('c1');
+
+      expect(result.errors).to.deep.equal([
+        { _id: 'c1', error: 'conflict', reason: 'Document update conflict' },
+      ]);
+    });
+
+    it('writes in batches of 100 documents', async () => {
+      const docs = [];
+      for (let i = 0; i < 150; i++) {
+        docs.push(contactDoc(`c${i}`));
+      }
+      stubCount(150);
+      stubSubtree(docs);
+      stubReports([]);
+
+      await service.deleteHierarchy('c0');
+
+      expect(bulkDocs.callCount).to.equal(2);
+      expect(bulkDocs.firstCall.args[0]).to.have.length(100);
+      expect(bulkDocs.secondCall.args[0]).to.have.length(50);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

First slice of the delete endpoint for #10706 (sub-issue #10626). Adds the core service that recursively deletes a contact, all of its descendant contacts, and all reports for which any of those contacts is the subject.

Faithful port of `cht-conf`'s `delete-hierarchy.js`, adapted to write directly to CouchDB instead of staging documents to disk:

- Subtree fetched via `medic/contacts_by_depth` (`{ key: [id] }`, tombstone-filtered), matching cht-conf's `getContactWithDescendants`.
- Subject reports fetched via `medic-client/reports_by_subject`, keyed by each contact's uuid and shortcode (the view indexes both).
- Documents marked `_deleted` and written via `bulkDocs` in batches of 100; per-document errors are surfaced in the result rather than swallowed.
- Pre-flight size guard: hierarchies larger than 5,000 contacts are rejected with a clear message, to avoid silently exceeding the HTTP gateway timeout on very large subtrees. The service is kept separate from any transport concern so an async/queued path can be layered on later without changing this logic.

No new CouchDB views.

## Scope

Service layer and unit tests only. Wiring (controller, route, OpenAPI) and integration tests follow in separate PRs. Two deliberate enhancements over the cht-conf reference (clearing a deleted primary contact's parent reference, and removing reports authored by deleted contacts) are also split into their own PRs so each can be reviewed independently.

## Files

- `api/src/services/contact-hierarchy.js`
- `api/tests/mocha/services/contact-hierarchy.spec.js` (8 unit tests)

## Testing

`npm run unit-api`: lint clean, 8/8 new tests passing.

Review/merge bottom-up: #11163 → #11167 → #11172 → #11176