### PR TITLE
fix: clean up Bikram Sambat picker instances

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -625,5 +625,11 @@ module.exports = defineConfig([
       ['@typescript-eslint/no-unused-expressions']: 'off',
       ['@typescript-eslint/no-require-imports']: 'off'
     },
+  },
+  {
+    files: ['webapp/src/js/enketo/widgets/bikram-sambat-picker-shared.js'],
+    languageOptions: {
+      ecmaVersion: 2020,
+    },
   }
 ]);

--- a/webapp/src/js/enketo/widgets/bikram-sambat-datepicker.js
+++ b/webapp/src/js/enketo/widgets/bikram-sambat-datepicker.js
@@ -7,7 +7,13 @@ const eurodigit = require( 'eurodigit' );
 const toDevanagari = eurodigit.to_non_euro.devanagari;
 const fromDevanagari = eurodigit.to_euro;
 
-const { setupNepaliDatePicker, hideDatePicker } = require('./bikram-sambat-picker-shared');
+const {
+  setupNepaliDatePicker,
+  hideDatePicker,
+  destroyDatePicker,
+} = require('./bikram-sambat-picker-shared');
+
+const activeWidgets = new Set();
 
 const NEPALI_MONTH_NAMES = [
   'बैशाख', 'जेठ', 'असार', 'साउन', 'भदौ', 'असोज', 'कार्तिक', 'मंसिर', 'पौष', 'माघ', 'फाल्गुन', 'चैत'
@@ -18,6 +24,12 @@ const MONTH_PLACEHOLDER = 'महिना';
 class Bikramsambatdatepicker extends Widget {
   static get selector() {
     return 'input[type=date]';
+  }
+
+  static globalReset() {
+    activeWidgets.forEach(widget => widget.destroy());
+    activeWidgets.clear();
+    return super.globalReset();
   }
 
   _init() {
@@ -96,13 +108,11 @@ class Bikramsambatdatepicker extends Widget {
       });
   }
 
-  destroy( element ) {
+  destroy() {
     if ( this.$hiddenDateInput ) {
-      hideDatePicker(this.$hiddenDateInput);
+      destroyDatePicker(this.$hiddenDateInput);
+      this.$hiddenDateInput = null;
     }
-    $('.nepali-date-picker-overlay').remove();
-    $('.nepali-date-picker').remove();
-    super.destroy( element );
   }
 }
 
@@ -114,6 +124,7 @@ const setupCalendarPicker = ($parent, widget) => {
   const $hiddenDateInput = $('<input type="text" class="nepali-datepicker-input">');
   $calendarBtn.after($hiddenDateInput);
   widget.$hiddenDateInput = $hiddenDateInput;
+  activeWidgets.add(widget);
 
   setupNepaliDatePicker($hiddenDateInput, {
     closeOnDateSelect: false,

--- a/webapp/src/js/enketo/widgets/bikram-sambat-picker-shared.js
+++ b/webapp/src/js/enketo/widgets/bikram-sambat-picker-shared.js
@@ -57,7 +57,7 @@ const hideDatePicker = ($hiddenInput) => {
 };
 
 const destroyDatePicker = ($hiddenInput) => {
-  if (!$hiddenInput || !$hiddenInput.length) {
+  if (!$hiddenInput?.length) {
     return;
   }
 
@@ -65,7 +65,7 @@ const destroyDatePicker = ($hiddenInput) => {
   hideDatePicker($hiddenInput);
   $hiddenInput.off('dateSelect close show');
 
-  if ($picker && $picker.length) {
+  if ($picker?.length) {
     $picker.remove();
   }
 

--- a/webapp/src/js/enketo/widgets/bikram-sambat-picker-shared.js
+++ b/webapp/src/js/enketo/widgets/bikram-sambat-picker-shared.js
@@ -56,6 +56,26 @@ const hideDatePicker = ($hiddenInput) => {
   $hiddenInput.removeData('activeElementBeforeShow');
 };
 
+const destroyDatePicker = ($hiddenInput) => {
+  if (!$hiddenInput || !$hiddenInput.length) {
+    return;
+  }
+
+  const $picker = $hiddenInput.data('picker');
+  hideDatePicker($hiddenInput);
+  $hiddenInput.off('dateSelect close show');
+
+  if ($picker && $picker.length) {
+    $picker.remove();
+  }
+
+  $hiddenInput.remove();
+
+  if (!$('.nepali-date-picker').length) {
+    $('.nepali-date-picker-overlay').remove();
+  }
+};
+
 const ensureClearButton = (container, onClear) => {
   if (typeof onClear !== 'function') {
     return;
@@ -231,4 +251,5 @@ const setupNepaliDatePicker = ($hiddenInput, {
 module.exports = {
   setupNepaliDatePicker,
   hideDatePicker,
+  destroyDatePicker,
 };

--- a/webapp/tests/karma/js/enketo/widgets/bikram-sambat-datepicker.spec.ts
+++ b/webapp/tests/karma/js/enketo/widgets/bikram-sambat-datepicker.spec.ts
@@ -110,6 +110,21 @@ describe('Enketo: Bikram Sambat Datepicker Widget', () => {
     expect($('.nepali-date-picker .close-btn')).to.have.lengthOf(1);
   });
 
+  it('removes body-appended picker nodes during global widget reset', async () => {
+    for (let i = 0; i < 4; i++) {
+      const widget = await initWidget();
+      $('.calendar-btn').click();
+
+      expect($('.nepali-date-picker')).to.have.lengthOf(1);
+      BikramSambatDatepicker.globalReset();
+      $('#bikram-sambat-test').remove();
+      expect(widget.$hiddenDateInput).to.be.null;
+    }
+
+    expect($('.nepali-date-picker')).to.have.lengthOf(0);
+    expect($('.nepali-date-picker-overlay')).to.have.lengthOf(0);
+  });
+
   it('closes calendar popup and backdrop when close button is clicked', async () => {
     await initWidget();
     $('.calendar-btn').click();


### PR DESCRIPTION
## Summary

Fixes #11245.

Repeatedly opening the Bikram Sambat date picker leaves body-appended picker nodes behind because Enketo's `Form.resetView()` path invokes the static widget reset hook rather than each widget instance's `destroy()` method. The previous instance cleanup therefore did not run, and calling `super.destroy()` would not be valid because the base widget does not provide that method.

This PR:

- Tracks active Bikram Sambat date-picker widget instances.
- Cleans up those instances from `Widget.globalReset()`, the teardown path Enketo actually invokes.
- Removes only the picker and hidden input belonging to each widget, and removes the shared overlay once no picker remains.
- Adds a regression test covering four open/reset cycles.

## Validation

- Webapp Angular unit tests: 2,811 passed, 4 skipped.
- CHT form unit tests: 30 passed.
- Admin unit tests: 431 passed.
- API unit tests: 1,645 passed.
- Sentinel unit tests: 230 passed.
- CouchDB cluster unit tests: 6 passed.
- API integration tests: 11 passed.
- Lint and `git diff --check` passed.
- The dedicated Bikram Sambat widget regression test passed: 15 tests completed.

The shared-library suite has one pre-existing environment-level coverage gate in `shared-libs/outbound`: its 39 tests pass, but the runner reports coverage just below its configured threshold. It is unrelated to this change.

SonarCloud's two `S6582` suggestions were applied with optional chaining. Because the inherited `@medic` ESLint configuration pins Espree to ES2018, a file-scoped `ecmaVersion: 2020` override was added for this widget so the repository lint accepts the syntax. The separate `S5906` suggestion for the test assertion has also been applied with `expect(widget.$hiddenDateInput).to.be.null`.

## Evidence

The following screenshots show the picker working in the browser harness and the DOM cleanup proof after repeated form teardown cycles.

<details>
<summary>Show browser evidence</summary>

<img width="800" alt="Bikram Sambat calendar picker open" src="https://github.com/user-attachments/assets/c4f2aef1-6b8b-4717-9f76-918a9cb60fa8" />

<img width="800" alt="Four teardown cycles passing" src="https://github.com/user-attachments/assets/726e17cd-eda6-4e03-9085-fab241609285" />

<img width="1000" alt="Console and DOM cleanup evidence" src="https://github.com/user-attachments/assets/7d26bfd5-8100-491c-9737-b014f50f34b6" />

</details>

## Timeline

1. The issue identified that repeated form opens accumulated body-appended `.nepali-date-picker` nodes.
2. Inspection of Enketo's lifecycle showed that reset uses the static widget hook, so instance `destroy()` is not the reliable cleanup path.
3. The implementation was adapted to register active widgets and perform scoped cleanup during `globalReset()`.
4. A four-cycle browser regression proof and automated test confirmed zero picker and orphaned nodes after every reset.

_Target branch: `10707-dmp-2026-enhance-bikram-sambat-support-in-cht`, where the existing widget implementation was introduced._

_This PR was developed by Codex under the supervision of jmtdev0._
