### PR TITLE
fix(#11218): prevent replication log writes when client disconnects during requests

### DIFF
--- a/api/src/controllers/replication.js
+++ b/api/src/controllers/replication.js
@@ -4,7 +4,7 @@ const serverUtils = require('../server-utils');
 module.exports = {
   getDocIds: async (req, res) => {
     try {
-      const context = await replication.getContext(req.userCtx);
+      const context = await replication.getContext(req.userCtx, res);
       const docIdsRevs = await replication.getDocIdsRevPairs(context.docIds);
       return res.json({
         doc_ids_revs: docIdsRevs,

--- a/api/src/services/replication/replication.js
+++ b/api/src/services/replication/replication.js
@@ -20,7 +20,7 @@ const getContext = async (userCtx, res) => {
   const unpurgedWarnIds = _.intersection(unpurgedIds, warnIds);
 
   // user could have disconnected
-  if (!res || !res.closed) {
+  if (!res?.closed) {
     await replicationLimitLog.put(userCtx.name, unpurgedIds.length, allowedIds.length);
   }
 

--- a/api/src/services/replication/replication.js
+++ b/api/src/services/replication/replication.js
@@ -4,7 +4,7 @@ const purgedDocs = require('./purged-docs');
 const _ = require('lodash');
 const replicationLimitLog = require('./replication-limit-log');
 
-const getContext = async (userCtx, res) => {
+const getContext = async (userCtx) => {
   const info = await db.medic.info();
   const authContext = await authorization.getAuthorizationContext(userCtx);
   userCtx.subjectsCount = authContext.subjectIds.length;
@@ -21,7 +21,7 @@ const getContext = async (userCtx, res) => {
 
   // user could have disconnected
   // if (!res || !res.closed) {
-    await replicationLimitLog.put(userCtx.name, unpurgedIds.length, allowedIds.length);
+  await replicationLimitLog.put(userCtx.name, unpurgedIds.length, allowedIds.length);
   // }
 
   return {

--- a/api/src/services/replication/replication.js
+++ b/api/src/services/replication/replication.js
@@ -4,7 +4,7 @@ const purgedDocs = require('./purged-docs');
 const _ = require('lodash');
 const replicationLimitLog = require('./replication-limit-log');
 
-const getContext = async (userCtx) => {
+const getContext = async (userCtx, res) => {
   const info = await db.medic.info();
   const authContext = await authorization.getAuthorizationContext(userCtx);
   userCtx.subjectsCount = authContext.subjectIds.length;
@@ -20,9 +20,9 @@ const getContext = async (userCtx) => {
   const unpurgedWarnIds = _.intersection(unpurgedIds, warnIds);
 
   // user could have disconnected
-  // if (!res || !res.closed) {
-  await replicationLimitLog.put(userCtx.name, unpurgedIds.length, allowedIds.length);
-  // }
+  if (!res || !res.closed) {
+    await replicationLimitLog.put(userCtx.name, unpurgedIds.length, allowedIds.length);
+  }
 
   return {
     docIds: unpurgedIds,

--- a/api/src/services/replication/replication.js
+++ b/api/src/services/replication/replication.js
@@ -4,7 +4,7 @@ const purgedDocs = require('./purged-docs');
 const _ = require('lodash');
 const replicationLimitLog = require('./replication-limit-log');
 
-const getContext = async (userCtx) => {
+const getContext = async (userCtx, res) => {
   const info = await db.medic.info();
   const authContext = await authorization.getAuthorizationContext(userCtx);
   userCtx.subjectsCount = authContext.subjectIds.length;
@@ -19,7 +19,10 @@ const getContext = async (userCtx) => {
   const warnIds = authorization.filterAllowedDocIds(authContext, docsByReplicationKey, excludeTasks);
   const unpurgedWarnIds = _.intersection(unpurgedIds, warnIds);
 
-  await replicationLimitLog.put(userCtx.name, unpurgedIds.length, allowedIds.length);
+  // user could have disconnected
+  // if (!res || !res.closed) {
+    await replicationLimitLog.put(userCtx.name, unpurgedIds.length, allowedIds.length);
+  // }
 
   return {
     docIds: unpurgedIds,

--- a/api/tests/mocha/controllers/replication.spec.js
+++ b/api/tests/mocha/controllers/replication.spec.js
@@ -34,7 +34,7 @@ describe('Initial Replication controller', () => {
 
       await controller.getDocIds(req, res);
 
-      expect(replicationService.getContext.args).to.deep.equal([[req.userCtx]]);
+      expect(replicationService.getContext.args).to.deep.equal([[req.userCtx, res]]);
       expect(replicationService.getDocIdsRevPairs.args).to.deep.equal([[[1, 2, 3]]]);
       expect(res.json.args).to.deep.equal([[{
         doc_ids_revs: [
@@ -65,7 +65,7 @@ describe('Initial Replication controller', () => {
 
       await controller.getDocIds(req, res);
 
-      expect(replicationService.getContext.args).to.deep.equal([[req.userCtx]]);
+      expect(replicationService.getContext.args).to.deep.equal([[req.userCtx, res]]);
       expect(replicationService.getDocIdsRevPairs.args).to.deep.equal([[[4, 5, 6]]]);
       expect(res.json.args).to.deep.equal([[{
         doc_ids_revs: [

--- a/api/tests/mocha/services/replication/replication.spec.js
+++ b/api/tests/mocha/services/replication/replication.spec.js
@@ -56,7 +56,7 @@ describe('Initial Replication service', () => {
       expect(replicationLimitLog.put.args).to.deep.equal([[userCtx.name, 3, 4]]);
     });
 
-    xit('should register the doc count when the client is still connected', async () => {
+    it('should register the doc count when the client is still connected', async () => {
       sinon.stub(db.medic, 'info').resolves({ update_seq: '123-aaa' });
       sinon.stub(authorization, 'getAuthorizationContext').resolves(authContext);
       sinon.stub(authorization, 'getDocsByReplicationKey').resolves(docsByReplicationKey);
@@ -69,7 +69,7 @@ describe('Initial Replication service', () => {
       expect(replicationLimitLog.put.args).to.deep.equal([[userCtx.name, 3, 4]]);
     });
 
-    xit('should not register the doc count when the client has disconnected', async () => {
+    it('should not register the doc count when the client has disconnected', async () => {
       sinon.stub(db.medic, 'info').resolves({ update_seq: '123-aaa' });
       sinon.stub(authorization, 'getAuthorizationContext').resolves(authContext);
       sinon.stub(authorization, 'getDocsByReplicationKey').resolves(docsByReplicationKey);

--- a/api/tests/mocha/services/replication/replication.spec.js
+++ b/api/tests/mocha/services/replication/replication.spec.js
@@ -56,6 +56,34 @@ describe('Initial Replication service', () => {
       expect(replicationLimitLog.put.args).to.deep.equal([[userCtx.name, 3, 4]]);
     });
 
+    xit('should register the doc count when the client is still connected', async () => {
+      sinon.stub(db.medic, 'info').resolves({ update_seq: '123-aaa' });
+      sinon.stub(authorization, 'getAuthorizationContext').resolves(authContext);
+      sinon.stub(authorization, 'getDocsByReplicationKey').resolves(docsByReplicationKey);
+      sinon.stub(authorization, 'filterAllowedDocIds').returns([1, 2, 3, 'purged']);
+      sinon.stub(purgedDocs, 'getUnPurgedIds').resolves([1, 2, 3]);
+      sinon.stub(replicationLimitLog, 'put');
+
+      await replication.getContext(userCtx, { closed: false });
+
+      expect(replicationLimitLog.put.args).to.deep.equal([[userCtx.name, 3, 4]]);
+    });
+
+    xit('should not register the doc count when the client has disconnected', async () => {
+      sinon.stub(db.medic, 'info').resolves({ update_seq: '123-aaa' });
+      sinon.stub(authorization, 'getAuthorizationContext').resolves(authContext);
+      sinon.stub(authorization, 'getDocsByReplicationKey').resolves(docsByReplicationKey);
+      sinon.stub(authorization, 'filterAllowedDocIds').returns([1, 2, 3, 'purged']);
+      sinon.stub(purgedDocs, 'getUnPurgedIds').resolves([1, 2, 3]);
+      sinon.stub(replicationLimitLog, 'put');
+
+      // The couchdb promise chain is not cancelled on abort
+      const result = await replication.getContext(userCtx, { closed: true });
+
+      expect(replicationLimitLog.put.callCount).to.equal(0);
+      expect(result.docIds).to.deep.equal([1, 2, 3]);
+    });
+
     it('should warn if there are too many allowed docs', async () => {
       sinon.stub(db.medic, 'info').resolves({ update_seq: '222-bbb' });
       sinon.stub(authorization, 'getAuthorizationContext').resolves(authContext);

--- a/tests/integration/.mocharc-all.js
+++ b/tests/integration/.mocharc-all.js
@@ -1,6 +1,8 @@
 const baseConfig = require('./.mocharc-base');
+const specs = require('./specs');
 
 module.exports = {
   ...baseConfig,
-  spec: require('./specs').all,
+  spec: specs.all,
+  ignore: specs.allIgnore,
 };

--- a/tests/integration/api/controllers/replication-limit-log-abort.spec.js
+++ b/tests/integration/api/controllers/replication-limit-log-abort.spec.js
@@ -60,7 +60,6 @@ describe('replication limit log on aborted requests @docker', () => {
   afterEach(() => utils.deleteLogsByPrefix('replication-count-'));
 
   after(async () => {
-    await utils.startService('nouveau');
     await utils.deleteUsers([mathilUser]);
     await utils.revertDb();
   });

--- a/tests/integration/api/controllers/replication-limit-log-abort.spec.js
+++ b/tests/integration/api/controllers/replication-limit-log-abort.spec.js
@@ -49,7 +49,8 @@ const hasCountLog = async (username) => {
   }
 };
 
-// k3d pairs nouveau with couchdb, so stopping nouveau makes get-ids hang inside couchdb.
+// this test is ignored in CI, due to a 60s required wait period
+// to run this test, run the wdio replication suite locally.
 describe('replication limit log on aborted requests @docker', () => {
   before(async () => {
     await utils.saveDocs([facility, mathilPlace, mathilContact]);

--- a/tests/integration/api/controllers/replication-limit-log-abort.spec.js
+++ b/tests/integration/api/controllers/replication-limit-log-abort.spec.js
@@ -50,7 +50,7 @@ const hasCountLog = async (username) => {
 };
 
 // k3d pairs nouveau with couchdb, so stopping nouveau makes get-ids hang inside couchdb.
-describe.only('replication limit log on aborted requests @docker', () => {
+describe('replication limit log on aborted requests @docker', () => {
   before(async () => {
     await utils.saveDocs([facility, mathilPlace, mathilContact]);
     await utils.createUsers([mathilUser], true);

--- a/tests/integration/api/controllers/replication-limit-log-abort.spec.js
+++ b/tests/integration/api/controllers/replication-limit-log-abort.spec.js
@@ -1,0 +1,82 @@
+const utils = require('@utils');
+const { CONTACT_TYPES } = require('@medic/constants');
+const userFactory = require('@factories/cht/users/users');
+const placeFactory = require('@factories/cht/contacts/place');
+const personFactory = require('@factories/cht/contacts/person');
+
+const password = 'passwordSUP3RS3CR37!';
+
+// Abort the client well before couchdb gives up on its (stopped) nouveau connection.
+const ABORT_AFTER_MS = 2000;
+// couchdb waits up to ~60s for nouveau, so the stray server-side chain can resolve any time within
+// that window after nouveau is restarted. Poll long enough to be sure the count was never written.
+const WATCH_MS = 65000;
+const POLL_INTERVAL_MS = 2000;
+
+const replicationGetIds = (username) => utils.request({
+  path: '/api/v1/replication/get-ids',
+  auth: { username, password },
+  signal: AbortSignal.timeout(ABORT_AFTER_MS),
+});
+
+const facility = placeFactory.place().build({ type: CONTACT_TYPES.DISTRICT_HOSPITAL });
+const mathilPlace = placeFactory.place().build({
+  type: CONTACT_TYPES.HEALTH_CENTER,
+  parent: { _id: facility._id },
+  place_id: 'shortcode:mathilville'
+});
+const mathilContact = personFactory.build({
+  role: 'chw',
+  parent: { _id: mathilPlace._id, parent: { _id: facility._id } },
+  name: 'Mathil',
+  patient_id: 'shortcode:user:mathil'
+});
+const mathilUser = userFactory.build({
+  username: 'mathil', password, place: mathilPlace._id, contact: mathilContact._id,
+});
+
+const countLogId = (username) => `replication-count-${username}`;
+
+const hasCountLog = async (username) => {
+  try {
+    await utils.logsDb.get(countLogId(username));
+    return true;
+  } catch (err) {
+    if (err.status === 404) {
+      return false;
+    }
+    throw err;
+  }
+};
+
+// k3d pairs nouveau with couchdb, so stopping nouveau makes get-ids hang inside couchdb.
+describe.only('replication limit log on aborted requests @docker', () => {
+  before(async () => {
+    await utils.saveDocs([facility, mathilPlace, mathilContact]);
+    await utils.createUsers([mathilUser], true);
+    await utils.deleteLogsByPrefix('replication-count-');
+  });
+
+  afterEach(() => utils.deleteLogsByPrefix('replication-count-'));
+
+  after(async () => {
+    await utils.startService('nouveau');
+    await utils.deleteUsers([mathilUser]);
+    await utils.revertDb();
+  });
+
+  it('should not register a doc count when the client aborts the request', async () => {
+    await utils.stopService('nouveau');
+    // The client gives up while couchdb is still waiting on nouveau.
+    await expect(replicationGetIds('mathil')).to.be.rejectedWith();
+    // Bring nouveau back so the un-cancelled server-side chain resolves and would write the log.
+    await utils.startService('nouveau');
+
+    const deadline = Date.now() + WATCH_MS;
+    while (Date.now() < deadline) {
+      // Fail fast on the regression: the guard is missing if the count ever lands.
+      expect(await hasCountLog('mathil')).to.equal(false);
+      await utils.delayPromise(POLL_INTERVAL_MS);
+    }
+  });
+});

--- a/tests/integration/specs.js
+++ b/tests/integration/specs.js
@@ -4,6 +4,11 @@ module.exports = {
     'tests/integration/!(cht-conf|sentinel)/**/*.spec.js',
     'tests/integration/cht-conf/**/*.spec.js', // Executing last to not side-effect other tests.
   ],
+  allIgnore: [
+    // this test takes 60 seconds to complete., but the behavior reproduction is elaborate enough to keep the test code
+    // this test only runs as part of the replication suite, which is not called in CI
+    'tests/integration/api/controllers/replication-limit-log-abort.spec.js',
+  ],
   sentinel: [ 'tests/integration/sentinel/**/*.spec.js' ],
   replication: [
     'tests/integration/api/controllers/all-docs.spec.js',
@@ -15,7 +20,6 @@ module.exports = {
     'tests/integration/api/controllers/replication-health.spec.js',
     'tests/integration/api/controllers/replication-limit-log.spec.js',
     'tests/integration/api/controllers/replication-limit-log-abort.spec.js',
-
   ],
   couchdb: [
     'tests/integration/couchdb/**/*.spec.js',

--- a/tests/integration/specs.js
+++ b/tests/integration/specs.js
@@ -12,6 +12,10 @@ module.exports = {
     'tests/integration/api/controllers/db-doc.spec.js',
     'tests/integration/api/controllers/replication.spec.js',
     'tests/integration/api/controllers/replication-failure-log.spec.js',
+    'tests/integration/api/controllers/replication-health.spec.js',
+    'tests/integration/api/controllers/replication-limit-log.spec.js',
+    'tests/integration/api/controllers/replication-limit-log-abort.spec.js',
+
   ],
   couchdb: [
     'tests/integration/couchdb/**/*.spec.js',


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: build|feat|fix|perf|refactor|test|chore

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->

closes #11218

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [ ] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:11218-replication-limit-log-flake-/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:11218-replication-limit-log-flake-/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:11218-replication-limit-log-flake-/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

