### PR TITLE
Add CONTACT constant to DOC_TYPES

### DIFF
--- a/shared-libs/constants/src/index.js
+++ b/shared-libs/constants/src/index.js
@@ -26,7 +26,8 @@ const DOC_TYPES = {
   TOKEN_LOGIN: 'token_login',
   TRANSLATIONS: 'translations',
   DATA_RECORD: 'data_record',
-  UI_EXTENSION: 'ui-extension'
+  UI_EXTENSION: 'ui-extension',
+  CONTACT: 'contact'
 };
 
 // HTTP Headers


### PR DESCRIPTION
This PR adds the missing CONTACT constant to the DOC_TYPES object within shared-libs/constants/src/index.js. It also fixes a missing trailing comma on the preceding UI_EXTENSION property to maintain clean object formatting.

Fixes / References: #10545

Changes
shared-libs/constants/src/index.js:

Added CONTACT: 'contact' to DOC_TYPES.

Added a trailing comma to UI_EXTENSION for consistent syntax.