### PR TITLE
feat(#10626): add DELETE /api/v1/contact/:uuid endpoint

### DIFF
--- a/api/src/controllers/contact.js
+++ b/api/src/controllers/contact.js
@@ -2,6 +2,7 @@ const auth = require('../auth');
 const { Contact, Qualifier } = require('@medic/cht-datasource');
 const ctx = require('../services/data-context');
 const serverUtils = require('../server-utils');
+const contactHierarchy = require('../services/contact-hierarchy');
 
 const getContact = ctx.bind(Contact.v1.get);
 const getContactWithLineage = ctx.bind(Contact.v1.getWithLineage);
@@ -131,6 +132,70 @@ module.exports = {
       }
       const docs = await getContactIds(qualifier, req.query.cursor, req.query.limit);
       return res.json(docs);
+    }),
+
+    /**
+     * @openapi
+     * /api/v1/contact/{uuid}:
+     *   delete:
+     *     summary: Delete a contact
+     *     operationId: v1ContactUuidDelete
+     *     description: >
+     *       Deletes the contact identified by `uuid` and all reports for which it is the subject.
+     *       Without `recursive=true`, a contact that has child contacts is rejected. With
+     *       `recursive=true`, the contact and its entire descendant hierarchy are deleted.
+     *     tags: [Contact]
+     *     x-since: 4.22.0
+     *     x-permissions:
+     *       hasAny: [can_delete_contacts, can_edit]
+     *     parameters:
+     *       - in: path
+     *         name: uuid
+     *         required: true
+     *         schema:
+     *           type: string
+     *         description: The id of the contact to delete
+     *       - in: query
+     *         name: recursive
+     *         required: false
+     *         schema:
+     *           type: boolean
+     *           default: false
+     *         description: When true, also delete all descendant contacts and their reports
+     *     responses:
+     *       '200':
+     *         description: Summary of the deleted documents
+     *         content:
+     *           application/json:
+     *             schema:
+     *               type: object
+     *               properties:
+     *                 deleted_contacts:
+     *                   type: integer
+     *                 deleted_reports:
+     *                   type: integer
+     *                 errors:
+     *                   type: array
+     *                   items:
+     *                     type: object
+     *       '400':
+     *         $ref: '#/components/responses/BadRequest'
+     *       '401':
+     *         $ref: '#/components/responses/Unauthorized'
+     *       '403':
+     *         $ref: '#/components/responses/Forbidden'
+     *       '404':
+     *         $ref: '#/components/responses/NotFound'
+     */
+    delete: serverUtils.doOrError(async (req, res) => {
+      await auth.assertPermissions(req, { isOnline: true, hasAny: ['can_delete_contacts', 'can_edit'] });
+      const { uuid } = req.params;
+      const recursive = req.query.recursive === 'true';
+      const result = await contactHierarchy.deleteHierarchy(uuid, { recursive });
+      if (!result) {
+        return serverUtils.error({ status: 404, message: `Contact with id '${uuid}' could not be found` }, req, res);
+      }
+      return res.json(result);
     }),
   },
 };

--- a/api/src/controllers/contact.js
+++ b/api/src/controllers/contact.js
@@ -18,7 +18,7 @@ module.exports = {
   v1: {
     /**
      * @openapi
-     * /api/v1/contact/{id}:
+     * /api/v1/contact/{uuid}:
      *   get:
      *     summary: Get a contact by id
      *     operationId: v1ContactIdGet
@@ -30,7 +30,7 @@ module.exports = {
      *       hasAll: [can_view_contacts]
      *     parameters:
      *       - in: path
-     *         name: id
+     *         name: uuid
      *         required: true
      *         schema:
      *           type: string

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -739,6 +739,7 @@ app.putJson('/api/v1/person/:uuid', person.v1.update);
 
 app.get('/api/v1/contact/uuid', contact.v1.getUuids);
 app.get('/api/v1/contact/:uuid', contact.v1.get);
+app.delete('/api/v1/contact/:uuid', contact.v1.delete);
 
 app.get('/api/v1/report/uuid', report.v1.getUuids);
 app.get('/api/v1/report/:uuid', report.v1.get);

--- a/api/src/services/contact-hierarchy.js
+++ b/api/src/services/contact-hierarchy.js
@@ -8,20 +8,15 @@ const BATCH_SIZE = 100;
 const MAX_HIERARCHY_SIZE = 5000;
 
 // contacts_by_depth emits a bare [ancestorId] key for a contact and each of its
-// ancestors, so { key: [contactId] } returns one row per member of the subtree.
-const countSubtree = async (contactId) => {
-  const result = await db.medic.query('medic/contacts_by_depth', { key: [contactId] });
-  return result.rows.length;
-};
-
-const getSubtreeContacts = async (contactId) => {
+// ancestors, so { key: [contactId] } returns one row per member of the subtree. Cap the
+// query one past the max so an oversized hierarchy is rejected without loading it all.
+const getSubtreeRows = async (contactId) => {
   const result = await db.medic.query('medic/contacts_by_depth', {
     key: [contactId],
     include_docs: true,
+    limit: MAX_HIERARCHY_SIZE + 1,
   });
-  return result.rows
-    .map(row => row.doc)
-    .filter(doc => doc && doc.type !== 'tombstone');
+  return result.rows;
 };
 
 // reports_by_subject indexes by both shortcode (patient_id/place_id) and uuid, so a
@@ -65,24 +60,27 @@ const bulkWrite = async (docs) => {
 };
 
 const deleteHierarchy = async (contactId, { recursive = false } = {}) => {
-  const count = await countSubtree(contactId);
-  if (!count) {
+  const rows = await getSubtreeRows(contactId);
+  const subtreeSize = rows.length;
+  if (!subtreeSize) {
     return null;
   }
-  if (!recursive && count > 1) {
+  if (!recursive && subtreeSize > 1) {
     const error = new Error('Contact has descendants. Pass recursive=true to delete the whole hierarchy.');
     error.code = 400;
     throw error;
   }
-  if (count > MAX_HIERARCHY_SIZE) {
+  if (subtreeSize > MAX_HIERARCHY_SIZE) {
     const error = new Error(
-      `Hierarchy too large to delete via the API (${count} contacts, max ${MAX_HIERARCHY_SIZE}). Use cht-conf instead.`
+      `Hierarchy too large to delete via the API (more than ${MAX_HIERARCHY_SIZE} contacts). Use cht-conf instead.`
     );
     error.code = 400;
     throw error;
   }
 
-  const contacts = await getSubtreeContacts(contactId);
+  const contacts = rows
+    .map(row => row.doc)
+    .filter(doc => doc && doc.type !== 'tombstone');
   const reports = await getSubjectReports(contacts);
 
   const deletedDocs = [...contacts, ...reports].map(doc => ({ ...doc, _deleted: true }));
@@ -93,12 +91,13 @@ const deleteHierarchy = async (contactId, { recursive = false } = {}) => {
   const parentUpdates = parents.filter(parent => !deletedIds.has(parent._id));
 
   const errors = await bulkWrite([...deletedDocs, ...parentUpdates]);
+  const failedIds = new Set(errors.map(error => error._id));
 
   logger.info(`Deleted contact ${contactId}: ${contacts.length} contact(s), ${reports.length} report(s)`);
 
   return {
-    deleted_contacts: contacts.length,
-    deleted_reports: reports.length,
+    deleted_contacts: contacts.filter(contact => !failedIds.has(contact._id)).length,
+    deleted_reports: reports.filter(report => !failedIds.has(report._id)).length,
     errors,
   };
 };

--- a/api/src/services/contact-hierarchy.js
+++ b/api/src/services/contact-hierarchy.js
@@ -6,6 +6,7 @@ const bulkDocsUtils = require('@medic/bulk-docs-utils')({ Promise, dataContext }
 
 const BATCH_SIZE = 100;
 const MAX_HIERARCHY_SIZE = 5000;
+const MAX_WRITE_ATTEMPTS = 3;
 
 // contacts_by_depth emits a bare [ancestorId] key for a contact and each of its
 // ancestors, so { key: [contactId] } returns one row per member of the subtree. Cap the
@@ -19,42 +20,75 @@ const getSubtreeRows = async (contactId) => {
   return result.rows;
 };
 
-// reports_by_subject indexes by both shortcode (patient_id/place_id) and uuid, so a
-// contact's reports are matched by either identifier.
-const getSubjectKeys = (contacts) => {
-  const keys = new Set();
-  contacts.forEach((contact) => {
-    keys.add(contact._id);
-    const shortcode = contact.patient_id || contact.place_id;
-    if (shortcode) {
-      keys.add(shortcode);
-    }
-  });
-  return [...keys];
-};
-
+// Match reports by the contact uuid only. reports_by_subject also indexes shortcodes
+// (patient_id/place_id), but those are resolvable references rather than guaranteed-unique
+// permanent ids, so matching on them risks deleting a report about a different contact that
+// shares or has reused a shortcode. cht-conf's delete queries by uuid for the same reason.
 const getSubjectReports = async (contacts) => {
-  const keys = getSubjectKeys(contacts);
+  const ids = contacts.map(contact => contact._id);
   const reportsById = new Map();
-  for (let i = 0; i < keys.length; i += BATCH_SIZE) {
-    const result = await db.medic.query('medic-client/reports_by_subject', {
-      keys: keys.slice(i, i + BATCH_SIZE),
-      include_docs: true,
-    });
-    result.rows.forEach(row => row.doc && reportsById.set(row.doc._id, row.doc));
+  for (let i = 0; i < ids.length; i += BATCH_SIZE) {
+    const keys = ids.slice(i, i + BATCH_SIZE);
+    // Page through the results so a subject with a very large report volume does not load
+    // every matching doc into memory in a single response.
+    let skip = 0;
+    let rows;
+    do {
+      const result = await db.medic.query('medic-client/reports_by_subject', {
+        keys,
+        include_docs: true,
+        limit: BATCH_SIZE,
+        skip,
+      });
+      rows = result.rows;
+      rows.forEach(row => row.doc && reportsById.set(row.doc._id, row.doc));
+      skip += rows.length;
+    } while (rows.length >= BATCH_SIZE);
   }
   return [...reportsById.values()];
 };
 
+// Re-fetch fresh revisions for docs that hit a conflict and re-apply the intended change
+// (deletion, or clearing a parent's primary-contact reference) so the retry is not stale.
+const refreshConflicts = async (docs) => {
+  const result = await db.medic.allDocs({ keys: docs.map(doc => doc._id), include_docs: true });
+  const liveById = new Map();
+  result.rows.forEach(row => row.doc && liveById.set(row.doc._id, row.doc));
+  return docs
+    .map((doc) => {
+      const live = liveById.get(doc._id);
+      if (!live) {
+        return null;
+      }
+      return doc._deleted ? { ...live, _deleted: true } : { ...live, contact: null };
+    })
+    .filter(doc => doc);
+};
+
 const bulkWrite = async (docs) => {
   const errors = [];
-  for (let i = 0; i < docs.length; i += BATCH_SIZE) {
-    const results = await db.medic.bulkDocs(docs.slice(i, i + BATCH_SIZE));
-    results.forEach((result) => {
-      if (result.error) {
-        errors.push({ _id: result.id, error: result.error, reason: result.reason });
-      }
-    });
+  let pending = docs;
+  for (let attempt = 1; pending.length; attempt++) {
+    const conflicts = [];
+    for (let i = 0; i < pending.length; i += BATCH_SIZE) {
+      const batch = pending.slice(i, i + BATCH_SIZE);
+      const results = await db.medic.bulkDocs(batch);
+      results.forEach((result, index) => {
+        if (!result.error) {
+          return;
+        }
+        // A conflict means another client wrote the doc first; retry with a fresh revision.
+        if (result.error === 'conflict' && attempt < MAX_WRITE_ATTEMPTS) {
+          conflicts.push(batch[index]);
+        } else {
+          errors.push({ _id: result.id, error: result.error, reason: result.reason });
+        }
+      });
+    }
+    if (!conflicts.length) {
+      break;
+    }
+    pending = await refreshConflicts(conflicts);
   }
   return errors;
 };

--- a/api/src/services/contact-hierarchy.js
+++ b/api/src/services/contact-hierarchy.js
@@ -62,13 +62,15 @@ const refreshConflicts = async (docs) => {
       }
       return doc._deleted ? { ...live, _deleted: true } : { ...live, contact: null };
     })
-    .filter(doc => doc);
+    .filter(Boolean);
 };
 
 const bulkWrite = async (docs) => {
   const errors = [];
   let pending = docs;
-  for (let attempt = 1; pending.length; attempt++) {
+  let attempt = 0;
+  while (pending.length) {
+    attempt += 1;
     const conflicts = [];
     for (let i = 0; i < pending.length; i += BATCH_SIZE) {
       const batch = pending.slice(i, i + BATCH_SIZE);

--- a/api/src/services/contact-hierarchy.js
+++ b/api/src/services/contact-hierarchy.js
@@ -1,5 +1,8 @@
 const db = require('../db');
+const dataContext = require('./data-context');
 const logger = require('@medic/logger');
+
+const bulkDocsUtils = require('@medic/bulk-docs-utils')({ Promise, dataContext });
 
 const BATCH_SIZE = 100;
 const MAX_HIERARCHY_SIZE = 5000;
@@ -48,11 +51,10 @@ const getSubjectReports = async (contacts) => {
   return [...reportsById.values()];
 };
 
-const bulkDelete = async (docs) => {
+const bulkWrite = async (docs) => {
   const errors = [];
-  const tombstones = docs.map(doc => ({ ...doc, _deleted: true }));
-  for (let i = 0; i < tombstones.length; i += BATCH_SIZE) {
-    const results = await db.medic.bulkDocs(tombstones.slice(i, i + BATCH_SIZE));
+  for (let i = 0; i < docs.length; i += BATCH_SIZE) {
+    const results = await db.medic.bulkDocs(docs.slice(i, i + BATCH_SIZE));
     results.forEach((result) => {
       if (result.error) {
         errors.push({ _id: result.id, error: result.error, reason: result.reason });
@@ -77,7 +79,15 @@ const deleteHierarchy = async (contactId) => {
 
   const contacts = await getSubtreeContacts(contactId);
   const reports = await getSubjectReports(contacts);
-  const errors = await bulkDelete([...contacts, ...reports]);
+
+  const deletedDocs = [...contacts, ...reports].map(doc => ({ ...doc, _deleted: true }));
+  const deletedIds = new Set(deletedDocs.map(doc => doc._id));
+
+  // Clear the primary-contact reference on any surviving parent of a deleted contact.
+  const { docs: parents } = await bulkDocsUtils.updateParentContacts(deletedDocs);
+  const parentUpdates = parents.filter(parent => !deletedIds.has(parent._id));
+
+  const errors = await bulkWrite([...deletedDocs, ...parentUpdates]);
 
   logger.info(`Deleted contact ${contactId}: ${contacts.length} contact(s), ${reports.length} report(s)`);
 

--- a/api/src/services/contact-hierarchy.js
+++ b/api/src/services/contact-hierarchy.js
@@ -64,10 +64,15 @@ const bulkWrite = async (docs) => {
   return errors;
 };
 
-const deleteHierarchy = async (contactId) => {
+const deleteHierarchy = async (contactId, { recursive = false } = {}) => {
   const count = await countSubtree(contactId);
   if (!count) {
     return null;
+  }
+  if (!recursive && count > 1) {
+    const error = new Error('Contact has descendants. Pass recursive=true to delete the whole hierarchy.');
+    error.code = 400;
+    throw error;
   }
   if (count > MAX_HIERARCHY_SIZE) {
     const error = new Error(

--- a/api/src/services/contact-hierarchy.js
+++ b/api/src/services/contact-hierarchy.js
@@ -1,0 +1,93 @@
+const db = require('../db');
+const logger = require('@medic/logger');
+
+const BATCH_SIZE = 100;
+const MAX_HIERARCHY_SIZE = 5000;
+
+// contacts_by_depth emits a bare [ancestorId] key for a contact and each of its
+// ancestors, so { key: [contactId] } returns one row per member of the subtree.
+const countSubtree = async (contactId) => {
+  const result = await db.medic.query('medic/contacts_by_depth', { key: [contactId] });
+  return result.rows.length;
+};
+
+const getSubtreeContacts = async (contactId) => {
+  const result = await db.medic.query('medic/contacts_by_depth', {
+    key: [contactId],
+    include_docs: true,
+  });
+  return result.rows
+    .map(row => row.doc)
+    .filter(doc => doc && doc.type !== 'tombstone');
+};
+
+// reports_by_subject indexes by both shortcode (patient_id/place_id) and uuid, so a
+// contact's reports are matched by either identifier.
+const getSubjectKeys = (contacts) => {
+  const keys = new Set();
+  contacts.forEach((contact) => {
+    keys.add(contact._id);
+    const shortcode = contact.patient_id || contact.place_id;
+    if (shortcode) {
+      keys.add(shortcode);
+    }
+  });
+  return [...keys];
+};
+
+const getSubjectReports = async (contacts) => {
+  const keys = getSubjectKeys(contacts);
+  const reportsById = new Map();
+  for (let i = 0; i < keys.length; i += BATCH_SIZE) {
+    const result = await db.medic.query('medic-client/reports_by_subject', {
+      keys: keys.slice(i, i + BATCH_SIZE),
+      include_docs: true,
+    });
+    result.rows.forEach(row => row.doc && reportsById.set(row.doc._id, row.doc));
+  }
+  return [...reportsById.values()];
+};
+
+const bulkDelete = async (docs) => {
+  const errors = [];
+  const tombstones = docs.map(doc => ({ ...doc, _deleted: true }));
+  for (let i = 0; i < tombstones.length; i += BATCH_SIZE) {
+    const results = await db.medic.bulkDocs(tombstones.slice(i, i + BATCH_SIZE));
+    results.forEach((result) => {
+      if (result.error) {
+        errors.push({ _id: result.id, error: result.error, reason: result.reason });
+      }
+    });
+  }
+  return errors;
+};
+
+const deleteHierarchy = async (contactId) => {
+  const count = await countSubtree(contactId);
+  if (!count) {
+    return null;
+  }
+  if (count > MAX_HIERARCHY_SIZE) {
+    const error = new Error(
+      `Hierarchy too large to delete via the API (${count} contacts, max ${MAX_HIERARCHY_SIZE}). Use cht-conf instead.`
+    );
+    error.code = 400;
+    throw error;
+  }
+
+  const contacts = await getSubtreeContacts(contactId);
+  const reports = await getSubjectReports(contacts);
+  const errors = await bulkDelete([...contacts, ...reports]);
+
+  logger.info(`Deleted contact ${contactId}: ${contacts.length} contact(s), ${reports.length} report(s)`);
+
+  return {
+    deleted_contacts: contacts.length,
+    deleted_reports: reports.length,
+    errors,
+  };
+};
+
+module.exports = {
+  deleteHierarchy,
+};

--- a/api/tests/mocha/controllers/contact.spec.js
+++ b/api/tests/mocha/controllers/contact.spec.js
@@ -2,6 +2,7 @@ const sinon = require('sinon');
 const auth = require('../../../src/auth');
 const dataContext = require('../../../src/services/data-context');
 const serverUtils = require('../../../src/server-utils');
+const contactHierarchy = require('../../../src/services/contact-hierarchy');
 const { Contact, Qualifier } = require('@medic/cht-datasource');
 const {expect} = require('chai');
 
@@ -250,6 +251,62 @@ describe('Contact Controller', () => {
         expect(qualifierByFreetext.notCalled).to.be.true;
         expect(contactGetUuidsPage.notCalled).to.be.true;
         expect(res.json.notCalled).to.be.true;
+        expect(serverUtilsError.calledOnceWithExactly(err, req, res)).to.be.true;
+      });
+    });
+
+    describe('delete', () => {
+      let deleteHierarchy;
+
+      beforeEach(() => {
+        deleteHierarchy = sinon.stub(contactHierarchy, 'deleteHierarchy');
+        req = { params: { uuid: 'contact-1' }, query: {} };
+      });
+
+      it('deletes a contact and returns the summary', async () => {
+        const result = { deleted_contacts: 3, deleted_reports: 5, errors: [] };
+        deleteHierarchy.resolves(result);
+
+        await controller.v1.delete(req, res);
+
+        expect(assertPermissions.calledOnceWithExactly(
+          req,
+          { isOnline: true, hasAny: ['can_delete_contacts', 'can_edit'] }
+        )).to.be.true;
+        expect(deleteHierarchy.calledOnceWithExactly('contact-1', { recursive: false })).to.be.true;
+        expect(res.json.calledOnceWithExactly(result)).to.be.true;
+        expect(serverUtilsError.notCalled).to.be.true;
+      });
+
+      it('passes recursive=true through when the query param is set', async () => {
+        req.query = { recursive: 'true' };
+        deleteHierarchy.resolves({ deleted_contacts: 1, deleted_reports: 0, errors: [] });
+
+        await controller.v1.delete(req, res);
+
+        expect(deleteHierarchy.calledOnceWithExactly('contact-1', { recursive: true })).to.be.true;
+      });
+
+      it('returns 404 when the contact does not exist', async () => {
+        deleteHierarchy.resolves(null);
+
+        await controller.v1.delete(req, res);
+
+        expect(serverUtilsError.calledOnceWithExactly(
+          { status: 404, message: `Contact with id 'contact-1' could not be found` },
+          req,
+          res
+        )).to.be.true;
+        expect(res.json.notCalled).to.be.true;
+      });
+
+      it('surfaces a permission failure', async () => {
+        const err = new Error('Insufficient privileges');
+        assertPermissions.rejects(err);
+
+        await controller.v1.delete(req, res);
+
+        expect(deleteHierarchy.notCalled).to.be.true;
         expect(serverUtilsError.calledOnceWithExactly(err, req, res)).to.be.true;
       });
     });

--- a/api/tests/mocha/services/contact-hierarchy.spec.js
+++ b/api/tests/mocha/services/contact-hierarchy.spec.js
@@ -1,6 +1,7 @@
 const sinon = require('sinon');
 const { expect } = require('chai');
 const db = require('../../../src/db');
+const dataContext = require('../../../src/services/data-context');
 const service = require('../../../src/services/contact-hierarchy');
 
 const CONTACTS_BY_DEPTH = 'medic/contacts_by_depth';
@@ -18,6 +19,7 @@ describe('contact-hierarchy service', () => {
   beforeEach(() => {
     query = sinon.stub(db.medic, 'query');
     bulkDocs = sinon.stub(db.medic, 'bulkDocs').resolves([]);
+    sinon.stub(dataContext, 'bind').returns(sinon.stub().resolves(undefined));
   });
 
   afterEach(() => sinon.restore());
@@ -131,6 +133,52 @@ describe('contact-hierarchy service', () => {
       expect(result.errors).to.deep.equal([
         { _id: 'c1', error: 'conflict', reason: 'Document update conflict' },
       ]);
+    });
+
+    it('clears the primary-contact reference on a deleted contact\'s surviving parent', async () => {
+      stubCount(1);
+      stubSubtree([contactDoc('chw', { parent: { _id: 'hca' } })]);
+      stubReports([]);
+      const parent = { _id: 'hca', _rev: '1-abc', type: 'health_center', contact: { _id: 'chw' } };
+      dataContext.bind.returns(sinon.stub().resolves(parent));
+
+      await service.deleteHierarchy('chw');
+
+      const written = bulkDocs.firstCall.args[0];
+      const writtenParent = written.find(doc => doc._id === 'hca');
+      expect(writtenParent).to.exist;
+      expect(writtenParent.contact).to.be.null;
+      expect(writtenParent._deleted).to.be.undefined;
+    });
+
+    it('leaves a parent untouched when its primary contact is not being deleted', async () => {
+      stubCount(1);
+      stubSubtree([contactDoc('chw', { parent: { _id: 'hca' } })]);
+      stubReports([]);
+      const parent = { _id: 'hca', _rev: '1-abc', type: 'health_center', contact: { _id: 'someone-else' } };
+      dataContext.bind.returns(sinon.stub().resolves(parent));
+
+      await service.deleteHierarchy('chw');
+
+      expect(bulkDocs.firstCall.args[0].map(doc => doc._id)).to.deep.equal(['chw']);
+    });
+
+    it('does not write a parent that is itself being deleted', async () => {
+      stubCount(2);
+      stubSubtree([
+        contactDoc('place', { type: 'clinic', parent: { _id: 'hc' }, contact: { _id: 'person' } }),
+        contactDoc('person', { parent: { _id: 'place' } }),
+      ]);
+      stubReports([]);
+      // the deleted person is the primary contact of the deleted place
+      const place = { _id: 'place', _rev: '1-abc', type: 'clinic', contact: { _id: 'person' } };
+      dataContext.bind.returns(sinon.stub().resolves(place));
+
+      await service.deleteHierarchy('place');
+
+      const written = bulkDocs.firstCall.args[0];
+      expect(written.filter(doc => doc._id === 'place')).to.have.length(1);
+      expect(written.every(doc => doc._deleted)).to.be.true;
     });
 
     it('writes in batches of 100 documents', async () => {

--- a/api/tests/mocha/services/contact-hierarchy.spec.js
+++ b/api/tests/mocha/services/contact-hierarchy.spec.js
@@ -51,7 +51,7 @@ describe('contact-hierarchy service', () => {
       stubCount(5001);
 
       try {
-        await service.deleteHierarchy('huge');
+        await service.deleteHierarchy('huge', { recursive: true });
         expect.fail('expected deleteHierarchy to throw');
       } catch (err) {
         expect(err.code).to.equal(400);
@@ -75,12 +75,25 @@ describe('contact-hierarchy service', () => {
       expect(written[0]._deleted).to.be.true;
     });
 
+    it('rejects with code 400 when the contact has descendants and recursive is not set', async () => {
+      stubCount(3);
+
+      try {
+        await service.deleteHierarchy('root');
+        expect.fail('expected deleteHierarchy to throw');
+      } catch (err) {
+        expect(err.code).to.equal(400);
+        expect(err.message).to.contain('recursive=true');
+      }
+      expect(bulkDocs.called).to.be.false;
+    });
+
     it('recursively deletes the contact and all of its descendants', async () => {
       stubCount(3);
       stubSubtree([contactDoc('root'), contactDoc('child1'), contactDoc('child2')]);
       stubReports([]);
 
-      const result = await service.deleteHierarchy('root');
+      const result = await service.deleteHierarchy('root', { recursive: true });
 
       expect(result.deleted_contacts).to.equal(3);
       const written = bulkDocs.firstCall.args[0];
@@ -98,7 +111,7 @@ describe('contact-hierarchy service', () => {
         ] });
       stubReports([]);
 
-      const result = await service.deleteHierarchy('root');
+      const result = await service.deleteHierarchy('root', { recursive: true });
 
       expect(result.deleted_contacts).to.equal(1);
       expect(bulkDocs.firstCall.args[0].map(doc => doc._id)).to.deep.equal(['root']);
@@ -174,7 +187,7 @@ describe('contact-hierarchy service', () => {
       const place = { _id: 'place', _rev: '1-abc', type: 'clinic', contact: { _id: 'person' } };
       dataContext.bind.returns(sinon.stub().resolves(place));
 
-      await service.deleteHierarchy('place');
+      await service.deleteHierarchy('place', { recursive: true });
 
       const written = bulkDocs.firstCall.args[0];
       expect(written.filter(doc => doc._id === 'place')).to.have.length(1);
@@ -190,7 +203,7 @@ describe('contact-hierarchy service', () => {
       stubSubtree(docs);
       stubReports([]);
 
-      await service.deleteHierarchy('c0');
+      await service.deleteHierarchy('c0', { recursive: true });
 
       expect(bulkDocs.callCount).to.equal(2);
       expect(bulkDocs.firstCall.args[0]).to.have.length(100);

--- a/api/tests/mocha/services/contact-hierarchy.spec.js
+++ b/api/tests/mocha/services/contact-hierarchy.spec.js
@@ -24,14 +24,14 @@ describe('contact-hierarchy service', () => {
 
   afterEach(() => sinon.restore());
 
-  // count query omits include_docs; subtree query sets it.
-  const stubCount = (count) => query
-    .withArgs(CONTACTS_BY_DEPTH, sinon.match(opts => !opts.include_docs))
-    .resolves({ rows: new Array(count).fill({ id: 'x', key: ['x'] }) });
-
   const stubSubtree = (docs) => query
     .withArgs(CONTACTS_BY_DEPTH, sinon.match({ include_docs: true }))
     .resolves({ rows: docs.map(contactRow) });
+
+  // For guard tests we only care about the subtree row count, not the doc bodies.
+  const stubSubtreeRows = (count) => query
+    .withArgs(CONTACTS_BY_DEPTH, sinon.match({ include_docs: true }))
+    .resolves({ rows: new Array(count).fill({ id: 'x', key: ['x'] }) });
 
   const stubReports = (docs) => query
     .withArgs(REPORTS_BY_SUBJECT, sinon.match.any)
@@ -39,7 +39,7 @@ describe('contact-hierarchy service', () => {
 
   describe('deleteHierarchy', () => {
     it('returns null when the contact does not exist', async () => {
-      stubCount(0);
+      stubSubtreeRows(0);
 
       const result = await service.deleteHierarchy('missing');
 
@@ -48,7 +48,7 @@ describe('contact-hierarchy service', () => {
     });
 
     it('rejects with code 400 when the subtree exceeds the size guard', async () => {
-      stubCount(5001);
+      stubSubtreeRows(5001);
 
       try {
         await service.deleteHierarchy('huge', { recursive: true });
@@ -61,7 +61,6 @@ describe('contact-hierarchy service', () => {
     });
 
     it('deletes a single contact with no children or reports', async () => {
-      stubCount(1);
       stubSubtree([contactDoc('c1', { patient_id: 'SC1' })]);
       stubReports([]);
 
@@ -76,7 +75,7 @@ describe('contact-hierarchy service', () => {
     });
 
     it('rejects with code 400 when the contact has descendants and recursive is not set', async () => {
-      stubCount(3);
+      stubSubtreeRows(3);
 
       try {
         await service.deleteHierarchy('root');
@@ -89,7 +88,6 @@ describe('contact-hierarchy service', () => {
     });
 
     it('recursively deletes the contact and all of its descendants', async () => {
-      stubCount(3);
       stubSubtree([contactDoc('root'), contactDoc('child1'), contactDoc('child2')]);
       stubReports([]);
 
@@ -102,7 +100,6 @@ describe('contact-hierarchy service', () => {
     });
 
     it('filters out tombstone documents from the subtree', async () => {
-      stubCount(2);
       query
         .withArgs(CONTACTS_BY_DEPTH, sinon.match({ include_docs: true }))
         .resolves({ rows: [
@@ -119,7 +116,6 @@ describe('contact-hierarchy service', () => {
 
     it('queries reports_by_subject by both uuid and shortcode, and dedupes reports', async () => {
       const report = reportDoc('r1');
-      stubCount(1);
       stubSubtree([contactDoc('c1', { patient_id: 'SC1' })]);
       // same report emitted under both the uuid key and the shortcode key
       query
@@ -135,8 +131,7 @@ describe('contact-hierarchy service', () => {
       expect(bulkDocs.firstCall.args[0].map(doc => doc._id)).to.have.members(['c1', 'r1']);
     });
 
-    it('surfaces per-document bulkDocs errors in the response', async () => {
-      stubCount(1);
+    it('surfaces per-document bulkDocs errors and excludes them from the deleted counts', async () => {
       stubSubtree([contactDoc('c1')]);
       stubReports([]);
       bulkDocs.resolves([{ id: 'c1', error: 'conflict', reason: 'Document update conflict' }]);
@@ -146,10 +141,22 @@ describe('contact-hierarchy service', () => {
       expect(result.errors).to.deep.equal([
         { _id: 'c1', error: 'conflict', reason: 'Document update conflict' },
       ]);
+      expect(result.deleted_contacts).to.equal(0);
+    });
+
+    it('reports only the documents that were actually deleted when some writes fail', async () => {
+      stubSubtree([contactDoc('root'), contactDoc('child')]);
+      stubReports([reportDoc('r1')]);
+      bulkDocs.resolves([{ id: 'child', error: 'conflict', reason: 'Document update conflict' }]);
+
+      const result = await service.deleteHierarchy('root', { recursive: true });
+
+      expect(result.deleted_contacts).to.equal(1);
+      expect(result.deleted_reports).to.equal(1);
+      expect(result.errors).to.have.length(1);
     });
 
     it('clears the primary-contact reference on a deleted contact\'s surviving parent', async () => {
-      stubCount(1);
       stubSubtree([contactDoc('chw', { parent: { _id: 'hca' } })]);
       stubReports([]);
       const parent = { _id: 'hca', _rev: '1-abc', type: 'health_center', contact: { _id: 'chw' } };
@@ -165,7 +172,6 @@ describe('contact-hierarchy service', () => {
     });
 
     it('leaves a parent untouched when its primary contact is not being deleted', async () => {
-      stubCount(1);
       stubSubtree([contactDoc('chw', { parent: { _id: 'hca' } })]);
       stubReports([]);
       const parent = { _id: 'hca', _rev: '1-abc', type: 'health_center', contact: { _id: 'someone-else' } };
@@ -177,7 +183,6 @@ describe('contact-hierarchy service', () => {
     });
 
     it('does not write a parent that is itself being deleted', async () => {
-      stubCount(2);
       stubSubtree([
         contactDoc('place', { type: 'clinic', parent: { _id: 'hc' }, contact: { _id: 'person' } }),
         contactDoc('person', { parent: { _id: 'place' } }),
@@ -199,7 +204,6 @@ describe('contact-hierarchy service', () => {
       for (let i = 0; i < 150; i++) {
         docs.push(contactDoc(`c${i}`));
       }
-      stubCount(150);
       stubSubtree(docs);
       stubReports([]);
 

--- a/api/tests/mocha/services/contact-hierarchy.spec.js
+++ b/api/tests/mocha/services/contact-hierarchy.spec.js
@@ -1,0 +1,152 @@
+const sinon = require('sinon');
+const { expect } = require('chai');
+const db = require('../../../src/db');
+const service = require('../../../src/services/contact-hierarchy');
+
+const CONTACTS_BY_DEPTH = 'medic/contacts_by_depth';
+const REPORTS_BY_SUBJECT = 'medic-client/reports_by_subject';
+
+const contactDoc = (id, extra = {}) => ({ _id: id, _rev: '1-abc', type: 'person', ...extra });
+const reportDoc = (id) => ({ _id: id, _rev: '1-abc', type: 'data_record', form: 'assessment' });
+const contactRow = (doc) => ({ id: doc._id, key: [doc._id], doc });
+const reportRow = (doc) => ({ id: doc._id, key: 'subject', doc });
+
+describe('contact-hierarchy service', () => {
+  let query;
+  let bulkDocs;
+
+  beforeEach(() => {
+    query = sinon.stub(db.medic, 'query');
+    bulkDocs = sinon.stub(db.medic, 'bulkDocs').resolves([]);
+  });
+
+  afterEach(() => sinon.restore());
+
+  // count query omits include_docs; subtree query sets it.
+  const stubCount = (count) => query
+    .withArgs(CONTACTS_BY_DEPTH, sinon.match(opts => !opts.include_docs))
+    .resolves({ rows: new Array(count).fill({ id: 'x', key: ['x'] }) });
+
+  const stubSubtree = (docs) => query
+    .withArgs(CONTACTS_BY_DEPTH, sinon.match({ include_docs: true }))
+    .resolves({ rows: docs.map(contactRow) });
+
+  const stubReports = (docs) => query
+    .withArgs(REPORTS_BY_SUBJECT, sinon.match.any)
+    .resolves({ rows: docs.map(reportRow) });
+
+  describe('deleteHierarchy', () => {
+    it('returns null when the contact does not exist', async () => {
+      stubCount(0);
+
+      const result = await service.deleteHierarchy('missing');
+
+      expect(result).to.be.null;
+      expect(bulkDocs.called).to.be.false;
+    });
+
+    it('rejects with code 400 when the subtree exceeds the size guard', async () => {
+      stubCount(5001);
+
+      try {
+        await service.deleteHierarchy('huge');
+        expect.fail('expected deleteHierarchy to throw');
+      } catch (err) {
+        expect(err.code).to.equal(400);
+        expect(err.message).to.contain('too large');
+      }
+      expect(bulkDocs.called).to.be.false;
+    });
+
+    it('deletes a single contact with no children or reports', async () => {
+      stubCount(1);
+      stubSubtree([contactDoc('c1', { patient_id: 'SC1' })]);
+      stubReports([]);
+
+      const result = await service.deleteHierarchy('c1');
+
+      expect(result).to.deep.equal({ deleted_contacts: 1, deleted_reports: 0, errors: [] });
+      expect(bulkDocs.calledOnce).to.be.true;
+      const written = bulkDocs.firstCall.args[0];
+      expect(written).to.have.length(1);
+      expect(written[0]._id).to.equal('c1');
+      expect(written[0]._deleted).to.be.true;
+    });
+
+    it('recursively deletes the contact and all of its descendants', async () => {
+      stubCount(3);
+      stubSubtree([contactDoc('root'), contactDoc('child1'), contactDoc('child2')]);
+      stubReports([]);
+
+      const result = await service.deleteHierarchy('root');
+
+      expect(result.deleted_contacts).to.equal(3);
+      const written = bulkDocs.firstCall.args[0];
+      expect(written.map(doc => doc._id)).to.have.members(['root', 'child1', 'child2']);
+      expect(written.every(doc => doc._deleted)).to.be.true;
+    });
+
+    it('filters out tombstone documents from the subtree', async () => {
+      stubCount(2);
+      query
+        .withArgs(CONTACTS_BY_DEPTH, sinon.match({ include_docs: true }))
+        .resolves({ rows: [
+          contactRow(contactDoc('root')),
+          contactRow({ _id: 'old', _rev: '2-abc', type: 'tombstone' }),
+        ] });
+      stubReports([]);
+
+      const result = await service.deleteHierarchy('root');
+
+      expect(result.deleted_contacts).to.equal(1);
+      expect(bulkDocs.firstCall.args[0].map(doc => doc._id)).to.deep.equal(['root']);
+    });
+
+    it('queries reports_by_subject by both uuid and shortcode, and dedupes reports', async () => {
+      const report = reportDoc('r1');
+      stubCount(1);
+      stubSubtree([contactDoc('c1', { patient_id: 'SC1' })]);
+      // same report emitted under both the uuid key and the shortcode key
+      query
+        .withArgs(REPORTS_BY_SUBJECT, sinon.match.any)
+        .resolves({ rows: [reportRow(report), reportRow(report)] });
+
+      const result = await service.deleteHierarchy('c1');
+
+      expect(result.deleted_reports).to.equal(1);
+      const keys = query.withArgs(REPORTS_BY_SUBJECT, sinon.match.any).firstCall.args[1].keys;
+      expect(keys).to.include('c1');
+      expect(keys).to.include('SC1');
+      expect(bulkDocs.firstCall.args[0].map(doc => doc._id)).to.have.members(['c1', 'r1']);
+    });
+
+    it('surfaces per-document bulkDocs errors in the response', async () => {
+      stubCount(1);
+      stubSubtree([contactDoc('c1')]);
+      stubReports([]);
+      bulkDocs.resolves([{ id: 'c1', error: 'conflict', reason: 'Document update conflict' }]);
+
+      const result = await service.deleteHierarchy('c1');
+
+      expect(result.errors).to.deep.equal([
+        { _id: 'c1', error: 'conflict', reason: 'Document update conflict' },
+      ]);
+    });
+
+    it('writes in batches of 100 documents', async () => {
+      const docs = [];
+      for (let i = 0; i < 150; i++) {
+        docs.push(contactDoc(`c${i}`));
+      }
+      stubCount(150);
+      stubSubtree(docs);
+      stubReports([]);
+
+      await service.deleteHierarchy('c0');
+
+      expect(bulkDocs.callCount).to.equal(2);
+      expect(bulkDocs.firstCall.args[0]).to.have.length(100);
+      expect(bulkDocs.secondCall.args[0]).to.have.length(50);
+    });
+  });
+});

--- a/api/tests/mocha/services/contact-hierarchy.spec.js
+++ b/api/tests/mocha/services/contact-hierarchy.spec.js
@@ -15,10 +15,15 @@ const reportRow = (doc) => ({ id: doc._id, key: 'subject', doc });
 describe('contact-hierarchy service', () => {
   let query;
   let bulkDocs;
+  let allDocs;
 
   beforeEach(() => {
     query = sinon.stub(db.medic, 'query');
     bulkDocs = sinon.stub(db.medic, 'bulkDocs').resolves([]);
+    // Conflict retries re-fetch fresh revisions; return a minimal live doc for any id.
+    allDocs = sinon.stub(db.medic, 'allDocs').callsFake(({ keys }) => Promise.resolve({
+      rows: keys.map(id => ({ id, doc: { _id: id, _rev: '9-fresh' } })),
+    }));
     sinon.stub(dataContext, 'bind').returns(sinon.stub().resolves(undefined));
   });
 
@@ -36,6 +41,20 @@ describe('contact-hierarchy service', () => {
   const stubReports = (docs) => query
     .withArgs(REPORTS_BY_SUBJECT, sinon.match.any)
     .resolves({ rows: docs.map(reportRow) });
+
+  // bulkDocs returns one result per input doc; conflict for the given ids until `healAfter`.
+  const stubConflicts = (conflictIds, { healAfter = Infinity } = {}) => {
+    let call = 0;
+    bulkDocs.callsFake((docs) => {
+      call += 1;
+      return Promise.resolve(docs.map((doc) => {
+        const stillConflicts = conflictIds.includes(doc._id) && call < healAfter;
+        return stillConflicts
+          ? { id: doc._id, error: 'conflict', reason: 'Document update conflict' }
+          : { id: doc._id, ok: true };
+      }));
+    });
+  };
 
   describe('deleteHierarchy', () => {
     it('returns null when the contact does not exist', async () => {
@@ -114,10 +133,10 @@ describe('contact-hierarchy service', () => {
       expect(bulkDocs.firstCall.args[0].map(doc => doc._id)).to.deep.equal(['root']);
     });
 
-    it('queries reports_by_subject by both uuid and shortcode, and dedupes reports', async () => {
+    it('queries reports_by_subject by contact uuid only, and dedupes reports', async () => {
       const report = reportDoc('r1');
       stubSubtree([contactDoc('c1', { patient_id: 'SC1' })]);
-      // same report emitted under both the uuid key and the shortcode key
+      // same report emitted under more than one key
       query
         .withArgs(REPORTS_BY_SUBJECT, sinon.match.any)
         .resolves({ rows: [reportRow(report), reportRow(report)] });
@@ -127,14 +146,45 @@ describe('contact-hierarchy service', () => {
       expect(result.deleted_reports).to.equal(1);
       const keys = query.withArgs(REPORTS_BY_SUBJECT, sinon.match.any).firstCall.args[1].keys;
       expect(keys).to.include('c1');
-      expect(keys).to.include('SC1');
+      expect(keys).to.not.include('SC1');
       expect(bulkDocs.firstCall.args[0].map(doc => doc._id)).to.have.members(['c1', 'r1']);
     });
 
-    it('surfaces per-document bulkDocs errors and excludes them from the deleted counts', async () => {
+    it('pages through reports_by_subject until a short page is returned', async () => {
+      stubSubtree([contactDoc('c1')]);
+      const firstPage = [];
+      for (let i = 0; i < 100; i++) {
+        firstPage.push(reportDoc(`r${i}`));
+      }
+      const secondPage = [reportDoc('r100'), reportDoc('r101')];
+      const reportsQuery = query.withArgs(REPORTS_BY_SUBJECT, sinon.match.any);
+      reportsQuery.onFirstCall().resolves({ rows: firstPage.map(reportRow) });
+      reportsQuery.onSecondCall().resolves({ rows: secondPage.map(reportRow) });
+
+      const result = await service.deleteHierarchy('c1');
+
+      expect(result.deleted_reports).to.equal(102);
+      expect(reportsQuery.firstCall.args[1].skip).to.equal(0);
+      expect(reportsQuery.secondCall.args[1].skip).to.equal(100);
+    });
+
+    it('retries a conflicting write with a fresh revision and then succeeds', async () => {
       stubSubtree([contactDoc('c1')]);
       stubReports([]);
-      bulkDocs.resolves([{ id: 'c1', error: 'conflict', reason: 'Document update conflict' }]);
+      stubConflicts(['c1'], { healAfter: 2 });
+
+      const result = await service.deleteHierarchy('c1');
+
+      expect(result.deleted_contacts).to.equal(1);
+      expect(result.errors).to.deep.equal([]);
+      expect(bulkDocs.callCount).to.equal(2);
+      expect(allDocs.calledOnce).to.be.true;
+    });
+
+    it('surfaces a conflict that persists past the retry limit and excludes it from the counts', async () => {
+      stubSubtree([contactDoc('c1')]);
+      stubReports([]);
+      stubConflicts(['c1']);
 
       const result = await service.deleteHierarchy('c1');
 
@@ -142,12 +192,13 @@ describe('contact-hierarchy service', () => {
         { _id: 'c1', error: 'conflict', reason: 'Document update conflict' },
       ]);
       expect(result.deleted_contacts).to.equal(0);
+      expect(bulkDocs.callCount).to.equal(3);
     });
 
-    it('reports only the documents that were actually deleted when some writes fail', async () => {
+    it('reports only the documents that were actually deleted when a write fails', async () => {
       stubSubtree([contactDoc('root'), contactDoc('child')]);
       stubReports([reportDoc('r1')]);
-      bulkDocs.resolves([{ id: 'child', error: 'conflict', reason: 'Document update conflict' }]);
+      stubConflicts(['child']);
 
       const result = await service.deleteHierarchy('root', { recursive: true });
 


### PR DESCRIPTION
## Summary

Follow-up to #11163 and #11167. This adds the HTTP layer for the delete service: `DELETE /api/v1/contact/:uuid`.

By default, deleting a contact that still has children is rejected with a 400, so a single call can't wipe out a whole branch of the hierarchy by accident. Pass `?recursive=true` to delete the contact along with its descendants and the reports they're the subject of. An unknown id returns 404. The endpoint is online-only and gated on `can_delete_contacts` or `can_edit`.

The `recursive` option on the service lives in this PR rather than #11163, since it only matters once there's a transport in front of it deciding whether a recursive delete is allowed.

This sits on top of #11163 and #11167.

## Changes

- `api/src/controllers/contact.js` (delete handler + OpenAPI annotation)
- `api/src/routing.js` (route registration)
- `api/src/services/contact-hierarchy.js` (recursive option)
- `api/tests/mocha/controllers/contact.spec.js` (4 new tests)
- `api/tests/mocha/services/contact-hierarchy.spec.js` (1 new test)

`npm run unit-api`: lint clean, service 12 passing, controller 13 passing.

Review/merge bottom-up: #11163 → #11167 → #11172 → #11176