### PR TITLE
test(#11207): introduce temp config isolation and cleanup to cht-conf utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ config/*/forms/contact/*.xlsx
 /**/*/.snapshots/local.json
 tests/integration/results/
 allure*
-tests/config-temp
+tests/utils/config-temp
 .eslintcache
 doc-conflicts/
 cht-docker-compose.log

--- a/tests/integration/cht-conf/cht-conf-actions.spec.js
+++ b/tests/integration/cht-conf/cht-conf-actions.spec.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const { DOC_IDS } = require('@medic/constants');
 
-const { runCommand } = require('@utils/cht-conf');
+const chtConfUtils = require('@utils/cht-conf');
 const utils = require('@utils');
 
 //Not all actions tested here due to missing forms and config
@@ -20,20 +20,25 @@ const actions = [
   'upload-branding',
   'upload-partners'
 ];
-const configPath = 'config/default';
+const configPath = chtConfUtils.getDirPath();
 let originalVersion;
 
 describe('cht-conf actions tests', () => {
   before(async () => {
+    await chtConfUtils.copyDefaultConfig();
+
     const settings = await utils.getDoc(DOC_IDS.SETTINGS);
     originalVersion = Number(settings._rev.charAt(0));
     expect(settings.settings.roles).to.not.include.any.keys('program_officer', 'chw_supervisor');
   });
 
-  after(async () => await utils.revertSettings(true));
+  after(async () => {
+    await utils.revertSettings(true);
+    await chtConfUtils.clearTempDir();
+  });
 
   it('should execute upload-app-settings', async () => {
-    const result = await runCommand('upload-app-settings', configPath);
+    const result = await chtConfUtils.runCommand('upload-app-settings', configPath);
     expect(result).to.contain(`INFO Settings updated successfully`);
     const settings = await utils.getDoc(DOC_IDS.SETTINGS);
     const newVersion = Number(settings._rev.charAt(0));
@@ -43,7 +48,7 @@ describe('cht-conf actions tests', () => {
 
   for (const action of actions) {
     it(`should execute ${action}`, async () => {
-      const result = await runCommand(action, configPath);
+      const result = await chtConfUtils.runCommand(action, configPath);
       expect(result).to.contain(`INFO ${action} complete.`);
     });
   }

--- a/tests/utils/cht-conf.js
+++ b/tests/utils/cht-conf.js
@@ -18,10 +18,19 @@ const runCommand = async (action, dirPath) => {
 const getDirPath = () => path.join(__dirname, 'config-temp');
 
 const createDirectory = async (dir) => {
+  await clearDirectory(dir);
+  await fs.promises.mkdir(dir);
+};
+const clearDirectory = async (dir) => {
   if (fs.existsSync(dir)) {
     await fs.promises.rm(dir, { recursive: true });
   }
-  await fs.promises.mkdir(dir);
+};
+
+// project eslint needs to be root, as cht-core eslint rules fail for the "default" layout
+const writeRootEslint = async (dir) => {
+  const eslintRules = { env: { node: true, es2022: true }, parserOptions: { ecmaVersion: 2022 }, root: true };
+  await fs.promises.writeFile(path.join(dir, '.eslintrc'), JSON.stringify(eslintRules));
 };
 
 const initializeConfigDir = async () => {
@@ -29,11 +38,7 @@ const initializeConfigDir = async () => {
 
   await createDirectory(dir);
   await runCommand('initialise-project-layout', dir);
-  // project eslint needs to be root, as cht-core eslint rules fail for the "default" layout
-  const eslintPath = path.join(dir, '.eslintrc');
-  const eslintRules = JSON.parse(await fs.promises.readFile(eslintPath, 'utf-8'));
-  eslintRules.root = true;
-  await fs.promises.writeFile(eslintPath, JSON.stringify(eslintRules));
+  await writeRootEslint(dir);
 };
 
 const compileConfig = async ({ tasks, targets, contactSummary, contactSummaryExtras }) => {
@@ -86,9 +91,32 @@ const compileAndUploadAppForms = async (formsDir) => {
   await runCommand('upload-app-forms', dir);
 };
 
+// Copies config/default into config-temp so actions can run against an isolated copy instead of
+// mutating the checked-in config (compile-app-settings, backup-* and convert-* all write into the config dir).
+const copyDefaultConfig = async () => {
+  const defaultConfigDir = path.join(__dirname, '..', '..', 'config', 'default');
+  const dir = getDirPath();
+
+  await createDirectory(dir);
+  await fs.promises.cp(defaultConfigDir, dir, {
+    recursive: true,
+    filter: src => !src.includes(`${path.sep}node_modules${path.sep}`) && !src.endsWith(`${path.sep}node_modules`),
+  });
+  await writeRootEslint(dir);
+  return dir;
+};
+
+const clearTempDir = () => {
+  return clearDirectory(getDirPath());
+};
+
 module.exports = {
   runCommand,
   compileConfig,
   initializeConfigDir,
   compileAndUploadAppForms,
+
+  getDirPath,
+  copyDefaultConfig,
+  clearTempDir,
 };


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: build|feat|fix|perf|refactor|test|chore

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

closes #11207

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [ ] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:run-integration-in-isolation/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:run-integration-in-isolation/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:run-integration-in-isolation/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

