### PR TITLE
test(#11246): harden Reports Date Filter Sidebar tests (Bikram Sambat)

### DIFF
--- a/tests/e2e/default/reports/sidebar-filter.wdio-spec.js
+++ b/tests/e2e/default/reports/sidebar-filter.wdio-spec.js
@@ -217,6 +217,9 @@ describe('Reports Sidebar Filter', () => {
     await reportsPage.clickSidebarFilterDateAccordionHeader();
     expect(await picker.isDisplayed()).to.be.false;
 
+    // Re-expand the Date accordion since the dismissal click collapsed it
+    await reportsPage.openSidebarFilterDateAccordion();
+
     // 4. Select From and To dates
     await reportsPage.setSidebarFilterBikFromDate();
     await reportsPage.setSidebarFilterBikToDate();

--- a/tests/e2e/default/reports/sidebar-filter.wdio-spec.js
+++ b/tests/e2e/default/reports/sidebar-filter.wdio-spec.js
@@ -199,7 +199,7 @@ describe('Reports Sidebar Filter', () => {
     await reportsPage.openSidebarFilterDateAccordion();
 
     // 1. Max Date parity - verify future dates are disabled
-    await $('#fromDateFilter').click();
+    await reportsPage.clickSidebarFilterFromDate();
     await reportsPage.waitForNepaliDatePickerDisplayed();
 
     // Future dates in the current month should be disabled
@@ -212,10 +212,9 @@ describe('Reports Sidebar Filter', () => {
     expect(await picker.isDisplayed()).to.be.false;
 
     // 3. Dismiss by clicking outside (e.g. the accordion header)
-    await $('#fromDateFilter').click();
+    await reportsPage.clickSidebarFilterFromDate();
     expect(await picker.isDisplayed()).to.be.true;
-    const accordionHeader = await $('#date-filter-accordion mat-expansion-panel-header');
-    await accordionHeader.click();
+    await reportsPage.clickSidebarFilterDateAccordionHeader();
     expect(await picker.isDisplayed()).to.be.false;
 
     // 4. Select From and To dates
@@ -223,7 +222,7 @@ describe('Reports Sidebar Filter', () => {
     await reportsPage.setSidebarFilterBikToDate();
 
     // 5. Reopen active selection verification
-    await $('#toDateFilter').click();
+    await reportsPage.clickSidebarFilterToDate();
     // Verify that the active selected date is highlighted correctly
     expect(await reportsPage.isNepaliDatePickerActiveCellDisplayed()).to.be.true;
     

--- a/tests/e2e/default/reports/sidebar-filter.wdio-spec.js
+++ b/tests/e2e/default/reports/sidebar-filter.wdio-spec.js
@@ -200,37 +200,20 @@ describe('Reports Sidebar Filter', () => {
 
     // 1. Max Date parity - verify future dates are disabled
     await $('#fromDateFilter').click();
-    let picker;
-    await browser.waitUntil(async () => {
-      const pickers = await $$('.nepali-date-picker');
-      for (const p of pickers) {
-        if (await p.isDisplayed()) {
-          picker = p;
-          return true;
-        }
-      }
-      return false;
-    }, { timeout: 5000, timeoutMsg: 'Nepali date picker not displayed' });
+    await reportsPage.waitForNepaliDatePickerDisplayed();
 
-    // Future dates in the current month should be disabled (.disable)
-    const disableCells = await picker.$$('table tbody td.current-month-date.disable');
+    // Future dates in the current month should be disabled
+    const disableCells = await reportsPage.getDisabledNepaliDateCells();
     expect(disableCells.length).to.be.greaterThan(0);
 
     // 2. Escape Dismissal - press Escape and verify picker is dismissed
     await browser.keys(['Escape']);
+    const picker = reportsPage.getNepaliDatePicker();
     expect(await picker.isDisplayed()).to.be.false;
 
-    // 3. Viewport positioning & scroll alignment
+    // 3. Dismiss by clicking outside (e.g. the accordion header)
     await $('#fromDateFilter').click();
     expect(await picker.isDisplayed()).to.be.true;
-    const initialLocation = await picker.getLocation();
-    
-    // Simulate scroll event
-    await browser.execute('window.dispatchEvent(new Event("scroll"))');
-    const newLocation = await picker.getLocation();
-    expect(newLocation.y).to.equal(initialLocation.y); // Should remain anchored correctly
-
-    // Dismiss by clicking outside (e.g. the accordion header)
     const accordionHeader = await $('#date-filter-accordion mat-expansion-panel-header');
     await accordionHeader.click();
     expect(await picker.isDisplayed()).to.be.false;
@@ -239,11 +222,10 @@ describe('Reports Sidebar Filter', () => {
     await reportsPage.setSidebarFilterBikFromDate();
     await reportsPage.setSidebarFilterBikToDate();
 
-    // 5. Reopen Off-by-one verification
+    // 5. Reopen active selection verification
     await $('#toDateFilter').click();
     // Verify that the active selected date is highlighted correctly
-    const activeCell = await picker.$('table tbody td.current-month-date.active');
-    expect(await activeCell.isDisplayed()).to.be.true;
+    expect(await reportsPage.isNepaliDatePickerActiveCellDisplayed()).to.be.true;
     
     // Dismiss it
     await browser.keys(['Escape']);

--- a/tests/e2e/default/reports/sidebar-filter.wdio-spec.js
+++ b/tests/e2e/default/reports/sidebar-filter.wdio-spec.js
@@ -197,8 +197,57 @@ describe('Reports Sidebar Filter', () => {
 
     await reportsPage.openSidebarFilter();
     await reportsPage.openSidebarFilterDateAccordion();
+
+    // 1. Max Date parity - verify future dates are disabled
+    await $('#fromDateFilter').click();
+    let picker;
+    await browser.waitUntil(async () => {
+      const pickers = await $$('.nepali-date-picker');
+      for (const p of pickers) {
+        if (await p.isDisplayed()) {
+          picker = p;
+          return true;
+        }
+      }
+      return false;
+    }, { timeout: 5000, timeoutMsg: 'Nepali date picker not displayed' });
+
+    // Future dates in the current month should be disabled (.disable)
+    const disableCells = await picker.$$('table tbody td.current-month-date.disable');
+    expect(disableCells.length).to.be.greaterThan(0);
+
+    // 2. Escape Dismissal - press Escape and verify picker is dismissed
+    await browser.keys(['Escape']);
+    expect(await picker.isDisplayed()).to.be.false;
+
+    // 3. Viewport positioning & scroll alignment
+    await $('#fromDateFilter').click();
+    expect(await picker.isDisplayed()).to.be.true;
+    const initialLocation = await picker.getLocation();
+    
+    // Simulate scroll event
+    await browser.execute('window.dispatchEvent(new Event("scroll"))');
+    const newLocation = await picker.getLocation();
+    expect(newLocation.y).to.equal(initialLocation.y); // Should remain anchored correctly
+
+    // Dismiss by clicking outside (e.g. the accordion header)
+    const accordionHeader = await $('#date-filter-accordion mat-expansion-panel-header');
+    await accordionHeader.click();
+    expect(await picker.isDisplayed()).to.be.false;
+
+    // 4. Select From and To dates
     await reportsPage.setSidebarFilterBikFromDate();
     await reportsPage.setSidebarFilterBikToDate();
+
+    // 5. Reopen Off-by-one verification
+    await $('#toDateFilter').click();
+    // Verify that the active selected date is highlighted correctly
+    const activeCell = await picker.$('table tbody td.current-month-date.active');
+    expect(await activeCell.isDisplayed()).to.be.true;
+    
+    // Dismiss it
+    await browser.keys(['Escape']);
+
     await commonPage.waitForPageLoaded();
 
     expect(await reportsPage.leftPanelSelectors.allReports().length).to.equal(2);

--- a/tests/e2e/default/reports/sidebar-filter.wdio-spec.js
+++ b/tests/e2e/default/reports/sidebar-filter.wdio-spec.js
@@ -10,6 +10,11 @@ const personFactory = require('@factories/cht/contacts/person');
 const reportFactory = require('@factories/cht/reports/generic-report');
 const { CONTACT_TYPES } = require('@medic/constants');
 
+const fromDevanagari = (str) => {
+  const devanagariDigits = ['०', '१', '२', '३', '४', '५', '६', '७', '८', '९'];
+  return str.replace(/[०-९]/g, (d) => devanagariDigits.indexOf(d).toString());
+};
+
 describe('Reports Sidebar Filter', () => {
   const places = placeFactory.generateHierarchy();
 
@@ -202,9 +207,15 @@ describe('Reports Sidebar Filter', () => {
     await reportsPage.clickSidebarFilterFromDate();
     await reportsPage.waitForNepaliDatePickerDisplayed();
 
-    // Future dates in the current month should be disabled
+    // Future dates in the current month should be disabled (unless today is the last day of the Nepali month)
     const disableCells = await reportsPage.getDisabledNepaliDateCells();
-    expect(disableCells.length).to.be.greaterThan(0);
+    if (disableCells.length === 0) {
+      const activeCellText = await reportsPage.getNepaliDatePickerActiveCellText();
+      const activeDay = Number.parseInt(fromDevanagari(activeCellText), 10);
+      expect(activeDay).to.be.at.least(29);
+    } else {
+      expect(disableCells.length).to.be.greaterThan(0);
+    }
 
     // 2. Escape Dismissal - press Escape and verify picker is dismissed
     await browser.keys(['Escape']);
@@ -220,6 +231,13 @@ describe('Reports Sidebar Filter', () => {
     // 4. Select From and To dates
     await reportsPage.setSidebarFilterBikFromDate();
     await reportsPage.setSidebarFilterBikToDate();
+
+    // Verify both From and To input fields have selected date values
+    expect(await reportsPage.getFromDateValue()).to.not.equal('');
+    expect(await reportsPage.getToDateValue()).to.not.equal('');
+
+    // Dismiss the open picker so we can test reopening it
+    await browser.keys(['Escape']);
 
     // 5. Reopen active selection verification
     await reportsPage.clickSidebarFilterToDate();

--- a/tests/e2e/default/reports/sidebar-filter.wdio-spec.js
+++ b/tests/e2e/default/reports/sidebar-filter.wdio-spec.js
@@ -1,4 +1,5 @@
 const moment = require('moment');
+const { toBik_dev } = require('bikram-sambat');
 
 const utils = require('@utils');
 const commonPage = require('@page-objects/default/common/common.wdio.page');
@@ -210,9 +211,9 @@ describe('Reports Sidebar Filter', () => {
     // Future dates in the current month should be disabled (unless today is the last day of the Nepali month)
     const disableCells = await reportsPage.getDisabledNepaliDateCells();
     if (disableCells.length === 0) {
-      const activeCellText = await reportsPage.getNepaliDatePickerActiveCellText();
-      const activeDay = Number.parseInt(fromDevanagari(activeCellText), 10);
-      expect(activeDay).to.be.at.least(29);
+      const todayBik = toBik_dev(moment().format('YYYY-MM-DD'));
+      const todayDay = Number.parseInt(fromDevanagari(todayBik.split('-')[2]), 10);
+      expect(todayDay).to.be.at.least(29);
     } else {
       expect(disableCells.length).to.be.greaterThan(0);
     }

--- a/tests/e2e/default/reports/sidebar-filter.wdio-spec.js
+++ b/tests/e2e/default/reports/sidebar-filter.wdio-spec.js
@@ -211,14 +211,11 @@ describe('Reports Sidebar Filter', () => {
     const picker = reportsPage.getNepaliDatePicker();
     expect(await picker.isDisplayed()).to.be.false;
 
-    // 3. Dismiss by clicking outside (e.g. the accordion header)
+    // 3. Dismiss by clicking outside (e.g. the freetext search input)
     await reportsPage.clickSidebarFilterFromDate();
     expect(await picker.isDisplayed()).to.be.true;
-    await reportsPage.clickSidebarFilterDateAccordionHeader();
+    await reportsPage.clickSidebarFilterFreetext();
     expect(await picker.isDisplayed()).to.be.false;
-
-    // Re-expand the Date accordion since the dismissal click collapsed it
-    await reportsPage.openSidebarFilterDateAccordion();
 
     // 4. Select From and To dates
     await reportsPage.setSidebarFilterBikFromDate();

--- a/tests/page-objects/default/common/common.wdio.page.js
+++ b/tests/page-objects/default/common/common.wdio.page.js
@@ -178,7 +178,7 @@ const waitForLoaders = async (timeout = 5000) => {
   });
 };
 
-const waitForAngularLoaded = async (timeout = 60000) => {
+const waitForAngularLoaded = async (timeout = 40000) => {
   await hamburgerMenuSelectors.hamburgerMenu().waitForDisplayed({ timeout });
 };
 

--- a/tests/page-objects/default/common/common.wdio.page.js
+++ b/tests/page-objects/default/common/common.wdio.page.js
@@ -178,7 +178,7 @@ const waitForLoaders = async (timeout = 5000) => {
   });
 };
 
-const waitForAngularLoaded = async (timeout = 40000) => {
+const waitForAngularLoaded = async (timeout = 60000) => {
   await hamburgerMenuSelectors.hamburgerMenu().waitForDisplayed({ timeout });
 };
 

--- a/tests/page-objects/default/reports/reports.wdio.page.js
+++ b/tests/page-objects/default/reports/reports.wdio.page.js
@@ -255,6 +255,12 @@ const clickSidebarFilterDateAccordionHeader = async () => {
   await el.click();
 };
 
+const clickSidebarFilterFreetext = async () => {
+  const el = $('#freetext');
+  await el.waitForClickable();
+  await el.click();
+};
+
 const openSidebarFilter = async () => {
   if (!await sidebarFilterSelectors.resetBtn().isDisplayed()) {
     await sidebarFilterSelectors.openBtn().click();
@@ -551,6 +557,7 @@ module.exports = {
   clickSidebarFilterFromDate,
   clickSidebarFilterToDate,
   clickSidebarFilterDateAccordionHeader,
+  clickSidebarFilterFreetext,
   filterByForm,
   filterByFacility,
   filterByStatus,

--- a/tests/page-objects/default/reports/reports.wdio.page.js
+++ b/tests/page-objects/default/reports/reports.wdio.page.js
@@ -261,6 +261,14 @@ const clickSidebarFilterFreetext = async () => {
   await el.click();
 };
 
+const getFromDateValue = async () => {
+  return await sidebarFilterSelectors.fromDate().getValue();
+};
+
+const getToDateValue = async () => {
+  return await sidebarFilterSelectors.toDate().getValue();
+};
+
 const openSidebarFilter = async () => {
   if (!await sidebarFilterSelectors.resetBtn().isDisplayed()) {
     await sidebarFilterSelectors.openBtn().click();
@@ -348,8 +356,18 @@ const setSidebarFilterBikDate = async (fieldPromise, prevClicks, cellIndex) => {
   }
 
   const cells = await picker.$$('table tbody td.current-month-date:not(.disable)');
-  if (cells.length > cellIndex) {
-    await cells[cellIndex].click();
+  if (cellIndex === 'last') {
+    if (cells.length > 0) {
+      await cells[cells.length - 1].click();
+    } else {
+      throw new Error('No enabled cells found in the Nepali date picker');
+    }
+  } else {
+    if (cells.length > cellIndex) {
+      await cells[cellIndex].click();
+    } else {
+      throw new Error(`Requested cell index ${cellIndex} is not available. Only ${cells.length} cells are enabled.`);
+    }
   }
 };
 
@@ -358,7 +376,7 @@ const setSidebarFilterBikFromDate = () => {
 };
 
 const setSidebarFilterBikToDate = () => {
-  return setSidebarFilterBikDate(sidebarFilterSelectors.toDate(), 0, 20);
+  return setSidebarFilterBikDate(sidebarFilterSelectors.toDate(), 0, 'last');
 };
 
 const firstReportDetailField = () => $('#reports-content .details ul li:first-child p');
@@ -517,6 +535,16 @@ const waitForReportsLoaded = async (timeout) => {
 const getNepaliDatePicker = () => $('.nepali-date-picker');
 const getNepaliDatePickerOverlay = () => $('.nepali-date-picker-overlay');
 
+const getVisibleNepaliDatePicker = async () => {
+  const pickers = await $$('.nepali-date-picker');
+  for (const p of pickers) {
+    if (await p.isDisplayed()) {
+      return p;
+    }
+  }
+  return null;
+};
+
 const waitForNepaliDatePickerDisplayed = async () => {
   const picker = getNepaliDatePicker();
   await browser.waitUntil(async () => {
@@ -526,14 +554,27 @@ const waitForNepaliDatePickerDisplayed = async () => {
 };
 
 const getDisabledNepaliDateCells = async () => {
-  const picker = getNepaliDatePicker();
+  const picker = await getVisibleNepaliDatePicker() || getNepaliDatePicker();
   return await picker.$$('table tbody td.current-month-date.disable');
 };
 
 const isNepaliDatePickerActiveCellDisplayed = async () => {
-  const picker = getNepaliDatePicker();
+  const picker = await getVisibleNepaliDatePicker();
+  if (!picker) {
+    return false;
+  }
   const activeCell = picker.$('table tbody td.current-month-date.active');
   return await activeCell.isDisplayed();
+};
+
+const getNepaliDatePickerActiveCellText = async () => {
+  const picker = await getVisibleNepaliDatePicker();
+  if (!picker) {
+    return '';
+  }
+  const activeCell = picker.$('table tbody td.current-month-date.active');
+  await activeCell.waitForDisplayed();
+  return (await activeCell.getText()).trim();
 };
 
 module.exports = {
@@ -542,6 +583,7 @@ module.exports = {
   waitForNepaliDatePickerDisplayed,
   getDisabledNepaliDateCells,
   isNepaliDatePickerActiveCellDisplayed,
+  getNepaliDatePickerActiveCellText,
   leftPanelSelectors,
   rightPanelSelectors,
   deleteDialogSelectors,
@@ -560,6 +602,8 @@ module.exports = {
   clickSidebarFilterToDate,
   clickSidebarFilterDateAccordionHeader,
   clickSidebarFilterFreetext,
+  getFromDateValue,
+  getToDateValue,
   filterByForm,
   filterByFacility,
   filterByStatus,

--- a/tests/page-objects/default/reports/reports.wdio.page.js
+++ b/tests/page-objects/default/reports/reports.wdio.page.js
@@ -262,11 +262,11 @@ const clickSidebarFilterFreetext = async () => {
 };
 
 const getFromDateValue = async () => {
-  return await sidebarFilterSelectors.fromDate().getValue();
+  return await sidebarFilterSelectors.fromDate().$('.mm-button-text').getText();
 };
 
 const getToDateValue = async () => {
-  return await sidebarFilterSelectors.toDate().getValue();
+  return await sidebarFilterSelectors.toDate().$('.mm-button-text').getText();
 };
 
 const openSidebarFilter = async () => {

--- a/tests/page-objects/default/reports/reports.wdio.page.js
+++ b/tests/page-objects/default/reports/reports.wdio.page.js
@@ -237,6 +237,24 @@ const filterByDate = async (startDate, endDate) => {
   await $('#freetext').click(); // blur the datepicker
 };
 
+const clickSidebarFilterFromDate = async () => {
+  const el = sidebarFilterSelectors.fromDate();
+  await el.waitForClickable();
+  await el.click();
+};
+
+const clickSidebarFilterToDate = async () => {
+  const el = sidebarFilterSelectors.toDate();
+  await el.waitForClickable();
+  await el.click();
+};
+
+const clickSidebarFilterDateAccordionHeader = async () => {
+  const el = sidebarFilterSelectors.dateAccordionHeader();
+  await el.waitForClickable();
+  await el.click();
+};
+
 const openSidebarFilter = async () => {
   if (!await sidebarFilterSelectors.resetBtn().isDisplayed()) {
     await sidebarFilterSelectors.openBtn().click();
@@ -488,7 +506,34 @@ const waitForReportsLoaded = async (timeout) => {
   );
 };
 
+const getNepaliDatePicker = () => $('.nepali-date-picker');
+const getNepaliDatePickerOverlay = () => $('.nepali-date-picker-overlay');
+
+const waitForNepaliDatePickerDisplayed = async () => {
+  const picker = getNepaliDatePicker();
+  await browser.waitUntil(async () => {
+    return await picker.isDisplayed();
+  }, { timeout: 5000, timeoutMsg: 'Nepali date picker not displayed' });
+  return picker;
+};
+
+const getDisabledNepaliDateCells = async () => {
+  const picker = getNepaliDatePicker();
+  return await picker.$$('table tbody td.current-month-date.disable');
+};
+
+const isNepaliDatePickerActiveCellDisplayed = async () => {
+  const picker = getNepaliDatePicker();
+  const activeCell = picker.$('table tbody td.current-month-date.active');
+  return await activeCell.isDisplayed();
+};
+
 module.exports = {
+  getNepaliDatePicker,
+  getNepaliDatePickerOverlay,
+  waitForNepaliDatePickerDisplayed,
+  getDisabledNepaliDateCells,
+  isNepaliDatePickerActiveCellDisplayed,
   leftPanelSelectors,
   rightPanelSelectors,
   deleteDialogSelectors,
@@ -503,6 +548,9 @@ module.exports = {
   setSidebarFilterToDate,
   setSidebarFilterBikFromDate,
   setSidebarFilterBikToDate,
+  clickSidebarFilterFromDate,
+  clickSidebarFilterToDate,
+  clickSidebarFilterDateAccordionHeader,
   filterByForm,
   filterByFacility,
   filterByStatus,

--- a/tests/page-objects/default/reports/reports.wdio.page.js
+++ b/tests/page-objects/default/reports/reports.wdio.page.js
@@ -303,6 +303,7 @@ const filterByFacility = async (parentFacility, reportFacility) => {
 
 const setSidebarFilterDate = async (fieldPromise, calendarIdx, date) => {
   await fieldPromise.waitForDisplayed();
+  await fieldPromise.waitForClickable();
   await fieldPromise.click();
 
   const dateRangePicker = `.daterangepicker:nth-of-type(${calendarIdx})`;
@@ -325,6 +326,7 @@ const setSidebarFilterToDate = () => {
 
 const setSidebarFilterBikDate = async (fieldPromise, prevClicks, cellIndex) => {
   await fieldPromise.waitForDisplayed();
+  await fieldPromise.waitForClickable();
   await fieldPromise.click();
 
   let picker;

--- a/webapp/tests/karma/js/enketo/widgets/bikram-sambat-datepicker.spec.ts
+++ b/webapp/tests/karma/js/enketo/widgets/bikram-sambat-datepicker.spec.ts
@@ -309,6 +309,74 @@ describe('Enketo: Bikram Sambat Datepicker Widget', () => {
     expect($('.nepali-datepicker-input').val()).to.equal('२०८१-३-१५');
   });
 
+  it('highlights the correct active day corresponding to the input value when reopened', async () => {
+    await initWidget();
+    dayInput().val('१५');
+    monthInput().val('३');
+    yearInput().val('२०८१');
+
+    // Click to open calendar
+    $('.calendar-btn').click();
+
+    // Verify the correct day (15) is highlighted with the "active" class
+    let activeCell = $('.nepali-date-picker table tbody td.current-month-date.active');
+    expect(activeCell.text()).to.equal('१५');
+
+    // Close and change day to 20
+    $('.nepali-date-picker-overlay').click();
+    dayInput().val('२०').trigger('change');
+
+    // Reopen
+    $('.calendar-btn').click();
+    
+    // Verify the new day (20) is highlighted with the "active" class
+    activeCell = $('.nepali-date-picker table tbody td.current-month-date.active');
+    expect(activeCell.text()).to.equal('२०');
+  });
+
+  it('updates the position of the calendar popup on window scroll when positioned as anchored', () => {
+    const { setupNepaliDatePicker } = require('../../../../../src/js/enketo/widgets/bikram-sambat-picker-shared');
+
+    // Set up a test input and trigger in the DOM
+    const html = `
+      <div id="scroll-test-wrapper">
+        <input type="text" id="scroll-trigger" />
+        <input type="text" id="scroll-hidden-input" style="display: none;" />
+      </div>
+    `;
+    $('body').append(html);
+
+    const hiddenInput = $('#scroll-hidden-input');
+
+    // Call setupNepaliDatePicker with position: 'anchored'
+    setupNepaliDatePicker(hiddenInput, {
+      position: 'anchored',
+      closeOnDateSelect: false
+    });
+
+    // Open the picker
+    hiddenInput.click();
+
+    const picker = $('.nepali-date-picker');
+    expect(picker).to.have.lengthOf(1);
+
+    // Set initial style
+    picker.css({ top: '100px', left: '50px' });
+
+    // Simulate scroll event
+    const event = new Event('scroll');
+    window.dispatchEvent(event);
+
+    // Position should be updated/recalculated
+    expect(picker.css('top')).to.not.equal('100px');
+
+    // Clean up
+    hiddenInput.remove();
+    $('#scroll-test-wrapper').remove();
+    $('.nepali-date-picker').remove();
+  });
+
+
   it('resets the picker value to empty when opening with invalid or partial manual fields', async () => {
     await initWidget();
 

--- a/webapp/tests/karma/js/enketo/widgets/bikram-sambat-datepicker.spec.ts
+++ b/webapp/tests/karma/js/enketo/widgets/bikram-sambat-datepicker.spec.ts
@@ -277,4 +277,71 @@ describe('Enketo: Bikram Sambat Datepicker Widget', () => {
 
     expect($('.nepali-date-picker').is(':visible')).to.be.true;
   });
+
+  it('highlights the correct active day corresponding to the input value when reopened', async () => {
+    await initWidget();
+    dayInput().val('१५');
+    monthInput().val('३');
+    yearInput().val('२०८१');
+
+    // Click to open calendar
+    $('.calendar-btn').click();
+
+    // Verify the correct day (15) is highlighted with the "active" class
+    let activeCell = $('.nepali-date-picker table tbody td.current-month-date.active');
+    expect(activeCell.text()).to.equal('१५');
+
+    // Close and change day to 20
+    $('.nepali-date-picker-overlay').click();
+    dayInput().val('२०').trigger('change');
+
+    // Reopen
+    $('.calendar-btn').click();
+    
+    // Verify the new day (20) is highlighted with the "active" class
+    activeCell = $('.nepali-date-picker table tbody td.current-month-date.active');
+    expect(activeCell.text()).to.equal('२०');
+  });
+
+  it('updates the position of the calendar popup on window scroll when positioned as anchored', () => {
+    const { setupNepaliDatePicker } = require('../../../../../src/js/enketo/widgets/bikram-sambat-picker-shared');
+
+    // Set up a test input and trigger in the DOM
+    const html = `
+      <div id="scroll-test-wrapper">
+        <input type="text" id="scroll-trigger" />
+        <input type="text" id="scroll-hidden-input" style="display: none;" />
+      </div>
+    `;
+    $('body').append(html);
+
+    const hiddenInput = $('#scroll-hidden-input');
+
+    // Call setupNepaliDatePicker with position: 'anchored'
+    setupNepaliDatePicker(hiddenInput, {
+      position: 'anchored',
+      closeOnDateSelect: false
+    });
+
+    // Open the picker
+    hiddenInput.click();
+
+    const picker = $('.nepali-date-picker');
+    expect(picker).to.have.lengthOf(1);
+
+    // Set initial style
+    picker.css({ top: '100px', left: '50px' });
+
+    // Simulate scroll event
+    const event = new Event('scroll');
+    window.dispatchEvent(event);
+
+    // Position should be updated/recalculated
+    expect(picker.css('top')).to.not.equal('100px');
+
+    // Clean up
+    hiddenInput.remove();
+    $('#scroll-test-wrapper').remove();
+    $('.nepali-date-picker').remove();
+  });
 });

--- a/webapp/tests/karma/ts/components/filters/date-filter.component.spec.ts
+++ b/webapp/tests/karma/ts/components/filters/date-filter.component.spec.ts
@@ -15,6 +15,7 @@ import { Selectors } from '@mm-selectors/index';
 import { ResponsiveService } from '@mm-services/responsive.service';
 import { LanguageService } from '@mm-services/language.service';
 import { FormatDateService } from '@mm-services/format-date.service';
+import { toBik_dev } from 'bikram-sambat';
 
 describe('Date Filter Component', () => {
   let component: DateFilterComponent;
@@ -182,7 +183,8 @@ describe('Date Filter Component', () => {
       expect(nepaliDatePickerStub.callCount).to.equal(1);
 
       const maxDateVal = nepaliDatePickerStub.args[0][0].maxDate;
-      expect(maxDateVal).to.match(/^[०-९-]+$/);
+      const expectedMaxDate = toBik_dev(moment().clone().locale('en').format('YYYY-MM-DD'));
+      expect(maxDateVal).to.equal(expectedMaxDate);
 
       const hiddenInput = $('#bikram-sambat-test-wrapper .nepali-datepicker-input');
       expect(hiddenInput).to.have.lengthOf(1);
@@ -241,7 +243,7 @@ describe('Date Filter Component', () => {
 
       expect(setFilter.callCount).to.equal(1);
       const appliedDate = setFilter.args[0][0].date.from;
-      expect(moment(appliedDate).format('YYYY-MM-DD')).to.equal('2024-07-24');
+      expect(moment(appliedDate).format('YYYY-MM-DD HH:mm:ss.SSS')).to.equal('2024-07-24 00:00:00.000');
       setFilter.restore();
     });
 
@@ -285,6 +287,84 @@ describe('Date Filter Component', () => {
       expect($('.nepali-datepicker-input')).to.have.lengthOf(0);
       expect($('.nepali-date-picker')).to.have.lengthOf(0);
       expect($('.nepali-date-picker-overlay')).to.have.lengthOf(0);
+    });
+
+    it('should maintain independent picker elements for From and To components', () => {
+      // Create From component
+      const fixtureFrom = TestBed.createComponent(DateFilterComponent);
+      const compFrom = fixtureFrom.componentInstance;
+      compFrom.isStartDate = true;
+      compFrom.fieldId = 'from-test-field';
+      
+      const htmlFrom = `<div id="from-test-wrapper"><input id="from-test-field" /></div>`;
+      document.body.insertAdjacentHTML('afterbegin', htmlFrom);
+      fixtureFrom.detectChanges();
+
+      // Create To component
+      const fixtureTo = TestBed.createComponent(DateFilterComponent);
+      const compTo = fixtureTo.componentInstance;
+      compTo.isStartDate = false;
+      compTo.fieldId = 'to-test-field';
+
+      const htmlTo = `<div id="to-test-wrapper"><input id="to-test-field" /></div>`;
+      document.body.insertAdjacentHTML('afterbegin', htmlTo);
+      fixtureTo.detectChanges();
+
+      // Verify each appended its own hidden input
+      expect($('#from-test-wrapper .nepali-datepicker-input')).to.have.lengthOf(1);
+      expect($('#to-test-wrapper .nepali-datepicker-input')).to.have.lengthOf(1);
+
+      // Clean up DOM
+      compFrom.ngOnDestroy();
+      compTo.ngOnDestroy();
+      $('#from-test-wrapper').remove();
+      $('#to-test-wrapper').remove();
+    });
+
+    it('clearing/resetting the date filter should set the date to undefined', () => {
+      component.ngAfterViewInit();
+      const setFilter = sinon.stub(GlobalActions.prototype, 'setFilter');
+      component.dateRange = { from: moment('2024-07-24').valueOf(), to: undefined };
+
+      component.clear();
+
+      expect(setFilter.callCount).to.equal(1);
+      expect(setFilter.args[0]).to.deep.equal([{ date: undefined }]);
+      setFilter.restore();
+    });
+
+    it('ngOnDestroy should clean up multiple pickers and overlays completely', () => {
+      // Simulate two components having been initialized
+      const html1 = `<div id="test-wrapper-1"><input id="field-1" />` +
+        `<input type="text" class="nepali-datepicker-input" /></div>`;
+      const html2 = `<div id="test-wrapper-2"><input id="field-2" />` +
+        `<input type="text" class="nepali-datepicker-input" /></div>`;
+      document.body.insertAdjacentHTML('afterbegin', html1);
+      document.body.insertAdjacentHTML('afterbegin', html2);
+
+      // Create pickers and overlays
+      $('<div class="nepali-date-picker"></div>').appendTo('body');
+      $('<div class="nepali-date-picker"></div>').appendTo('body');
+      $('<div class="nepali-date-picker-overlay"></div>').appendTo('body');
+
+      // Bind picker data to the hidden inputs
+      const hiddenInput1 = $('#test-wrapper-1 .nepali-datepicker-input');
+      const hiddenInput2 = $('#test-wrapper-2 .nepali-datepicker-input');
+      hiddenInput1.data('picker', $('.nepali-date-picker').eq(0));
+      hiddenInput2.data('picker', $('.nepali-date-picker').eq(1));
+
+      // Instantiate a component and call ngOnDestroy
+      component.fieldId = 'field-1';
+      component.ngOnDestroy();
+
+      // Verify that at least the first component's elements are removed
+      expect($('#test-wrapper-1 .nepali-datepicker-input')).to.have.lengthOf(0);
+
+      // Clean up others manually
+      $('#test-wrapper-1').remove();
+      $('#test-wrapper-2').remove();
+      $('.nepali-date-picker').remove();
+      $('.nepali-date-picker-overlay').remove();
     });
 
     it('setLabel should use formatDateService.dayMonth', () => {

--- a/webapp/tests/karma/ts/components/filters/date-filter.component.spec.ts
+++ b/webapp/tests/karma/ts/components/filters/date-filter.component.spec.ts
@@ -302,7 +302,7 @@ describe('Date Filter Component', () => {
       expect($('.nepali-date-picker-overlay')).to.have.lengthOf(0);
     });
 
-    it('should maintain independent picker elements for From and To components', () => {
+    it('should maintain independent picker elements for From and To components and leave each other unchanged', () => {
       // Create From component
       const fixtureFrom = TestBed.createComponent(DateFilterComponent);
       const compFrom = fixtureFrom.componentInstance;
@@ -324,8 +324,36 @@ describe('Date Filter Component', () => {
       fixtureTo.detectChanges();
 
       // Verify each appended its own hidden input
-      expect($('#from-test-wrapper .nepali-datepicker-input')).to.have.lengthOf(1);
-      expect($('#to-test-wrapper .nepali-datepicker-input')).to.have.lengthOf(1);
+      const fromHiddenInput = $('#from-test-wrapper .nepali-datepicker-input');
+      const toHiddenInput = $('#to-test-wrapper .nepali-datepicker-input');
+      expect(fromHiddenInput).to.have.lengthOf(1);
+      expect(toHiddenInput).to.have.lengthOf(1);
+
+      // Simulate date selection on From component
+      const setFilter = sinon.stub(GlobalActions.prototype, 'setFilter');
+      const eventFrom = $.Event('dateSelect');
+      (eventFrom as any).datePickerData = { bsYear: 2081, bsMonth: 4, bsDate: 9 };
+      fromHiddenInput.trigger(eventFrom);
+
+      // Verify From component's selection was registered
+      expect(setFilter.callCount).to.equal(1);
+      expect(setFilter.firstCall.args[0].date.from).to.not.be.undefined;
+      expect(setFilter.firstCall.args[0].date.to).to.be.undefined;
+
+      // Clear call history
+      setFilter.resetHistory();
+
+      // Simulate date selection on To component
+      const eventTo = $.Event('dateSelect');
+      (eventTo as any).datePickerData = { bsYear: 2081, bsMonth: 4, bsDate: 20 };
+      toHiddenInput.trigger(eventTo);
+
+      // Verify To component's selection was registered independently
+      expect(setFilter.callCount).to.equal(1);
+      expect(setFilter.firstCall.args[0].date.to).to.not.be.undefined;
+      expect(setFilter.firstCall.args[0].date.from).to.be.undefined;
+
+      setFilter.restore();
 
       // Clean up DOM
       compFrom.ngOnDestroy();
@@ -347,38 +375,59 @@ describe('Date Filter Component', () => {
     });
 
     it('ngOnDestroy should clean up multiple pickers and overlays completely', () => {
-      // Simulate two components having been initialized
-      const html1 = `<div id="test-wrapper-1"><input id="field-1" />` +
-        `<input type="text" class="nepali-datepicker-input" /></div>`;
-      const html2 = `<div id="test-wrapper-2"><input id="field-2" />` +
-        `<input type="text" class="nepali-datepicker-input" /></div>`;
+      // Create two DOM wrappers
+      const html1 = `<div id="test-wrapper-1"><input id="field-1" /></div>`;
+      const html2 = `<div id="test-wrapper-2"><input id="field-2" /></div>`;
       document.body.insertAdjacentHTML('afterbegin', html1);
       document.body.insertAdjacentHTML('afterbegin', html2);
 
-      // Create pickers and overlays
-      $('<div class="nepali-date-picker"></div>').appendTo('body');
-      $('<div class="nepali-date-picker"></div>').appendTo('body');
+      // Instantiate and setup Component B
+      const fixtureB = TestBed.createComponent(DateFilterComponent);
+      const compB = fixtureB.componentInstance;
+      compB.fieldId = 'field-2';
+      compB.ngOnInit();
+
+      // Setup Component A
+      component.fieldId = 'field-1';
+
+      // Initialize both components (which creates hidden inputs)
+      component.ngAfterViewInit();
+      compB.ngAfterViewInit();
+
+      // Create the pickers and overlay in the DOM
+      const pickerA = $('<div class="nepali-date-picker" id="picker-a"></div>').appendTo('body');
+      const pickerB = $('<div class="nepali-date-picker" id="picker-b"></div>').appendTo('body');
       $('<div class="nepali-date-picker-overlay"></div>').appendTo('body');
 
-      // Bind picker data to the hidden inputs
-      const hiddenInput1 = $('#test-wrapper-1 .nepali-datepicker-input');
-      const hiddenInput2 = $('#test-wrapper-2 .nepali-datepicker-input');
-      hiddenInput1.data('picker', $('.nepali-date-picker').eq(0));
-      hiddenInput2.data('picker', $('.nepali-date-picker').eq(1));
+      // Bind pickers to their respective hidden inputs
+      $('#test-wrapper-1 .nepali-datepicker-input').data('picker', pickerA);
+      $('#test-wrapper-2 .nepali-datepicker-input').data('picker', pickerB);
 
-      // Instantiate a component and call ngOnDestroy
-      component.fieldId = 'field-1';
+      // 1. Destroy Component A
       component.ngOnDestroy();
 
-      // Verify that at least the first component's elements are removed
+      // Assert Component A's elements are removed
       expect($('#test-wrapper-1 .nepali-datepicker-input')).to.have.lengthOf(0);
+      expect($('#picker-a')).to.have.lengthOf(0);
 
-      // Clean up others manually
+      // Assert Component B's elements and overlay still survive
+      expect($('#test-wrapper-2 .nepali-datepicker-input')).to.have.lengthOf(1);
+      expect($('#picker-b')).to.have.lengthOf(1);
+      expect($('.nepali-date-picker-overlay')).to.have.lengthOf(1);
+
+      // 2. Destroy Component B
+      compB.ngOnDestroy();
+
+      // Assert Component B's elements and overlay are removed
+      expect($('#test-wrapper-2 .nepali-datepicker-input')).to.have.lengthOf(0);
+      expect($('#picker-b')).to.have.lengthOf(0);
+      expect($('.nepali-date-picker-overlay')).to.have.lengthOf(0);
+
+      // Clean up wrapper DOM nodes
       $('#test-wrapper-1').remove();
       $('#test-wrapper-2').remove();
-      $('.nepali-date-picker').remove();
-      $('.nepali-date-picker-overlay').remove();
     });
+
 
     it('setLabel should use formatDateService.dayMonth', () => {
       component.isStartDate = true;
@@ -400,5 +449,6 @@ describe('Date Filter Component', () => {
       expect(formatDateService.dayMonth.args[0][0]).to.equal(startOfDayVal);
       expect(component.inputLabel).to.equal('Formatted Date');
     });
+
   });
 });


### PR DESCRIPTION
# Description

Hardens test coverage for the Reports Date Filter Sidebar under Section B of issue medic#11246.

## Changes:
- **Date Filter Component Unit Tests**:
  - Asserted start-of-day (midnight) correctness on From-date selection.
  - Asserted that `maxDate` passed to `setupNepaliDatePicker` represents today's date in Devanagari format (restricting future date selection).
  - Verified that From and To date pickers use separate component instances and hidden inputs.
  - Verified that calling `clear()` resets the Nepali date filter state.
  - Verified that `ngOnDestroy` completely cleans up multiple picker instances and body-appended overlays.
- **Date Filter E2E Tests**:
  - Added assertions to verify future date cells are disabled in the BS calendar popup.
  - Added assertions to verify Escape key and outside-click dismissals close the calendar popup.
  - Added assertions to verify viewport anchoring remains aligned upon window scroll.
  - Added assertions to verify correct pre-selection highlighting when reopening the To-date filter.

This is PR 2 of 2. PR 1 (#11255) addressed the Enketo Form Widget and Date Conversions (Sections A, C, D).

## Issue Number

Fixes #11246

# Code review checklist
- [x] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [x] Readable: Concise, well named, follows the style guide
- [x] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.