### PR TITLE
fix(#11252): guard BS datepicker against invalid day value crash

### DIFF
--- a/webapp/src/js/enketo/widgets/bikram-sambat-datepicker.js
+++ b/webapp/src/js/enketo/widgets/bikram-sambat-datepicker.js
@@ -6,6 +6,7 @@ const bikram_sambat_bs = require( 'bikram-sambat-bootstrap' );
 const eurodigit = require( 'eurodigit' );
 const toDevanagari = eurodigit.to_non_euro.devanagari;
 const fromDevanagari = eurodigit.to_euro;
+const BikramSambat = require( 'bikram-sambat' );
 
 const {
   setupNepaliDatePicker,
@@ -94,13 +95,27 @@ class Bikramsambatdatepicker extends Widget {
         // setTimeout) after both "change" and "blur", once the library's
         // own handlers have finished running.
         const clearIfIncomplete = () => {
-          const day   = $parent.find( 'input[name="day"]' ).val();
-          const month = $parent.find( 'input[name="month"]' ).val();
-          const year  = $parent.find( 'input[name="year"]' ).val();
+          const dayDev   = $parent.find( 'input[name="day"]' ).val();
+          const monthDev = $parent.find( 'input[name="month"]' ).val();
+          const yearDev  = $parent.find( 'input[name="year"]' ).val();
 
-          if ( !day || !month || !year ) {
+          if ( !dayDev || !monthDev || !yearDev ) {
             $realDateInput.val( '' );
             $realDateInput.trigger( 'change' );
+            return;
+          }
+
+          const day = Number(fromDevanagari(dayDev));
+          const month = Number(fromDevanagari(monthDev));
+          const year = Number(fromDevanagari(yearDev));
+
+          if (!Number.isNaN(day) && !Number.isNaN(month) && !Number.isNaN(year)) {
+            const maxDays = BikramSambat.daysInMonth(year, month);
+            if (day < 1 || day > maxDays) {
+              $realDateInput.val( '' );
+              $realDateInput.trigger( 'change' );
+              $parent.find( 'input[name="day"]' ).val( '' );
+            }
           }
         };
 
@@ -154,6 +169,11 @@ const setupCalendarPicker = ($parent, widget) => {
       const year = data.bsYear;
       const monthNum = data.bsMonth;
       const day = data.bsDate;
+
+      // Guard against invalid days (e.g. Mansir 30, 2082)
+      if (day > BikramSambat.daysInMonth(year, monthNum)) {
+        return;
+      }
       const monthName = NEPALI_MONTH_NAMES[monthNum - 1];
       if (monthName) {
         // Update the input fields with Devanagari digits and trigger change

--- a/webapp/src/js/enketo/widgets/bikram-sambat-datepicker.js
+++ b/webapp/src/js/enketo/widgets/bikram-sambat-datepicker.js
@@ -109,6 +109,7 @@ class Bikramsambatdatepicker extends Widget {
 
           if (!Number.isNaN(day) && !Number.isNaN(month) && !Number.isNaN(year)) {
             const maxDays = BikramSambat.daysInMonth(year, month);
+            // Guard against invalid day values on manual entry (see #11252)
             if (day < 1 || day > maxDays) {
               $realDateInput.val( '' );
               $realDateInput.trigger( 'change' );
@@ -170,6 +171,7 @@ const setupCalendarPicker = ($parent, widget) => {
       const day = data.bsDate;
 
       // Guard against invalid days (e.g. Mansir 30, 2082)
+      // Clicks on non-existent/phantom days are ignored intentionally (see #11252)
       if (day > BikramSambat.daysInMonth(year, monthNum)) {
         return;
       }

--- a/webapp/src/js/enketo/widgets/bikram-sambat-datepicker.js
+++ b/webapp/src/js/enketo/widgets/bikram-sambat-datepicker.js
@@ -108,9 +108,16 @@ class Bikramsambatdatepicker extends Widget {
           const year = Number(fromDevanagari(yearDev));
 
           if (!Number.isNaN(day) && !Number.isNaN(month) && !Number.isNaN(year)) {
-            const maxDays = BikramSambat.daysInMonth(year, month);
-            // Guard against invalid day values on manual entry (see #11252)
-            if (day < 1 || day > maxDays) {
+            try {
+              const maxDays = BikramSambat.daysInMonth(year, month);
+              // Guard against invalid day values on manual entry (see #11252)
+              if (day < 1 || day > maxDays) {
+                $realDateInput.val( '' );
+                $realDateInput.trigger( 'change' );
+                $parent.find( 'input[name="day"]' ).val( '' );
+              }
+            } catch ( e ) {
+              // If the library throws for out-of-range years, treat as invalid and clear (see #11252)
               $realDateInput.val( '' );
               $realDateInput.trigger( 'change' );
               $parent.find( 'input[name="day"]' ).val( '' );
@@ -172,22 +179,38 @@ const setupCalendarPicker = ($parent, widget) => {
 
       // Guard against invalid days (e.g. Mansir 30, 2082)
       // Clicks on non-existent/phantom days are ignored intentionally (see #11252)
-      if (day > BikramSambat.daysInMonth(year, monthNum)) {
-        return;
+      try {
+        if (day > BikramSambat.daysInMonth(year, monthNum)) {
+          return;
+        }
+      } catch ( e ) {
+        return; // Ignore if the library throws for out-of-range years/months
       }
       const monthName = NEPALI_MONTH_NAMES[monthNum - 1];
       if (monthName) {
-        // Update the input fields with Devanagari digits and trigger change
-        $parent.find('input[name="day"]').val(toDevanagari(day.toString())).trigger('change');
-        $parent.find('input[name="month"]').val(toDevanagari(monthNum.toString())).trigger('change');
-        $parent.find('input[name="year"]').val(toDevanagari(year.toString())).trigger('change').trigger('blur');
+        // Set all values first to prevent validation checks against stale/intermediate DOM states (see #11252)
+        $parent.find('input[name="day"]').val(toDevanagari(day.toString()));
+        $parent.find('input[name="month"]').val(toDevanagari(monthNum.toString()));
+        $parent.find('input[name="year"]').val(toDevanagari(year.toString()));
+
+        // Then trigger change and blur events so validation runs on the complete set of values
+        $parent.find('input[name="day"]').trigger('change');
+        $parent.find('input[name="month"]').trigger('change');
+        $parent.find('input[name="year"]').trigger('change').trigger('blur');
         $group.find('.month-dropdown button').html(monthName + ' <span class="caret"></span>');
       }
     },
     onClear: () => {
-      $parent.find('input[name="day"]').val('').trigger('change');
-      $parent.find('input[name="month"]').val('').trigger('change');
-      $parent.find('input[name="year"]').val('').trigger('change').trigger('blur');
+      // Set all values first to prevent validation checks against stale/intermediate DOM states
+      $parent.find('input[name="day"]').val('');
+      $parent.find('input[name="month"]').val('');
+      $parent.find('input[name="year"]').val('');
+
+      // Then trigger change and blur events so validation runs on the complete set of values
+      $parent.find('input[name="day"]').trigger('change');
+      $parent.find('input[name="month"]').trigger('change');
+      $parent.find('input[name="year"]').trigger('change').trigger('blur');
+
       $group.find('.month-dropdown button').html(`${MONTH_PLACEHOLDER} <span class="caret"></span>`);
       $hiddenDateInput.val('');
       const $picker = $hiddenDateInput.data('picker');

--- a/webapp/src/js/enketo/widgets/bikram-sambat-datepicker.js
+++ b/webapp/src/js/enketo/widgets/bikram-sambat-datepicker.js
@@ -37,6 +37,15 @@ const NEPALI_MONTH_NAMES = [
 
 const MONTH_PLACEHOLDER = 'महिना';
 
+const isDayValid = (day, month, year) => {
+  try {
+    return day >= 1 && day <= BikramSambat.daysInMonth(year, month);
+  } catch (_e) {
+    console.warn('BikramSambat validation error:', _e);
+    return false;
+  }
+};
+
 class Bikramsambatdatepicker extends Widget {
   static get selector() {
     return 'input[type=date]';
@@ -107,21 +116,10 @@ class Bikramsambatdatepicker extends Widget {
           const month = Number(fromDevanagari(monthDev));
           const year = Number(fromDevanagari(yearDev));
 
-          if (!Number.isNaN(day) && !Number.isNaN(month) && !Number.isNaN(year)) {
-            try {
-              const maxDays = BikramSambat.daysInMonth(year, month);
-              // Guard against invalid day values on manual entry (see #11252)
-              if (day < 1 || day > maxDays) {
-                $realDateInput.val( '' );
-                $realDateInput.trigger( 'change' );
-                $parent.find( 'input[name="day"]' ).val( '' );
-              }
-            } catch ( e ) {
-              // If the library throws for out-of-range years, treat as invalid and clear (see #11252)
-              $realDateInput.val( '' );
-              $realDateInput.trigger( 'change' );
-              $parent.find( 'input[name="day"]' ).val( '' );
-            }
+          if (Number.isNaN(day) || Number.isNaN(month) || Number.isNaN(year) || !isDayValid(day, month, year)) {
+            $realDateInput.val( '' );
+            $realDateInput.trigger( 'change' );
+            $parent.find( 'input[name="day"]' ).val( '' );
           }
         };
 
@@ -183,7 +181,8 @@ const setupCalendarPicker = ($parent, widget) => {
         if (day > BikramSambat.daysInMonth(year, monthNum)) {
           return;
         }
-      } catch ( e ) {
+      } catch ( _e ) {
+        console.warn('BikramSambat date limit check error:', _e);
         return; // Ignore if the library throws for out-of-range years/months
       }
       const monthName = NEPALI_MONTH_NAMES[monthNum - 1];

--- a/webapp/src/ts/components/filters/date-filter/date-filter.component.ts
+++ b/webapp/src/ts/components/filters/date-filter/date-filter.component.ts
@@ -16,7 +16,7 @@ import { TranslatePipe } from '@ngx-translate/core';
 
 import { LanguageService } from '@mm-services/language.service';
 import { FormatDateService } from '@mm-services/format-date.service';
-import { toBik, toGreg_text, toBik_dev } from 'bikram-sambat';
+import { toBik, toGreg_text, toBik_dev, daysInMonth } from 'bikram-sambat';
 import { setupNepaliDatePicker, hideDatePicker } from '../../../../js/enketo/widgets/bikram-sambat-picker-shared';
 
 @Component({
@@ -131,6 +131,10 @@ export class DateFilterComponent implements OnInit, OnDestroy, AfterViewInit {
 
     setupNepaliDatePicker($hiddenDateInput, {
       onDateSelect: (data: any) => {
+        const maxDays = daysInMonth(data.bsYear, data.bsMonth);
+        if (data.bsDate > maxDays) {
+          return;
+        }
         const gregDateStr = toGreg_text(data.bsYear, data.bsMonth, data.bsDate);
         const gregMoment = moment(gregDateStr);
         const normalizedMoment = this.isStartDate ? gregMoment.startOf('day') : gregMoment.endOf('day');

--- a/webapp/src/ts/components/filters/date-filter/date-filter.component.ts
+++ b/webapp/src/ts/components/filters/date-filter/date-filter.component.ts
@@ -140,7 +140,8 @@ export class DateFilterComponent implements OnInit, OnDestroy, AfterViewInit {
           if (data.bsDate > maxDays) {
             return;
           }
-        } catch (e) {
+        } catch (_e) {
+          console.warn('BikramSambat date limit check error:', _e);
           return; // Ignore if the library throws for out-of-range years/months
         }
         const gregDateStr = toGreg_text(data.bsYear, data.bsMonth, data.bsDate);

--- a/webapp/src/ts/components/filters/date-filter/date-filter.component.ts
+++ b/webapp/src/ts/components/filters/date-filter/date-filter.component.ts
@@ -134,9 +134,14 @@ export class DateFilterComponent implements OnInit, OnDestroy, AfterViewInit {
 
     setupNepaliDatePicker($hiddenDateInput, {
       onDateSelect: (data: any) => {
-        const maxDays = daysInMonth(data.bsYear, data.bsMonth);
-        if (data.bsDate > maxDays) {
-          return;
+        // Clicks on non-existent/phantom days are ignored intentionally (see #11252)
+        try {
+          const maxDays = daysInMonth(data.bsYear, data.bsMonth);
+          if (data.bsDate > maxDays) {
+            return;
+          }
+        } catch (e) {
+          return; // Ignore if the library throws for out-of-range years/months
         }
         const gregDateStr = toGreg_text(data.bsYear, data.bsMonth, data.bsDate);
         const gregMoment = moment(gregDateStr);

--- a/webapp/tests/karma/js/enketo/widgets/bikram-sambat-datepicker.spec.ts
+++ b/webapp/tests/karma/js/enketo/widgets/bikram-sambat-datepicker.spec.ts
@@ -277,4 +277,41 @@ describe('Enketo: Bikram Sambat Datepicker Widget', () => {
 
     expect($('.nepali-date-picker').is(':visible')).to.be.true;
   });
+
+  it('ignores dateSelect event with an invalid/non-existent day', async () => {
+    await initWidget();
+    const hiddenInput = $('.nepali-datepicker-input');
+    const event: any = $.Event('dateSelect');
+    event.datePickerData = {
+      bsYear: 2082,
+      bsMonth: 8,
+      bsDate: 30
+    };
+    
+    let threwError = false;
+    try {
+      hiddenInput.trigger(event);
+    } catch (_e) {
+      threwError = true;
+    }
+
+    expect(threwError).to.be.false;
+    expect(dayInput().val()).to.equal('');
+    expect(monthInput().val()).to.equal('');
+    expect(yearInput().val()).to.equal('');
+    expect(realDateInput().val()).to.equal('');
+  });
+
+  it('clears invalid day input on manual entry of non-existent day', async () => {
+    await initWidget();
+
+    dayInput().val('३०').trigger('change');
+    monthInput().val('८').trigger('change');
+    yearInput().val('२०८२').trigger('change').trigger('blur');
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(dayInput().val()).to.equal('');
+    expect(realDateInput().val()).to.equal('');
+  });
 });

--- a/webapp/tests/karma/js/enketo/widgets/bikram-sambat-datepicker.spec.ts
+++ b/webapp/tests/karma/js/enketo/widgets/bikram-sambat-datepicker.spec.ts
@@ -385,4 +385,48 @@ describe('Enketo: Bikram Sambat Datepicker Widget', () => {
     ($.fn as any).nepaliDatePicker = originalPlugin;
     expect(errorThrown).to.be.false;
   });
+
+  it('ignores dateSelect event with an invalid/non-existent day', async () => {
+    await initWidget();
+    const hiddenInput = $('.nepali-datepicker-input');
+
+    // Seed a valid date first to verify it survives the invalid event
+    dayInput().val('१५');
+    monthInput().val('३');
+    yearInput().val('२०८१');
+
+    const event: any = $.Event('dateSelect');
+    event.datePickerData = {
+      bsYear: 2082,
+      bsMonth: 8, // Mansir
+      bsDate: 30  // Invalid day (Mansir 2082 only has 29 days)
+    };
+    
+    let threwError = false;
+    try {
+      hiddenInput.trigger(event);
+    } catch (_e) {
+      threwError = true;
+    }
+
+    expect(threwError).to.be.false;
+    // Verify that the valid date is NOT cleared because the event was ignored
+    expect(dayInput().val()).to.equal('१५');
+    expect(monthInput().val()).to.equal('३');
+    expect(yearInput().val()).to.equal('२०८१');
+  });
+
+  it('clears invalid day input on manual entry of non-existent day', async () => {
+    await initWidget();
+
+    dayInput().val('३०').trigger('change');
+    monthInput().val('८').trigger('change');
+    yearInput().val('२०८२').trigger('change').trigger('blur');
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(dayInput().val()).to.equal('');
+    expect(realDateInput().val()).to.equal('');
+  });
 });
+

--- a/webapp/tests/karma/js/enketo/widgets/bikram-sambat-datepicker.spec.ts
+++ b/webapp/tests/karma/js/enketo/widgets/bikram-sambat-datepicker.spec.ts
@@ -496,5 +496,59 @@ describe('Enketo: Bikram Sambat Datepicker Widget', () => {
     expect(dayInput().val()).to.equal('');
     expect(realDateInput().val()).to.equal('');
   });
+
+  it('accepts dateSelect event on month boundary (day === daysInMonth)', async () => {
+    await initWidget();
+    const hiddenInput = $('.nepali-datepicker-input');
+
+    const event: any = $.Event('dateSelect');
+    event.datePickerData = {
+      bsYear: 2082,
+      bsMonth: 8, // Mansir
+      bsDate: 29  // Valid day (Mansir 2082 has exactly 29 days)
+    };
+
+    hiddenInput.trigger(event);
+
+    expect(dayInput().val()).to.equal('२९');
+    expect(monthInput().val()).to.equal('८');
+    expect(yearInput().val()).to.equal('२०८२');
+    expect(realDateInput().val()).to.not.equal('');
+  });
+
+  it('successfully updates date on sequential selections in different months without swallowing the second pick', async () => {
+    await initWidget();
+    const hiddenInput = $('.nepali-datepicker-input');
+
+    // First selection: Mansir 8, 2082
+    const firstEvent: any = $.Event('dateSelect');
+    firstEvent.datePickerData = {
+      bsYear: 2082,
+      bsMonth: 8,
+      bsDate: 8
+    };
+    hiddenInput.trigger(firstEvent);
+
+    expect(dayInput().val()).to.equal('८');
+    expect(monthInput().val()).to.equal('८');
+    expect(yearInput().val()).to.equal('२०८२');
+
+    // Second selection: Baisakh 31, 2082 (Baisakh has 31 days)
+    const secondEvent: any = $.Event('dateSelect');
+    secondEvent.datePickerData = {
+      bsYear: 2082,
+      bsMonth: 1,
+      bsDate: 31
+    };
+    hiddenInput.trigger(secondEvent);
+
+    // Allow the guard's deferred checks to run
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(dayInput().val()).to.equal('३१');
+    expect(monthInput().val()).to.equal('१');
+    expect(yearInput().val()).to.equal('२०८२');
+    expect(realDateInput().val()).to.not.equal('');
+  });
 });
 

--- a/webapp/tests/karma/js/enketo/widgets/bikram-sambat-datepicker.spec.ts
+++ b/webapp/tests/karma/js/enketo/widgets/bikram-sambat-datepicker.spec.ts
@@ -516,7 +516,7 @@ describe('Enketo: Bikram Sambat Datepicker Widget', () => {
     expect(realDateInput().val()).to.not.equal('');
   });
 
-  it('successfully updates date on sequential selections in different months without swallowing the second pick', async () => {
+  it('updates date on sequential selections without swallowing second pick', async () => {
     await initWidget();
     const hiddenInput = $('.nepali-datepicker-input');
 

--- a/webapp/tests/karma/ts/components/filters/date-filter.component.spec.ts
+++ b/webapp/tests/karma/ts/components/filters/date-filter.component.spec.ts
@@ -267,6 +267,26 @@ describe('Date Filter Component', () => {
       setFilter.restore();
     });
 
+    it('should ignore selection of invalid/non-existent days', () => {
+      component.ngAfterViewInit();
+      component.isStartDate = true;
+      component.dateRange = { from: undefined, to: undefined };
+
+      const hiddenInput = $('#bikram-sambat-test-wrapper .nepali-datepicker-input');
+      const setFilter = sinon.stub(GlobalActions.prototype, 'setFilter');
+
+      const event = $.Event('dateSelect');
+      (event as any).datePickerData = {
+        bsYear: 2082,
+        bsMonth: 8,
+        bsDate: 30
+      };
+      hiddenInput.trigger(event);
+
+      expect(setFilter.callCount).to.equal(0);
+      setFilter.restore();
+    });
+
     it('ngOnDestroy should clean up specific picker container and overlay', () => {
       component.ngAfterViewInit();
       const hiddenInput = $('#bikram-sambat-test-wrapper .nepali-datepicker-input');


### PR DESCRIPTION
# Description

Implements a conversion guard for the Bikram Sambat datepicker (reports date filter and Enketo form widget) to validate day selections and manual entries against `daysInMonth` using the `bikram-sambat` library, preventing crashes on invalid days (e.g. Mansir 30, 2082).

## Changes:
- **Date Filter Component**:
  - Guarded calendar datepicker selections with a `daysInMonth` check. Clicks on invalid days are safely ignored.
  - Added unit test asserting invalid day selections are ignored.
- **Enketo Datepicker Widget**:
  - Guarded calendar picker selection with `daysInMonth` check.
  - Updated the manual input `clearIfIncomplete` guard to clear the day input field if the entered day is invalid for the specified month/year, preventing under-the-hood crashes.
  - Added unit tests asserting invalid day calendar select is ignored and invalid manual entries reset/clear the fields.

## Issue Number

Fixes #11252

# Code review checklist
- [x] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [x] Readable: Concise, well named, follows the style guide
- [x] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.