### PR TITLE
fix(#11245): clean up Bikram Sambat picker instances

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -625,5 +625,11 @@ module.exports = defineConfig([
       ['@typescript-eslint/no-unused-expressions']: 'off',
       ['@typescript-eslint/no-require-imports']: 'off'
     },
+  },
+  {
+    files: ['webapp/src/js/enketo/widgets/bikram-sambat-picker-shared.js'],
+    languageOptions: {
+      ecmaVersion: 2020,
+    },
   }
 ]);

--- a/webapp/src/js/enketo/widgets/bikram-sambat-datepicker.js
+++ b/webapp/src/js/enketo/widgets/bikram-sambat-datepicker.js
@@ -7,7 +7,28 @@ const eurodigit = require( 'eurodigit' );
 const toDevanagari = eurodigit.to_non_euro.devanagari;
 const fromDevanagari = eurodigit.to_euro;
 
-const { setupNepaliDatePicker, hideDatePicker } = require('./bikram-sambat-picker-shared');
+const {
+  setupNepaliDatePicker,
+  hideDatePicker,
+  destroyDatePicker,
+} = require('./bikram-sambat-picker-shared');
+
+const activeWidgets = new Set();
+let domObserver = null;
+
+const startDOMObserver = () => {
+  if (domObserver) {
+    return;
+  }
+  domObserver = new MutationObserver(() => {
+    activeWidgets.forEach(widget => {
+      if (!document.body.contains(widget.element)) {
+        widget.destroy();
+      }
+    });
+  });
+  domObserver.observe(document.body, { childList: true, subtree: true });
+};
 
 const NEPALI_MONTH_NAMES = [
   'बैशाख', 'जेठ', 'असार', 'साउन', 'भदौ', 'असोज', 'कार्तिक', 'मंसिर', 'पौष', 'माघ', 'फाल्गुन', 'चैत'
@@ -18,6 +39,16 @@ const MONTH_PLACEHOLDER = 'महिना';
 class Bikramsambatdatepicker extends Widget {
   static get selector() {
     return 'input[type=date]';
+  }
+
+  static globalReset() {
+    if (domObserver) {
+      domObserver.disconnect();
+      domObserver = null;
+    }
+    activeWidgets.forEach(widget => widget.destroy());
+    activeWidgets.clear();
+    return super.globalReset();
   }
 
   _init() {
@@ -96,13 +127,13 @@ class Bikramsambatdatepicker extends Widget {
       });
   }
 
-  destroy( element ) {
+  destroy() {
     if ( this.$hiddenDateInput ) {
-      hideDatePicker(this.$hiddenDateInput);
+      destroyDatePicker(this.$hiddenDateInput, this.$picker);
+      this.$hiddenDateInput = null;
+      this.$picker = null;
     }
-    $('.nepali-date-picker-overlay').remove();
-    $('.nepali-date-picker').remove();
-    super.destroy( element );
+    activeWidgets.delete(this);
   }
 }
 
@@ -114,6 +145,8 @@ const setupCalendarPicker = ($parent, widget) => {
   const $hiddenDateInput = $('<input type="text" class="nepali-datepicker-input">');
   $calendarBtn.after($hiddenDateInput);
   widget.$hiddenDateInput = $hiddenDateInput;
+  activeWidgets.add(widget);
+  startDOMObserver();
 
   setupNepaliDatePicker($hiddenDateInput, {
     closeOnDateSelect: false,
@@ -147,6 +180,7 @@ const setupCalendarPicker = ($parent, widget) => {
       hideDatePicker($hiddenDateInput);
     }
   });
+  widget.$picker = $hiddenDateInput.data('picker');
 
   $calendarBtn.on('click', function(e) {
     e.preventDefault();

--- a/webapp/src/js/enketo/widgets/bikram-sambat-picker-shared.js
+++ b/webapp/src/js/enketo/widgets/bikram-sambat-picker-shared.js
@@ -303,7 +303,24 @@ const setupNepaliDatePicker = ($hiddenInput, {
   $hiddenInput.on('show', () => handleShow($hiddenInput, onClear, position));
 };
 
+const destroyDatePicker = ($hiddenInput, $pickerOverride) => {
+  if (!$hiddenInput?.length) {
+    return;
+  }
+  const $picker = $pickerOverride || $hiddenInput.data('picker');
+  hideDatePicker($hiddenInput);
+  $hiddenInput.off('dateSelect close show');
+  if ($picker?.length) {
+    $picker.remove();
+  }
+  $hiddenInput.remove();
+  if (!$('.nepali-date-picker').length) {
+    $('.nepali-date-picker-overlay').remove();
+  }
+};
+
 module.exports = {
   setupNepaliDatePicker,
   hideDatePicker,
+  destroyDatePicker,
 };

--- a/webapp/tests/karma/js/enketo/widgets/bikram-sambat-datepicker.spec.ts
+++ b/webapp/tests/karma/js/enketo/widgets/bikram-sambat-datepicker.spec.ts
@@ -19,6 +19,19 @@ describe('Enketo: Bikram Sambat Datepicker Widget', () => {
     document.body.insertAdjacentHTML('afterbegin', html);
   };
 
+  const buildHtmlMultiple = (count: number) => {
+    let html = '<div id="bikram-sambat-test">';
+    for (let i = 0; i < count; i++) {
+      html += `
+        <label class="question non-select or-appearance-bikram-sambat">
+          <span lang="" class="question-label active">Visit date ${i}</span>
+          <input type="date" name="/data/visit_date_${i}" data-type-xml="date">
+        </label>`;
+    }
+    html += '</div>';
+    document.body.insertAdjacentHTML('afterbegin', html);
+  };
+
   const dayInput = () => $('.bikram-sambat-input-group input[name="day"]');
   const monthInput = () => $('.bikram-sambat-input-group input[name="month"]');
   const yearInput = () => $('.bikram-sambat-input-group input[name="year"]');
@@ -99,6 +112,45 @@ describe('Enketo: Bikram Sambat Datepicker Widget', () => {
   it('initializes with a calendar button', async () => {
     await initWidget();
     expect($('.calendar-btn')).to.have.lengthOf(1);
+  });
+
+  it('removes body-appended picker nodes during global widget reset for multiple concurrent widgets', async () => {
+    buildHtmlMultiple(3);
+    const widgets: any[] = [];
+    const elements = $(BikramSambatDatepicker.selector);
+    for (let i = 0; i < elements.length; i++) {
+      const widget = new BikramSambatDatepicker(elements[i]);
+      widgets.push(widget);
+    }
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    $('.calendar-btn').each(function() {
+      $(this).click();
+    });
+
+    expect($('.nepali-date-picker')).to.have.lengthOf(3);
+    
+    BikramSambatDatepicker.globalReset();
+
+    expect($('.nepali-date-picker')).to.have.lengthOf(0);
+    expect($('.nepali-date-picker-overlay')).to.have.lengthOf(0);
+    widgets.forEach(w => expect(w.$hiddenDateInput).to.be.null);
+  });
+
+  it('automatically cleans up pickers when widget DOM element is removed from body (repeat row removal)', async () => {
+    const widget = await initWidget();
+    $('.calendar-btn').click();
+
+    expect($('.nepali-date-picker')).to.have.lengthOf(1);
+    expect($('.nepali-date-picker-overlay')).to.have.lengthOf(1);
+
+    $('#bikram-sambat-test').remove();
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect($('.nepali-date-picker')).to.have.lengthOf(0);
+    expect($('.nepali-date-picker-overlay')).to.have.lengthOf(0);
+    expect(widget.$hiddenDateInput).to.be.null;
   });
 
   it('opens calendar popup and backdrop when calendar button is clicked', async () => {


### PR DESCRIPTION
# Description

Fixes #11245

This PR fixes a DOM and listener leak where opening Nepali-locale forms with a Bikram Sambat datepicker appends a new calendar container (`.nepali-date-picker`) and backdrop (`.nepali-date-picker-overlay`) to `<body>` on every form load without destroying them. 

Since Enketo Core unloads forms via static `Widget.globalReset()` rather than instance `destroy()` calls, these elements accumulated in the body across form opens.

## Changes:
- Track active widget instances in a static `Set` on the `Bikramsambatdatepicker` class.
- Implement static `globalReset()` to loop over active instances, trigger their instance `destroy()` method, and clear the set.
- Scoped element cleanup inside `destroyDatePicker` using the widget's stored `$picker` data reference, preventing all calendar pickers on the page from being broadly deleted.
- Removed the dead `super.destroy()` call in the widget to avoid runtime `TypeError` issues.
- Added Karma unit test coverage in `bikram-sambat-datepicker.spec.ts` to assert that body nodes are properly cleaned up on reset.

# Code review checklist
- [x] UI/UX backwards compatible
- [x] Readable
- [ ] Documented
- [x] Tested
- [x] Internationalised
- [x] Backwards compatible