### PR TITLE
fix(#11181): be more defensive in release notes for null user objects

### DIFF
--- a/scripts/release-notes/index.js
+++ b/scripts/release-notes/index.js
@@ -323,7 +323,7 @@ Commits:
     const lines = [];
     const authors = commits.flatMap((commit) => commit.authors.nodes);
     authors.forEach((author) => {
-      if (author.user === null ){
+      if (author.user === null ) {
         return;
       }
       const { login, name, url } = author.user;

--- a/scripts/release-notes/index.js
+++ b/scripts/release-notes/index.js
@@ -176,7 +176,9 @@ const getIssueNumbers = commitMessage => {
     const authors = commit.authors.nodes;
     let authConcat = '';
     authors.forEach((author) => {
-      authConcat += ` (${author.user.login})`;
+      if (author.user !== null) {
+        authConcat += ` (${author.user.login})`;
+      }
     });
     return authConcat.trim();
   };

--- a/scripts/release-notes/index.js
+++ b/scripts/release-notes/index.js
@@ -323,6 +323,9 @@ Commits:
     const lines = [];
     const authors = commits.flatMap((commit) => commit.authors.nodes);
     authors.forEach((author) => {
+      if (author.user === null ){
+        return;
+      }
       const { login, name, url } = author.user;
       if (login && !ignoreLogins.has(login)) {
         ignoreLogins.add(login);

--- a/scripts/release-notes/index.js
+++ b/scripts/release-notes/index.js
@@ -165,7 +165,7 @@ const getIssueNumbers = commitMessage => {
   const commitMadeByDependabot = commit => {
     let result = false;
     commit.authors.nodes.forEach((author) => {
-      if (BOTS.includes(author.user.login)) {
+      if (author.user !== null && BOTS.includes(author.user.login)) {
         result = true;
       }
     });


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: build|feat|fix|perf|refactor|test|chore

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

In our release notes script we expect the commit objects with users to look like this:

```json
[
  {
    "user": {
      "login": "mrjones-plip",
      "name": "mrjones",
      "url": "https://github.com/mrjones-plip"
    }
  }
]
```

but some times it has a null entry like this:

```json
[
  {
    "user": null
  },
  {
    "user": {
      "login": "OriginalGary",
      "name": "Original Gary",
      "url": "https://github.com/OriginalGary"
    }
  }
]
```

The fix is to then be more defensive and check the variable is set before referencing it. 

See CI that [successfully ran](https://github.com/medic/cht-core/actions/runs/27656592229) against this branch.

closes #11181

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [x] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [x] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:11181-release-notes-fix/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:11181-release-notes-fix/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:11181-release-notes-fix/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

