### PR TITLE
feat(#10626): clear deleted contact's parent reference on delete

### DIFF
--- a/api/src/services/contact-hierarchy.js
+++ b/api/src/services/contact-hierarchy.js
@@ -1,5 +1,8 @@
 const db = require('../db');
+const dataContext = require('./data-context');
 const logger = require('@medic/logger');
+
+const bulkDocsUtils = require('@medic/bulk-docs-utils')({ Promise, dataContext });
 
 const BATCH_SIZE = 100;
 const MAX_HIERARCHY_SIZE = 5000;
@@ -48,11 +51,10 @@ const getSubjectReports = async (contacts) => {
   return [...reportsById.values()];
 };
 
-const bulkDelete = async (docs) => {
+const bulkWrite = async (docs) => {
   const errors = [];
-  const tombstones = docs.map(doc => ({ ...doc, _deleted: true }));
-  for (let i = 0; i < tombstones.length; i += BATCH_SIZE) {
-    const results = await db.medic.bulkDocs(tombstones.slice(i, i + BATCH_SIZE));
+  for (let i = 0; i < docs.length; i += BATCH_SIZE) {
+    const results = await db.medic.bulkDocs(docs.slice(i, i + BATCH_SIZE));
     results.forEach((result) => {
       if (result.error) {
         errors.push({ _id: result.id, error: result.error, reason: result.reason });
@@ -77,7 +79,15 @@ const deleteHierarchy = async (contactId) => {
 
   const contacts = await getSubtreeContacts(contactId);
   const reports = await getSubjectReports(contacts);
-  const errors = await bulkDelete([...contacts, ...reports]);
+
+  const deletedDocs = [...contacts, ...reports].map(doc => ({ ...doc, _deleted: true }));
+  const deletedIds = new Set(deletedDocs.map(doc => doc._id));
+
+  // Clear the primary-contact reference on any surviving parent of a deleted contact.
+  const { docs: parents } = await bulkDocsUtils.updateParentContacts(deletedDocs);
+  const parentUpdates = parents.filter(parent => !deletedIds.has(parent._id));
+
+  const errors = await bulkWrite([...deletedDocs, ...parentUpdates]);
 
   logger.info(`Deleted contact ${contactId}: ${contacts.length} contact(s), ${reports.length} report(s)`);
 

--- a/api/src/services/contact-hierarchy.js
+++ b/api/src/services/contact-hierarchy.js
@@ -1,0 +1,93 @@
+const db = require('../db');
+const logger = require('@medic/logger');
+
+const BATCH_SIZE = 100;
+const MAX_HIERARCHY_SIZE = 5000;
+
+// contacts_by_depth emits a bare [ancestorId] key for a contact and each of its
+// ancestors, so { key: [contactId] } returns one row per member of the subtree.
+const countSubtree = async (contactId) => {
+  const result = await db.medic.query('medic/contacts_by_depth', { key: [contactId] });
+  return result.rows.length;
+};
+
+const getSubtreeContacts = async (contactId) => {
+  const result = await db.medic.query('medic/contacts_by_depth', {
+    key: [contactId],
+    include_docs: true,
+  });
+  return result.rows
+    .map(row => row.doc)
+    .filter(doc => doc && doc.type !== 'tombstone');
+};
+
+// reports_by_subject indexes by both shortcode (patient_id/place_id) and uuid, so a
+// contact's reports are matched by either identifier.
+const getSubjectKeys = (contacts) => {
+  const keys = new Set();
+  contacts.forEach((contact) => {
+    keys.add(contact._id);
+    const shortcode = contact.patient_id || contact.place_id;
+    if (shortcode) {
+      keys.add(shortcode);
+    }
+  });
+  return [...keys];
+};
+
+const getSubjectReports = async (contacts) => {
+  const keys = getSubjectKeys(contacts);
+  const reportsById = new Map();
+  for (let i = 0; i < keys.length; i += BATCH_SIZE) {
+    const result = await db.medic.query('medic-client/reports_by_subject', {
+      keys: keys.slice(i, i + BATCH_SIZE),
+      include_docs: true,
+    });
+    result.rows.forEach(row => row.doc && reportsById.set(row.doc._id, row.doc));
+  }
+  return [...reportsById.values()];
+};
+
+const bulkDelete = async (docs) => {
+  const errors = [];
+  const tombstones = docs.map(doc => ({ ...doc, _deleted: true }));
+  for (let i = 0; i < tombstones.length; i += BATCH_SIZE) {
+    const results = await db.medic.bulkDocs(tombstones.slice(i, i + BATCH_SIZE));
+    results.forEach((result) => {
+      if (result.error) {
+        errors.push({ _id: result.id, error: result.error, reason: result.reason });
+      }
+    });
+  }
+  return errors;
+};
+
+const deleteHierarchy = async (contactId) => {
+  const count = await countSubtree(contactId);
+  if (!count) {
+    return null;
+  }
+  if (count > MAX_HIERARCHY_SIZE) {
+    const error = new Error(
+      `Hierarchy too large to delete via the API (${count} contacts, max ${MAX_HIERARCHY_SIZE}). Use cht-conf instead.`
+    );
+    error.code = 400;
+    throw error;
+  }
+
+  const contacts = await getSubtreeContacts(contactId);
+  const reports = await getSubjectReports(contacts);
+  const errors = await bulkDelete([...contacts, ...reports]);
+
+  logger.info(`Deleted contact ${contactId}: ${contacts.length} contact(s), ${reports.length} report(s)`);
+
+  return {
+    deleted_contacts: contacts.length,
+    deleted_reports: reports.length,
+    errors,
+  };
+};
+
+module.exports = {
+  deleteHierarchy,
+};

--- a/api/tests/mocha/services/contact-hierarchy.spec.js
+++ b/api/tests/mocha/services/contact-hierarchy.spec.js
@@ -1,6 +1,7 @@
 const sinon = require('sinon');
 const { expect } = require('chai');
 const db = require('../../../src/db');
+const dataContext = require('../../../src/services/data-context');
 const service = require('../../../src/services/contact-hierarchy');
 
 const CONTACTS_BY_DEPTH = 'medic/contacts_by_depth';
@@ -18,6 +19,7 @@ describe('contact-hierarchy service', () => {
   beforeEach(() => {
     query = sinon.stub(db.medic, 'query');
     bulkDocs = sinon.stub(db.medic, 'bulkDocs').resolves([]);
+    sinon.stub(dataContext, 'bind').returns(sinon.stub().resolves(undefined));
   });
 
   afterEach(() => sinon.restore());
@@ -131,6 +133,52 @@ describe('contact-hierarchy service', () => {
       expect(result.errors).to.deep.equal([
         { _id: 'c1', error: 'conflict', reason: 'Document update conflict' },
       ]);
+    });
+
+    it('clears the primary-contact reference on a deleted contact\'s surviving parent', async () => {
+      stubCount(1);
+      stubSubtree([contactDoc('chw', { parent: { _id: 'hca' } })]);
+      stubReports([]);
+      const parent = { _id: 'hca', _rev: '1-abc', type: 'health_center', contact: { _id: 'chw' } };
+      dataContext.bind.returns(sinon.stub().resolves(parent));
+
+      await service.deleteHierarchy('chw');
+
+      const written = bulkDocs.firstCall.args[0];
+      const writtenParent = written.find(doc => doc._id === 'hca');
+      expect(writtenParent).to.exist;
+      expect(writtenParent.contact).to.be.null;
+      expect(writtenParent._deleted).to.be.undefined;
+    });
+
+    it('leaves a parent untouched when its primary contact is not being deleted', async () => {
+      stubCount(1);
+      stubSubtree([contactDoc('chw', { parent: { _id: 'hca' } })]);
+      stubReports([]);
+      const parent = { _id: 'hca', _rev: '1-abc', type: 'health_center', contact: { _id: 'someone-else' } };
+      dataContext.bind.returns(sinon.stub().resolves(parent));
+
+      await service.deleteHierarchy('chw');
+
+      expect(bulkDocs.firstCall.args[0].map(doc => doc._id)).to.deep.equal(['chw']);
+    });
+
+    it('does not write a parent that is itself being deleted', async () => {
+      stubCount(2);
+      stubSubtree([
+        contactDoc('place', { type: 'clinic', parent: { _id: 'hc' }, contact: { _id: 'person' } }),
+        contactDoc('person', { parent: { _id: 'place' } }),
+      ]);
+      stubReports([]);
+      // the deleted person is the primary contact of the deleted place
+      const place = { _id: 'place', _rev: '1-abc', type: 'clinic', contact: { _id: 'person' } };
+      dataContext.bind.returns(sinon.stub().resolves(place));
+
+      await service.deleteHierarchy('place');
+
+      const written = bulkDocs.firstCall.args[0];
+      expect(written.filter(doc => doc._id === 'place')).to.have.length(1);
+      expect(written.every(doc => doc._deleted)).to.be.true;
     });
 
     it('writes in batches of 100 documents', async () => {

--- a/api/tests/mocha/services/contact-hierarchy.spec.js
+++ b/api/tests/mocha/services/contact-hierarchy.spec.js
@@ -1,0 +1,152 @@
+const sinon = require('sinon');
+const { expect } = require('chai');
+const db = require('../../../src/db');
+const service = require('../../../src/services/contact-hierarchy');
+
+const CONTACTS_BY_DEPTH = 'medic/contacts_by_depth';
+const REPORTS_BY_SUBJECT = 'medic-client/reports_by_subject';
+
+const contactDoc = (id, extra = {}) => ({ _id: id, _rev: '1-abc', type: 'person', ...extra });
+const reportDoc = (id) => ({ _id: id, _rev: '1-abc', type: 'data_record', form: 'assessment' });
+const contactRow = (doc) => ({ id: doc._id, key: [doc._id], doc });
+const reportRow = (doc) => ({ id: doc._id, key: 'subject', doc });
+
+describe('contact-hierarchy service', () => {
+  let query;
+  let bulkDocs;
+
+  beforeEach(() => {
+    query = sinon.stub(db.medic, 'query');
+    bulkDocs = sinon.stub(db.medic, 'bulkDocs').resolves([]);
+  });
+
+  afterEach(() => sinon.restore());
+
+  // count query omits include_docs; subtree query sets it.
+  const stubCount = (count) => query
+    .withArgs(CONTACTS_BY_DEPTH, sinon.match(opts => !opts.include_docs))
+    .resolves({ rows: new Array(count).fill({ id: 'x', key: ['x'] }) });
+
+  const stubSubtree = (docs) => query
+    .withArgs(CONTACTS_BY_DEPTH, sinon.match({ include_docs: true }))
+    .resolves({ rows: docs.map(contactRow) });
+
+  const stubReports = (docs) => query
+    .withArgs(REPORTS_BY_SUBJECT, sinon.match.any)
+    .resolves({ rows: docs.map(reportRow) });
+
+  describe('deleteHierarchy', () => {
+    it('returns null when the contact does not exist', async () => {
+      stubCount(0);
+
+      const result = await service.deleteHierarchy('missing');
+
+      expect(result).to.be.null;
+      expect(bulkDocs.called).to.be.false;
+    });
+
+    it('rejects with code 400 when the subtree exceeds the size guard', async () => {
+      stubCount(5001);
+
+      try {
+        await service.deleteHierarchy('huge');
+        expect.fail('expected deleteHierarchy to throw');
+      } catch (err) {
+        expect(err.code).to.equal(400);
+        expect(err.message).to.contain('too large');
+      }
+      expect(bulkDocs.called).to.be.false;
+    });
+
+    it('deletes a single contact with no children or reports', async () => {
+      stubCount(1);
+      stubSubtree([contactDoc('c1', { patient_id: 'SC1' })]);
+      stubReports([]);
+
+      const result = await service.deleteHierarchy('c1');
+
+      expect(result).to.deep.equal({ deleted_contacts: 1, deleted_reports: 0, errors: [] });
+      expect(bulkDocs.calledOnce).to.be.true;
+      const written = bulkDocs.firstCall.args[0];
+      expect(written).to.have.length(1);
+      expect(written[0]._id).to.equal('c1');
+      expect(written[0]._deleted).to.be.true;
+    });
+
+    it('recursively deletes the contact and all of its descendants', async () => {
+      stubCount(3);
+      stubSubtree([contactDoc('root'), contactDoc('child1'), contactDoc('child2')]);
+      stubReports([]);
+
+      const result = await service.deleteHierarchy('root');
+
+      expect(result.deleted_contacts).to.equal(3);
+      const written = bulkDocs.firstCall.args[0];
+      expect(written.map(doc => doc._id)).to.have.members(['root', 'child1', 'child2']);
+      expect(written.every(doc => doc._deleted)).to.be.true;
+    });
+
+    it('filters out tombstone documents from the subtree', async () => {
+      stubCount(2);
+      query
+        .withArgs(CONTACTS_BY_DEPTH, sinon.match({ include_docs: true }))
+        .resolves({ rows: [
+          contactRow(contactDoc('root')),
+          contactRow({ _id: 'old', _rev: '2-abc', type: 'tombstone' }),
+        ] });
+      stubReports([]);
+
+      const result = await service.deleteHierarchy('root');
+
+      expect(result.deleted_contacts).to.equal(1);
+      expect(bulkDocs.firstCall.args[0].map(doc => doc._id)).to.deep.equal(['root']);
+    });
+
+    it('queries reports_by_subject by both uuid and shortcode, and dedupes reports', async () => {
+      const report = reportDoc('r1');
+      stubCount(1);
+      stubSubtree([contactDoc('c1', { patient_id: 'SC1' })]);
+      // same report emitted under both the uuid key and the shortcode key
+      query
+        .withArgs(REPORTS_BY_SUBJECT, sinon.match.any)
+        .resolves({ rows: [reportRow(report), reportRow(report)] });
+
+      const result = await service.deleteHierarchy('c1');
+
+      expect(result.deleted_reports).to.equal(1);
+      const keys = query.withArgs(REPORTS_BY_SUBJECT, sinon.match.any).firstCall.args[1].keys;
+      expect(keys).to.include('c1');
+      expect(keys).to.include('SC1');
+      expect(bulkDocs.firstCall.args[0].map(doc => doc._id)).to.have.members(['c1', 'r1']);
+    });
+
+    it('surfaces per-document bulkDocs errors in the response', async () => {
+      stubCount(1);
+      stubSubtree([contactDoc('c1')]);
+      stubReports([]);
+      bulkDocs.resolves([{ id: 'c1', error: 'conflict', reason: 'Document update conflict' }]);
+
+      const result = await service.deleteHierarchy('c1');
+
+      expect(result.errors).to.deep.equal([
+        { _id: 'c1', error: 'conflict', reason: 'Document update conflict' },
+      ]);
+    });
+
+    it('writes in batches of 100 documents', async () => {
+      const docs = [];
+      for (let i = 0; i < 150; i++) {
+        docs.push(contactDoc(`c${i}`));
+      }
+      stubCount(150);
+      stubSubtree(docs);
+      stubReports([]);
+
+      await service.deleteHierarchy('c0');
+
+      expect(bulkDocs.callCount).to.equal(2);
+      expect(bulkDocs.firstCall.args[0]).to.have.length(100);
+      expect(bulkDocs.secondCall.args[0]).to.have.length(50);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #11163 (the core delete service). This handles one extra case: when the contact being deleted is the primary contact of a place that isn't itself being deleted, clear that place's `contact` field so it doesn't end up pointing at a deleted doc.

It uses `updateParentContacts` from `@medic/bulk-docs-utils` (set up the same way as in `api/src/services/replication/bulk-docs.js`), and skips any parent that's also in the delete set so nothing gets written twice.

This sits on top of #11163, so the diff here currently includes that commit too. The new work is just the second commit.

One thing worth flagging: cht-conf's `delete-hierarchy.js` doesn't clear parent references, so this goes a little beyond the reference behaviour. I added it so a place isn't left pointing at a contact that no longer exists, but happy to drop it if you'd rather stay closer to cht-conf.

## Changes

- `api/src/services/contact-hierarchy.js`
- `api/tests/mocha/services/contact-hierarchy.spec.js` (3 new tests)

`npm run unit-api`: lint clean, 11 passing.

Review/merge bottom-up: #11163 → #11167 → #11172 → #11176