### PR TITLE
feat(#10706): add bulk operation status endpoint

### DIFF
--- a/api/src/controllers/bulk-operations.js
+++ b/api/src/controllers/bulk-operations.js
@@ -1,0 +1,66 @@
+const service = require('../services/bulk-operations');
+const serverUtils = require('../server-utils');
+const auth = require('../auth');
+
+/**
+ * @openapi
+ * tags:
+ *   - name: Bulk operations
+ *     description: Status of long-running bulk operations (delete, move, merge)
+ */
+module.exports = {
+  v1: {
+    /**
+     * @openapi
+     * /api/v1/bulk-operations/{id}:
+     *   get:
+     *     summary: Get the status of a bulk operation
+     *     operationId: v1BulkOperationIdGet
+     *     description: >
+     *       Returns the log document for a bulk operation, including the per-action status and the
+     *       count of changes applied so far. Used to poll the progress of an operation that was
+     *       started through one of the bulk endpoints.
+     *     tags: [Bulk operations]
+     *     x-since: 5.1.0
+     *     parameters:
+     *       - in: path
+     *         name: id
+     *         required: true
+     *         schema:
+     *           type: string
+     *         description: The id of the bulk operation, as returned when it was started.
+     *     responses:
+     *       '200':
+     *         description: The bulk operation log
+     *         content:
+     *           application/json:
+     *             schema:
+     *               type: object
+     *               properties:
+     *                 _id:
+     *                   type: string
+     *                   description: The bulk operation id.
+     *                 start_date:
+     *                   type: string
+     *                   format: date-time
+     *                   description: When the operation was started.
+     *                 actions:
+     *                   type: object
+     *                   description: Per-action status, keyed by action id.
+     *       '401':
+     *         $ref: '#/components/responses/Unauthorized'
+     *       '403':
+     *         $ref: '#/components/responses/Forbidden'
+     *       '404':
+     *         $ref: '#/components/responses/NotFound'
+     */
+    get: serverUtils.doOrError(async (req, res) => {
+      await auth.assertPermissions(req, { isOnline: true });
+      const log = await service.getLog(req.params.id);
+      if (!log) {
+        return serverUtils.error({ status: 404, message: 'Bulk operation not found' }, req, res);
+      }
+      res.json(log);
+    })
+  }
+};

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -46,6 +46,7 @@ const { people, places } = require('@medic/contacts')(config, db, dataContext);
 const upgrade = require('./controllers/upgrade');
 const settings = require('./controllers/settings');
 const bulkDocs = require('./controllers/bulk-docs');
+const bulkOperations = require('./controllers/bulk-operations');
 const monitoring = require('./controllers/monitoring');
 const africasTalking = require('./controllers/africas-talking');
 const rapidPro = require('./controllers/rapidpro');
@@ -477,6 +478,8 @@ app.get('/api/deploy-info', async (req, res) => {
 app.get('/api/v1/monitoring', deprecation.deprecate('/api/v2/monitoring'), monitoring.getV1);
 app.get('/api/v2/monitoring', monitoring.getV2);
 app.get('/api/v1/impact', impact.v1.get);
+
+app.get('/api/v1/bulk-operations/:id', bulkOperations.v1.get);
 
 app.post('/api/v1/upgrade', jsonParser, upgrade.upgrade);
 app.post('/api/v1/upgrade/stage', jsonParser, upgrade.stage);

--- a/api/src/services/bulk-operations.js
+++ b/api/src/services/bulk-operations.js
@@ -1,0 +1,25 @@
+const db = require('../db');
+const { LOG_ID_PREFIX } = require('@medic/bulk-operations');
+
+// Reads only bulk operation log documents from the medic-logs database. The prefix guard keeps the
+// endpoint from returning the other kinds of log documents that share this database.
+const getLog = async (id) => {
+  if (!id || !id.startsWith(LOG_ID_PREFIX)) {
+    return null;
+  }
+
+  try {
+    const log = await db.medicLogs.get(id);
+    delete log._rev;
+    return log;
+  } catch (err) {
+    if (err.status === 404) {
+      return null;
+    }
+    throw err;
+  }
+};
+
+module.exports = {
+  getLog,
+};

--- a/api/src/services/bulk-operations.js
+++ b/api/src/services/bulk-operations.js
@@ -4,7 +4,7 @@ const { LOG_ID_PREFIX } = require('@medic/bulk-operations');
 // Reads only bulk operation log documents from the medic-logs database. The prefix guard keeps the
 // endpoint from returning the other kinds of log documents that share this database.
 const getLog = async (id) => {
-  if (!id || !id.startsWith(LOG_ID_PREFIX)) {
+  if (!id?.startsWith(LOG_ID_PREFIX)) {
     return null;
   }
 

--- a/api/tests/mocha/controllers/bulk-operations.spec.js
+++ b/api/tests/mocha/controllers/bulk-operations.spec.js
@@ -1,0 +1,68 @@
+const sinon = require('sinon');
+const chai = require('chai');
+
+const serverUtils = require('../../../src/server-utils');
+const controller = require('../../../src/controllers/bulk-operations');
+const service = require('../../../src/services/bulk-operations');
+const auth = require('../../../src/auth');
+const { PermissionError } = require('../../../src/errors');
+
+describe('Bulk operations controller', () => {
+  let req;
+  let res;
+
+  beforeEach(() => {
+    sinon.stub(serverUtils, 'error');
+    req = { params: { id: 'bulk-operation:abc' } };
+    res = { json: sinon.stub() };
+  });
+
+  afterEach(() => sinon.restore());
+
+  describe('v1 get', () => {
+    it('returns the bulk operation log for an authorised online user', () => {
+      const log = { _id: 'bulk-operation:abc', start_date: 'date', actions: {} };
+      sinon.stub(auth, 'assertPermissions').resolves();
+      sinon.stub(service, 'getLog').resolves(log);
+
+      return controller.v1.get(req, res).then(() => {
+        chai.expect(auth.assertPermissions.calledOnceWithExactly(req, { isOnline: true })).to.equal(true);
+        chai.expect(service.getLog.calledOnceWithExactly('bulk-operation:abc')).to.equal(true);
+        chai.expect(res.json.calledOnceWithExactly(log)).to.equal(true);
+        chai.expect(serverUtils.error.called).to.equal(false);
+      });
+    });
+
+    it('returns a 404 when the operation is not found', () => {
+      sinon.stub(auth, 'assertPermissions').resolves();
+      sinon.stub(service, 'getLog').resolves(null);
+
+      return controller.v1.get(req, res).then(() => {
+        chai.expect(res.json.called).to.equal(false);
+        chai.expect(serverUtils.error.calledOnce).to.equal(true);
+        chai.expect(serverUtils.error.args[0][0]).to.deep.equal({ status: 404, message: 'Bulk operation not found' });
+      });
+    });
+
+    it('does not reach the service when the user is not permitted', () => {
+      sinon.stub(auth, 'assertPermissions').rejects(new PermissionError('Insufficient privileges'));
+      sinon.stub(service, 'getLog').resolves({});
+
+      return controller.v1.get(req, res).then(() => {
+        chai.expect(service.getLog.called).to.equal(false);
+        chai.expect(res.json.called).to.equal(false);
+        chai.expect(serverUtils.error.calledOnce).to.equal(true);
+      });
+    });
+
+    it('handles a service rejection gracefully', () => {
+      sinon.stub(auth, 'assertPermissions').resolves();
+      sinon.stub(service, 'getLog').rejects(new Error('db down'));
+
+      return controller.v1.get(req, res).then(() => {
+        chai.expect(res.json.called).to.equal(false);
+        chai.expect(serverUtils.error.calledOnce).to.equal(true);
+      });
+    });
+  });
+});

--- a/api/tests/mocha/services/bulk-operations.spec.js
+++ b/api/tests/mocha/services/bulk-operations.spec.js
@@ -1,0 +1,64 @@
+const chai = require('chai');
+const sinon = require('sinon');
+
+const db = require('../../../src/db');
+const service = require('../../../src/services/bulk-operations');
+
+describe('Bulk operations service', () => {
+  afterEach(() => sinon.restore());
+
+  describe('getLog', () => {
+    it('returns the log document without the couch _rev', () => {
+      const doc = {
+        _id: 'bulk-operation:abc',
+        _rev: '1-xyz',
+        start_date: 'date',
+        actions: { 'bulk-operation-action:abc:1': { status: 'queued' } },
+      };
+      sinon.stub(db.medicLogs, 'get').resolves(doc);
+
+      return service.getLog('bulk-operation:abc').then((log) => {
+        chai.expect(db.medicLogs.get.calledOnceWithExactly('bulk-operation:abc')).to.equal(true);
+        chai.expect(log).to.deep.equal({
+          _id: 'bulk-operation:abc',
+          start_date: 'date',
+          actions: { 'bulk-operation-action:abc:1': { status: 'queued' } },
+        });
+        chai.expect(log._rev).to.equal(undefined);
+      });
+    });
+
+    it('returns null when the operation does not exist', () => {
+      sinon.stub(db.medicLogs, 'get').rejects({ status: 404 });
+
+      return service.getLog('bulk-operation:missing').then((log) => {
+        chai.expect(log).to.equal(null);
+      });
+    });
+
+    it('does not query the database for an id that is not a bulk operation', () => {
+      const get = sinon.stub(db.medicLogs, 'get');
+
+      return Promise
+        .all([
+          service.getLog(undefined),
+          service.getLog(''),
+          service.getLog('upgrade_log:something'),
+          service.getLog('some-other-doc'),
+        ])
+        .then((results) => {
+          chai.expect(results).to.deep.equal([null, null, null, null]);
+          chai.expect(get.called).to.equal(false);
+        });
+    });
+
+    it('rethrows errors that are not a 404', () => {
+      sinon.stub(db.medicLogs, 'get').rejects({ status: 500 });
+
+      return service
+        .getLog('bulk-operation:boom')
+        .then(() => chai.expect.fail('should have thrown'))
+        .catch((err) => chai.expect(err.status).to.equal(500));
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -5750,6 +5750,10 @@
       "resolved": "shared-libs/bulk-docs-utils",
       "link": true
     },
+    "node_modules/@medic/bulk-operations": {
+      "resolved": "shared-libs/bulk-operations",
+      "link": true
+    },
     "node_modules/@medic/calendar-interval": {
       "resolved": "shared-libs/calendar-interval",
       "link": true
@@ -44272,6 +44276,11 @@
     },
     "shared-libs/bulk-docs-utils": {
       "name": "@medic/bulk-docs-utils",
+      "version": "1.0.0",
+      "license": "Apache-2.0"
+    },
+    "shared-libs/bulk-operations": {
+      "name": "@medic/bulk-operations",
       "version": "1.0.0",
       "license": "Apache-2.0"
     },

--- a/shared-libs/bulk-operations/package.json
+++ b/shared-libs/bulk-operations/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@medic/bulk-operations",
+  "version": "1.0.0",
+  "description": "Shared document model for the CHT-Core bulk operation framework (delete, move, merge)",
+  "main": "src/index.js",
+  "scripts": {
+    "test": "nyc --nycrcPath='../nyc.config.js' mocha ./test"
+  },
+  "author": "",
+  "license": "Apache-2.0"
+}

--- a/shared-libs/bulk-operations/src/index.js
+++ b/shared-libs/bulk-operations/src/index.js
@@ -1,0 +1,98 @@
+const { v7: uuid } = require('uuid');
+
+/**
+ * Document model for the bulk operation framework.
+ *
+ * A bulk operation is recorded with two kinds of document:
+ *  - a single LOG document (stored in medic-logs) that tracks overall status and is read by the polling endpoint.
+ *  - one ACTION document per action type (stored in medic-sentinel) that Sentinel processes in batches.
+ *
+ * Delete, move and merge all express their work as a set of these actions.
+ */
+
+const LOG_ID_PREFIX = 'bulk-operation:';
+const ACTION_ID_PREFIX = 'bulk-operation-action:';
+
+const ACTIONS = {
+  ARCHIVE: 'archive',
+  SET_CONTACT: 'set-contact',
+  DELETE_USER: 'delete-user',
+};
+
+const STATUSES = {
+  QUEUED: 'queued',
+  COMPLETED: 'completed',
+  FAILED: 'failed',
+};
+
+// The per-item params for each action live in an attachment rather than inline, so updating the
+// action document's cursor as Sentinel works through the batches does not rewrite the whole list.
+const OPERATIONS_ATTACHMENT = 'operations';
+const OPERATIONS_CONTENT_TYPE = 'application/json';
+
+const getOperationUuid = (operationId) => operationId.slice(LOG_ID_PREFIX.length);
+
+const generateOperationId = () => `${LOG_ID_PREFIX}${uuid()}`;
+
+const generateActionId = (operationId) => `${ACTION_ID_PREFIX}${getOperationUuid(operationId)}:${uuid()}`;
+
+const encodeOperations = (operations) => ({
+  content_type: OPERATIONS_CONTENT_TYPE,
+  data: Buffer.from(JSON.stringify(operations)).toString('base64'),
+});
+
+const decodeOperations = (attachment) => JSON.parse(Buffer.from(attachment.data, 'base64').toString());
+
+const buildActionDoc = (operationId, action, operations) => ({
+  _id: generateActionId(operationId),
+  bulk_operation_id: operationId,
+  action,
+  cursor: 0,
+  total: operations.length,
+  _attachments: {
+    [OPERATIONS_ATTACHMENT]: encodeOperations(operations),
+  },
+});
+
+const buildLogAction = (action, totalChangesCount, date) => ({
+  status: STATUSES.QUEUED,
+  action,
+  updated_date: date,
+  total_changes_count: totalChangesCount,
+});
+
+/**
+ * Builds the documents that make up a single bulk operation.
+ * @param {Array<{action: string, operations: Object[]}>} actionOperations - one entry per action type, each holding
+ *   its list of per-item params
+ * @param {Date} date - the operation start date, also the initial updated_date of every action
+ * @returns {{log: Object, actions: Object[]}} the log document (for medic-logs) and the action documents
+ *   (for medic-sentinel); the log's `actions` map is keyed by each action document's `_id`
+ */
+const buildBulkOperation = (actionOperations, date) => {
+  const operationId = generateOperationId();
+  const actions = actionOperations.map(({ action, operations }) => buildActionDoc(operationId, action, operations));
+
+  const logActions = {};
+  actions.forEach((actionDoc) => {
+    logActions[actionDoc._id] = buildLogAction(actionDoc.action, actionDoc.total, date);
+  });
+
+  const log = {
+    _id: operationId,
+    start_date: date,
+    actions: logActions,
+  };
+
+  return { log, actions };
+};
+
+module.exports = {
+  LOG_ID_PREFIX,
+  ACTION_ID_PREFIX,
+  ACTIONS,
+  STATUSES,
+  OPERATIONS_ATTACHMENT,
+  buildBulkOperation,
+  decodeOperations,
+};

--- a/shared-libs/bulk-operations/test/index.js
+++ b/shared-libs/bulk-operations/test/index.js
@@ -1,0 +1,100 @@
+const chai = require('chai');
+const { validate: isUuid } = require('uuid');
+
+const service = require('../src/index');
+
+const expect = chai.expect;
+
+describe('bulk-operations document model', () => {
+  describe('constants', () => {
+    it('exposes the action types', () => {
+      expect(service.ACTIONS).to.deep.equal({
+        ARCHIVE: 'archive',
+        SET_CONTACT: 'set-contact',
+        DELETE_USER: 'delete-user',
+      });
+    });
+
+    it('exposes the statuses', () => {
+      expect(service.STATUSES).to.deep.equal({
+        QUEUED: 'queued',
+        COMPLETED: 'completed',
+        FAILED: 'failed',
+      });
+    });
+
+    it('exposes the document id prefixes', () => {
+      expect(service.LOG_ID_PREFIX).to.equal('bulk-operation:');
+      expect(service.ACTION_ID_PREFIX).to.equal('bulk-operation-action:');
+    });
+  });
+
+  describe('buildBulkOperation', () => {
+    const date = new Date('2026-06-29T12:00:00.000Z');
+
+    it('builds a log document with a uuid-v7 operation id', () => {
+      const { log } = service.buildBulkOperation([{ action: 'archive', operations: [{ id: 'a' }] }], date);
+
+      expect(log._id.startsWith('bulk-operation:')).to.equal(true);
+      expect(isUuid(log._id.slice('bulk-operation:'.length))).to.equal(true);
+      expect(log.start_date).to.equal(date);
+    });
+
+    it('builds one action document per action type, linked back to the operation', () => {
+      const groups = [
+        { action: 'archive', operations: [{ id: 'person' }, { id: 'report' }] },
+        { action: 'set-contact', operations: [{ id: 'place', current_contact_id: 'person' }] },
+        { action: 'delete-user', operations: [{ id: 'org.couchdb.user:chw' }] },
+      ];
+
+      const { log, actions } = service.buildBulkOperation(groups, date);
+
+      expect(actions).to.have.length(3);
+      actions.forEach((actionDoc, i) => {
+        expect(actionDoc._id.startsWith('bulk-operation-action:')).to.equal(true);
+        // the action id embeds the operation's uuid, so the two ids stay parseable together
+        expect(actionDoc._id).to.include(log._id.slice('bulk-operation:'.length));
+        expect(actionDoc.bulk_operation_id).to.equal(log._id);
+        expect(actionDoc.action).to.equal(groups[i].action);
+        expect(actionDoc.cursor).to.equal(0);
+        expect(actionDoc.total).to.equal(groups[i].operations.length);
+        expect(service.decodeOperations(actionDoc._attachments.operations)).to.deep.equal(groups[i].operations);
+      });
+    });
+
+    it('stores the operation params in a base64 json attachment', () => {
+      const operations = [{ id: 'place', current_contact_id: 'person' }];
+      const { actions } = service.buildBulkOperation([{ action: 'set-contact', operations }], date);
+
+      const attachment = actions[0]._attachments.operations;
+      expect(attachment.content_type).to.equal('application/json');
+      expect(attachment.data).to.be.a('string');
+      expect(service.decodeOperations(attachment)).to.deep.equal(operations);
+    });
+
+    it('cross-links each action document to its entry in the log', () => {
+      const groups = [
+        { action: 'archive', operations: [{ id: 'person' }] },
+        { action: 'set-contact', operations: [{ id: 'place' }, { id: 'place2' }] },
+      ];
+
+      const { log, actions } = service.buildBulkOperation(groups, date);
+
+      expect(Object.keys(log.actions)).to.deep.equal(actions.map(actionDoc => actionDoc._id));
+      actions.forEach((actionDoc) => {
+        const logAction = log.actions[actionDoc._id];
+        expect(logAction.status).to.equal('queued');
+        expect(logAction.action).to.equal(actionDoc.action);
+        expect(logAction.updated_date).to.equal(date);
+        expect(logAction.total_changes_count).to.equal(actionDoc.total);
+      });
+    });
+
+    it('generates a distinct operation id on each call', () => {
+      const first = service.buildBulkOperation([{ action: 'archive', operations: [] }], date);
+      const second = service.buildBulkOperation([{ action: 'archive', operations: [] }], date);
+
+      expect(first.log._id).to.not.equal(second.log._id);
+    });
+  });
+});


### PR DESCRIPTION
# Description

Adds `GET /api/v1/bulk-operations/{id}` so a caller can poll the progress of a bulk operation (delete, move or merge) by its id. It returns the operation's log document from the `medic-logs` database, with the per-action status and the count of changes so far.

The service only resolves ids that carry the `bulk-operation:` prefix, so the endpoint can't be used to read the other log documents that share `medic-logs`. Online users only; a missing or non bulk-operation id returns 404. Documented with an OpenAPI annotation.

Builds on #11222 (the `@medic/bulk-operations` doc model). Until that one merges into the feature branch, the diff here also includes the doc model; it'll narrow to just the endpoint once #11222 lands.

Part of #10706

# Code review checklist
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [x] Documented: OpenAPI annotation for the new endpoint
- [x] Tested: Unit and/or e2e where appropriate
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [ ] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.