### PR TITLE
fix(#11198): prevent false ERR_STREAM_PREMATURE_CLOSE errors in node-fetch

### DIFF
--- a/patches/node-fetch+2.7.0.patch
+++ b/patches/node-fetch+2.7.0.patch
@@ -1,0 +1,28 @@
+diff --git a/node_modules/node-fetch/lib/index.js b/node_modules/node-fetch/lib/index.js
+index 567ff5d..48adb3c 100644
+--- a/node_modules/node-fetch/lib/index.js
++++ b/node_modules/node-fetch/lib/index.js
+@@ -1737,6 +1737,14 @@ function fixResponseChunkedTransferBadEnding(request, errorCallback) {
+ 		const headers = response.headers;
+ 
+ 		if (headers['transfer-encoding'] === 'chunked' && !headers['content-length']) {
++			// Node >=22.23.0 / >=24.17.0 (CVE-2026-48931 fix, commit 0a22d40180) keeps the
++			// socket 'data' listener attached after a clean response, so the listener-count
++			// heuristic below alone yields false ERR_STREAM_PREMATURE_CLOSE errors. Track the
++			// response's own 'end' to tell a completed response from a genuinely truncated one.
++			let responseEnded = false;
++			response.once('end', function () {
++				responseEnded = true;
++			});
+ 			response.once('close', function (hadError) {
+ 				// tests for socket presence, as in some situations the
+ 				// the 'socket' event is not triggered for the request
+@@ -1744,7 +1752,7 @@ function fixResponseChunkedTransferBadEnding(request, errorCallback) {
+ 				// if a data listener is still present we didn't end cleanly
+ 				const hasDataListener = socket && socket.listenerCount('data') > 0;
+ 
+-				if (hasDataListener && !hadError) {
++				if (hasDataListener && !hadError && !responseEnded) {
+ 					const err = new Error('Premature close');
+ 					err.code = 'ERR_STREAM_PREMATURE_CLOSE';
+ 					errorCallback(err);


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: build|feat|fix|perf|refactor|test|chore

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

closes #11198 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [ ] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:11198-use-undici-fetch/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:11198-use-undici-fetch/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:11198-use-undici-fetch/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

