### PR TITLE
fix(#11241): ensure Bikram Sambat date conversion uses local date string format

### DIFF
--- a/webapp/src/ts/services/format-date.service.ts
+++ b/webapp/src/ts/services/format-date.service.ts
@@ -67,8 +67,14 @@ export class FormatDateService {
       return momentDate.format(this.config[key]);
     }
 
+    // bikram-sambat expects an ISO date string (YYYY-MM-DD). Passing a moment made it `Date.parse`
+    // a full timestamp, so an evening time-of-day rolled the day over before local midnight in
+    // timezones ahead of UTC (Nepal at 18:15). Clone with 'en' locale so the active 'ne' locale
+    // doesn't emit Devanagari numerals that `Date.parse` can't read. Ref: #11241
+    const localDate = momentDate.clone().locale('en').format('YYYY-MM-DD');
+
     if (key === 'dayMonth') {
-      const bikDate = toBikramSambat(momentDate);
+      const bikDate = toBikramSambat(localDate);
       const devanagariDate = toDevanagariDate(
         bikDate.year,
         bikDate.month,
@@ -77,7 +83,7 @@ export class FormatDateService {
       return `${devanagariDate.day} ${devanagariDate.month}`;
     }
 
-    const bkDateText = toBikramSambatText(momentDate);
+    const bkDateText = toBikramSambatText(localDate);
     if (key === 'date') {
       return bkDateText;
     }

--- a/webapp/tests/karma/ts/services/format-date.service.spec.ts
+++ b/webapp/tests/karma/ts/services/format-date.service.spec.ts
@@ -268,7 +268,7 @@ describe('FormatDate service', () => {
       const time = now.format('hh:mm:ss A');
       expect(service.datetime(now)).to.equal('bk date, ' + time);
       expect(BikramSambat.toBik_text.callCount).to.equal(1);
-      expect(BikramSambat.toBik_text.args[0]).to.deep.equal([now]);
+      expect(BikramSambat.toBik_text.args[0]).to.deep.equal([now.format('YYYY-MM-DD')]);
     });
   });
 
@@ -296,7 +296,50 @@ describe('FormatDate service', () => {
       const now = moment();
       expect(service.date(now)).to.equal('bk converted date');
       expect(BikramSambat.toBik_text.callCount).to.equal(1);
-      expect(BikramSambat.toBik_text.args[0]).to.deep.equal([now]);
+      expect(BikramSambat.toBik_text.args[0]).to.deep.equal([now.format('YYYY-MM-DD')]);
+    });
+
+    it('should convert using the local calendar date, not the timestamp (#11241)', () => {
+      // bikram-sambat expects an ISO date string (YYYY-MM-DD); given a moment it Date.parses the
+      // whole timestamp, so an evening time-of-day rolls the day over early in timezones ahead of
+      // UTC. The service must pass the local date string so the date is pinned to the local day.
+      languageService.useDevanagariScript.returns(true);
+      sinon.stub(BikramSambat, 'toBik_text').returns('bk converted date');
+
+      const startOfDay = moment().startOf('day');
+      const endOfDay = moment().endOf('day');
+      const localDate = moment().format('YYYY-MM-DD');
+
+      service.date(startOfDay);
+      service.date(endOfDay);
+
+      expect(BikramSambat.toBik_text.callCount).to.equal(2);
+      // Same local day in, same date string out - regardless of time-of-day.
+      expect(BikramSambat.toBik_text.args[0]).to.deep.equal([localDate]);
+      expect(BikramSambat.toBik_text.args[1]).to.deep.equal([localDate]);
+    });
+
+    it('should pass ASCII digits to the library even when the locale renders Devanagari (#11241)', () => {
+      // The Nepali locale formats numbers as Devanagari digits; the date string handed to the
+      // library must still use ASCII digits, otherwise its Date.parse fails with
+      // "Date outside supported range". Simulate that locale with a Devanagari postformat.
+      const previousLocale = moment.locale();
+      if (!moment.locales().includes('test-devanagari')) {
+        moment.defineLocale('test-devanagari', {
+          postformat: (num: string) => num.replace(/[0-9]/g, (digit: string) => '०१२३४५६७८९'[Number(digit)]),
+        });
+      }
+      moment.locale('test-devanagari');
+      try {
+        languageService.useDevanagariScript.returns(true);
+        sinon.stub(BikramSambat, 'toBik_text').returns('bk converted date');
+
+        service.date(moment('2026-03-28'));
+
+        expect(BikramSambat.toBik_text.args[0]).to.deep.equal(['2026-03-28']);
+      } finally {
+        moment.locale(previousLocale);
+      }
     });
   });
 
@@ -315,7 +358,7 @@ describe('FormatDate service', () => {
       const now = moment();
       expect(service.dayMonth(now)).to.equal('devday devmonth');
       expect(BikramSambat.toBik.callCount).to.equal(1);
-      expect(BikramSambat.toBik.args[0]).to.deep.equal([now]);
+      expect(BikramSambat.toBik.args[0]).to.deep.equal([now.format('YYYY-MM-DD')]);
       expect(BikramSambat.toDev.callCount).to.equal(1);
       expect(BikramSambat.toDev.args[0]).to.deep.equal(['bkyear', 'bkmonth', 'bkday']);
     });


### PR DESCRIPTION
# Description

When the webapp is used in Nepali (Bikram Sambat calendar), the displayed date rolled over to the next day several hours before local midnight. In Nepal (UTC+5:45) it changed at 18:15 (6:15 PM) instead of midnight.

**Root cause:** `FormatDateService` passed a `moment` object to `bikram-sambat`, whose `toBik_text`/`toBik` expect an ISO date string (`YYYY-MM-DD`). The library's `Date.parse` then consumed the full timestamp, so an evening time-of-day rolled the day over early in timezones ahead of UTC. Additionally, with the `ne` locale active, `moment.format` emits Devanagari numerals, which `Date.parse` cannot read, causing the "Date outside supported range" crash.

**Fix:** format the moment to a local `YYYY-MM-DD` string before passing it to the library, and force the `en` locale on a clone so the numerals stay ASCII (the `datetime` time-portion remains localised). This pins the conversion to the local calendar day so the date changes at local midnight.

**Tests:** updated the existing `date/datetime/dayMonth` specs to assert the library now receives the local date string, and added two regression tests in `format-date.service.spec.ts`
- one proving time-of-day independence (start-of-day and end-of-day map to the same date),
- and another proving ASCII digits are passed even when the locale renders Devanagari.

Both new tests were verified to fail on the unfixed code and pass with the fix.


Fixes: #11241

## AI disclosure

Per the [AI contribution guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/):

- **Tool:** Claude Code (Anthropic).
- **How it was used:** investigating the bug report and understanding the relevant code, identifying the root cause (passing a `moment` to `bikram-sambat` instead of an ISO date string, plus the `ne`-locale Devanagari-numeral crash), implementing the fix, and writing the unit tests and code comments.

All changes were reviewed and tested by me; the new tests were verified to fail without the fix and pass with it.

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [ ] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

